### PR TITLE
feat: add use-case popup filter and use-case search matching to TUI

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1,6 +1,6 @@
 use llmfit_core::fit::{FitLevel, ModelFit, SortColumn, backend_compatible};
 use llmfit_core::hardware::SystemSpecs;
-use llmfit_core::models::ModelDatabase;
+use llmfit_core::models::{ModelDatabase, UseCase};
 use llmfit_core::plan::{PlanEstimate, PlanRequest, estimate_model_plan};
 use llmfit_core::providers::{
     self, LlamaCppProvider, MlxProvider, ModelProvider, OllamaProvider, PullEvent, PullHandle,
@@ -17,6 +17,7 @@ pub enum InputMode {
     Search,
     Plan,
     ProviderPopup,
+    UseCasePopup,
     DownloadProviderPopup,
 }
 
@@ -149,6 +150,8 @@ pub struct App {
     pub filtered_fits: Vec<usize>, // indices into all_fits
     pub providers: Vec<String>,
     pub selected_providers: Vec<bool>,
+    pub use_cases: Vec<UseCase>,
+    pub selected_use_cases: Vec<bool>,
 
     // Filters
     pub fit_filter: FitFilter,
@@ -173,6 +176,7 @@ pub struct App {
 
     // Provider popup
     pub provider_cursor: usize,
+    pub use_case_cursor: usize,
     pub download_provider_cursor: usize,
     pub download_provider_options: Vec<DownloadProvider>,
     pub download_provider_model: Option<String>,
@@ -269,6 +273,18 @@ impl App {
         model_providers.sort();
 
         let selected_providers = vec![true; model_providers.len()];
+        let model_use_cases = [
+            UseCase::General,
+            UseCase::Coding,
+            UseCase::Reasoning,
+            UseCase::Chat,
+            UseCase::Multimodal,
+            UseCase::Embedding,
+        ]
+        .into_iter()
+        .filter(|uc| all_fits.iter().any(|f| f.use_case == *uc))
+        .collect::<Vec<_>>();
+        let selected_use_cases = vec![true; model_use_cases.len()];
 
         let filtered_count = all_fits.len();
 
@@ -284,6 +300,8 @@ impl App {
             filtered_fits: (0..filtered_count).collect(),
             providers: model_providers,
             selected_providers,
+            use_cases: model_use_cases,
+            selected_use_cases,
             fit_filter: FitFilter::All,
             availability_filter: AvailabilityFilter::All,
             installed_first: false,
@@ -300,6 +318,7 @@ impl App {
             plan_estimate: None,
             plan_error: None,
             provider_cursor: 0,
+            use_case_cursor: 0,
             download_provider_cursor: 0,
             download_provider_options: Vec::new(),
             download_provider_model: None,
@@ -349,11 +368,12 @@ impl App {
                 } else {
                     // Combine all searchable fields into one string
                     let searchable = format!(
-                        "{} {} {} {}",
+                        "{} {} {} {} {}",
                         fit.model.name.to_lowercase(),
                         fit.model.provider.to_lowercase(),
                         fit.model.parameter_count.to_lowercase(),
-                        fit.model.use_case.to_lowercase()
+                        fit.model.use_case.to_lowercase(),
+                        fit.use_case.label().to_lowercase()
                     );
                     // All terms must be present (AND logic)
                     terms.iter().all(|term| searchable.contains(term))
@@ -363,6 +383,10 @@ impl App {
                 let provider_idx = self.providers.iter().position(|p| p == &fit.model.provider);
                 let matches_provider = provider_idx
                     .map(|idx| self.selected_providers[idx])
+                    .unwrap_or(true);
+                let use_case_idx = self.use_cases.iter().position(|uc| *uc == fit.use_case);
+                let matches_use_case = use_case_idx
+                    .map(|idx| self.selected_use_cases[idx])
                     .unwrap_or(true);
 
                 // Hide MLX-only models on non-Apple Silicon systems
@@ -390,7 +414,11 @@ impl App {
                     AvailabilityFilter::Installed => fit.installed,
                 };
 
-                matches_search && matches_provider && matches_fit && matches_availability
+                matches_search
+                    && matches_provider
+                    && matches_use_case
+                    && matches_fit
+                    && matches_availability
             })
             .map(|(i, _)| i)
             .collect();
@@ -705,6 +733,15 @@ impl App {
         self.input_mode = InputMode::Normal;
     }
 
+    pub fn open_use_case_popup(&mut self) {
+        self.input_mode = InputMode::UseCasePopup;
+        // Don't reset cursor -- keep it where it was last time
+    }
+
+    pub fn close_use_case_popup(&mut self) {
+        self.input_mode = InputMode::Normal;
+    }
+
     pub fn provider_popup_up(&mut self) {
         if self.provider_cursor > 0 {
             self.provider_cursor -= 1;
@@ -729,6 +766,35 @@ impl App {
         let all_selected = self.selected_providers.iter().all(|&s| s);
         let new_val = !all_selected;
         for s in &mut self.selected_providers {
+            *s = new_val;
+        }
+        self.apply_filters();
+    }
+
+    pub fn use_case_popup_up(&mut self) {
+        if self.use_case_cursor > 0 {
+            self.use_case_cursor -= 1;
+        }
+    }
+
+    pub fn use_case_popup_down(&mut self) {
+        if self.use_case_cursor + 1 < self.use_cases.len() {
+            self.use_case_cursor += 1;
+        }
+    }
+
+    pub fn use_case_popup_toggle(&mut self) {
+        if self.use_case_cursor < self.selected_use_cases.len() {
+            self.selected_use_cases[self.use_case_cursor] =
+                !self.selected_use_cases[self.use_case_cursor];
+            self.apply_filters();
+        }
+    }
+
+    pub fn use_case_popup_select_all(&mut self) {
+        let all_selected = self.selected_use_cases.iter().all(|&s| s);
+        let new_val = !all_selected;
+        for s in &mut self.selected_use_cases {
             *s = new_val;
         }
         self.apply_filters();

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -20,6 +20,7 @@ pub fn handle_events(app: &mut App) -> std::io::Result<bool> {
             InputMode::Search => handle_search_mode(app, key),
             InputMode::Plan => handle_plan_mode(app, key),
             InputMode::ProviderPopup => handle_provider_popup_mode(app, key),
+            InputMode::UseCasePopup => handle_use_case_popup_mode(app, key),
             InputMode::DownloadProviderPopup => handle_download_provider_popup_mode(app, key),
         }
         return Ok(true);
@@ -68,6 +69,7 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
 
         // Provider popup
         KeyCode::Char('P') => app.open_provider_popup(),
+        KeyCode::Char('U') => app.open_use_case_popup(),
 
         // Installed-first sort toggle (any provider)
         KeyCode::Char('i')
@@ -148,6 +150,21 @@ fn handle_plan_mode(app: &mut App, key: KeyEvent) {
             app.plan_clear_field()
         }
         KeyCode::Char(c) => app.plan_input(c),
+        _ => {}
+    }
+}
+
+fn handle_use_case_popup_mode(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('U') | KeyCode::Char('q') => app.close_use_case_popup(),
+
+        KeyCode::Up | KeyCode::Char('k') => app.use_case_popup_up(),
+        KeyCode::Down | KeyCode::Char('j') => app.use_case_popup_down(),
+
+        KeyCode::Char(' ') | KeyCode::Enter => app.use_case_popup_toggle(),
+
+        KeyCode::Char('a') => app.use_case_popup_select_all(),
+
         _ => {}
     }
 }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -50,9 +50,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 
     draw_status_bar(frame, app, outer[3], &tc);
 
-    // Draw provider popup on top if active
+    // Draw popup overlays on top if active
     if app.input_mode == InputMode::ProviderPopup {
         draw_provider_popup(frame, app, &tc);
+    } else if app.input_mode == InputMode::UseCasePopup {
+        draw_use_case_popup(frame, app, &tc);
     } else if app.input_mode == InputMode::DownloadProviderPopup {
         draw_download_provider_popup(frame, app, &tc);
     }
@@ -201,7 +203,8 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         .direction(Direction::Horizontal)
         .constraints([
             Constraint::Min(30),    // search
-            Constraint::Length(24), // provider summary
+            Constraint::Length(18), // provider summary
+            Constraint::Length(18), // use-case summary
             Constraint::Length(18), // sort column
             Constraint::Length(20), // fit filter
             Constraint::Length(20), // availability filter
@@ -215,6 +218,7 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         InputMode::Normal
         | InputMode::Plan
         | InputMode::ProviderPopup
+        | InputMode::UseCasePopup
         | InputMode::DownloadProviderPopup => Style::default().fg(tc.muted),
     };
 
@@ -272,6 +276,35 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
     .block(provider_block);
     frame.render_widget(providers, chunks[1]);
 
+    // Use-case filter summary
+    let active_count = app.selected_use_cases.iter().filter(|&&s| s).count();
+    let total_count = app.use_cases.len();
+    let use_case_text = if active_count == total_count {
+        "All".to_string()
+    } else {
+        format!("{}/{}", active_count, total_count)
+    };
+    let use_case_color = if active_count == total_count {
+        tc.good
+    } else if active_count == 0 {
+        tc.error
+    } else {
+        tc.warning
+    };
+
+    let use_case_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(tc.border))
+        .title(" Use Case (U) ")
+        .title_style(Style::default().fg(tc.muted));
+
+    let use_cases = Paragraph::new(Line::from(Span::styled(
+        format!(" {}", use_case_text),
+        Style::default().fg(use_case_color),
+    )))
+    .block(use_case_block);
+    frame.render_widget(use_cases, chunks[2]);
+
     // Sort column
     let sort_block = Block::default()
         .borders(Borders::ALL)
@@ -284,7 +317,7 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         Style::default().fg(tc.accent),
     )))
     .block(sort_block);
-    frame.render_widget(sort_text, chunks[2]);
+    frame.render_widget(sort_text, chunks[3]);
 
     // Fit filter
     let fit_style = match app.fit_filter {
@@ -304,7 +337,7 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
 
     let fit_text = Paragraph::new(Line::from(Span::styled(app.fit_filter.label(), fit_style)))
         .block(fit_block);
-    frame.render_widget(fit_text, chunks[3]);
+    frame.render_widget(fit_text, chunks[4]);
 
     // Availability filter
     let avail_style = match app.availability_filter {
@@ -324,7 +357,7 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         avail_style,
     )))
     .block(avail_block);
-    frame.render_widget(avail_text, chunks[4]);
+    frame.render_widget(avail_text, chunks[5]);
 
     // Theme indicator
     let theme_block = Block::default()
@@ -338,7 +371,7 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         Style::default().fg(tc.info),
     )))
     .block(theme_block);
