### PR TITLE
feat: Add Docker containerization support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Build artifacts
+target/
+*.swp
+*.swo
+*~
+
+# IDE
+.vscode/
+.idea/
+*.iml
+
+# Git
+.git/
+.gitignore
+.githooks/
+
+# Documentation and assets
+*.md
+!README.md
+*.png
+*.gif
+demo.gif
+download.gif
+home_laptop.png
+moe.png
+assets/
+.github/
+
+# Scripts (not needed in container)
+scripts/
+install.sh
+
+# Website files
+index.html
+CNAME
+
+# Release metadata
+.release-please-manifest.json
+
+# Skills (OpenClaw integration, not needed in container)
+skills/
+AGENTS.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,59 @@
+name: Docker Build and Push
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "!v*-mac"
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9c1f14d92e42ddbf766898043f72 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@5f0a5eb7e47090af52db6c4e7f4c30fb76fc17ee # v3.9.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@830126ccf9677aa6e98b8f5a8b7ea177ab1f8e63 # v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@902fa50bc17743d59c8c76c2f7df2d0dcb3b7fcf # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@48e3f23bcc8bdb93b40fcd04e45efa1f4f1fd45b # v6.12.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Multi-stage build for llmfit
+# Stage 1: Build the Rust binary
+FROM rust:1.85-slim as builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /build
+
+# Copy workspace configuration
+COPY Cargo.toml Cargo.lock ./
+
+# Copy all workspace members
+COPY llmfit-core/ ./llmfit-core/
+COPY llmfit-tui/ ./llmfit-tui/
+COPY llmfit-desktop/ ./llmfit-desktop/
+COPY data/ ./data/
+
+# Build release binary for llmfit-tui
+RUN cargo build --release -p llmfit
+
+# Stage 2: Runtime image
+FROM debian:bookworm-slim
+
+# Install runtime dependencies for hardware detection
+RUN apt-get update && apt-get install -y \
+    pciutils \
+    lshw \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the binary from builder
+COPY --from=builder /build/target/release/llmfit /usr/local/bin/llmfit
+
+# Create a non-root user
+RUN useradd -m -u 1000 llmfit && \
+    chown -R llmfit:llmfit /usr/local/bin/llmfit
+
+USER llmfit
+
+# Set default command to output JSON recommendations
+# In Kubernetes, this will run once per node and log results
+ENTRYPOINT ["/usr/local/bin/llmfit"]
+CMD ["recommend", "--json"]


### PR DESCRIPTION
## Overview

Addresses #106 - adds Docker containerization support for llmfit with automated builds on releases. Kubernetes manifests will be added in a follow-up PR with a proper Helm chart.

## Changes

### Dockerfile
Multi-stage build producing a ~50-70 MB image:
- **Build stage**: rust:1.85-slim with pkg-config and libssl-dev
- **Runtime**: debian:bookworm-slim with pciutils and lshw for hardware detection
- **Security**: Non-root user (UID 1000)
- **Default command**: `recommend --json` for programmatic output

### .dockerignore
Optimizes build context by excluding:
- Build artifacts (target/, *.swp)
- Documentation and assets (*.md, *.png, *.gif)
- Git metadata and scripts
- IDE files

### GitHub Actions Workflow (docker.yml)
Automated Docker image builds and publishing:
- **Trigger**: On version tags (v*) matching the release workflow
- **Multi-arch**: Builds for linux/amd64 and linux/arm64
- **Registry**: GitHub Container Registry (ghcr.io)
- **Tagging strategy**:
  - Semantic versions: `v1.2.3`, `1.2`, `1`
  - `latest` tag for default branch releases
- **Optimization**: Uses GitHub Actions cache for faster builds
- **Security**: Leverages `GITHUB_TOKEN` for GHCR authentication

## Usage

### Building locally
```bash
docker build -t llmfit:latest .
```

### Running locally
```bash
# Check hardware detection
docker run --rm llmfit:latest system --json

# Get top 5 recommendations
docker run --rm llmfit:latest recommend --json --limit 5

# Filter by use case
docker run --rm llmfit:latest recommend --json --use-case coding
```

### Pulling from GitHub Container Registry
After a release is published, users can pull pre-built multi-arch images:

```bash
# Pull latest
docker pull ghcr.io/alexsjones/llmfit:latest

# Pull specific version
docker pull ghcr.io/alexsjones/llmfit:0.4.7

# Pull for specific platform
docker pull --platform linux/arm64 ghcr.io/alexsjones/llmfit:latest
```

## Automated Release Process

When a version tag is pushed (e.g., `v0.5.0`):
1. **Release workflow** builds native binaries for all platforms
2. **Docker workflow** builds and pushes multi-arch images to GHCR
3. Images are automatically tagged with version and latest

Users get:
- Native binaries from GitHub Releases
- Container images from ghcr.io
- Homebrew formula update (existing)
- crates.io publish (existing)

## Use Cases

1. **Local hardware analysis** - Run llmfit in isolated environments without installing Rust
2. **CI/CD integration** - Test hardware capabilities in build pipelines
3. **Foundation for Kubernetes** - Base image for future DaemonSet/Helm deployment
4. **Cross-platform testing** - Run on any system with Docker (consistent environment)

## Security

- Runs as non-root (UID 1000)
- Minimal runtime dependencies
- Small attack surface (~50-70 MB)
- No privileged operations required
- Multi-arch support (amd64, arm64)

## Next Steps

Follow-up PR will add:
- Helm chart for Kubernetes deployment
- DaemonSet manifests for cluster-wide analysis
- Configurable scheduling and output options
- Multi-cluster support

Partially addresses #106 (Docker foundation + automated builds). Full K8s support coming in next PR.