### PR TITLE
fix: correctly estimate VRAM for APU integrated GPUs

### DIFF
--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -1027,6 +1027,20 @@ fn estimate_vram_from_name(name: &str) -> f64 {
     if lower.contains("5500") {
         return 4.0;
     }
+    // Integrated GPUs (APU iGPUs) — must check before generic fallbacks
+    // APU names like "AMD Radeon(TM) Graphics" or "Radeon Graphics" without
+    // a discrete model number (RX/HD/R5/R7/R9) have very limited dedicated VRAM.
+    if (lower.contains("radeon") || lower.contains("amd"))
+        && !lower.contains("rx ")
+        && !lower.contains("hd ")
+        && !lower.contains(" r5 ")
+        && !lower.contains(" r7 ")
+        && !lower.contains(" r9 ")
+        && (lower.contains("graphics") || lower.contains("igpu"))
+    {
+        return 0.5;
+    }
+
     // Generic fallbacks
     if lower.contains("rtx") {
         return 8.0;


### PR DESCRIPTION
## Problem

On systems with both an AMD APU integrated GPU and a discrete GPU, `estimate_vram_from_name()` matches APU names like `AMD Radeon(TM) Graphics` against the generic `radeon` fallback and returns 8 GB. These APU iGPUs typically have only ~0.5 GB dedicated VRAM.

This causes the iGPU to be listed first and ranked higher than the actual discrete GPU, affecting model recommendations.

## Fix

Added an early check before the generic fallbacks that detects APU integrated GPUs by matching names containing `radeon/amd` + `graphics/igpu` **without** a discrete model number (RX/HD/R5/R7/R9). These get 0.5 GB estimated VRAM.

Examples matched:
- `AMD Radeon(TM) Graphics` → 0.5 GB ✓ (was 8 GB)
- `Radeon Graphics` → 0.5 GB ✓ (was 8 GB)

Not affected (still use existing estimates):
- `AMD Radeon RX 7900 XTX` → 24 GB (has 'rx ')
- `Radeon HD 7970` → 8 GB fallback (has 'hd ')

Fixes #25