### PR TITLE
TUI: append (WSL) tag to RAM when running inside WSL

### DIFF
--- a/src/tui_ui.rs
+++ b/src/tui_ui.rs
@@ -10,6 +10,7 @@ use ratatui::{
 };
 
 use crate::fit::FitLevel;
+use crate::hardware::is_running_in_wsl;
 use crate::tui_app::{App, FitFilter, InputMode};
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
@@ -73,8 +74,10 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled("RAM: ", Style::default().fg(Color::DarkGray)),
         Span::styled(
             format!(
-                "{:.1} GB avail / {:.1} GB total",
-                app.specs.available_ram_gb, app.specs.total_ram_gb
+                "{:.1} GB avail / {:.1} GB total{}",
+                app.specs.available_ram_gb,
+                app.specs.total_ram_gb,
+                if is_running_in_wsl() { " (WSL)" } else { "" }
             ),
             Style::default().fg(Color::Cyan),
         ),


### PR DESCRIPTION
  ## Summary
  This PR adds a small clarification in the TUI system bar:
  - RAM text now appends ` (WSL)` when llmfit is running inside Windows Subsystem for Linux.

  Example:  
<img width="435" height="48" alt="image" src="https://github.com/user-attachments/assets/da4e61fb-e84d-4d4f-a635-869be77b122a" />


  ## Why
  I reported (#6) that RAM looked incorrect in WSL as it did not align with my installed size.
  I later found out that this is expected WSL behavior due to its set memory allocation, not a bug in llmfit’s RAM detection.
  This change makes that context explicit and avoids confusion for Windows+WSL users.

  ## Changes
  - Added internal WSL environment detection helper in `src/hardware.rs`.
  - Cached detection with `OnceLock` to avoid repeated checks in the render path.
  - Updated TUI RAM label formatting in `src/tui_ui.rs` to append ` (WSL)` when applicable.

  ## Validation
  - Verified behavior on native Windows (no suffix).
  - Verified behavior in WSL (suffix shown).