### PR TITLE
Fix confusing runtime/provider error messages

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1391,8 +1391,7 @@ impl App {
             self.pull_status = Some(if any_runtime {
                 Self::format_no_download_message(model_format, is_mlx_model)
             } else {
-                "No runtime available — install Ollama, llama.cpp, Docker, or LM Studio"
-                    .to_string()
+                "No runtime available — install Ollama, llama.cpp, Docker, or LM Studio".to_string()
             });
         }
     }


### PR DESCRIPTION
## Summary
- Replaced "No provider available" with "No runtime available" to fix the terminology confusion raised in #198
- When a runtime IS installed but the model format isn't compatible (e.g. AWQ/GPTQ model with only llama.cpp), now shows a specific message explaining why instead of the generic "No downloadable format found"
  - AWQ/GPTQ: tells you it needs vLLM or CUDA/ROCm
  - MLX: tells you it needs Apple Silicon with MLX
- Fixes the case from #123 where users had llama.cpp installed but got unhelpful errors on models that need a different format

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` passes all 238 tests
- [ ] Manual: select an AWQ model with llama.cpp installed, verify new message shows
- [ ] Manual: with no runtimes installed, verify "No runtime available" message

Closes #123
Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)