### PR TITLE
dockerhub-search for Docker Hub ai/ namespace

### DIFF
--- a/llmfit-core/src/lib.rs
+++ b/llmfit-core/src/lib.rs
@@ -12,5 +12,6 @@ pub use plan::{
     UpgradeDelta, estimate_model_plan, normalize_quant, resolve_model_selector,
 };
 pub use providers::{
-    LlamaCppProvider, LmStudioProvider, MlxProvider, ModelProvider, OllamaProvider,
+    DockerHubModel, LlamaCppProvider, LmStudioProvider, MlxProvider, ModelProvider,
+    OllamaProvider, search_dockerhub,
 };

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -2308,6 +2308,167 @@ pub fn ollama_pull_tag(hf_name: &str) -> Option<String> {
     lookup_ollama_tag(hf_name).map(|s| s.to_string())
 }
 
+// ---------------------------------------------------------------------------
+// Docker Hub model search
+// ---------------------------------------------------------------------------
+
+/// A model found on Docker Hub in the `ai/` namespace.
+#[derive(Debug, Clone)]
+pub struct DockerHubModel {
+    /// Full name, e.g. `ai/llama3.2`.
+    pub name: String,
+    /// Short description from the Hub listing.
+    pub description: String,
+    /// Total pull count.
+    pub pulls: u64,
+    /// Star count.
+    pub stars: u64,
+    /// Inferred backend: `"llama.cpp"`, `"vllm"`, or `"llama.cpp, vllm"`.
+    pub backend: String,
+    /// ISO-8601 last-updated timestamp.
+    pub updated_at: String,
+}
+
+/// Search Docker Hub's `ai/` namespace for models matching `query`.
+///
+/// Pass an empty string to list all models.  Results are sorted by
+/// pull count (descending) and capped at `limit`.
+pub fn search_dockerhub(query: &str, limit: usize) -> Vec<DockerHubModel> {
+    let limit = if limit == 0 { 32 } else { limit };
+    let query_lower = query.to_lowercase();
+    let mut results: Vec<DockerHubModel> = Vec::new();
+    let mut next_url: Option<String> = None;
+
+    eprintln!("Searching Docker Hub...");
+
+    loop {
+        let url = match &next_url {
+            Some(u) => u.clone(),
+            None => format!(
+                "https://hub.docker.com/v2/repositories/ai/?page_size=100&ordering=pull_count"
+            ),
+        };
+
+        let Ok(resp) = ureq::get(&url)
+            .config()
+            .timeout_global(Some(std::time::Duration::from_secs(15)))
+            .build()
+            .call()
+        else {
+            break;
+        };
+
+        let Ok(body) = resp.into_body().read_json::<serde_json::Value>() else {
+            break;
+        };
+
+        let repos = match body.get("results").and_then(|v| v.as_array()) {
+            Some(r) => r,
+            None => break,
+        };
+
+        for repo in repos {
+            let is_private = repo
+                .get("is_private")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if is_private {
+                continue;
+            }
+
+            let name = repo
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let description = repo
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            if !query_lower.is_empty() {
+                let name_match = name.to_lowercase().contains(&query_lower);
+                let desc_match = description.to_lowercase().contains(&query_lower);
+                if !name_match && !desc_match {
+                    continue;
+                }
+            }
+
+            let pulls = repo
+                .get("pull_count")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let stars = repo
+                .get("star_count")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let updated_at = repo
+                .get("last_updated")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let backend = dockerhub_backend(&name, &description);
+            let namespace = repo
+                .get("namespace")
+                .and_then(|v| v.as_str())
+                .unwrap_or("ai");
+
+            results.push(DockerHubModel {
+                name: format!("{}/{}", namespace, name),
+                description: truncate_str(&description, 60),
+                pulls,
+                stars,
+                backend,
+                updated_at,
+            });
+
+            if results.len() >= limit {
+                break;
+            }
+        }
+
+        if results.len() >= limit {
+            break;
+        }
+
+        next_url = body
+            .get("next")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        if next_url.is_none() {
+            break;
+        }
+    }
+
+    results
+}
+
+fn dockerhub_backend(name: &str, description: &str) -> String {
+    let combined = format!("{} {}", name.to_lowercase(), description.to_lowercase());
+    let has_vllm = combined.contains("vllm") || combined.contains("safetensors");
+    let has_llama = combined.contains("llama.cpp")
+        || combined.contains("llamacpp")
+        || combined.contains("gguf")
+        || combined.contains("llama-cpp");
+    match (has_vllm, has_llama) {
+        (true, true) => "llama.cpp, vllm".to_string(),
+        (true, false) => "vllm".to_string(),
+        (false, _) => "llama.cpp".to_string(),
+    }
+}
+
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max.saturating_sub(3)).collect();
+        format!("{}...", truncated)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -3,6 +3,7 @@ use llmfit_core::fit::{FitLevel, ModelFit};
 use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::LlmModel;
 use llmfit_core::plan::PlanEstimate;
