### PR TITLE
fix: add download confirmation to prevent accidental pulls

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -93,6 +93,8 @@ pub struct App {
     pub pull_model_name: Option<String>,
     /// Animation frame counter, incremented every tick while pulling.
     pub tick_count: u64,
+    /// When true, the next 'd' press will confirm and start the download.
+    pub confirm_download: bool,
 
     // Theme
     pub theme: Theme,
@@ -176,6 +178,7 @@ impl App {
             pull_percent: None,
             pull_model_name: None,
             tick_count: 0,
+            confirm_download: false,
             theme: Theme::load(),
         };
 
@@ -245,22 +248,26 @@ impl App {
     }
 
     pub fn move_up(&mut self) {
+        self.confirm_download = false;
         if self.selected_row > 0 {
             self.selected_row -= 1;
         }
     }
 
     pub fn move_down(&mut self) {
+        self.confirm_download = false;
         if !self.filtered_fits.is_empty() && self.selected_row < self.filtered_fits.len() - 1 {
             self.selected_row += 1;
         }
     }
 
     pub fn page_up(&mut self) {
+        self.confirm_download = false;
         self.selected_row = self.selected_row.saturating_sub(10);
     }
 
     pub fn page_down(&mut self) {
+        self.confirm_download = false;
         if !self.filtered_fits.is_empty() {
             self.selected_row = (self.selected_row + 10).min(self.filtered_fits.len() - 1);
         }

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -29,7 +29,10 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
     match key.code {
         // Quit
         KeyCode::Char('q') | KeyCode::Esc => {
-            if app.show_detail {
+            if app.confirm_download {
+                app.confirm_download = false;
+                app.pull_status = Some("Download cancelled".to_string());
+            } else if app.show_detail {
                 app.show_detail = false;
             } else {
                 app.should_quit = true;
@@ -66,8 +69,28 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
             app.toggle_installed_first()
         }
 
-        // Download model via best provider
-        KeyCode::Char('d') if app.ollama_available || app.mlx_available => app.start_download(),
+        // Download model via best provider (requires confirmation)
+        KeyCode::Char('d') if app.ollama_available || app.mlx_available => {
+            if app.confirm_download {
+                // Second press: confirmed, start the download
+                app.confirm_download = false;
+                app.start_download();
+            } else if app.pull_active.is_none() {
+                // First press: show confirmation prompt
+                if let Some(fit) = app.selected_fit() {
+                    if fit.installed {
+                        app.pull_status = Some("Already installed".to_string());
+                    } else {
+                        let size_est = fit.model.params_b() * 0.5; // rough Q4 estimate in GB
+                        app.pull_status = Some(format!(
+                            "Download {}? (~{:.1} GB) Press 'd' to confirm, Esc to cancel",
+                            fit.model.name, size_est
+                        ));
+                        app.confirm_download = true;
+                    }
+                }
+            }
+        }
 
         // Refresh installed models
         KeyCode::Char('r') if app.ollama_available || app.mlx_available => app.refresh_installed(),


### PR DESCRIPTION
## What

Adds a confirmation step before downloading models to prevent accidental multi-GB downloads from a stray `d` keypress.

## Problem

Pressing `d` immediately starts downloading the selected model with no way to cancel. Users accidentally trigger downloads of large models and have no idea how to stop them or where they go (#95).

## Solution

Double-press `d` confirmation:

1. **First `d`**: Shows confirmation prompt with model name and estimated size
   ```
   Download Llama-3.1-8B? (~4.0 GB) Press 'd' to confirm, Esc to cancel
   ```
2. **Second `d`**: Starts the download
3. **Esc**: Cancels the confirmation

The confirmation state is automatically cleared when navigating to a different model (up/down/page), so you can't accidentally confirm on the wrong model.

## Why This Approach

- **Zero UI overhead** — no modal dialog, stays fully keyboard-driven
- **Minimal code change** — single bool + event handler modification
- **Consistent UX** — similar to vim's `dd` pattern (deliberate double-press for destructive actions)

Fixes #95