-    frame.render_widget(theme_text, chunks[5]);
+    frame.render_widget(theme_text, chunks[6]);
 }
 
 fn fit_color(level: FitLevel, tc: &ThemeColors) -> Color {
@@ -1296,6 +1329,89 @@ fn draw_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
     frame.render_widget(paragraph, popup_area);
 }
 
+fn draw_use_case_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
+    let area = frame.area();
+
+    let max_name_len = app
+        .use_cases
+        .iter()
+        .map(|uc| uc.label().len())
+        .max()
+        .unwrap_or(10);
+    let popup_width = (max_name_len as u16 + 10).min(area.width.saturating_sub(4));
+    let popup_height = (app.use_cases.len() as u16 + 2).min(area.height.saturating_sub(4));
+
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(Clear, popup_area);
+
+    let inner_height = popup_height.saturating_sub(2) as usize;
+    let total = app.use_cases.len();
+
+    let scroll_offset = if app.use_case_cursor >= inner_height {
+        app.use_case_cursor - inner_height + 1
+    } else {
+        0
+    };
+
+    let lines: Vec<Line> = app
+        .use_cases
+        .iter()
+        .enumerate()
+        .skip(scroll_offset)
+        .take(inner_height)
+        .map(|(i, use_case)| {
+            let checkbox = if app.selected_use_cases[i] {
+                "[x]"
+            } else {
+                "[ ]"
+            };
+            let is_cursor = i == app.use_case_cursor;
+
+            let style = if is_cursor {
+                if app.selected_use_cases[i] {
+                    Style::default()
+                        .fg(tc.good)
+                        .add_modifier(Modifier::BOLD)
+                        .bg(tc.highlight_bg)
+                } else {
+                    Style::default()
+                        .fg(tc.fg)
+                        .add_modifier(Modifier::BOLD)
+                        .bg(tc.highlight_bg)
+                }
+            } else if app.selected_use_cases[i] {
+                Style::default().fg(tc.good)
+            } else {
+                Style::default().fg(tc.muted)
+            };
+
+            Line::from(Span::styled(
+                format!(" {} {}", checkbox, use_case.label()),
+                style,
+            ))
+        })
+        .collect();
+
+    let active_count = app.selected_use_cases.iter().filter(|&&s| s).count();
+    let title = format!(" Use Cases ({}/{}) ", active_count, total);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(tc.accent_secondary))
+        .title(title)
+        .title_style(
+            Style::default()
+                .fg(tc.accent_secondary)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, popup_area);
+}
+
 fn draw_download_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
     let area = frame.area();
     let popup_width = 44.min(area.width.saturating_sub(4));
