### PR TITLE
ci: split desktop release to separate v*-mac tag workflow

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,85 @@
+name: Release Desktop (macOS)
+
+on:
+  push:
+    tags:
+      - "v*-mac"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-desktop:
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --version "^2"
+
+      - name: Build Tauri app bundle
+        run: cargo tauri build --target ${{ matrix.target }} --bundles app
+        working-directory: llmfit-desktop
+
+      - name: Package .app bundle
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          # Search both possible target locations
+          for BASE in "target" "llmfit-desktop/target"; do
+            APP=$(find "${BASE}/${{ matrix.target }}/release/bundle" -name '*.app' -maxdepth 3 2>/dev/null | head -1)
+            [ -n "$APP" ] && break
+          done
+
+          if [ -z "$APP" ]; then
+            echo "::error::No .app bundle found"
+            find target/ llmfit-desktop/target/ -type d -name 'bundle' 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "Found app bundle: $APP"
+          DEST="llmfit-desktop-${TAG}-${{ matrix.target }}.app.tar.gz"
+          cd "$(dirname "$APP")"
+          tar czf "/tmp/${DEST}" "$(basename "$APP")"
+          echo "DESKTOP_ASSET=${DEST}" >> "$GITHUB_ENV"
+          echo "DESKTOP_ASSET_PATH=/tmp/${DEST}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.DESKTOP_ASSET }}
+          path: ${{ env.DESKTOP_ASSET_PATH }}
+
+  release:
+    needs: build-desktop
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/**/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "!v*-mac"
 
 permissions:
   contents: write
@@ -92,71 +93,8 @@ jobs:
           name: ${{ env.ASSET }}
           path: ${{ env.ASSET_PATH }}
 
-  build-desktop:
-    strategy:
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            os: macos-latest
-          - target: x86_64-apple-darwin
-            os: macos-latest
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "^2"
-
-      - name: Build Tauri app
-        run: cargo tauri build --target ${{ matrix.target }}
-        working-directory: llmfit-desktop
-
-      - name: Find and rename DMG
-        shell: bash
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          # Tauri outputs bundles under the workspace target dir
-          BUNDLE_DIR="target/${{ matrix.target }}/release/bundle"
-          # Also check if bundle ended up under llmfit-desktop/
-          if [ ! -d "$BUNDLE_DIR" ]; then
-            BUNDLE_DIR="llmfit-desktop/target/${{ matrix.target }}/release/bundle"
-          fi
-          DMG=$(find "$BUNDLE_DIR" -name '*.dmg' 2>/dev/null | head -1)
-          if [ -z "$DMG" ]; then
-            echo "No DMG found, checking for .app bundle..."
-            APP=$(find "$BUNDLE_DIR" -name '*.app' 2>/dev/null | head -1)
-            if [ -z "$APP" ]; then
-              echo "::error::No .dmg or .app bundle found under $BUNDLE_DIR"
-              find target/ llmfit-desktop/target/ -type f -name '*.dmg' -o -name '*.app' 2>/dev/null || true
-              exit 1
-            fi
-            cd "$(dirname "$APP")"
-            tar czf "/tmp/llmfit-desktop-${TAG}-${{ matrix.target }}.app.tar.gz" "$(basename "$APP")"
-            echo "DESKTOP_ASSET=llmfit-desktop-${TAG}-${{ matrix.target }}.app.tar.gz" >> "$GITHUB_ENV"
-            echo "DESKTOP_ASSET_PATH=/tmp/llmfit-desktop-${TAG}-${{ matrix.target }}.app.tar.gz" >> "$GITHUB_ENV"
-          else
-            DEST="llmfit-desktop-${TAG}-${{ matrix.target }}.dmg"
-            cp "$DMG" "/tmp/${DEST}"
-            echo "DESKTOP_ASSET=${DEST}" >> "$GITHUB_ENV"
-            echo "DESKTOP_ASSET_PATH=/tmp/${DEST}" >> "$GITHUB_ENV"
-          fi
-
-      - name: Upload desktop artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.DESKTOP_ASSET }}
-          path: ${{ env.DESKTOP_ASSET_PATH }}
-
   release:
-    needs: [build, build-desktop]
+    needs: build
     runs-on: ubuntu-latest
 
     steps:
@@ -169,9 +107,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: |
-            artifacts/**/*.tar.gz
-            artifacts/**/*.dmg
+          files: artifacts/**/*.tar.gz
 
   publish-crate:
     needs: release


### PR DESCRIPTION
Two fixes:

### 1. Split desktop build off the main release
- `release.yml` now excludes `v*-mac` tags — CLI releases are fast again
- New `release-desktop.yml` triggers only on `v*-mac` tags (e.g. `v0.4.0-mac`)

### 2. Fix bundle not found
- Uses `--bundles app` to explicitly produce `.app` bundle (DMG requires code signing)
- Searches both `target/` and `llmfit-desktop/target/` for the bundle
- Packages as `.app.tar.gz` for download

### Usage
- Normal release: tag `v0.4.1` → CLI binaries + crates.io + Homebrew
- Desktop release: tag `v0.4.1-mac` → macOS `.app` bundles (aarch64 + x86_64)

Signed-off-by: Three Foxes (in a Trenchcoat) <threefoxes53235@gmail.com>