### PR TITLE
fix: incorrect installed model count in TUI status bar

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -101,7 +101,7 @@ impl OllamaProvider {
 
     /// Single-pass startup probe to avoid duplicate `/api/tags` calls.
     /// Returns `(available, installed_models)`.
-    pub fn detect_with_installed(&self) -> (bool, HashSet<String>) {
+    pub fn detect_with_installed(&self) -> (bool, HashSet<String>, usize) {
         let mut set = HashSet::new();
         let Ok(resp) = ureq::get(&self.api_url("tags"))
             .config()
@@ -109,12 +109,13 @@ impl OllamaProvider {
             .build()
             .call()
         else {
-            return (false, set);
+            return (false, set, 0);
         };
 
         let Ok(tags): Result<TagsResponse, _> = resp.into_body().read_json() else {
-            return (true, set);
+            return (true, set, 0);
         };
+        let count = tags.models.len();
         for m in tags.models {
             let lower = m.name.to_lowercase();
             set.insert(lower.clone());
@@ -122,7 +123,34 @@ impl OllamaProvider {
                 set.insert(family.to_string());
             }
         }
-        (true, set)
+        (true, set, count)
+    }
+
+    /// Like `installed_models`, but also returns the true model count.
+    /// The HashSet may have fewer entries than 2*count due to family-name deduplication,
+    /// so `len() / 2` is unreliable for counting models.
+    pub fn installed_models_counted(&self) -> (HashSet<String>, usize) {
+        let mut set = HashSet::new();
+        let Ok(resp) = ureq::get(&self.api_url("tags"))
+            .config()
+            .timeout_global(Some(std::time::Duration::from_secs(5)))
+            .build()
+            .call()
+        else {
+            return (set, 0);
+        };
+        let Ok(tags): Result<TagsResponse, _> = resp.into_body().read_json() else {
+            return (set, 0);
+        };
+        let count = tags.models.len();
+        for m in tags.models {
+            let lower = m.name.to_lowercase();
+            set.insert(lower.clone());
+            if let Some(family) = lower.split(':').next() {
+                set.insert(family.to_string());
+            }
+        }
+        (set, count)
     }
 
     /// Best-effort check that a tag exists in Ollama's remote registry.
@@ -178,27 +206,7 @@ impl ModelProvider for OllamaProvider {
     }
 
     fn installed_models(&self) -> HashSet<String> {
-        let mut set = HashSet::new();
-        let Ok(resp) = ureq::get(&self.api_url("tags"))
-            .config()
-            .timeout_global(Some(std::time::Duration::from_secs(5)))
-            .build()
-            .call()
-        else {
-            return set;
-        };
-        let Ok(tags): Result<TagsResponse, _> = resp.into_body().read_json() else {
-            return set;
-        };
-        for m in tags.models {
-            let lower = m.name.to_lowercase();
-            // Store the full tag as-is (lowercased)
-            set.insert(lower.clone());
-            // Also store just the family (before the colon) so fuzzy matching works
-            if let Some(family) = lower.split(':').next() {
-                set.insert(family.to_string());
-            }
-        }
+        let (set, _) = self.installed_models_counted();
         set
     }
 
@@ -538,6 +546,25 @@ impl Default for LlamaCppProvider {
 impl LlamaCppProvider {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Like `installed_models`, but also returns the true GGUF file count.
+    /// The HashSet may have fewer entries than 2*count due to deduplication
+    /// when stripping quantization suffixes, so `len() / 2` is unreliable.
+    pub fn installed_models_counted(&self) -> (HashSet<String>, usize) {
+        let mut set = HashSet::new();
+        let mut count = 0usize;
+        for path in self.list_gguf_files() {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                count += 1;
+                let lower = stem.to_lowercase();
+                set.insert(lower.clone());
+                if let Some(base) = strip_gguf_quant_suffix(&lower) {
+                    set.insert(base);
+                }
+            }
+        }
+        (set, count)
     }
 
     /// Return the directory where GGUF models are cached.
@@ -936,18 +963,7 @@ impl ModelProvider for LlamaCppProvider {
     }
 
     fn installed_models(&self) -> HashSet<String> {
-        let mut set = HashSet::new();
-        for path in self.list_gguf_files() {
-            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                let lower = stem.to_lowercase();
-                set.insert(lower.clone());
-                // Also insert a normalized form: strip quantization suffix
-                // e.g. "llama-3.1-8b-instruct-q4_k_m" → "llama-3.1-8b-instruct"
-                if let Some(base) = strip_gguf_quant_suffix(&lower) {
-                    set.insert(base);
-                }
-            }
-        }
+        let (set, _) = self.installed_models_counted();
         set
     }
 

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -191,12 +191,14 @@ pub struct App {
     pub ollama_available: bool,
     pub ollama_binary_available: bool,
     pub ollama_installed: HashSet<String>,
+    pub ollama_installed_count: usize,
     ollama: OllamaProvider,
     pub mlx_available: bool,
     pub mlx_installed: HashSet<String>,
     mlx: MlxProvider,
     pub llamacpp_available: bool,
     pub llamacpp_installed: HashSet<String>,
+    pub llamacpp_installed_count: usize,
     llamacpp: LlamaCppProvider,
 
     // Download state
@@ -229,7 +231,8 @@ impl App {
 
         // Detect Ollama
         let ollama = OllamaProvider::new();
-        let (ollama_available, ollama_installed) = ollama.detect_with_installed();
+        let (ollama_available, ollama_installed, ollama_installed_count) =
+            ollama.detect_with_installed();
         let ollama_binary_available = command_exists("ollama");
 
         // Detect MLX
@@ -239,7 +242,7 @@ impl App {
         // Detect llama.cpp
         let llamacpp = LlamaCppProvider::new();
         let llamacpp_available = llamacpp.is_available();
-        let llamacpp_installed = llamacpp.installed_models();
+        let (llamacpp_installed, llamacpp_installed_count) = llamacpp.installed_models_counted();
 
         // Track how many we're skipping so the UI can surface it.
         let backend_hidden_count = db
@@ -335,12 +338,14 @@ impl App {
             ollama_available,
             ollama_binary_available,
             ollama_installed,
+            ollama_installed_count,
             ollama,
             mlx_available,
             mlx_installed,
             mlx,
             llamacpp_available,
             llamacpp_installed,
+            llamacpp_installed_count,
             llamacpp,
             pull_active: None,
             pull_status: None,
@@ -1152,9 +1157,13 @@ impl App {
 
     /// Re-query all providers for installed models and update all_fits.
     pub fn refresh_installed(&mut self) {
-        self.ollama_installed = self.ollama.installed_models();
+        let (ollama_set, ollama_count) = self.ollama.installed_models_counted();
+        self.ollama_installed = ollama_set;
+        self.ollama_installed_count = ollama_count;
         self.mlx_installed = self.mlx.installed_models();
-        self.llamacpp_installed = self.llamacpp.installed_models();
+        let (llamacpp_set, llamacpp_count) = self.llamacpp.installed_models_counted();
+        self.llamacpp_installed = llamacpp_set;
+        self.llamacpp_installed_count = llamacpp_count;
         for fit in &mut self.all_fits {
             fit.installed = providers::is_model_installed(&fit.model.name, &self.ollama_installed)
                 || providers::is_model_installed_mlx(&fit.model.name, &self.mlx_installed)

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -102,7 +102,7 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     };
 
     let ollama_info = if app.ollama_available {
-        format!("Ollama: ✓ ({} installed)", app.ollama_installed.len() / 2)
+        format!("Ollama: ✓ ({} installed)", app.ollama_installed_count)
     } else {
         "Ollama: ✗".to_string()
     };
@@ -128,10 +128,9 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     };
 
     let llamacpp_info = if app.llamacpp_available {
-        let n = app.llamacpp_installed.len() / 2; // stems + base names
-        format!("llama.cpp: ✓ ({} models)", n)
+        format!("llama.cpp: ✓ ({} models)", app.llamacpp_installed_count)
     } else if !app.llamacpp_installed.is_empty() {
-        format!("llama.cpp: ({} cached)", app.llamacpp_installed.len() / 2)
+        format!("llama.cpp: ({} cached)", app.llamacpp_installed_count)
     } else {
         "llama.cpp: ✗".to_string()
     };


### PR DESCRIPTION
## Summary
- The Ollama and llama.cpp status bar counts used `HashSet::len() / 2` to derive the number of installed models, assuming exactly 2 entries per model (full tag + family/base name). This assumption breaks when multiple models share the same family prefix (e.g. `qwen3.5:122b` and `qwen3.5:35b` both produce family `qwen3.5`), causing the HashSet to have fewer entries than expected and the count to be wrong.
- Added `installed_models_counted()` methods to `OllamaProvider` and `LlamaCppProvider` that track the true model count from the source data, and added `ollama_installed_count` / `llamacpp_installed_count` fields to the `App` struct.

Fixes #189

## Test plan
- [ ] Install multiple Ollama models from the same family (e.g. two Qwen3.5 variants) and verify the status bar count matches the actual number of installed models
- [ ] Verify llama.cpp count is also correct with multiple GGUF files that share a base name

🤖 Generated with [Claude Code](https://claude.com/claude-code)