### PR TITLE
fix: hide MLX-only models on non-Apple Silicon systems

### DIFF
--- a/llmfit-core/src/models.rs
+++ b/llmfit-core/src/models.rs
@@ -209,6 +209,12 @@ impl LlmModel {
         Some((size_gb * 1.1).max(0.5))
     }
 
+    /// Returns true if this model is MLX-specific (Apple Silicon only).
+    /// MLX models are identified by having "-MLX" in their name.
+    pub fn is_mlx_only(&self) -> bool {
+        self.name.to_uppercase().contains("-MLX")
+    }
+
     /// For MoE models, compute RAM needed for offloaded (inactive) experts.
     /// Returns None for dense models.
     pub fn moe_offloaded_ram_gb(&self) -> Option<f64> {

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -253,6 +253,13 @@ fn run_recommend(
         _ => true,
     });
 
+    // Hide MLX-only models on non-Apple Silicon systems
+    let is_apple_silicon =
+        specs.backend == llmfit_core::hardware::GpuBackend::Metal && specs.unified_memory;
+    if !is_apple_silicon {
+        fits.retain(|f| !f.model.is_mlx_only());
+    }
+
     // Filter by runtime
     match runtime_filter.to_lowercase().as_str() {
         "mlx" => fits.retain(|f| f.runtime == llmfit_core::fit::InferenceRuntime::Mlx),

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -222,6 +222,14 @@ impl App {
                     .map(|idx| self.selected_providers[idx])
                     .unwrap_or(true);
 
+                // Hide MLX-only models on non-Apple Silicon systems
+                let is_apple_silicon = self.specs.backend
+                    == llmfit_core::hardware::GpuBackend::Metal
+                    && self.specs.unified_memory;
+                if fit.model.is_mlx_only() && !is_apple_silicon {
+                    return false;
+                }
+
                 // Fit filter
                 let matches_fit = match self.fit_filter {
                     FitFilter::All => true,


### PR DESCRIPTION
Fixes #113

## Summary

- 70 models in the database have `-MLX` in their name (e.g. `lmstudio-community/Qwen3-4B-MLX-4bit`) — these are Apple Silicon-exclusive and cannot run on Linux, Windows, or Intel Mac systems
- Added `LlmModel::is_mlx_only()` which returns `true` when a model name contains `-MLX`
- MLX-only models are now filtered out in both the TUI (`apply_filters`) and the CLI `recommend` path when the system is not Apple Silicon (`GpuBackend::Metal + unified_memory`)

## Test plan

- [ ] On Linux/Windows: confirm MLX-named models no longer appear in the TUI or `recommend` output
- [ ] On Apple Silicon (Metal + unified memory): confirm MLX models still appear as before
- [ ] Run `cargo test` — all 66 tests pass