### PR TITLE
fix: correct PCI ID reading on Linux and improve AMD GPU identification

### DIFF
--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -600,6 +600,7 @@ impl SystemSpecs {
 
         let mut slot_hints: Vec<String> = Vec::new();
         let entries = std::fs::read_dir("/sys/class/drm").ok()?;
+
         for entry in entries.flatten() {
             let card_path = entry.path();
             let fname = card_path.file_name()?.to_str()?.to_string();
@@ -637,7 +638,6 @@ impl SystemSpecs {
             }
 
             // Try to get GPU name from lspci
-            let gpu_name = Self::get_amd_gpu_name_lspci();
             let gpu_name = Self::get_amd_gpu_name_lspci(&slot_hints);
             let name = gpu_name.unwrap_or_else(|| "AMD GPU".to_string());
 
@@ -728,7 +728,7 @@ impl SystemSpecs {
     /// Read lspci output, with host fallback for containerized environments.
     fn lspci_output() -> Option<String> {
         let local = std::process::Command::new("lspci")
-            .arg("-nn")
+            .arg("-nnD")
             .output()
             .ok()
             .filter(|o| o.status.success())
@@ -739,7 +739,7 @@ impl SystemSpecs {
         }
 
         std::process::Command::new("flatpak-spawn")
-            .args(["--host", "lspci", "-nn"])
+            .args(["--host", "lspci", "-nnD"])
             .output()
             .ok()
             .filter(|o| o.status.success())


### PR DESCRIPTION
This PR addresses the following issues within `llmfit_core::hardware`:
- `get_amd_gpu_name_lspci` did not take PCI IDs into account for matching, unlike its NVIDIA counterpart `get_nvidia_gpu_name_lspci`. This PR updates it to use slot hints.
- `/sys/class/drm/card*/device/uevent` returns "full" PCI IDs, which include their domain numbers. The existing functions did not account for this. To ensure accurate matching against the full PCI ID, the `-D` flag is now passed to `lspci` before matching the card's PCI IDs against the output.