### PR TITLE
fix: support OLLAMA_HOST in host:port form

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -52,20 +52,37 @@ pub struct OllamaProvider {
     base_url: String,
 }
 
+fn normalize_ollama_host(raw: &str) -> Option<String> {
+    let host = raw.trim();
+    if host.is_empty() {
+        return None;
+    }
+
+    if host.starts_with("http://") || host.starts_with("https://") {
+        return Some(host.to_string());
+    }
+
+    if host.contains("://") {
+        // Unsupported scheme (e.g. ftp://)
+        return None;
+    }
+
+    Some(format!("http://{host}"))
+}
+
 impl Default for OllamaProvider {
     fn default() -> Self {
         let base_url = std::env::var("OLLAMA_HOST")
             .ok()
-            .and_then(|url| {
-                if url.starts_with("http://") || url.starts_with("https://") {
-                    Some(url)
-                } else {
+            .and_then(|raw| {
+                let normalized = normalize_ollama_host(&raw);
+                if normalized.is_none() {
                     eprintln!(
-                        "Warning: OLLAMA_HOST must start with http:// or https://, ignoring: {}",
-                        url
+                        "Warning: could not parse OLLAMA_HOST='{}'. Expected host:port or http(s)://host:port",
+                        raw
                     );
-                    None
                 }
+                normalized
             })
             .unwrap_or_else(|| "http://localhost:11434".to_string());
         Self { base_url }
@@ -1580,6 +1597,30 @@ mod tests {
         let candidates =
             hf_name_to_ollama_candidates("deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct");
         assert!(candidates.contains(&"deepseek-coder-v2:16b".to_string()));
+    }
+
+    #[test]
+    fn test_normalize_ollama_host_with_scheme() {
+        assert_eq!(
+            normalize_ollama_host("https://ollama.example.com:11434"),
+            Some("https://ollama.example.com:11434".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_ollama_host_without_scheme() {
+        assert_eq!(
+            normalize_ollama_host("ollama.example.com:11434"),
+            Some("http://ollama.example.com:11434".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_ollama_host_rejects_unsupported_scheme() {
+        assert_eq!(
+            normalize_ollama_host("ftp://ollama.example.com:11434"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add robust normalization for `OLLAMA_HOST`
- accept both `http(s)://host:port` and plain `host:port` values
- keep rejecting unsupported schemes (for example `ftp://...`) with a clearer warning
- add unit tests for normalization behavior

## Why
Users often set `OLLAMA_HOST` as `host:port` without an explicit scheme. Previously this was ignored entirely, causing llmfit to silently fall back to the default endpoint and making provider detection appear broken in non-default setups.

This addresses the Ollama connectivity confusion tracked in #57.

## Validation
- `cargo fmt`
- `cargo test -p llmfit-core normalize_ollama_host`
- `cargo test`
