### PR TITLE
fix: add AMD RX 9060 series to VRAM estimation database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llmfit"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "colored",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-desktop"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "llmfit-core",
  "serde",

--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -1147,12 +1147,18 @@ fn estimate_vram_from_name(name: &str) -> f64 {
     if lower.contains("t4") {
         return 16.0;
     }
-    // AMD RX 9000 series
+    // AMD RX 9000 series (RDNA 4)
     if lower.contains("9070 xt") {
         return 16.0;
     }
     if lower.contains("9070") {
         return 12.0;
+    }
+    if lower.contains("9060 xt") {
+        return 16.0;
+    }
+    if lower.contains("9060") {
+        return 8.0;
     }
     // AMD RX 7000 series
     if lower.contains("7900 xtx") {


### PR DESCRIPTION
## Summary

Fixes #55 — the RX 9060 XT was showing 8GB instead of 16GB on Windows.

## Root Cause

Windows WMI's `AdapterRAM` field is a UINT32, which maxes out at ~4GB. For GPUs with more VRAM, the value gets truncated. The code falls back to `estimate_vram_from_name()`, but the RX 9060 series (RDNA 4) wasn't in the database.

## Changes

Added to `estimate_vram_from_name()`:
- RX 9060 XT: 16GB
- RX 9060: 8GB

Also clarified the comment that this is the RDNA 4 series.

## Testing

`cargo check` passes ✅