### PR TITLE
feat: add fuzzy search with space-separated terms

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -179,20 +179,28 @@ impl App {
 
     pub fn apply_filters(&mut self) {
         let query = self.search_query.to_lowercase();
+        // Split query into space-separated terms for fuzzy matching
+        let terms: Vec<&str> = query.split_whitespace().collect();
 
         self.filtered_fits = self
             .all_fits
             .iter()
             .enumerate()
             .filter(|(_, fit)| {
-                // Search filter
-                let matches_search = if query.is_empty() {
+                // Search filter: all terms must match (fuzzy/AND logic)
+                let matches_search = if terms.is_empty() {
                     true
                 } else {
-                    fit.model.name.to_lowercase().contains(&query)
-                        || fit.model.provider.to_lowercase().contains(&query)
-                        || fit.model.parameter_count.to_lowercase().contains(&query)
-                        || fit.model.use_case.to_lowercase().contains(&query)
+                    // Combine all searchable fields into one string
+                    let searchable = format!(
+                        "{} {} {} {}",
+                        fit.model.name.to_lowercase(),
+                        fit.model.provider.to_lowercase(),
+                        fit.model.parameter_count.to_lowercase(),
+                        fit.model.use_case.to_lowercase()
+                    );
+                    // All terms must be present (AND logic)
+                    terms.iter().all(|term| searchable.contains(term))
                 };
 
                 // Provider filter


### PR DESCRIPTION
## Summary

Fixes #65 — allows filtering by multiple space-separated terms with AND logic.

## Examples

| Search | Matches |
|--------|---------|
| `qwen` | All Qwen models (including DeepSeek-R1-Distill-Qwen) |
| `qwen next` | Qwen3-Coder-Next (single result instead of 56) |
| `qwen instruct` | All Qwen -Instruct models |
| `qwen 32b` | All 32B Qwen models |
| `llama code` | All Llama code/coder models |

## Implementation

- Split search query by whitespace into terms
- Combine all searchable fields (name, provider, param count, use case) into one string
- Require ALL terms to match (AND logic)

## Testing

- `cargo check` passes ✅
- All 59 tests pass ✅