### PR TITLE
fix: remove unused function to eliminate build-time warning

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -218,10 +218,6 @@ pub struct App {
 }
 
 impl App {
-    pub fn with_specs(specs: SystemSpecs) -> Self {
-        Self::with_specs_and_context(specs, None)
-    }
-
     pub fn with_specs_and_context(specs: SystemSpecs, context_limit: Option<u32>) -> Self {
         let db = ModelDatabase::new();
 


### PR DESCRIPTION
sorry for tiny PR, this warning was annoying me when debugging :)