### PR TITLE
Add copy model name to clipboard feature

### DIFF
--- a/llmfit-tui/Cargo.toml
+++ b/llmfit-tui/Cargo.toml
@@ -25,6 +25,7 @@ tabled = "0.20"
 colored = "3.1"
 ratatui = "0.30"
 crossterm = "0.29"
+arboard = "3.4"
 axum = "0.8"
 tokio = { version = "1.47", features = ["rt-multi-thread", "signal", "net"] }
 

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -778,6 +778,21 @@ impl App {
         self.pull_status = Some("Cleared compare mark".to_string());
     }
 
+    pub fn copy_selected_model_name(&mut self) {
+        let Some(fit) = self.selected_fit() else {
+            self.pull_status = Some("No model selected".to_string());
+            return;
+        };
+        let name = fit.model.name.clone();
+        match arboard::Clipboard::new() {
+            Ok(mut clipboard) => match clipboard.set_text(&name) {
+                Ok(()) => self.pull_status = Some(format!("Copied '{}' to clipboard", name)),
+                Err(e) => self.pull_status = Some(format!("Clipboard error: {}", e)),
+            },
+            Err(e) => self.pull_status = Some(format!("Clipboard error: {}", e)),
+        }
+    }
+
     pub fn selected_compare_pair(&self) -> Option<(&ModelFit, &ModelFit)> {
         let selected = self.selected_fit()?;
         let mark_name = self.compare_mark_model.as_deref()?;

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -132,6 +132,7 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char('m') => app.mark_selected_for_compare(),
         KeyCode::Char('c') => app.toggle_compare_view(),
         KeyCode::Char('x') => app.clear_compare_mark(),
+        KeyCode::Char('y') => app.copy_selected_model_name(),
 
         _ => {}
     }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2361,7 +2361,7 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             };
             (
                 format!(
-                    " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  v:visual  V:select  t:theme  p:plan  m:mark  c:compare  x:clear mark{}  P:providers  U:use cases  C:caps  q:quit  tok/s*:est",
+                    " ↑↓/jk:nav  {}  /:search  f:fit  s:sort  v:visual  V:select  t:theme  p:plan  m:mark  c:compare  x:clear mark  y:copy{}  P:providers  U:use cases  C:caps  q:quit  tok/s*:est",
                     detail_key, ollama_keys,
                 ),
                 "NORMAL".to_string(),


### PR DESCRIPTION
Follow-up to #169 with clean commit history as requested.

Adds a `y` keybinding in normal mode to copy the selected model's full name to the system clipboard.