### PR TITLE
fix: use MoE active parameters for tok/s estimation and clarify baseline speed labels

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -98,7 +98,7 @@ pub struct ModelFit {
     pub moe_offloaded_gb: Option<f64>, // GB of inactive experts offloaded to RAM
     pub score: f64,                    // weighted composite score 0-100
     pub score_components: ScoreComponents,
-    pub estimated_tps: f64,        // estimated tokens per second
+    pub estimated_tps: f64,        // baseline estimated tokens per second
     pub best_quant: String,        // best quantization for this hardware
     pub use_case: UseCase,         // inferred use case category
     pub runtime: InferenceRuntime, // inference runtime (MLX or llama.cpp)
@@ -302,7 +302,10 @@ impl ModelFit {
         let score = weighted_score(score_components, use_case);
 
         if estimated_tps > 0.0 {
-            notes.push(format!("Estimated speed: {:.1} tok/s", estimated_tps));
+            notes.push(format!(
+                "Baseline estimated speed: {:.1} tok/s",
+                estimated_tps
+            ));
         }
 
         ModelFit {
@@ -682,7 +685,14 @@ fn estimate_tps(
 ) -> f64 {
     use crate::hardware::gpu_memory_bandwidth_gbps;
 
-    let params = model.params_b().max(0.1);
+    // MoE models execute only active experts per token, so speed estimates should
+    // use active parameters when known; fit/memory paths still use full model size.
+    let params = model
+        .active_parameters
+        .filter(|_| model.is_moe)
+        .map(|p| (p as f64) / 1_000_000_000.0)
+        .unwrap_or_else(|| model.params_b())
+        .max(0.1);
 
     // ── Bandwidth-based estimation (preferred) ─────────────────────
     //
@@ -1478,6 +1488,60 @@ mod tests {
         // All should be positive
         assert!(tps_gpu > 0.0);
         assert!(tps_cpu > 0.0);
+    }
+
+    #[test]
+    fn test_estimate_tps_moe_uses_active_parameters() {
+        let dense_model = test_model("30B", 18.0, Some(18.0));
+        let mut moe_model = dense_model.clone();
+        moe_model.is_moe = true;
+        moe_model.active_parameters = Some(3_000_000_000);
+
+        let system = test_system(64.0, true, Some(24.0));
+
+        let tps_dense = estimate_tps(
+            &dense_model,
+            "Q4_K_M",
+            &system,
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+        );
+        let tps_moe = estimate_tps(
+            &moe_model,
+            "Q4_K_M",
+            &system,
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+        );
+
+        assert!(tps_moe > tps_dense * 5.0);
+    }
+
+    #[test]
+    fn test_estimate_tps_moe_without_active_parameters_falls_back_to_total() {
+        let dense_model = test_model("30B", 18.0, Some(18.0));
+        let mut moe_without_active = dense_model.clone();
+        moe_without_active.is_moe = true;
+        moe_without_active.active_parameters = None;
+
+        let system = test_system(64.0, true, Some(24.0));
+
+        let tps_dense = estimate_tps(
+            &dense_model,
+            "Q4_K_M",
+            &system,
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+        );
+        let tps_moe = estimate_tps(
+            &moe_without_active,
+            "Q4_K_M",
+            &system,
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+        );
+
+        assert_eq!(tps_dense, tps_moe);
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -17,7 +17,7 @@ struct ModelRow {
     size: String,
     #[tabled(rename = "Score")]
     score: String,
-    #[tabled(rename = "tok/s")]
+    #[tabled(rename = "tok/s est.")]
     tps: String,
     #[tabled(rename = "Quant")]
     quant: String,
@@ -91,6 +91,9 @@ pub fn display_model_fits(fits: &[ModelFit]) {
 
     let table = Table::new(rows).with(Style::rounded()).to_string();
     println!("{}", table);
+    println!(
+        "  Note: tok/s values are baseline estimates; real runtime depends on engine/runtime."
+    );
 }
 
 pub fn display_model_detail(fit: &ModelFit) {
@@ -111,7 +114,7 @@ pub fn display_model_detail(fit: &ModelFit) {
         println!("{}: {}", "Released".bold(), date);
     }
     println!(
-        "{}: {} (est. ~{:.1} tok/s)",
+        "{}: {} (baseline est. ~{:.1} tok/s)",
         "Runtime".bold(),
         fit.runtime_text(),
         fit.estimated_tps
@@ -127,7 +130,7 @@ pub fn display_model_detail(fit: &ModelFit) {
         fit.score_components.fit,
         fit.score_components.context
     );
-    println!("  Estimated Speed: {:.1} tok/s", fit.estimated_tps);
+    println!("  Baseline Est. Speed: {:.1} tok/s", fit.estimated_tps);
     println!();
 
     println!("{}", "Resource Requirements:".bold().underline());

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -384,7 +384,7 @@ fn pull_indicator(percent: Option<f64>, tick: u64) -> String {
 fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     let sort_col = app.sort_column;
     let header_names = [
-        "", "Inst", "Model", "Provider", "Params", "Score", "tok/s", "Quant", "Mode", "Mem %",
+        "", "Inst", "Model", "Provider", "Params", "Score", "tok/s*", "Quant", "Mode", "Mem %",
         "Ctx", "Date", "Fit", "Use Case",
     ];
     let sort_col_idx: Option<usize> = match sort_col {
@@ -652,7 +652,7 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
                 }),
             ),
             Span::styled(
-                format!(" (est. ~{:.1} tok/s)", fit.estimated_tps),
+                format!(" (baseline est. ~{:.1} tok/s)", fit.estimated_tps),
                 Style::default().fg(tc.muted),
             ),
         ]),
@@ -741,7 +741,7 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             ),
         ]),
         Line::from(vec![
-            Span::styled("  Est. Speed:  ", Style::default().fg(tc.muted)),
+            Span::styled("  Baseline Est:", Style::default().fg(tc.muted)),
             Span::styled(
                 format!("{:.1} tok/s", fit.estimated_tps),
                 Style::default().fg(tc.fg),
@@ -1381,7 +1381,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
                 };
                 (
                     format!(
-                        " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  t:theme  p:plan{}  P:providers  q:quit",
+                        " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  t:theme  p:plan{}  P:providers  q:quit  tok/s*:est",
                         detail_key, ollama_keys,
                     ),
                     "NORMAL",
@@ -1458,7 +1458,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             };
             (
                 format!(
-                    " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  t:theme  p:plan{}  P:providers  q:quit",
+                    " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  t:theme  p:plan{}  P:providers  q:quit  tok/s*:est",
                     detail_key, ollama_keys,
                 ),
                 "NORMAL",


### PR DESCRIPTION
### Related issue
- Tries to fix [#88](https://github.com/AlexsJones/llmfit/issues/88)
- This follows maintainer guidance in #88 to:
        - use MoE active parameters for throughput estimation, and
        - label tok/s as baseline/conservative estimates.

### Summary

This PR addresses issue #88 by reducing misleading tok/s underestimation for MoE models and making speed values explicitly baseline estimates.

### What changed

1. **MoE throughput estimation now uses active parameters**
- Updated `estimate_tps()` in `llmfit-core/src/fit.rs` to use:
  - `active_parameters` when `model.is_moe == true` and `active_parameters` is present
  - fallback to total parameter count otherwise
- Memory fit logic is unchanged (still based on existing fit/run mode paths).

2. **Clarified speed wording in notes and UI**
- Changed internal note from:
  - `Estimated speed: ... tok/s`
  - to `Baseline estimated speed: ... tok/s`
- Updated CLI/TUI labels to make this explicit:
  - CLI table column: `tok/s est.`
  - Detail/runtime text: `baseline est.`
  - Score breakdown label: `Baseline Est. Speed`
  - TUI header marker: `tok/s*` with status-bar hint `tok/s*:est`

3. **Added tests for MoE tok/s behavior**
- `test_estimate_tps_moe_uses_active_parameters`
- `test_estimate_tps_moe_without_active_parameters_falls_back_to_total`

### Why
Issue #88 reports a large gap between observed runtime throughput and llmfit’s tok/s estimate for an MoE model. A key reason is estimating speed from total params instead of active params for MoE inference.

### Tests : Before vs After comparison (same model)

Model tested: `moonshotai/Moonlight-16B-A3B-Instruct`  
Machine: Apple Silicon (unified memory), runtime shown by llmfit as `MLX`

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Runtime line | `MLX (est. ~19.8 tok/s)` | `MLX (baseline est. ~274.2 tok/s)` | +254.4 tok/s |
| Speed in score breakdown | `Estimated Speed: 19.8 tok/s` | `Baseline Est. Speed: 274.2 tok/s` | +254.4 tok/s |
| Overall score | 73.5 | 91.2 | +17.7 |
| Speed component | 50 | 100 | +50 |
| Fit status | Perfect | Perfect | unchanged |
| Run mode | GPU | GPU | unchanged |
| Memory utilization | 51.2% (8.2 / 16.0 GB) | 51.2% (8.2 / 16.0 GB) | unchanged |
| MoE architecture section | Present (`6 active / 256 total`) | Present (`6 active / 256 total`) | unchanged |

**Interpretation:**  
The tok/s estimate increased substantially because MoE throughput now uses active parameters instead of total parameters, while memory fit behavior remains unchanged. Labels were also clarified from generic `est.` to explicit `baseline est.`.

### Scope / Non-goals
- No benchmark integration in this PR.
- No engine-specific multipliers in this PR.
- No changes to fit level ordering or run mode selection logic.