### PR TITLE
fix: surface MoE offloaded RAM in JSON output

### DIFF
--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -500,6 +500,8 @@ fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "best_quant": fit.best_quant,
         "memory_required_gb": round2(fit.memory_required_gb),
         "memory_available_gb": round2(fit.memory_available_gb),
+        "moe_offloaded_gb": fit.moe_offloaded_gb.map(round2),
+        "total_memory_gb": round2(fit.memory_required_gb + fit.moe_offloaded_gb.unwrap_or(0.0)),
         "utilization_pct": round1(fit.utilization_pct),
         "notes": fit.notes,
         "gguf_sources": fit.model.gguf_sources,

--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -522,6 +522,8 @@ fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "best_quant": fit.best_quant,
         "memory_required_gb": round2(fit.memory_required_gb),
         "memory_available_gb": round2(fit.memory_available_gb),
+        "moe_offloaded_gb": fit.moe_offloaded_gb.map(round2),
+        "total_memory_gb": round2(fit.memory_required_gb + fit.moe_offloaded_gb.unwrap_or(0.0)),
         "utilization_pct": round1(fit.utilization_pct),
         "notes": fit.notes,
         "gguf_sources": fit.model.gguf_sources,


### PR DESCRIPTION
## Summary
- Add `moe_offloaded_gb` and `total_memory_gb` fields to JSON output (both `--json` flag and API server)
- `memory_required_gb` continues to represent VRAM for the run mode (active experts for MoeOffload, full model for GPU)
- `total_memory_gb` = VRAM + offloaded RAM, giving consumers the full memory picture
- For non-MoE models, `moe_offloaded_gb` is `null` and `total_memory_gb` equals `memory_required_gb`

## Context
The internal fit scoring logic is correct — it checks VRAM and RAM pools independently for MoE offload. The bug was that JSON output omitted `moe_offloaded_gb` (which the TUI/CLI text output already showed), making it look like MoE models need far less memory than they actually do.

Closes #230

## Test plan
- [x] All 126 existing tests pass
- [ ] Run `llmfit recommend --json` on a system with MoE models and verify `moe_offloaded_gb` and `total_memory_gb` appear in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)