### PR TITLE
fix: recognize installed Ollama tag variants (e.g. :7b-instruct)

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1458,11 +1458,30 @@ pub fn has_ollama_mapping(hf_name: &str) -> bool {
     lookup_ollama_tag(hf_name).is_some()
 }
 
+fn ollama_installed_matches_candidate(installed_name: &str, candidate: &str) -> bool {
+    if installed_name == candidate {
+        return true;
+    }
+
+    // Allow variant tags reported by `ollama list`, e.g.
+    // candidate: "qwen2.5-coder:7b"
+    // installed: "qwen2.5-coder:7b-instruct-q4_K_M"
+    if candidate.contains(':') {
+        return installed_name.starts_with(&format!("{candidate}-"));
+    }
+
+    false
+}
+
 /// Check if any of the Ollama candidates for an HF model appear in the
 /// installed set.
 pub fn is_model_installed(hf_name: &str, installed: &HashSet<String>) -> bool {
     let candidates = hf_name_to_ollama_candidates(hf_name);
-    candidates.iter().any(|c| installed.contains(c))
+    candidates.iter().any(|candidate| {
+        installed
+            .iter()
+            .any(|installed_name| ollama_installed_matches_candidate(installed_name, candidate))
+    })
 }
 
 /// Given an HF model name, return the Ollama tag to use for pulling.
@@ -1553,6 +1572,19 @@ mod tests {
         assert!(is_model_installed("Qwen/Qwen2.5-14B-Instruct", &installed));
         assert!(!is_model_installed(
             "Qwen/Qwen2.5-Coder-14B-Instruct",
+            &installed
+        ));
+    }
+
+    #[test]
+    fn test_installed_variant_suffix_matches_ollama_candidate() {
+        // Real-world `ollama list` may include variant suffixes that still map
+        // to the canonical pull tag in OLLAMA_MAPPINGS.
+        let mut installed = HashSet::new();
+        installed.insert("qwen2.5-coder:7b-instruct".to_string());
+
+        assert!(is_model_installed(
+            "Qwen/Qwen2.5-Coder-7B-Instruct",
             &installed
         ));
     }


### PR DESCRIPTION
## Summary
- make Ollama installed-model detection resilient to variant suffixes reported by `ollama list`
- treat canonical mapped tags like `qwen2.5-coder:7b` as installed when Ollama reports variants such as `qwen2.5-coder:7b-instruct`
- add a regression test for this real-world case

## Why
Some users have the model installed in Ollama, but llmfit still shows it as not installed because matching was strict-equality only. Ollama commonly appends variant suffixes to tags, so canonical mapped tags need prefix-aware matching.

This targets the detection problem discussed in #57.

## Validation
- `cargo fmt`
- `cargo test -p llmfit-core installed_variant_suffix_matches_ollama_candidate`
- `cargo test`