@@ -1381,7 +1497,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
                 };
                 (
                     format!(
-                        " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  t:theme  p:plan{}  P:providers  q:quit  tok/s*:est",
+                        " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  t:theme  p:plan{}  P:providers  U:use cases  q:quit  tok/s*:est",
                         detail_key, ollama_keys,
                     ),
                     "NORMAL",
@@ -1399,6 +1515,10 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             InputMode::ProviderPopup => (
                 "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
                 "PROVIDERS",
+            ),
+            InputMode::UseCasePopup => (
+                "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+                "USE CASES",
             ),
             InputMode::DownloadProviderPopup => (
                 "  ↑↓/jk:choose  Enter:download  Esc:cancel".to_string(),
@@ -1458,7 +1578,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             };
             (
                 format!(
-                    " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  t:theme  p:plan{}  P:providers  q:quit  tok/s*:est",
+                    " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  t:theme  p:plan{}  P:providers  U:use cases  q:quit  tok/s*:est",
                     detail_key, ollama_keys,
                 ),
                 "NORMAL",
@@ -1476,6 +1596,10 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         InputMode::ProviderPopup => (
             "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
             "PROVIDERS",
+        ),
+        InputMode::UseCasePopup => (
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "USE CASES",
         ),
         InputMode::DownloadProviderPopup => (
             "  ↑↓/jk:choose  Enter:download  Esc:cancel".to_string(),


### PR DESCRIPTION
## Summary
Adds a dedicated use-case popup filter to the TUI, parallel to the existing provider popup flow.

## What changed
- Added a new UseCasePopup input mode and use-case filter state in App.
- Added U keybindings to open/close the popup and navigate/toggle/select-all use cases.
- Added a use-case filter summary chip in the filter row.
- Added a centered use-case popup overlay with checkbox rendering and cursor highlighting.
- Updated apply_filters() so selected use cases are enforced in model list filtering.
- Extended search matching to include use-case labels (for example, searching `coding` matches Coding models).
- Updated status-bar help text to document the new U shortcut and popup controls.

## Validation
- cargo check passes

## Notes
- Behavior follows the same popup interaction pattern already used for provider selection.