### PR TITLE
docs: add CI, crates.io, and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 <p align="center">
   <img src="assets/icon.svg" alt="llmfit icon" width="128" height="128">
 </p>
+<p align="center">
+  <a href="https://github.com/AlexsJones/llmfit/actions/workflows/ci.yml"><img src="https://github.com/AlexsJones/llmfit/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://crates.io/crates/llmfit"><img src="https://img.shields.io/crates/v/llmfit.svg" alt="Crates.io"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+</p>
 
 **Hundreds of models & providers. One command to find what runs on your hardware.**
 


### PR DESCRIPTION
Add status badges to README for CI, crates.io version, and license.