### PR TITLE
Fix: filter models by GPU compute capability for vLLM quants

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -600,7 +600,24 @@ pub fn backend_compatible(model: &LlmModel, system: &SystemSpecs) -> bool {
     if model.is_mlx_model() {
         system.backend == GpuBackend::Metal && system.unified_memory
     } else if model.is_prequantized() {
-        matches!(system.backend, GpuBackend::Cuda | GpuBackend::Rocm)
+        if !matches!(system.backend, GpuBackend::Cuda | GpuBackend::Rocm) {
+            return false;
+        }
+        // For CUDA GPUs, check that the GPU's compute capability meets the
+        // minimum required by the quantization format (e.g. AWQ needs Turing+).
+        // ROCm and unrecognized NVIDIA GPUs are assumed compatible.
+        if system.backend == GpuBackend::Cuda {
+            if let Some(min_cc) =
+                crate::hardware::quant_min_compute_capability(&model.quantization)
+            {
+                if let Some(gpu_name) = &system.gpu_name {
+                    if let Some(gpu_cc) = crate::hardware::gpu_compute_capability(gpu_name) {
+                        return gpu_cc >= min_cc;
+                    }
+                }
+            }
+        }
+        true
     } else {
         true
     }
@@ -1805,7 +1822,7 @@ mod tests {
         let mut model = test_model("7B", 4.0, Some(4.0));
         model.format = models::ModelFormat::Awq;
 
-        // AWQ on CUDA → compatible
+        // AWQ on CUDA → compatible (default test GPU name is unrecognized, assumed ok)
         let cuda_sys = test_system(64.0, true, Some(24.0));
         assert!(backend_compatible(&model, &cuda_sys));
 
@@ -1828,5 +1845,82 @@ mod tests {
         let mut gguf_model = test_model("7B", 4.0, Some(4.0));
         gguf_model.format = models::ModelFormat::Gguf;
         assert!(backend_compatible(&gguf_model, &metal_sys));
+    }
+
+    #[test]
+    fn test_awq_incompatible_on_volta_v100() {
+        // V100 is Volta (cc 7.0) — AWQ requires cc >= 7.5
+        let mut model = test_model("7B", 4.0, Some(4.0));
+        model.format = models::ModelFormat::Awq;
+        model.quantization = "AWQ-4bit".to_string();
+
+        let v100_sys = test_system_with_gpu(64.0, 16.0, "Tesla V100-PCIE-16GB");
+        assert!(!backend_compatible(&model, &v100_sys));
+    }
+
+    #[test]
+    fn test_gptq_incompatible_on_volta_v100() {
+        let mut model = test_model("7B", 4.0, Some(4.0));
+        model.format = models::ModelFormat::Gptq;
+        model.quantization = "GPTQ-Int4".to_string();
+
+        let v100_sys = test_system_with_gpu(64.0, 16.0, "Tesla V100-PCIE-16GB");
+        assert!(!backend_compatible(&model, &v100_sys));
+    }
+
+    #[test]
+    fn test_awq_compatible_on_turing_and_newer() {
+        let mut model = test_model("7B", 4.0, Some(4.0));
+        model.format = models::ModelFormat::Awq;
+        model.quantization = "AWQ-4bit".to_string();
+
+        // T4 is Turing (cc 7.5) — should work
+        let t4_sys = test_system_with_gpu(64.0, 16.0, "Tesla T4");
+        assert!(backend_compatible(&model, &t4_sys));
+
+        // RTX 3090 is Ampere (cc 8.6) — should work
+        let ampere_sys =
+            test_system_with_gpu(64.0, 24.0, "NVIDIA GeForce RTX 3090");
+        assert!(backend_compatible(&model, &ampere_sys));
+
+        // RTX 4090 is Ada Lovelace (cc 8.9) — should work
+        let ada_sys =
+            test_system_with_gpu(64.0, 24.0, "NVIDIA GeForce RTX 4090");
+        assert!(backend_compatible(&model, &ada_sys));
+
+        // H100 is Hopper (cc 9.0) — should work
+        let hopper_sys = test_system_with_gpu(64.0, 80.0, "NVIDIA H100 SXM");
+        assert!(backend_compatible(&model, &hopper_sys));
+    }
+
+    #[test]
+    fn test_awq_on_rocm_always_compatible() {
+        // ROCm GPUs don't have NVIDIA compute capability — assume compatible
+        let mut model = test_model("7B", 4.0, Some(4.0));
+        model.format = models::ModelFormat::Awq;
+        model.quantization = "AWQ-4bit".to_string();
+
+        let mut rocm_sys = test_system_with_gpu(64.0, 24.0, "AMD Instinct MI300X");
+        rocm_sys.backend = GpuBackend::Rocm;
+        assert!(backend_compatible(&model, &rocm_sys));
+    }
+
+    #[test]
+    fn test_awq_on_pascal_incompatible() {
+        // P100 is Pascal (cc 6.1) — AWQ requires cc >= 7.5
+        let mut model = test_model("7B", 4.0, Some(4.0));
+        model.format = models::ModelFormat::Awq;
+        model.quantization = "AWQ-4bit".to_string();
+
+        let p100_sys = test_system_with_gpu(64.0, 16.0, "Tesla P100");
+        assert!(!backend_compatible(&model, &p100_sys));
+    }
+
+    #[test]
+    fn test_gguf_on_volta_still_compatible() {
+        // GGUF models should remain compatible on any GPU — no CC restriction
+        let model = test_model("7B", 4.0, Some(4.0));
+        let v100_sys = test_system_with_gpu(64.0, 16.0, "Tesla V100-PCIE-16GB");
+        assert!(backend_compatible(&model, &v100_sys));
     }
 }

--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -1872,6 +1872,108 @@ pub fn gpu_memory_bandwidth_gbps(name: &str) -> Option<f64> {
     None
 }
 
+/// Returns the NVIDIA compute capability (major, minor) for a known GPU name.
+/// Used to determine compatibility with quantization formats that require
+/// specific hardware features (e.g. AWQ requires Turing+ / cc >= 7.5).
+///
+/// Returns `None` for non-NVIDIA GPUs or unrecognized models.
+pub fn gpu_compute_capability(name: &str) -> Option<(u8, u8)> {
+    let lower = name.to_lowercase();
+
+    // ── Blackwell (RTX 50xx, B100/B200) ──────────────────────────
+    if lower.contains("5090")
+        || lower.contains("5080")
+        || lower.contains("5070")
+        || lower.contains("5060")
+        || lower.contains("b200")
+        || lower.contains("b100")
+        || lower.contains("gb200")
+        || lower.contains("gb100")
+    {
+        return Some((10, 0));
+    }
+
+    // ── Hopper (H100, H200) ─────────────────────────────────────
+    if lower.contains("h100") || lower.contains("h200") {
+        return Some((9, 0));
+    }
+
+    // ── Ada Lovelace (RTX 40xx, L4, L40/L40S) ──────────────────
+    if lower.contains("4090")
+        || lower.contains("4080")
+        || lower.contains("4070")
+        || lower.contains("4060")
+        || lower.contains("l40")
+        || lower.contains("l4")
+    {
+        return Some((8, 9));
+    }
+
+    // ── Ampere (RTX 30xx consumer = 8.6, A100/A10/A6000 = 8.0) ─
+    if lower.contains("a100") {
+        return Some((8, 0));
+    }
+    if lower.contains("3090")
+        || lower.contains("3080")
+        || lower.contains("3070")
+        || lower.contains("3060")
+        || lower.contains("a10")
+        || lower.contains("a6000")
+        || lower.contains("a5000")
+        || lower.contains("a4000")
+        || lower.contains("a2000")
+        || lower.contains("a16")
+    {
+        return Some((8, 6));
+    }
+
+    // ── Turing (RTX 20xx, GTX 16xx, T4) ─────────────────────────
+    if lower.contains("2080")
+        || lower.contains("2070")
+        || lower.contains("2060")
+        || lower.contains("1660")
+        || lower.contains("1650")
+        || lower.contains("t4")
+    {
+        return Some((7, 5));
+    }
+
+    // ── Volta (V100, Titan V) ───────────────────────────────────
+    if lower.contains("v100") || lower.contains("titan v") {
+        return Some((7, 0));
+    }
+
+    // ── Pascal (P100, GTX 10xx, Titan X Pascal) ─────────────────
+    if lower.contains("p100")
+        || lower.contains("1080")
+        || lower.contains("1070")
+        || lower.contains("1060")
+        || lower.contains("1050")
+        || lower.contains("p40")
+        || lower.contains("p4")
+    {
+        return Some((6, 1));
+    }
+
+    None
+}
+
+/// Minimum NVIDIA compute capability required by a quantization format
+/// when running under vLLM. Based on vLLM's documented hardware support:
+/// <https://docs.vllm.ai/en/latest/features/quantization/#supported-hardware>
+///
+/// Returns `None` for quantization formats that have no known CC restriction
+/// (e.g. GGUF quants which run through llama.cpp, not vLLM).
+pub fn quant_min_compute_capability(quantization: &str) -> Option<(u8, u8)> {
+    match quantization {
+        // AWQ requires Turing+ (int4 tensor-core kernels)
+        "AWQ-4bit" | "AWQ-8bit" => Some((7, 5)),
+        // GPTQ Marlin kernels require Turing+
+        "GPTQ-Int4" | "GPTQ-Int8" => Some((7, 5)),
+        _ => None,
+    }
+}
+
 /// Fallback VRAM estimation from GPU model name.
 /// Used when nvidia-smi or other tools report 0 VRAM.
 fn estimate_vram_from_name(name: &str) -> f64 {
@@ -2644,5 +2746,83 @@ GPU id = 1 (NVIDIA GeForce RTX 4090)
             super::gpu_memory_bandwidth_gbps("AMD Radeon RX 9070"),
             Some(488.0)
         );
+    }
+
+    // ── compute capability tests ──────────────────────────────────────
+
+    #[test]
+    fn test_compute_capability_nvidia_generations() {
+        // Pascal
+        assert_eq!(super::gpu_compute_capability("Tesla P100"), Some((6, 1)));
+        // Volta
+        assert_eq!(
+            super::gpu_compute_capability("Tesla V100-PCIE-16GB"),
+            Some((7, 0))
+        );
+        // Turing
+        assert_eq!(super::gpu_compute_capability("Tesla T4"), Some((7, 5)));
+        assert_eq!(
+            super::gpu_compute_capability("NVIDIA GeForce RTX 2080 Ti"),
+            Some((7, 5))
+        );
+        assert_eq!(
+            super::gpu_compute_capability("NVIDIA GeForce GTX 1660 Ti"),
+            Some((7, 5))
+        );
+        // Ampere
+        assert_eq!(super::gpu_compute_capability("NVIDIA A100"), Some((8, 0)));
+        assert_eq!(
+            super::gpu_compute_capability("NVIDIA GeForce RTX 3090"),
+            Some((8, 6))
+        );
+        // Ada Lovelace
+        assert_eq!(
+            super::gpu_compute_capability("NVIDIA GeForce RTX 4090"),
+            Some((8, 9))
+        );
+        assert_eq!(super::gpu_compute_capability("NVIDIA L40S"), Some((8, 9)));
+        // Hopper
+        assert_eq!(
+            super::gpu_compute_capability("NVIDIA H100 SXM"),
+            Some((9, 0))
+        );
+        // Blackwell
+        assert_eq!(
+            super::gpu_compute_capability("NVIDIA GeForce RTX 5090"),
+            Some((10, 0))
+        );
+    }
+
+    #[test]
+    fn test_compute_capability_unknown_returns_none() {
+        assert_eq!(super::gpu_compute_capability("Some Random GPU"), None);
+        assert_eq!(super::gpu_compute_capability("Apple M4 Max"), None);
+        assert_eq!(
+            super::gpu_compute_capability("AMD Radeon RX 7900 XTX"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_quant_min_compute_capability() {
+        assert_eq!(
+            super::quant_min_compute_capability("AWQ-4bit"),
+            Some((7, 5))
+        );
+        assert_eq!(
+            super::quant_min_compute_capability("AWQ-8bit"),
+            Some((7, 5))
+        );
+        assert_eq!(
+            super::quant_min_compute_capability("GPTQ-Int4"),
+            Some((7, 5))
+        );
+        assert_eq!(
+            super::quant_min_compute_capability("GPTQ-Int8"),
+            Some((7, 5))
+        );
+        // GGUF quants have no CC restriction
+        assert_eq!(super::quant_min_compute_capability("Q4_K_M"), None);
+        assert_eq!(super::quant_min_compute_capability("Q8_0"), None);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `gpu_compute_capability()` in `hardware.rs` to map NVIDIA GPU names to their compute capability (Pascal 6.1 through Blackwell 10.0)
- Adds `quant_min_compute_capability()` to define the minimum CC needed per quantization format (AWQ/GPTQ both need >= 7.5)
- Updates `backend_compatible()` to reject pre-quantized models when the GPU doesn't meet the requirement
- Conservative approach: unrecognized GPUs and ROCm are assumed compatible (no false rejections)

## Test plan
- [x] All 238 existing tests pass
- [x] 7 new tests covering: V100 rejection, Pascal rejection, Turing/Ampere/Ada/Hopper acceptance, ROCm passthrough, GGUF unaffected
- [ ] Manual verification on a Volta system if available

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)