### PR TITLE
fix: prefer exact matches in info selection

### DIFF
--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -659,26 +659,31 @@ fn fit_matches_filter(fit: &ModelFit, filter: FitArg) -> bool {
     }
 }
 
-fn find_fit_index_by_selector(fits: &[ModelFit], selector: &str) -> Result<usize, String> {
+fn find_name_index_by_selector<T>(
+    items: &[T],
+    selector: &str,
+    get_name: impl Fn(&T) -> &str,
+) -> Result<usize, String> {
     let needle = selector.trim().to_lowercase();
     if needle.is_empty() {
         return Err("Model selector cannot be empty".to_string());
     }
 
-    if let Some((idx, _)) = fits
+    if let Some((idx, _)) = items
         .iter()
         .enumerate()
-        .find(|(_, f)| f.model.name.to_lowercase() == needle)
+        .find(|(_, item)| get_name(item).to_lowercase() == needle)
     {
         return Ok(idx);
     }
 
-    let matches: Vec<(usize, &str)> = fits
+    let matches: Vec<(usize, String)> = items
         .iter()
         .enumerate()
-        .filter_map(|(i, f)| {
-            if f.model.name.to_lowercase().contains(&needle) {
-                Some((i, f.model.name.as_str()))
+        .filter_map(|(i, item)| {
+            let name = get_name(item);
+            if name.to_lowercase().contains(&needle) {
+                Some((i, name.to_string()))
             } else {
                 None
             }
@@ -701,6 +706,10 @@ fn find_fit_index_by_selector(fits: &[ModelFit], selector: &str) -> Result<usize
             ))
         }
     }
+}
+
+fn find_fit_index_by_selector(fits: &[ModelFit], selector: &str) -> Result<usize, String> {
+    find_name_index_by_selector(fits, selector, |fit| fit.model.name.as_str())
 }
 
 fn run_diff(
@@ -1346,22 +1355,17 @@ fn main() {
             Commands::Info { model } => {
                 let db = ModelDatabase::new();
                 let specs = detect_specs(&cli.memory);
-                let results = db.find_model(&model);
+                let models = db.get_all_models();
 
-                if results.is_empty() {
-                    println!("\nNo model found matching '{}'", model);
-                    return;
-                }
-
-                if results.len() > 1 {
-                    println!("\nMultiple models found. Please be more specific:");
-                    for m in results {
-                        println!("  - {}", m.name);
+                let idx = match find_name_index_by_selector(models, &model, |m| m.name.as_str()) {
+                    Ok(i) => i,
+                    Err(err) => {
+                        println!("\n{}", err);
+                        return;
                     }
-                    return;
-                }
+                };
 
-                let fit = ModelFit::analyze_with_context_limit(results[0], &specs, context_limit);
+                let fit = ModelFit::analyze_with_context_limit(&models[idx], &specs, context_limit);
                 if cli.json {
                     display::display_json_fits(&specs, &[fit]);
                 } else {
@@ -1551,5 +1555,56 @@ mod tests {
         ];
         let err = find_fit_index_by_selector(&fits, "model-a").expect_err("should be ambiguous");
         assert!(err.contains("Multiple models match"));
+    }
+
+    #[test]
+    fn generic_selector_prefers_exact_match_for_models() {
+        let models = vec![
+            LlmModel {
+                name: "Qwen/Qwen3-Coder-Next-FP8".to_string(),
+                provider: "Qwen".to_string(),
+                parameter_count: "7B".to_string(),
+                parameters_raw: None,
+                min_ram_gb: 4.0,
+                recommended_ram_gb: 8.0,
+                min_vram_gb: Some(4.0),
+                quantization: "Q4_K_M".to_string(),
+                context_length: 8192,
+                use_case: "general".to_string(),
+                is_moe: false,
+                num_experts: None,
+                active_experts: None,
+                active_parameters: None,
+                release_date: None,
+                gguf_sources: vec![],
+                capabilities: vec![],
+                format: llmfit_core::models::ModelFormat::default(),
+            },
+            LlmModel {
+                name: "Qwen/Qwen3-Coder-Next".to_string(),
+                provider: "Qwen".to_string(),
+                parameter_count: "7B".to_string(),
+                parameters_raw: None,
+                min_ram_gb: 4.0,
+                recommended_ram_gb: 8.0,
+                min_vram_gb: Some(4.0),
+                quantization: "Q4_K_M".to_string(),
+                context_length: 8192,
+                use_case: "general".to_string(),
+                is_moe: false,
+                num_experts: None,
+                active_experts: None,
+                active_parameters: None,
+                release_date: None,
+                gguf_sources: vec![],
+                capabilities: vec![],
+                format: llmfit_core::models::ModelFormat::default(),
+            },
+        ];
+
+        let idx =
+            find_name_index_by_selector(&models, "Qwen/Qwen3-Coder-Next", |m| m.name.as_str())
+                .expect("should resolve exact model");
+        assert_eq!(idx, 1);
     }
 }


### PR DESCRIPTION
$## Summary\n- make `llmfit info <model>` reuse exact-match-first selector logic instead of raw fuzzy search results\n- preserve substring fallback when there is no exact match\n- add unit coverage for exact-match preference on plain model lists\n\n## Testing\n- `cargo fmt --check`\n- `cargo test -p llmfit selector_prefers_exact_match -- --nocapture`\n- `cargo test -p llmfit generic_selector_prefers_exact_match_for_models -- --nocapture`\n\nCloses #172