### PR TITLE
feat: show approximate disk space usage

### DIFF
--- a/llmfit-core/src/models.rs
+++ b/llmfit-core/src/models.rs
@@ -338,6 +338,12 @@ impl LlmModel {
         }
     }
 
+    /// Approximate on-disk size (GB) for a given quantization level.
+    /// This is just the model weights: params_b * bytes_per_param.
+    pub fn estimate_disk_gb(&self, quant: &str) -> f64 {
+        self.params_b() * quant_bpp(quant)
+    }
+
     /// Estimate memory required (GB) at a given quantization and context length.
     /// Formula: model_weights + KV_cache + runtime_overhead
     pub fn estimate_memory_gb(&self, quant: &str, ctx: u32) -> f64 {

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -190,6 +190,21 @@ pub fn display_model_detail(fit: &ModelFit) {
     }
     println!("  Min RAM: {:.1} GB (CPU inference)", fit.model.min_ram_gb);
     println!("  Recommended RAM: {:.1} GB", fit.model.recommended_ram_gb);
+    println!(
+        "  Disk (est): {:.1} GB (at {})",
+        fit.model.estimate_disk_gb(&fit.best_quant),
+        fit.best_quant
+    );
+    let quants: &[&str] = if fit.best_quant.starts_with("mlx") {
+        &["mlx-8bit", "mlx-4bit"]
+    } else {
+        &["Q8_0", "Q6_K", "Q5_K_M", "Q4_K_M", "Q3_K_M", "Q2_K"]
+    };
+    let breakdown: Vec<String> = quants
+        .iter()
+        .map(|q| format!("{}: {:.1}G", q, fit.model.estimate_disk_gb(q)))
+        .collect();
+    println!("  Disk/quant: {}", breakdown.join("  "));
 
     // MoE Architecture info
     if fit.model.is_moe {
@@ -554,6 +569,7 @@ fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "runtime": fit.runtime_text(),
         "runtime_label": fit.runtime.label(),
         "best_quant": fit.best_quant,
+        "disk_size_gb": round2(fit.model.estimate_disk_gb(&fit.best_quant)),
         "memory_required_gb": round2(fit.memory_required_gb),
         "memory_available_gb": round2(fit.memory_available_gb),
         "moe_offloaded_gb": fit.moe_offloaded_gb.map(round2),

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -210,8 +210,9 @@ AGENT USAGE:
 
   JSON output fields: { system: {...}, models: [{ name, provider,
   parameter_count, fit_level, run_mode, score, score_components,
-  estimated_tps, memory_required_gb, memory_available_gb,
-  utilization_pct, best_quant, use_case, runtime }] }")]
+  estimated_tps, disk_size_gb, memory_required_gb,
+  memory_available_gb, utilization_pct, best_quant, use_case,
+  runtime }] }")]
     Fit {
         /// Show only models that perfectly match recommended specs
         #[arg(short, long)]
@@ -394,9 +395,9 @@ AGENT USAGE:
 
   JSON output is the default. Fields: { system: {...}, models: [{ name,
   provider, parameter_count, fit_level, run_mode, score, score_components
-  { quality, speed, fit, context }, estimated_tps, memory_required_gb,
-  memory_available_gb, utilization_pct, best_quant, use_case, license,
-  runtime, capabilities }] }")]
+  { quality, speed, fit, context }, estimated_tps, disk_size_gb,
+  memory_required_gb, memory_available_gb, utilization_pct, best_quant,
+  use_case, license, runtime, capabilities }] }")]
     Recommend {
         /// Limit number of recommendations
         #[arg(short = 'n', long, default_value = "5")]

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1294,7 +1294,7 @@ impl App {
     }
 
     pub fn select_column_right(&mut self) {
-        if self.select_column < 13 {
+        if self.select_column < 14 {
             self.select_column += 1;
         }
     }
@@ -1317,14 +1317,15 @@ impl App {
             7 => {
                 self.input_mode = InputMode::QuantPopup;
             } // Quant
-            8 => {
+            8 => {}                                // Disk (no filter/sort)
+            9 => {
                 self.input_mode = InputMode::RunModePopup;
             } // Mode
-            9 => self.set_or_toggle_sort(SortColumn::MemPct), // Mem%
-            10 => self.set_or_toggle_sort(SortColumn::Ctx), // Ctx
-            11 => self.set_or_toggle_sort(SortColumn::ReleaseDate), // Date
-            12 => self.cycle_fit_filter(),         // Fit
-            13 => {
+            10 => self.set_or_toggle_sort(SortColumn::MemPct), // Mem%
+            11 => self.set_or_toggle_sort(SortColumn::Ctx), // Ctx
+            12 => self.set_or_toggle_sort(SortColumn::ReleaseDate), // Date
+            13 => self.cycle_fit_filter(),         // Fit
+            14 => {
                 self.input_mode = InputMode::UseCasePopup;
             } // Use Case
             _ => {}

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -518,17 +518,17 @@ fn pull_indicator(percent: Option<f64>, tick: u64) -> String {
 fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     let sort_col = app.sort_column;
     let header_names = [
-        "", "Inst", "Model", "Provider", "Params", "Score", "tok/s*", "Quant", "Mode", "Mem %",
-        "Ctx", "Date", "Fit", "Use Case",
+        "", "Inst", "Model", "Provider", "Params", "Score", "tok/s*", "Quant", "Disk", "Mode",
+        "Mem %", "Ctx", "Date", "Fit", "Use Case",
     ];
     let sort_col_idx: Option<usize> = match sort_col {
         SortColumn::Score => Some(5),
         SortColumn::Tps => Some(6),
         SortColumn::Params => Some(4),
-        SortColumn::MemPct => Some(9),
-        SortColumn::Ctx => Some(10),
-        SortColumn::ReleaseDate => Some(11),
-        SortColumn::UseCase => Some(13),
+        SortColumn::MemPct => Some(10),
+        SortColumn::Ctx => Some(11),
+        SortColumn::ReleaseDate => Some(12),
+        SortColumn::UseCase => Some(14),
     };
     let in_select_mode = app.input_mode == InputMode::Select;
     let header_cells = header_names.iter().enumerate().map(|(i, h)| {
@@ -669,6 +669,11 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
                 Cell::from(format!("{:.0}", fit.score)).style(Style::default().fg(score_color)),
                 Cell::from(tps_text).style(Style::default().fg(tc.fg)),
                 Cell::from(fit.best_quant.clone()).style(Style::default().fg(tc.muted)),
+                Cell::from(format!(
+                    "{:.1}G",
+                    fit.model.estimate_disk_gb(&fit.best_quant)
+                ))
+                .style(Style::default().fg(tc.muted)),
                 Cell::from(fit.run_mode_text().to_string()).style(Style::default().fg(mode_color)),
                 Cell::from(format!("{:.0}%", fit.utilization_pct))
                     .style(Style::default().fg(color)),
@@ -699,6 +704,7 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
         Constraint::Length(6),  // score
         Constraint::Length(6),  // tok/s
         Constraint::Length(10), // quant (AWQ-4bit, GPTQ-Int4, GPTQ-Int8)
+        Constraint::Length(6),  // disk
         Constraint::Length(7),  // mode
         Constraint::Length(6),  // mem %
         Constraint::Length(5),  // ctx
@@ -1024,6 +1030,13 @@ fn render_compare_panel(
             Span::styled(metrics.mem.clone(), metrics.mem_style),
         ]),
         Line::from(vec![
+            Span::styled("  Disk:  ", Style::default().fg(tc.muted)),
+            Span::styled(
+                format!(" {:.1} GB", fit.model.estimate_disk_gb(&fit.best_quant)),
+                Style::default().fg(tc.fg),
+            ),
+        ]),
+        Line::from(vec![
             Span::styled("  Runtime:", Style::default().fg(tc.muted)),
             Span::styled(
                 format!(" {}", fit.runtime_text()),
@@ -1229,6 +1242,16 @@ fn draw_multi_compare(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors
                 }
             })
             .collect(),
+    });
+
+    // Disk
+    rows.push(AttrRow {
+        label: "Disk",
+        values: visible_models
+            .iter()
+            .map(|m| format!("{:.1} GB", m.model.estimate_disk_gb(&m.best_quant)))
+            .collect(),
+        styles: vec![Style::default().fg(tc.muted); n],
     });
 
     // Params
@@ -1746,7 +1769,43 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
                 Style::default().fg(tc.muted),
             ),
         ]),
+        Line::from(vec![
+            Span::styled("  Disk (est):  ", Style::default().fg(tc.muted)),
+            Span::styled(
+                format!("{:.1} GB", fit.model.estimate_disk_gb(&fit.best_quant)),
+                Style::default().fg(tc.fg),
+            ),
+            Span::styled(
+                format!("  (at {})", fit.best_quant),
+                Style::default().fg(tc.muted),
+            ),
+        ]),
     ]);
+
+    // Disk size breakdown per quant level
+    let quants: &[&str] = if fit.best_quant.starts_with("mlx") {
+        &["mlx-8bit", "mlx-4bit"]
+    } else {
+        &["Q8_0", "Q6_K", "Q5_K_M", "Q4_K_M", "Q3_K_M", "Q2_K"]
+    };
+    let mut disk_spans: Vec<Span> = vec![Span::styled(
+        "  Disk/quant:  ",
+        Style::default().fg(tc.muted),
+    )];
+    for (i, &q) in quants.iter().enumerate() {
+        if i > 0 {
+            disk_spans.push(Span::styled("  ", Style::default()));
+        }
+        let size = fit.model.estimate_disk_gb(q);
+        let text = format!("{}: {:.1}G", q, size);
+        let style = if q == fit.best_quant {
+            Style::default().fg(tc.good).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(tc.muted)
+        };
+        disk_spans.push(Span::styled(text, style));
+    }
+    lines.push(Line::from(disk_spans));
 
     // Build right-pane content (GGUF sources + notes)
     let has_right_pane = !fit.model.gguf_sources.is_empty() || !fit.notes.is_empty();


### PR DESCRIPTION
closes #134

adds an estimated disk size for models based on parameter count and quantization level (params * bytes_per_param). shows up in:

- TUI table as a "Disk" column (at the selected best_quant)
- detail view with a per-quant breakdown so you can see sizes across Q8_0, Q6_K, Q5_K_M, etc.
- both compare views (two-model and multi-compare)
- CLI `info` output under resource requirements
- JSON output as `disk_size_gb`

the math uses the existing `quant_bpp()` function so the estimates stay consistent with how memory is already calculated.