### PR TITLE
feat: add MiniMax-M2.7 to curated model database

### DIFF
--- a/data/hf_models.json
+++ b/data/hf_models.json
@@ -11308,6 +11308,28 @@
     "format": "awq"
   },
   {
+    "name": "MiniMaxAI/MiniMax-M2.7",
+    "provider": "minimaxai",
+    "parameter_count": "228.7B",
+    "parameters_raw": 228703644928,
+    "min_ram_gb": 127.8,
+    "recommended_ram_gb": 213.0,
+    "min_vram_gb": 117.1,
+    "quantization": "Q4_K_M",
+    "context_length": 196608,
+    "use_case": "Latest flagship with enhanced reasoning and coding",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "minimax_m2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2026-03-18",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 10000000000
+  },
+  {
     "name": "MiniMaxAI/MiniMax-M2.5",
     "provider": "minimaxai",
     "parameter_count": "228.7B",

--- a/llmfit-core/data/hf_models.json
+++ b/llmfit-core/data/hf_models.json
@@ -11728,6 +11728,28 @@
     "format": "awq"
   },
   {
+    "name": "MiniMaxAI/MiniMax-M2.7",
+    "provider": "minimaxai",
+    "parameter_count": "228.7B",
+    "parameters_raw": 228703644928,
+    "min_ram_gb": 127.8,
+    "recommended_ram_gb": 213.0,
+    "min_vram_gb": 117.1,
+    "quantization": "Q4_K_M",
+    "context_length": 196608,
+    "use_case": "Latest flagship with enhanced reasoning and coding",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "minimax_m2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2026-03-18",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 10000000000
+  },
+  {
     "name": "MiniMaxAI/MiniMax-M2.5",
     "provider": "minimaxai",
     "parameter_count": "228.7B",

--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -214,7 +214,8 @@ TARGET_MODELS = [
     "zai-org/GLM-5",
     # Moonshot Kimi K2.5
     "moonshotai/Kimi-K2.5",
-    # MiniMax M2.5
+    # MiniMax M2.7 / M2.5
+    "MiniMaxAI/MiniMax-M2.7",
     "MiniMaxAI/MiniMax-M2.5",
     # Xiaomi MiMo
     "XiaomiMiMo/MiMo-V2-Flash",
@@ -296,6 +297,7 @@ MOE_ACTIVE_PARAMS = {
     "moonshotai/Kimi-K2-Instruct": 32_000_000_000,
     "moonshotai/Kimi-K2.5": 32_000_000_000,
     "zai-org/GLM-5": 40_000_000_000,
+    "MiniMaxAI/MiniMax-M2.7": 10_000_000_000,
     "MiniMaxAI/MiniMax-M2.5": 10_000_000_000,
     "XiaomiMiMo/MiMo-V2-Flash": 15_000_000_000,
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": 3_000_000_000,
@@ -1408,6 +1410,18 @@ def main():
             "use_case": "Multimodal, vision and text",
             "pipeline_tag": "image-text-to-text", "architecture": "kimi",
             "hf_downloads": 0, "hf_likes": 0, "release_date": "2026-01-26",
+        },
+        {
+            "name": "MiniMaxAI/MiniMax-M2.7",
+            "provider": "MiniMax", "parameter_count": "230B",
+            "parameters_raw": 230000000000,
+            "min_ram_gb": 128.6, "recommended_ram_gb": 214.4, "min_vram_gb": 117.9,
+            "quantization": "Q4_K_M", "context_length": 131072,
+            "use_case": "Latest flagship with enhanced reasoning and coding",
+            "pipeline_tag": "text-generation", "architecture": "minimax",
+            "is_moe": True, "num_experts": 32, "active_experts": 2,
+            "active_parameters": 10000000000,
+            "hf_downloads": 0, "hf_likes": 0, "release_date": "2026-03-18",
         },
         {
             "name": "MiniMaxAI/MiniMax-M2.5",


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7 (latest flagship model) to the curated model database
- Add M2.7 entries to both `data/hf_models.json` and `llmfit-core/data/hf_models.json`
- Update `scripts/scrape_hf_models.py` with M2.7 in curated models list and active parameters

## Changes
- **scripts/scrape_hf_models.py**: Added `MiniMaxAI/MiniMax-M2.7` to `CURATED_MODELS`, `MOE_ACTIVE_PARAMS`, and manual curated entries
- **data/hf_models.json**: Added M2.7 model entry before M2.5
- **llmfit-core/data/hf_models.json**: Added M2.7 model entry before M2.5

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities, succeeding M2.5. All previous models (M2, M2.1, M2.5) are retained as alternatives.

## Testing
- Both JSON files validated as valid JSON
- Python script syntax verified
- M2.7 correctly placed before M2.5 in model order
