### PR TITLE
fix: bump Dockerfile Rust version to 1.88 for dependency compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for llmfit
 # Stage 1: Build the Rust binary
-FROM rust:1.85-slim as builder
+FROM rust:1.88-slim AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Several dependencies (ratatui 0.30, sysinfo 0.38, darling 0.23, time 0.3.47) now require rustc >= 1.86–1.88, breaking the Docker build on rust:1.85-slim.