### PR TITLE
feat: add context-length cap for memory estimation (--max-context)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ llmfit --memory=24G recommend --json
 
 Accepted suffixes: `G`/`GB`/`GiB` (gigabytes), `M`/`MB`/`MiB` (megabytes), `T`/`TB`/`TiB` (terabytes). Case-insensitive. If no GPU was detected, the override creates a synthetic GPU entry so models are scored for GPU inference.
 
+### Context-length cap for estimation
+
+Use `--max-context` to cap context length used for memory estimation (without changing each model's advertised maximum context):
+
+```sh
+# Estimate memory fit at 4K context
+llmfit --max-context 4096 --cli
+
+# Works with subcommands
+llmfit --max-context 8192 fit --perfect -n 5
+llmfit --max-context 16384 recommend --json --limit 5
+```
+
+If `--max-context` is not set, llmfit will use `OLLAMA_CONTEXT_LENGTH` when available.
+
 ### JSON output
 
 Add `--json` to any subcommand for machine-readable output:

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -102,6 +102,10 @@ pub struct App {
 
 impl App {
     pub fn with_specs(specs: SystemSpecs) -> Self {
+        Self::with_specs_and_context(specs, None)
+    }
+
+    pub fn with_specs_and_context(specs: SystemSpecs, context_limit: Option<u32>) -> Self {
         let db = ModelDatabase::new();
 
         // Detect Ollama
@@ -128,7 +132,7 @@ impl App {
             .get_all_models()
             .iter()
             .map(|m| {
-                let mut fit = ModelFit::analyze(m, &specs);
+                let mut fit = ModelFit::analyze_with_context_limit(m, &specs, context_limit);
                 fit.installed = providers::is_model_installed(&m.name, &ollama_installed)
                     || providers::is_model_installed_mlx(&m.name, &mlx_installed);
                 fit


### PR DESCRIPTION
## Summary

This PR implements issue #108 by adding a context-length cap used during memory estimation and model-fit analysis.

Today, `llmfit` estimates memory against each model’s full advertised context window, which can significantly overestimate required memory for users running smaller contexts in practice (for example via Ollama).

This change adds:

- A global CLI flag: `--max-context <TOKENS>`
- Environment fallback: `OLLAMA_CONTEXT_LENGTH` (used when `--max-context` is not provided)
- Context-capped analysis path in core fit logic
- Propagation across CLI/TUI flows (`fit`, `recommend`, `info`, `--cli`, default TUI startup)

## Why This Is Useful

Many users intentionally run models at lower context (4K/8K/16K) for latency and memory reasons.  
Without a cap, recommendations can be overly conservative and hide viable models.

With this PR:

- Estimates better match real runtime configuration
- More accurate fit/ranking for constrained hardware
- Existing behavior is preserved by default when no cap is set

## Design Notes

- The cap affects **memory estimation only**.
- Model metadata remains unchanged (the model’s actual max context is still displayed/stored).
- Effective estimation context is `min(model.context_length, context_limit)`.
- If a cap is applied, analysis notes include:  
  `Context capped for estimation: <model_ctx> -> <effective_ctx> tokens`

## Implementation Details

### `llmfit-core`

- Added `ModelFit::analyze_with_context_limit(model, system, context_limit)`
- Kept `ModelFit::analyze(...)` as a compatibility wrapper to preserve existing call sites
- Updated quant-selection and CPU/GPU path memory estimation to use capped estimation context

### `llmfit` (TUI/CLI crate)

- Added `--max-context` global option (`u32`, positive only)
- Added `resolve_context_limit()`:
  - prefers CLI flag
  - falls back to `OLLAMA_CONTEXT_LENGTH`
  - warns on invalid env values
- Wired cap through `run_fit`, `run_recommend`, `info`, and TUI app initialization

### TUI App

- Added `App::with_specs_and_context(...)`
- Existing `App::with_specs(...)` preserved as wrapper (`None`) for compatibility

### Docs

- Added README section with examples for `--max-context` and env fallback

## Testing

Added a focused unit test in `fit.rs`:

- `test_analyze_with_context_limit_reduces_memory_estimate`  
- Verifies capped analysis reduces memory estimate and emits the context-cap note

## Example Usage

```sh
llmfit --max-context 4096 --cli
llmfit --max-context 8192 fit --perfect -n 5
llmfit --max-context 16384 recommend --json --limit 5

# fallback when flag is omitted:
OLLAMA_CONTEXT_LENGTH=4096 llmfit recommend --json

## Backward Compatibility
No breaking changes.
Existing behavior remains unchanged when no context cap is provided.

Fixes #108