### PR TITLE
Add new Qwen3.5 models to database

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -1,6 +1,6 @@
 # Supported Models
 
-llmfit ships with a curated database of 94 LLM models from HuggingFace. All memory estimates assume Q4_K_M quantization (0.5 bytes per parameter) unless noted otherwise.
+llmfit ships with a curated database of 98 LLM models from HuggingFace. All memory estimates assume Q4_K_M quantization (0.5 bytes per parameter) unless noted otherwise.
 
 ### 01.ai
 
@@ -25,12 +25,16 @@ llmfit ships with a curated database of 94 LLM models from HuggingFace. All memo
 | [Qwen/Qwen2.5-14B-Instruct](https://huggingface.co/Qwen/Qwen2.5-14B-Instruct) | 14.8B | Q4_K_M | 128k | Instruction following, chat |
 | [Qwen/Qwen3-14B](https://huggingface.co/Qwen/Qwen3-14B) | 14.8B | Q4_K_M | 128k | General purpose text generation |
 | [Qwen/Qwen2.5-Coder-14B-Instruct](https://huggingface.co/Qwen/Qwen2.5-Coder-14B-Instruct) | 14.8B | Q4_K_M | 32k | Code generation and completion |
+| [Qwen/Qwen3.5-27B](https://huggingface.co/Qwen/Qwen3.5-27B) | 27.8B | Q4_K_M | 256k | Multimodal, vision and text |
 | [Qwen/Qwen3-30B-A3B](https://huggingface.co/Qwen/Qwen3-30B-A3B) | 30.5B (MoE) | Q4_K_M | 40k | Efficient MoE, general purpose |
+| [Qwen/Qwen3.5-35B-A3B](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) | 36.0B (MoE) | Q4_K_M | 256k | Multimodal, vision and text |
 | [Qwen/Qwen2.5-32B-Instruct](https://huggingface.co/Qwen/Qwen2.5-32B-Instruct) | 32.5B | Q4_K_M | 128k | Instruction following, chat |
 | [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) | 32.8B | Q4_K_M | 40k | General purpose text generation |
 | [Qwen/Qwen2.5-Coder-32B-Instruct](https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct) | 32.8B | Q4_K_M | 32k | Code generation and completion |
 | [Qwen/Qwen2.5-72B-Instruct](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct) | 72.7B | Q4_K_M | 32k | Instruction following, chat |
+| [Qwen/Qwen3.5-122B-A10B](https://huggingface.co/Qwen/Qwen3.5-122B-A10B) | 125.1B (MoE) | Q4_K_M | 256k | Multimodal, vision and text |
 | [Qwen/Qwen3-235B-A22B](https://huggingface.co/Qwen/Qwen3-235B-A22B) | 235B (MoE) | Q4_K_M | 40k | State-of-the-art, MoE architecture |
+| [Qwen/Qwen3.5-397B-A17B](https://huggingface.co/Qwen/Qwen3.5-397B-A17B) | 403.4B (MoE) | Q4_K_M | 256k | Multimodal, vision and text |
 | [Qwen/Qwen3-Coder-480B-A35B-Instruct](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct) | 480B (MoE) | Q4_K_M | 256k | Code generation and completion |
 
 ### Allen Institute

--- a/data/hf_models.json
+++ b/data/hf_models.json
@@ -53,7 +53,7 @@
     "pipeline_tag": "text-generation",
     "architecture": "llama",
     "hf_downloads": 1834889,
-    "hf_likes": 1536,
+    "hf_likes": 1537,
     "release_date": "2023-12-30"
   },
   {
@@ -422,7 +422,7 @@
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
     "hf_downloads": 19284289,
-    "hf_likes": 1101,
+    "hf_likes": 1102,
     "release_date": "2024-09-16",
     "gguf_sources": [
       {
@@ -998,6 +998,29 @@
     ]
   },
   {
+    "name": "Qwen/Qwen3.5-27B",
+    "provider": "Alibaba",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 217725,
+    "hf_likes": 466,
+    "release_date": "2026-02-24",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-27B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
     "name": "allenai/OLMo-2-0325-32B-Instruct",
     "provider": "allenai",
     "parameter_count": "32.2B",
@@ -1155,6 +1178,29 @@
     ]
   },
   {
+    "name": "Qwen/Qwen3.5-35B-A3B",
+    "provider": "Alibaba",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 481446,
+    "hf_likes": 731,
+    "release_date": "2026-02-24",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-35B-A3B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
     "name": "tiiuae/falcon-40b-instruct",
     "provider": "TII",
     "parameter_count": "40.0B",
@@ -1271,12 +1317,35 @@
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
     "hf_downloads": 530114,
-    "hf_likes": 914,
+    "hf_likes": 915,
     "release_date": "2024-09-16",
     "gguf_sources": [
       {
         "repo": "bartowski/Qwen2.5-72B-Instruct-GGUF",
         "provider": "bartowski"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-122B-A10B",
+    "provider": "Alibaba",
+    "parameter_count": "125.1B",
+    "parameters_raw": 125086497008,
+    "min_ram_gb": 69.9,
+    "recommended_ram_gb": 116.5,
+    "min_vram_gb": 64.1,
+    "quantization": "Q4_K_M",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 127141,
+    "hf_likes": 357,
+    "release_date": "2026-02-24",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-122B-A10B-GGUF",
+        "provider": "unsloth"
       }
     ]
   },
@@ -1425,6 +1494,29 @@
     "gguf_sources": [
       {
         "repo": "unsloth/Llama-4-Maverick-17B-128E-Instruct-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-397B-A17B",
+    "provider": "Alibaba",
+    "parameter_count": "403.4B",
+    "parameters_raw": 403397928944,
+    "min_ram_gb": 225.4,
+    "recommended_ram_gb": 375.7,
+    "min_vram_gb": 206.6,
+    "quantization": "Q4_K_M",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 1030009,
+    "hf_likes": 1143,
+    "release_date": "2026-02-16",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-397B-A17B-GGUF",
         "provider": "unsloth"
       }
     ]

--- a/llmfit-core/data/hf_models.json
+++ b/llmfit-core/data/hf_models.json
@@ -53,7 +53,7 @@
     "pipeline_tag": "text-generation",
     "architecture": "llama",
     "hf_downloads": 1834889,
-    "hf_likes": 1536,
+    "hf_likes": 1537,
     "release_date": "2023-12-30"
   },
   {
@@ -422,7 +422,7 @@
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
     "hf_downloads": 19284289,
-    "hf_likes": 1101,
+    "hf_likes": 1102,
     "release_date": "2024-09-16",
     "gguf_sources": [
       {
@@ -998,6 +998,29 @@
     ]
   },
   {
+    "name": "Qwen/Qwen3.5-27B",
+    "provider": "Alibaba",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 217725,
+    "hf_likes": 466,
+    "release_date": "2026-02-24",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-27B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
     "name": "allenai/OLMo-2-0325-32B-Instruct",
     "provider": "allenai",
     "parameter_count": "32.2B",
@@ -1155,6 +1178,29 @@
     ]
   },
   {
+    "name": "Qwen/Qwen3.5-35B-A3B",
+    "provider": "Alibaba",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 481446,
+    "hf_likes": 731,
+    "release_date": "2026-02-24",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-35B-A3B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
     "name": "tiiuae/falcon-40b-instruct",
     "provider": "TII",
     "parameter_count": "40.0B",
@@ -1271,12 +1317,35 @@
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
     "hf_downloads": 530114,
-    "hf_likes": 914,
+    "hf_likes": 915,
     "release_date": "2024-09-16",
     "gguf_sources": [
       {
         "repo": "bartowski/Qwen2.5-72B-Instruct-GGUF",
         "provider": "bartowski"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-122B-A10B",
+    "provider": "Alibaba",
+    "parameter_count": "125.1B",
+    "parameters_raw": 125086497008,
+    "min_ram_gb": 69.9,
+    "recommended_ram_gb": 116.5,
+    "min_vram_gb": 64.1,
+    "quantization": "Q4_K_M",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 127141,
+    "hf_likes": 357,
+    "release_date": "2026-02-24",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-122B-A10B-GGUF",
+        "provider": "unsloth"
       }
     ]
   },
@@ -1425,6 +1494,29 @@
     "gguf_sources": [
       {
         "repo": "unsloth/Llama-4-Maverick-17B-128E-Instruct-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-397B-A17B",
+    "provider": "Alibaba",
+    "parameter_count": "403.4B",
+    "parameters_raw": 403397928944,
+    "min_ram_gb": 225.4,
+    "recommended_ram_gb": 375.7,
+    "min_vram_gb": 206.6,
+    "quantization": "Q4_K_M",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 1030009,
+    "hf_likes": 1143,
+    "release_date": "2026-02-16",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-397B-A17B-GGUF",
         "provider": "unsloth"
       }
     ]

--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -78,6 +78,10 @@ TARGET_MODELS = [
     "Qwen/Qwen3-30B-A3B",
     "Qwen/Qwen3-235B-A22B",
     "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+    "Qwen/Qwen3.5-27B",
+    "Qwen/Qwen3.5-35B-A3B",
+    "Qwen/Qwen3.5-122B-A10B",
+    "Qwen/Qwen3.5-397B-A17B",
     # Microsoft Phi
     "microsoft/phi-3-mini-4k-instruct",
     "microsoft/Phi-3-medium-14b-instruct",
@@ -198,6 +202,9 @@ MOE_ACTIVE_PARAMS = {
     "Qwen/Qwen3-30B-A3B": 3_300_000_000,
     "Qwen/Qwen3-235B-A22B": 22_000_000_000,
     "Qwen/Qwen3-Coder-480B-A35B-Instruct": 35_000_000_000,
+    "Qwen/Qwen3.5-35B-A3B": 3_000_000_000,
+    "Qwen/Qwen3.5-122B-A10B": 10_000_000_000,
+    "Qwen/Qwen3.5-397B-A17B": 17_000_000_000,
     "meta-llama/Llama-4-Scout-17B-16E-Instruct": 17_000_000_000,
     "meta-llama/Llama-4-Maverick-17B-128E-Instruct": 17_000_000_000,
     "xai-org/grok-1": 86_000_000_000,
@@ -337,18 +344,31 @@ def infer_context_length(config: dict | None) -> int:
     """Try to extract context length from model config."""
     if not config:
         return 4096
+
     # Common config keys for max sequence length
-    for key in [
+    keys_to_check = [
         "max_position_embeddings",
         "max_sequence_length",
         "seq_length",
         "n_positions",
         "sliding_window",
-    ]:
+    ]
+
+    # Check top-level config
+    for key in keys_to_check:
         if key in config:
             val = config[key]
             if isinstance(val, int) and val > 0:
                 return val
+
+    # For multimodal models (e.g., Qwen3.5), check text_config
+    if "text_config" in config and isinstance(config["text_config"], dict):
+        for key in keys_to_check:
+            if key in config["text_config"]:
+                val = config["text_config"][key]
+                if isinstance(val, int) and val > 0:
+                    return val
+
     return 4096
 
 
@@ -1134,6 +1154,46 @@ def main():
             "quantization": "Q4_K_M", "context_length": 131072,
             "use_case": "General purpose text generation",
             "pipeline_tag": "text-generation", "architecture": "qwen3",
+            "hf_downloads": 0, "hf_likes": 0, "release_date": None,
+        },
+        {
+            "name": "Qwen/Qwen3.5-27B",
+            "provider": "Alibaba", "parameter_count": "27.8B",
+            "parameters_raw": 27781427952,
+            "min_ram_gb": 15.5, "recommended_ram_gb": 25.9, "min_vram_gb": 14.2,
+            "quantization": "Q4_K_M", "context_length": 262144,
+            "use_case": "Multimodal, vision and text",
+            "pipeline_tag": "image-text-to-text", "architecture": "qwen3_5",
+            "hf_downloads": 0, "hf_likes": 0, "release_date": None,
+        },
+        {
+            "name": "Qwen/Qwen3.5-35B-A3B",
+            "provider": "Alibaba", "parameter_count": "36.0B",
+            "parameters_raw": 35951822704,
+            "min_ram_gb": 20.1, "recommended_ram_gb": 33.5, "min_vram_gb": 18.4,
+            "quantization": "Q4_K_M", "context_length": 262144,
+            "use_case": "Multimodal, vision and text",
+            "pipeline_tag": "image-text-to-text", "architecture": "qwen3_5_moe",
+            "hf_downloads": 0, "hf_likes": 0, "release_date": None,
+        },
+        {
+            "name": "Qwen/Qwen3.5-122B-A10B",
+            "provider": "Alibaba", "parameter_count": "125.1B",
+            "parameters_raw": 125086497008,
+            "min_ram_gb": 69.9, "recommended_ram_gb": 116.5, "min_vram_gb": 64.1,
+            "quantization": "Q4_K_M", "context_length": 262144,
+            "use_case": "Multimodal, vision and text",
+            "pipeline_tag": "image-text-to-text", "architecture": "qwen3_5_moe",
+            "hf_downloads": 0, "hf_likes": 0, "release_date": None,
+        },
+        {
+            "name": "Qwen/Qwen3.5-397B-A17B",
+            "provider": "Alibaba", "parameter_count": "403.4B",
+            "parameters_raw": 403397928944,
+            "min_ram_gb": 225.4, "recommended_ram_gb": 375.7, "min_vram_gb": 206.6,
+            "quantization": "Q4_K_M", "context_length": 262144,
+            "use_case": "Multimodal, vision and text",
+            "pipeline_tag": "image-text-to-text", "architecture": "qwen3_5_moe",
             "hf_downloads": 0, "hf_likes": 0, "release_date": None,
         },
     ]


### PR DESCRIPTION
### All Multimodal vision and text models:
- Qwen3.5-27B (27.8B params, 256k context)
- Qwen3.5-35B-A3B (36.0B MoE, 256k context)
- Qwen3.5-122B-A10B (125.1B MoE, 256k context)
- Qwen3.5-397B-A17B (403.4B MoE, 256k context)

### Updated context length detection in `scrape_hf_models.py`                                                                                                                                                  

**Problem:** The scraper was returning `context_length: 4096` instead of the correct `262144` for Qwen3.5 models.                                                                                                                                                                                                   
**Cause:** Qwen3.5 models have a nested config structure. The `infer_context_length()`function only checked top-level config keys, missing the nested text_config.max_position_embeddings.
**Fix**: Updated infer_context_length() to also check text_config for multimodal models after checking top-level keys.
           