### PR TITLE
fix: support sudo in piped install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@
 #
 # Downloads the latest llmfit release from GitHub and installs
 # the binary to /usr/local/bin (or ~/.local/bin with --local or if no sudo).
+# Supports piped execution: sudo prompts read from /dev/tty when stdin is a pipe.
 
 set -e
 
@@ -139,10 +140,17 @@ install() {
     elif [ -w /usr/local/bin ]; then
         # /usr/local/bin is writable without sudo
         INSTALL_DIR="/usr/local/bin"
-    elif command -v sudo >/dev/null 2>&1 && [ -t 0 ]; then
-        # sudo is available and we're in an interactive terminal
+    elif command -v sudo >/dev/null 2>&1; then
+        # sudo is available — use /dev/tty for password prompt when stdin is a pipe
         info "Installing to /usr/local/bin (requires sudo)..."
-        if sudo mv "$BIN" "/usr/local/bin/${BINARY}"; then
+        if [ -t 0 ]; then
+            SUDO_ASKPASS="" sudo mv "$BIN" "/usr/local/bin/${BINARY}"
+        elif [ -e /dev/tty ]; then
+            SUDO_ASKPASS="" sudo mv "$BIN" "/usr/local/bin/${BINARY}" </dev/tty
+        else
+            false
+        fi
+        if [ $? -eq 0 ]; then
             info "Installed ${BINARY} to /usr/local/bin/${BINARY}"
             return
         else


### PR DESCRIPTION
## Summary
Fixes #158 — the install script fails to use sudo when run via `curl ... | sh`.

## Problem
When piped, stdin is the curl stream, so `[ -t 0 ]` returns false. The script skipped the sudo path entirely and silently fell back to `~/.local/bin`, which confused users expecting a system-wide install.

## Fix
- If stdin is a TTY (`[ -t 0 ]`): use sudo normally (existing behavior)
- If stdin is a pipe but `/dev/tty` exists: redirect sudo's stdin from `/dev/tty` so the password prompt reaches the user
- If neither: fall back to `~/.local/bin` (headless/CI environments)

This matches how other popular install scripts handle the `curl | sh` pattern (e.g., Rustup, Homebrew).

## Testing
```bash
# Piped install (the failing case)
curl -fsSL https://raw.githubusercontent.com/.../install.sh | sh

# Direct execution (unchanged behavior)
./install.sh

# Local mode (unchanged)
curl -fsSL ... | sh -s -- --local
```