### PR TITLE
Fix compile warnings in providers and TUI

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -150,7 +150,6 @@ impl ModelProvider for OllamaProvider {
                 Ok(resp) => {
                     let reader = std::io::BufReader::new(resp.into_reader());
                     use std::io::BufRead;
-                    let mut saw_success = false;
                     for line in reader.lines() {
                         let Ok(line) = line else { break };
                         if line.is_empty() {
@@ -171,19 +170,16 @@ impl ModelProvider for OllamaProvider {
                                 percent,
                             });
                             if parsed.status == "success" {
-                                saw_success = true;
                                 let _ = tx.send(PullEvent::Done);
                                 return;
                             }
                         }
                     }
                     // Stream ended without "success" — treat as error
-                    if !saw_success {
-                        let _ = tx.send(PullEvent::Error(
-                            "Pull ended without success (model may not exist in Ollama registry)"
-                                .to_string(),
-                        ));
-                    }
+                    let _ = tx.send(PullEvent::Error(
+                        "Pull ended without success (model may not exist in Ollama registry)"
+                            .to_string(),
+                    ));
                 }
                 Err(e) => {
                     let _ = tx.send(PullEvent::Error(format!("{e}")));

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -94,10 +94,6 @@ pub struct App {
 }
 
 impl App {
-    pub fn new() -> Self {
-        Self::with_specs(SystemSpecs::detect())
-    }
-
     pub fn with_specs(specs: SystemSpecs) -> Self {
         let db = ModelDatabase::new();
 

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -1019,11 +1019,3 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
     frame.render_widget(Paragraph::new(status_line), area);
 }
-
-fn truncate_str(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
-        s.to_string()
-    } else {
-        format!("{}…", &s[..max_len - 1])
-    }
-}


### PR DESCRIPTION
## Summary
- remove unused `saw_success` assignment in Ollama pull stream handling
- remove unused `App::new()` constructor from TUI app state
- remove unused `truncate_str()` helper from TUI UI module

## Validation
- `cargo build`
- `cargo run -- --cli -n 1`

Both commands complete without warnings.