+use llmfit_core::DockerHubModel;
 use tabled::{Table, Tabled, settings::Style};
 
 #[derive(Tabled)]
@@ -29,6 +30,22 @@ struct ModelRow {
     mem_use: String,
     #[tabled(rename = "Context")]
     context: String,
+}
+
+#[derive(Tabled)]
+struct DockerHubRow {
+    #[tabled(rename = "Model")]
+    name: String,
+    #[tabled(rename = "Description")]
+    description: String,
+    #[tabled(rename = "Pulls")]
+    pulls: String,
+    #[tabled(rename = "Stars")]
+    stars: String,
+    #[tabled(rename = "Backend")]
+    backend: String,
+    #[tabled(rename = "Updated")]
+    updated_at: String,
 }
 
 pub fn display_all_models(models: &[LlmModel]) {
@@ -392,6 +409,41 @@ pub fn display_search_results(models: &[&LlmModel], query: &str) {
             mode: "-".to_string(),
             mem_use: "-".to_string(),
             context: format!("{}k", m.context_length / 1000),
+        })
+        .collect();
+
+    let table = Table::new(rows).with(Style::rounded()).to_string();
+    println!("{}", table);
+}
+
+pub fn display_hub_search_results(models: &[DockerHubModel], query: &str) {
+    if models.is_empty() {
+        let msg = if query.is_empty() {
+            "No models found on Docker Hub".to_string()
+        } else {
+            format!("No Docker Hub models found matching '{}'", query)
+        };
+        println!("\n{}", msg.yellow());
+        return;
+    }
+
+    let header = if query.is_empty() {
+        "=== Docker Hub Models (ai/) ===".to_string()
+    } else {
+        format!("=== Docker Hub Models matching '{}' ===", query)
+    };
+    println!("\n{}", header.bold().cyan());
+    println!("Found {} model(s)\n", models.len());
+
+    let rows: Vec<DockerHubRow> = models
+        .iter()
+        .map(|m| DockerHubRow {
+            name: m.name.clone(),
+            description: m.description.clone(),
+            pulls: m.pulls.to_string(),
+            stars: m.stars.to_string(),
+            backend: m.backend.clone(),
+            updated_at: m.updated_at.clone(),
         })
         .collect();
 

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -15,6 +15,7 @@ use llmfit_core::fit::{ModelFit, SortColumn, backend_compatible};
 use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::ModelDatabase;
 use llmfit_core::plan::{PlanRequest, estimate_model_plan, resolve_model_selector};
+use llmfit_core::search_dockerhub;
 
 const DEFAULT_DASHBOARD_HOST: &str = "0.0.0.0";
 const DEFAULT_DASHBOARD_PORT: u16 = 8787;
@@ -244,6 +245,31 @@ AGENT USAGE:
     Search {
         /// Search query (model name, provider, or size)
         query: String,
+    },
+
+    /// Search Docker Hub ai/ namespace for models
+    #[command(long_about = "\
+Search Docker Hub's ai/ namespace for models.
+
+Queries hub.docker.com/v2/repositories/ai/ and filters results by the
+optional search term (matched against name and description). Results are
+sorted by pull count.
+
+PRECONDITIONS:
+  Network access to hub.docker.com.
+
+SIDE EFFECTS:
+  None — read-only.
+
+EXIT CODES:
+  0  Success (even if no matches found)")]
+    DockerhubSearch {
+        /// Optional search query (leave empty to list all)
+        query: Option<String>,
+
+        /// Maximum number of results to show
+        #[arg(short = 'n', long, default_value_t = 32)]
+        limit: usize,
     },
 
     /// Show detailed information about a specific model
@@ -1523,6 +1549,12 @@ fn main() {
                 let db = ModelDatabase::new();
                 let results = db.find_model(&query);
                 display::display_search_results(&results, &query);
+            }
+
+            Commands::DockerhubSearch { query, limit } => {
+                let q = query.as_deref().unwrap_or("");
+                let results = search_dockerhub(q, limit);
+                display::display_hub_search_results(&results, q);
             }
 
             Commands::Info { model } => {


### PR DESCRIPTION
Adds `llmfit dockerhub-search [QUERY]` command that queries
hub.docker.com/v2/repositories/ai/, filters by name/description,
and displays results sorted by pull count. Mirrors the behavior of
`model-cli search --source dockerhub` in model-runner.

This is a clean re-cut of #263 against the latest main.

Signed-off-by: Eric Curtin <eric.curtin@docker.com>