### PR TITLE
feat: add 13 new models and expand provider mappings (Apr 2026)

### DIFF
--- a/data/hf_models.json
+++ b/data/hf_models.json
@@ -1,5 +1,4362 @@
 [
   {
+    "name": "nomic-ai/nomic-embed-text-v1.5",
+    "provider": "Nomic",
+    "parameter_count": "137M",
+    "parameters_raw": 136731648,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Text embeddings for RAG",
+    "capabilities": [],
+    "pipeline_tag": "sentence-similarity",
+    "architecture": "nomic_bert",
+    "hf_downloads": 10548767,
+    "hf_likes": 791,
+    "release_date": "2024-02-10",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/nomic-embed-text-v1.5-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "BAAI/bge-large-en-v1.5",
+    "provider": "BAAI",
+    "parameter_count": "335M",
+    "parameters_raw": 335142400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 512,
+    "use_case": "Text embeddings for RAG",
+    "capabilities": [],
+    "pipeline_tag": "feature-extraction",
+    "architecture": "bert",
+    "hf_downloads": 6782849,
+    "hf_likes": 641,
+    "release_date": "2023-09-12",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/bge-large-en-v1.5-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-ColBERT-350M",
+    "provider": "Liquid AI",
+    "parameter_count": "353M",
+    "parameters_raw": 353322752,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "sentence-similarity",
+    "architecture": "lfm2",
+    "hf_downloads": 27092,
+    "hf_likes": 127,
+    "release_date": "2025-10-28"
+  },
+  {
+    "name": "LiquidAI/LFM2-350M",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 35470,
+    "hf_likes": 246,
+    "release_date": "2025-07-10",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-350M-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/LFM2-350M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-350M-Extract",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 1199,
+    "hf_likes": 77,
+    "release_date": "2025-09-03",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-350M-Extract-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-350M-Math",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 666,
+    "hf_likes": 57,
+    "release_date": "2025-08-25",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-350M-Math-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-350M-ENJP-MT",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "translation",
+    "architecture": "lfm2",
+    "hf_downloads": 799,
+    "hf_likes": 87,
+    "release_date": "2025-09-03",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-350M-ENJP-MT-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-350M-PII-Extract-JP",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 927,
+    "hf_likes": 54,
+    "release_date": "2025-09-30",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-350M-PII-Extract-JP-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-VL-450M",
+    "provider": "Liquid AI",
+    "parameter_count": "451M",
+    "parameters_raw": 450822656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "lfm2_vl",
+    "hf_downloads": 15337,
+    "hf_likes": 146,
+    "release_date": "2025-08-12",
+    "gguf_sources": [
+      {
+        "repo": "ggml-org/LFM2-VL-450M-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/LFM2-VL-450M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-0.5B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "494M",
+    "parameters_raw": 494032768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 6231939,
+    "hf_likes": 493,
+    "release_date": "2024-09-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-700M",
+    "provider": "Liquid AI",
+    "parameter_count": "742M",
+    "parameters_raw": 742489344,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 11599,
+    "hf_likes": 110,
+    "release_date": "2025-07-10",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-700M-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-0.6B",
+    "provider": "Alibaba",
+    "parameter_count": "752M",
+    "parameters_raw": 751632384,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3",
+    "hf_downloads": 14235258,
+    "hf_likes": 1172,
+    "release_date": "2025-04-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-0.6B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-0.6B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3-0.6B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-0.8B",
+    "provider": "Alibaba",
+    "parameter_count": "873M",
+    "parameters_raw": 873438784,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 2077133,
+    "hf_likes": 472,
+    "release_date": "2026-02-28",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-0.8B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-0.8B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-0.8B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "873M",
+    "parameters_raw": 873438784,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 147054,
+    "hf_likes": 63,
+    "release_date": "2026-02-28"
+  },
+  {
+    "name": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "provider": "Community",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100048384,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 2917542,
+    "hf_likes": 1560,
+    "release_date": "2023-12-30",
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/TinyLlama-1.1B-Chat-v1.0-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-1.2B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 39580,
+    "hf_likes": 352,
+    "release_date": "2025-07-10",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-1.2B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-1.2B-Base",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 28345,
+    "hf_likes": 121,
+    "release_date": "2026-01-05",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2.5-1.2B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-1.2B-Instruct",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 298234,
+    "hf_likes": 551,
+    "release_date": "2026-01-06",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2.5-1.2B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/LFM2.5-1.2B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-1.2B-Thinking",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 27721,
+    "hf_likes": 327,
+    "release_date": "2026-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2.5-1.2B-Thinking-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/LFM2.5-1.2B-Thinking-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-1.2B-JP",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 2481,
+    "hf_likes": 142,
+    "release_date": "2026-01-04",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2.5-1.2B-JP-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-1.2B-Tool",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 428,
+    "hf_likes": 97,
+    "release_date": "2025-09-03",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-1.2B-Tool-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-1.2B-RAG",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 694,
+    "hf_likes": 115,
+    "release_date": "2025-09-03",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-1.2B-RAG-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-1.2B-Extract",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 1390,
+    "hf_likes": 106,
+    "release_date": "2025-08-22",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-1.2B-Extract-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/Llama-3.2-1B",
+    "provider": "Meta",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1672905,
+    "hf_likes": 2352,
+    "release_date": "2024-09-18",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-1B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-4.0-1.2B",
+    "provider": "lgai-exaone",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1279391488,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone4",
+    "hf_downloads": 32631,
+    "hf_likes": 177,
+    "release_date": "2025-07-11",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/EXAONE-4.0-1.2B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-Audio-1.5B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1470308496,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "audio-to-audio",
+    "architecture": "unknown",
+    "hf_downloads": 268,
+    "hf_likes": 346,
+    "release_date": "2025-08-28",
+    "gguf_sources": [
+      {
+        "repo": "ggml-org/LFM2-Audio-1.5B-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-Audio-1.5B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1470308496,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "audio-to-audio",
+    "architecture": "unknown",
+    "hf_downloads": 1038,
+    "hf_likes": 374,
+    "release_date": "2025-12-18"
+  },
+  {
+    "name": "Qwen/Qwen2.5-1.5B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 9788462,
+    "hf_likes": 654,
+    "release_date": "2024-09-17",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-1.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-1.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 707325,
+    "hf_likes": 110,
+    "release_date": "2024-09-18",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-Coder-1.5B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Qwen2.5-Coder-1.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-1.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-VL-1.6B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1584804000,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "lfm2_vl",
+    "hf_downloads": 5012,
+    "hf_likes": 226,
+    "release_date": "2025-08-12",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-VL-1.6B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-VL-1.6B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1596625904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "lfm2_vl",
+    "hf_downloads": 138277,
+    "hf_likes": 264,
+    "release_date": "2026-01-05",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2.5-VL-1.6B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "stabilityai/stablelm-2-1_6b-chat",
+    "provider": "Stability AI",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1644515328,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "stablelm",
+    "hf_downloads": 1796,
+    "hf_likes": 34,
+    "release_date": "2024-04-08",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/stablelm-2-1_6b-chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "tiiuae/Falcon3-1B-Instruct",
+    "provider": "TII",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1669408768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 10980,
+    "hf_likes": 46,
+    "release_date": "2024-12-14",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Falcon3-1B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Falcon3-1B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+    "provider": "DeepSeek",
+    "parameter_count": "1.8B",
+    "parameters_raw": 1777088000,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 789335,
+    "hf_likes": 1468,
+    "release_date": "2025-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-1.7B",
+    "provider": "Alibaba",
+    "parameter_count": "2.0B",
+    "parameters_raw": 2031739904,
+    "min_ram_gb": 1.1,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3",
+    "hf_downloads": 7527100,
+    "hf_likes": 439,
+    "release_date": "2025-04-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-1.7B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-1.7B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3-1.7B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-2B",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2274069824,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.1,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 1428994,
+    "hf_likes": 236,
+    "release_date": "2026-02-28",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-2B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-2B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-2B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2274069824,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.1,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 79145,
+    "hf_likes": 64,
+    "release_date": "2026-02-28"
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-Deep-2.4B",
+    "provider": "lgai-exaone",
+    "parameter_count": "2.4B",
+    "parameters_raw": 2405327360,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone",
+    "hf_downloads": 1277,
+    "hf_likes": 98,
+    "release_date": "2025-03-12"
+  },
+  {
+    "name": "LiquidAI/LFM2-2.6B",
+    "provider": "Liquid AI",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2569272320,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 7357,
+    "hf_likes": 184,
+    "release_date": "2025-09-22",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-2.6B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-2.6B-Exp",
+    "provider": "Liquid AI",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2569272320,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 25155,
+    "hf_likes": 337,
+    "release_date": "2025-12-25",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-2.6B-Exp-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/LFM2-2.6B-Exp-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-2.6B-Transcript",
+    "provider": "Liquid AI",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2569272320,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 404,
+    "hf_likes": 162,
+    "release_date": "2026-01-05",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-2.6B-Transcript-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-2-2b-it",
+    "provider": "Google",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2614341888,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "gemma2",
+    "hf_downloads": 377375,
+    "hf_likes": 1320,
+    "release_date": "2024-07-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/gemma-2-2b-it-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/gemma-2-2b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-VL-3B",
+    "provider": "Liquid AI",
+    "parameter_count": "3.0B",
+    "parameters_raw": 2998975216,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.8,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "lfm2_vl",
+    "hf_downloads": 12094,
+    "hf_likes": 132,
+    "release_date": "2025-10-22"
+  },
+  {
+    "name": "HuggingFaceTB/SmolLM3-3B",
+    "provider": "huggingfacetb",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3075098624,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "smollm3",
+    "hf_downloads": 1092647,
+    "hf_likes": 927,
+    "release_date": "2025-07-08",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/SmolLM3-3B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/SmolLM3-3B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/SmolLM3-3B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-3B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3085938688,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 8032389,
+    "hf_likes": 431,
+    "release_date": "2024-09-17",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-3B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-3B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "ibm-granite/granite-4.0-h-micro",
+    "provider": "ibm-granite",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3191396096,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 47860,
+    "hf_likes": 142,
+    "release_date": "2025-09-16",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/granite-4.0-h-micro-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/granite-4.0-h-micro-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/Llama-3.2-3B",
+    "provider": "Meta",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3212749824,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1266035,
+    "hf_likes": 730,
+    "release_date": "2024-09-18",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-3B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "tiiuae/Falcon3-3B-Instruct",
+    "provider": "TII",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3227655168,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 8872,
+    "hf_likes": 28,
+    "release_date": "2024-12-14",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Falcon3-3B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Falcon3-3B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-VL-3B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3754622976,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 6326695,
+    "hf_likes": 635,
+    "release_date": "2025-01-26",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-VL-3B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen2.5-VL-3B-Instruct-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-VL-3B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-4-mini-reasoning",
+    "provider": "Microsoft",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3800000000,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "Q4_K_M",
+    "context_length": 16384,
+    "use_case": "Lightweight reasoning",
+    "pipeline_tag": "text-generation",
+    "architecture": "phi4",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-04-01",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Phi-4-mini-reasoning-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Phi-4-mini-reasoning-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/phi-3-mini-4k-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3821079552,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.6,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "phi3",
+    "hf_downloads": 678067,
+    "hf_likes": 1406,
+    "release_date": "2024-04-22",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/phi-3-mini-4k-instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/phi-3-mini-4k-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-3.5-mini-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3821079552,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.6,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "phi3",
+    "hf_downloads": 738734,
+    "hf_likes": 969,
+    "release_date": "2024-08-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Phi-3.5-mini-instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Phi-3.5-mini-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3n-E2B-it",
+    "provider": "Google",
+    "parameter_count": "4B",
+    "parameters_raw": 4000000000,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.1,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Multimodal, on-device (effective 2B)",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma3n",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-06-25",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3n-E2B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3n-E2B-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-4B",
+    "provider": "Alibaba",
+    "parameter_count": "4.7B",
+    "parameters_raw": 4659865088,
+    "min_ram_gb": 2.6,
+    "recommended_ram_gb": 4.3,
+    "min_vram_gb": 2.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 2755159,
+    "hf_likes": 436,
+    "release_date": "2026-02-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-4B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-4B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-4B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "4.7B",
+    "parameters_raw": 4659865088,
+    "min_ram_gb": 2.6,
+    "recommended_ram_gb": 4.3,
+    "min_vram_gb": 2.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 95699,
+    "hf_likes": 55,
+    "release_date": "2026-02-27"
+  },
+  {
+    "name": "google/gemma-4-E2B-it",
+    "provider": "Google",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5123178051,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "any-to-any",
+    "architecture": "gemma4",
+    "hf_downloads": 167166,
+    "hf_likes": 248,
+    "release_date": "2026-03-02",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-4-E2B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-4-E2B-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-4-multimodal-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "5.6B",
+    "parameters_raw": 5574460384,
+    "min_ram_gb": 3.1,
+    "recommended_ram_gb": 5.2,
+    "min_vram_gb": 2.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "automatic-speech-recognition",
+    "architecture": "phi4mm",
+    "hf_downloads": 282837,
+    "hf_likes": 1577,
+    "release_date": "2025-02-24"
+  },
+  {
+    "name": "01-ai/Yi-6B-Chat",
+    "provider": "01.ai",
+    "parameter_count": "6.1B",
+    "parameters_raw": 6061035520,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 26597,
+    "hf_likes": 70,
+    "release_date": "2023-11-22",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Yi-6B-Chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lmsys/vicuna-7b-v1.5",
+    "provider": "LMSYS",
+    "parameter_count": "7.0B",
+    "parameters_raw": 6738415616,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.3,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/vicuna-7b-v1.5-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/vicuna-7b-v1.5-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/CodeLlama-7b-Instruct-hf",
+    "provider": "Meta",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6738546688,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.3,
+    "min_vram_gb": 3.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1526,
+    "hf_likes": 59,
+    "release_date": "2024-03-13",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/CodeLlama-7b-Instruct-hf-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "ibm-granite/granite-4.0-h-tiny",
+    "provider": "ibm-granite",
+    "parameter_count": "6.9B",
+    "parameters_raw": 6939037248,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 74389,
+    "hf_likes": 198,
+    "release_date": "2025-09-16",
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 964959866,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/granite-4.0-h-tiny-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/granite-4.0-h-tiny-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "openchat/openchat-3.5-0106",
+    "provider": "OpenChat",
+    "parameter_count": "7.0B",
+    "parameters_raw": 7000000000,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/openchat-3.5-0106-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/openchat-3.5-0106-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "XiaomiMiMo/MiMo-7B-RL",
+    "provider": "Xiaomi",
+    "parameter_count": "7.0B",
+    "parameters_raw": 7000000000,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "context_length": 32768,
+    "use_case": "Advanced reasoning, math and code",
+    "pipeline_tag": "text-generation",
+    "architecture": "mimo",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-05-01"
+  },
+  {
+    "name": "microsoft/Orca-2-7b",
+    "provider": "Microsoft",
+    "parameter_count": "7.0B",
+    "parameters_raw": 7016400896,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Reasoning, step-by-step solutions",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Orca-2-7b-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Orca-2-7b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "bigcode/starcoder2-7b",
+    "provider": "BigCode",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7173923840,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "starcoder2",
+    "hf_downloads": 18604,
+    "hf_likes": 210,
+    "release_date": "2024-02-20"
+  },
+  {
+    "name": "tiiuae/falcon-7b-instruct",
+    "provider": "TII",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7217189760,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "falcon",
+    "hf_downloads": 58735,
+    "hf_likes": 1031,
+    "release_date": "2023-04-25",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/falcon-7b-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "HuggingFaceH4/zephyr-7b-beta",
+    "provider": "HuggingFace",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 129252,
+    "hf_likes": 1836,
+    "release_date": "2023-10-26",
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/zephyr-7b-beta-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/zephyr-7b-beta-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Mistral-7B-Instruct-v0.3",
+    "provider": "Mistral AI",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7248023552,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 2189625,
+    "hf_likes": 2496,
+    "release_date": "2024-05-22",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Mistral-7B-Instruct-v0.3-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Mistral-7B-Instruct-v0.3-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "allenai/OLMo-2-1124-7B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "7.3B",
+    "parameters_raw": 7298617344,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "olmo2",
+    "hf_downloads": 17570,
+    "hf_likes": 48,
+    "release_date": "2024-12-18",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/OLMo-2-1124-7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/OLMo-2-1124-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "tiiuae/Falcon3-7B-Instruct",
+    "provider": "TII",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7455550464,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 23516,
+    "hf_likes": 77,
+    "release_date": "2024-11-29",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Falcon3-7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Falcon3-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-7B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 13544700,
+    "hf_likes": 1184,
+    "release_date": "2024-09-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-7B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 2499046,
+    "hf_likes": 678,
+    "release_date": "2024-09-17",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-Coder-7B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Qwen2.5-Coder-7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+    "provider": "DeepSeek",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 613455,
+    "hf_likes": 802,
+    "release_date": "2025-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-7B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-Deep-7.8B",
+    "provider": "lgai-exaone",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7818448896,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone",
+    "hf_downloads": 270744,
+    "hf_likes": 100,
+    "release_date": "2025-03-12",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/EXAONE-Deep-7.8B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-4-E4B-it",
+    "provider": "Google",
+    "parameter_count": "8.0B",
+    "parameters_raw": 7996156490,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.4,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "any-to-any",
+    "architecture": "gemma4",
+    "hf_downloads": 197704,
+    "hf_likes": 345,
+    "release_date": "2026-03-02",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-4-E4B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-4-E4B-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3n-E4B-it",
+    "provider": "Google",
+    "parameter_count": "8B",
+    "parameters_raw": 8000000000,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Multimodal, on-device (effective 4B)",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma3n",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-06-25",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3n-E4B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3n-E4B-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-3n-E4B-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/Llama-3.1-8B",
+    "provider": "Meta",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1360242,
+    "hf_likes": 2137,
+    "release_date": "2024-07-14"
+  },
+  {
+    "name": "meta-llama/Llama-3.1-8B-Instruct",
+    "provider": "Meta",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 8507661,
+    "hf_likes": 5661,
+    "release_date": "2024-07-18",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Llama-3.1-8B-Instruct-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Ministral-8B-Instruct-2410",
+    "provider": "Mistral AI",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Ministral-8B-Instruct-2410-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Ministral-8B-Instruct-2410-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-8B",
+    "provider": "Alibaba",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8190735360,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3",
+    "hf_downloads": 9315480,
+    "hf_likes": 1025,
+    "release_date": "2025-04-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-8B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-8B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3-8B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-VL-7B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8292166656,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 4399050,
+    "hf_likes": 1484,
+    "release_date": "2025-01-26",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen2.5-VL-7B-Instruct-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-VL-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-8B-A1B",
+    "provider": "Liquid AI",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8339929856,
+    "min_ram_gb": 4.7,
+    "recommended_ram_gb": 7.8,
+    "min_vram_gb": 4.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2_moe",
+    "hf_downloads": 49084,
+    "hf_likes": 344,
+    "release_date": "2025-10-07",
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 1500000000,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-8B-A1B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+    "provider": "nvidia",
+    "parameter_count": "8.9B",
+    "parameters_raw": 8888227328,
+    "min_ram_gb": 5.0,
+    "recommended_ram_gb": 8.3,
+    "min_vram_gb": 4.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "nemotron_h",
+    "hf_downloads": 461012,
+    "hf_likes": 487,
+    "release_date": "2025-08-12"
+  },
+  {
+    "name": "google/gemma-2-9b-it",
+    "provider": "Google",
+    "parameter_count": "9.2B",
+    "parameters_raw": 9241705984,
+    "min_ram_gb": 5.2,
+    "recommended_ram_gb": 8.6,
+    "min_vram_gb": 4.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "gemma2",
+    "hf_downloads": 219508,
+    "hf_likes": 784,
+    "release_date": "2024-06-24",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/gemma-2-9b-it-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/gemma-2-9b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "THUDM/glm-4-9b-chat",
+    "provider": "thudm",
+    "parameter_count": "9.4B",
+    "parameters_raw": 9399951392,
+    "min_ram_gb": 5.3,
+    "recommended_ram_gb": 8.8,
+    "min_vram_gb": 4.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "chatglm",
+    "hf_downloads": 170011,
+    "hf_likes": 704,
+    "release_date": "2024-06-04",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/glm-4-9b-chat-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/glm-4-9b-chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-9B",
+    "provider": "Alibaba",
+    "parameter_count": "9.7B",
+    "parameters_raw": 9653104368,
+    "min_ram_gb": 5.4,
+    "recommended_ram_gb": 9.0,
+    "min_vram_gb": 4.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 4869308,
+    "hf_likes": 1185,
+    "release_date": "2026-02-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-9B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-9B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-9B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "9.7B",
+    "parameters_raw": 9653104368,
+    "min_ram_gb": 5.4,
+    "recommended_ram_gb": 9.0,
+    "min_vram_gb": 4.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 104575,
+    "hf_likes": 62,
+    "release_date": "2026-02-26"
+  },
+  {
+    "name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    "provider": "Meta",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10670220835,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 9.9,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "mllama",
+    "hf_downloads": 231775,
+    "hf_likes": 1583,
+    "release_date": "2024-09-18"
+  },
+  {
+    "name": "upstage/SOLAR-10.7B-Instruct-v1.0",
+    "provider": "Upstage",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 38534,
+    "hf_likes": 649,
+    "release_date": "2023-12-12",
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/SOLAR-10.7B-Instruct-v1.0-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3-12b-it",
+    "provider": "Google",
+    "parameter_count": "12B",
+    "parameters_raw": 12000000000,
+    "min_ram_gb": 6.7,
+    "recommended_ram_gb": 11.2,
+    "min_vram_gb": 6.1,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Multimodal, vision and text",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma3",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3-12b-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3-12b-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-3-12b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Mistral-Nemo-Instruct-2407",
+    "provider": "Mistral AI",
+    "parameter_count": "12.2B",
+    "parameters_raw": 12247076864,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.4,
+    "min_vram_gb": 6.3,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Mistral-Nemo-Instruct-2407-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Mistral-Nemo-Instruct-2407-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Mistral-Nemo-Instruct-2407-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Orca-2-13b",
+    "provider": "Microsoft",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13015864320,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Reasoning, step-by-step solutions",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Orca-2-13b-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Orca-2-13b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lmsys/vicuna-13b-v1.5",
+    "provider": "LMSYS",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13015864320,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/vicuna-13b-v1.5-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/vicuna-13b-v1.5-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "WizardLMTeam/WizardLM-13B-V1.2",
+    "provider": "WizardLM",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13015864320,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/WizardLM-13B-V1.2-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/WizardLM-13B-V1.2-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/CodeLlama-13b-Instruct-hf",
+    "provider": "Meta",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13016028160,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 258,
+    "hf_likes": 27,
+    "release_date": "2024-03-13",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/CodeLlama-13b-Instruct-hf-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "allenai/OLMo-2-1124-13B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "13.7B",
+    "parameters_raw": 13716198400,
+    "min_ram_gb": 7.7,
+    "recommended_ram_gb": 12.8,
+    "min_vram_gb": 7.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "olmo2",
+    "hf_downloads": 8608,
+    "hf_likes": 47,
+    "release_date": "2024-12-18",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/OLMo-2-1124-13B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/OLMo-2-1124-13B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/phi-4",
+    "provider": "Microsoft",
+    "parameter_count": "14B",
+    "parameters_raw": 14000000000,
+    "min_ram_gb": 7.8,
+    "recommended_ram_gb": 13.0,
+    "min_vram_gb": 7.2,
+    "quantization": "Q4_K_M",
+    "context_length": 16384,
+    "use_case": "Reasoning, STEM, code generation",
+    "pipeline_tag": "text-generation",
+    "architecture": "phi",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/phi-4-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/phi-4-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/phi-4-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-3-medium-14b-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "14B",
+    "parameters_raw": 14000000000,
+    "min_ram_gb": 7.8,
+    "recommended_ram_gb": 13.0,
+    "min_vram_gb": 7.2,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Balanced performance and size",
+    "pipeline_tag": "text-generation",
+    "architecture": "phi3",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
+  },
+  {
+    "name": "microsoft/Phi-4-reasoning",
+    "provider": "Microsoft",
+    "parameter_count": "14B",
+    "parameters_raw": 14000000000,
+    "min_ram_gb": 7.8,
+    "recommended_ram_gb": 13.0,
+    "min_vram_gb": 7.2,
+    "quantization": "Q4_K_M",
+    "context_length": 32768,
+    "use_case": "Advanced reasoning, math and code",
+    "pipeline_tag": "text-generation",
+    "architecture": "phi4",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-04-01",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Phi-4-reasoning-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Phi-4-reasoning-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-14B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770000000,
+    "min_ram_gb": 8.2,
+    "recommended_ram_gb": 13.7,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-14B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-14B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-14B",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770000000,
+    "min_ram_gb": 8.2,
+    "recommended_ram_gb": 13.7,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-14B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-14B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3-14B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-14B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770033664,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 888451,
+    "hf_likes": 145,
+    "release_date": "2024-11-06",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-Coder-14B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Qwen2.5-Coder-14B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-14B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+    "provider": "DeepSeek",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770033664,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 576201,
+    "hf_likes": 621,
+    "release_date": "2025-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-14B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "WizardLMTeam/WizardCoder-15B-V1.0",
+    "provider": "WizardLM",
+    "parameter_count": "15.5B",
+    "parameters_raw": 15515334656,
+    "min_ram_gb": 8.7,
+    "recommended_ram_gb": 14.5,
+    "min_vram_gb": 7.9,
+    "quantization": "Q4_K_M",
+    "context_length": 8192,
+    "use_case": "Code generation and completion",
+    "pipeline_tag": "text-generation",
+    "architecture": "starcoder",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/WizardCoder-15B-V1.0-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "bigcode/starcoder2-15b",
+    "provider": "BigCode",
+    "parameter_count": "15.7B",
+    "parameters_raw": 15700000000,
+    "min_ram_gb": 8.8,
+    "recommended_ram_gb": 14.6,
+    "min_vram_gb": 8.0,
+    "quantization": "Q4_K_M",
+    "context_length": 16384,
+    "use_case": "Code generation and completion",
+    "pipeline_tag": "text-generation",
+    "architecture": "starcoder2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/starcoder2-15b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
+    "provider": "DeepSeek",
+    "parameter_count": "15.7B",
+    "parameters_raw": 15706484224,
+    "min_ram_gb": 8.8,
+    "recommended_ram_gb": 14.6,
+    "min_vram_gb": 8.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 163840,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v2",
+    "hf_downloads": 400985,
+    "hf_likes": 575,
+    "release_date": "2024-06-14",
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2400000000,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "inclusionAI/Ling-lite",
+    "provider": "inclusionai",
+    "parameter_count": "16.8B",
+    "parameters_raw": 16801974272,
+    "min_ram_gb": 9.4,
+    "recommended_ram_gb": 15.6,
+    "min_vram_gb": 8.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "bailing_moe",
+    "hf_downloads": 436,
+    "hf_likes": 78,
+    "release_date": "2025-02-28",
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2336524543,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Ling-lite-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Devstral-Small-2505",
+    "provider": "Mistral AI",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23572403200,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 97867,
+    "hf_likes": 866,
+    "release_date": "2025-05-12",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Devstral-Small-2505-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-24B-A2B",
+    "provider": "Liquid AI",
+    "parameter_count": "23.8B",
+    "parameters_raw": 23843661440,
+    "min_ram_gb": 13.3,
+    "recommended_ram_gb": 22.2,
+    "min_vram_gb": 12.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2_moe",
+    "hf_downloads": 40933,
+    "hf_likes": 304,
+    "release_date": "2026-02-24",
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 4,
+    "active_parameters": 2300000000,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-24B-A2B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Mistral-Small-24B-Instruct-2501",
+    "provider": "Mistral AI",
+    "parameter_count": "24B",
+    "parameters_raw": 24000000000,
+    "min_ram_gb": 13.4,
+    "recommended_ram_gb": 22.4,
+    "min_vram_gb": 12.3,
+    "quantization": "Q4_K_M",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Mistral-Small-24B-Instruct-2501-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Mistral-Small-24B-Instruct-2501-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Mistral-Small-24B-Instruct-2501-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-4-26B-A4B-it",
+    "provider": "Google",
+    "parameter_count": "26.5B",
+    "parameters_raw": 26544131376,
+    "min_ram_gb": 14.8,
+    "recommended_ram_gb": 24.7,
+    "min_vram_gb": 13.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma4",
+    "hf_downloads": 271222,
+    "hf_likes": 388,
+    "release_date": "2026-03-11",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-4-26B-A4B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-4-26B-A4B-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-4-26B-A4B-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-2-27b-it",
+    "provider": "Google",
+    "parameter_count": "27.2B",
+    "parameters_raw": 27227128320,
+    "min_ram_gb": 15.2,
+    "recommended_ram_gb": 25.4,
+    "min_vram_gb": 13.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "gemma2",
+    "hf_downloads": 258287,
+    "hf_likes": 563,
+    "release_date": "2024-06-24",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/gemma-2-27b-it-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/gemma-2-27b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3-27b-it",
+    "provider": "Google",
+    "parameter_count": "27.4B",
+    "parameters_raw": 27432406640,
+    "min_ram_gb": 15.3,
+    "recommended_ram_gb": 25.5,
+    "min_vram_gb": 14.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma3",
+    "hf_downloads": 899424,
+    "hf_likes": 1946,
+    "release_date": "2025-03-01",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3-27b-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3-27b-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-3-27b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-27B",
+    "provider": "Alibaba",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 3004081,
+    "hf_likes": 862,
+    "release_date": "2026-02-24",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-27B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-27B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    "provider": "nvidia",
+    "parameter_count": "31.6B",
+    "parameters_raw": 31577937344,
+    "min_ram_gb": 17.6,
+    "recommended_ram_gb": 29.4,
+    "min_vram_gb": 16.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "nemotron_h",
+    "hf_downloads": 1116073,
+    "hf_likes": 703,
+    "release_date": "2025-12-04",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-Deep-32B",
+    "provider": "lgai-exaone",
+    "parameter_count": "32.0B",
+    "parameters_raw": 32003200000,
+    "min_ram_gb": 17.9,
+    "recommended_ram_gb": 29.8,
+    "min_vram_gb": 16.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone",
+    "hf_downloads": 4682,
+    "hf_likes": 299,
+    "release_date": "2025-03-12",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/EXAONE-Deep-32B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-4.0-32B",
+    "provider": "lgai-exaone",
+    "parameter_count": "32.0B",
+    "parameters_raw": 32003216384,
+    "min_ram_gb": 17.9,
+    "recommended_ram_gb": 29.8,
+    "min_vram_gb": 16.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone4",
+    "hf_downloads": 23440,
+    "hf_likes": 281,
+    "release_date": "2025-07-11",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/EXAONE-4.0-32B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "allenai/OLMo-2-0325-32B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "32.2B",
+    "parameters_raw": 32234279936,
+    "min_ram_gb": 18.0,
+    "recommended_ram_gb": 30.0,
+    "min_vram_gb": 16.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "olmo2",
+    "hf_downloads": 16393,
+    "hf_likes": 148,
+    "release_date": "2025-03-12",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/OLMo-2-0325-32B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/OLMo-2-0325-32B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-32B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "32.5B",
+    "parameters_raw": 32510000000,
+    "min_ram_gb": 18.2,
+    "recommended_ram_gb": 30.3,
+    "min_vram_gb": 16.7,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-32B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-32B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-4-31B-it",
+    "provider": "Google",
+    "parameter_count": "32.7B",
+    "parameters_raw": 32682372656,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.4,
+    "min_vram_gb": 16.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma4",
+    "hf_downloads": 490192,
+    "hf_likes": 964,
+    "release_date": "2026-03-11",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-4-31B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-4-31B-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-32B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.5,
+    "min_vram_gb": 16.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 957436,
+    "hf_likes": 2000,
+    "release_date": "2024-11-06",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-Coder-32B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-32B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/QwQ-32B",
+    "provider": "Alibaba",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.5,
+    "min_vram_gb": 16.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 69719,
+    "hf_likes": 2886,
+    "release_date": "2025-03-05",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/QwQ-32B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/QwQ-32B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    "provider": "DeepSeek",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.5,
+    "min_vram_gb": 16.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 929875,
+    "hf_likes": 1528,
+    "release_date": "2025-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/CodeLlama-34b-Instruct-hf",
+    "provider": "Meta",
+    "parameter_count": "33.7B",
+    "parameters_raw": 33743970304,
+    "min_ram_gb": 18.9,
+    "recommended_ram_gb": 31.4,
+    "min_vram_gb": 17.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 595,
+    "hf_likes": 19,
+    "release_date": "2024-03-14",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/CodeLlama-34b-Instruct-hf-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "01-ai/Yi-34B-Chat",
+    "provider": "01.ai",
+    "parameter_count": "34.4B",
+    "parameters_raw": 34386780160,
+    "min_ram_gb": 19.2,
+    "recommended_ram_gb": 32.0,
+    "min_vram_gb": 17.6,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Multilingual, Chinese/English chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "yi",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Yi-34B-Chat-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Yi-34B-Chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "CohereForAI/c4ai-command-r-v01",
+    "provider": "Cohere",
+    "parameter_count": "35B",
+    "parameters_raw": 35000000000,
+    "min_ram_gb": 19.5,
+    "recommended_ram_gb": 32.6,
+    "min_vram_gb": 17.9,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "RAG, tool use, agents",
+    "pipeline_tag": "text-generation",
+    "architecture": "cohere",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/c4ai-command-r-v01-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/c4ai-command-r-v01-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-35B-A3B",
+    "provider": "Alibaba",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 3181547,
+    "hf_likes": 1328,
+    "release_date": "2026-02-24",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 3000000000,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-35B-A3B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3.5-35B-A3B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-35B-A3B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "tiiuae/falcon-40b-instruct",
+    "provider": "TII",
+    "parameter_count": "40.0B",
+    "parameters_raw": 40000000000,
+    "min_ram_gb": 22.4,
+    "recommended_ram_gb": 37.3,
+    "min_vram_gb": 20.5,
+    "quantization": "Q4_K_M",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "falcon",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/falcon-40b-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "provider": "Mistral AI",
+    "parameter_count": "46.7B",
+    "parameters_raw": 46702792704,
+    "min_ram_gb": 26.1,
+    "recommended_ram_gb": 43.5,
+    "min_vram_gb": 23.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 433678,
+    "hf_likes": 4654,
+    "release_date": "2023-12-10",
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 12900000000,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Mixtral-8x7B-Instruct-v0.1-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
+    "provider": "NousResearch",
+    "parameter_count": "46.7B",
+    "parameters_raw": 46702809088,
+    "min_ram_gb": 26.1,
+    "recommended_ram_gb": 43.5,
+    "min_vram_gb": 23.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "mixtral",
+    "hf_downloads": 8992,
+    "hf_likes": 452,
+    "release_date": "2024-01-11",
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 12900000000,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Nous-Hermes-2-Mixtral-8x7B-DPO-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Nous-Hermes-2-Mixtral-8x7B-DPO-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/Llama-3.3-Nemotron-Super-49B-v1",
+    "provider": "nvidia",
+    "parameter_count": "49.9B",
+    "parameters_raw": 49867145216,
+    "min_ram_gb": 27.9,
+    "recommended_ram_gb": 46.4,
+    "min_vram_gb": 25.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "nemotron-nas",
+    "hf_downloads": 31937,
+    "hf_likes": 321,
+    "release_date": "2025-03-16"
+  },
+  {
+    "name": "meta-llama/Llama-3.1-70B-Instruct",
+    "provider": "Meta",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1005297,
+    "hf_likes": 905,
+    "release_date": "2024-07-16"
+  },
+  {
+    "name": "meta-llama/Llama-3.3-70B-Instruct",
+    "provider": "Meta",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 401076,
+    "hf_likes": 2688,
+    "release_date": "2024-11-26",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Llama-3.3-70B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Llama-3.3-70B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Llama-3.3-70B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF",
+    "provider": "nvidia",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 10915,
+    "hf_likes": 2063,
+    "release_date": "2024-10-12",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Llama-3.1-Nemotron-70B-Instruct-HF-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Llama-3.1-Nemotron-70B-Instruct-HF-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-72B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "72.7B",
+    "parameters_raw": 72706203648,
+    "min_ram_gb": 40.6,
+    "recommended_ram_gb": 67.7,
+    "min_vram_gb": 37.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 672969,
+    "hf_likes": 924,
+    "release_date": "2024-09-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-72B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-72B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-VL-72B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "73.4B",
+    "parameters_raw": 73410777344,
+    "min_ram_gb": 41.0,
+    "recommended_ram_gb": 68.4,
+    "min_vram_gb": 37.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 88913,
+    "hf_likes": 605,
+    "release_date": "2025-01-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-VL-72B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen2.5-VL-72B-Instruct-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-VL-72B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-Coder-Next",
+    "provider": "Alibaba",
+    "parameter_count": "79.7B",
+    "parameters_raw": 79674391296,
+    "min_ram_gb": 44.5,
+    "recommended_ram_gb": 74.2,
+    "min_vram_gb": 40.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3_next",
+    "hf_downloads": 779315,
+    "hf_likes": 1226,
+    "release_date": "2026-01-30",
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 3000000000,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-Coder-Next-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-Coder-Next-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "CohereForAI/c4ai-command-r-plus-08-2024",
+    "provider": "Cohere",
+    "parameter_count": "103.8B",
+    "parameters_raw": 103810674688,
+    "min_ram_gb": 58.0,
+    "recommended_ram_gb": 96.7,
+    "min_vram_gb": 53.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "cohere",
+    "hf_downloads": 3399,
+    "hf_likes": 282,
+    "release_date": "2024-08-21",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/c4ai-command-r-plus-08-2024-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/c4ai-command-r-plus-08-2024-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "CohereForAI/c4ai-command-a-03-2025",
+    "provider": "Cohere",
+    "parameter_count": "111.1B",
+    "parameters_raw": 111057580032,
+    "min_ram_gb": 62.1,
+    "recommended_ram_gb": 103.4,
+    "min_vram_gb": 56.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "cohere2",
+    "hf_downloads": 4144,
+    "hf_likes": 383,
+    "release_date": "2025-03-11",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/c4ai-command-a-03-2025-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-122B-A10B",
+    "provider": "Alibaba",
+    "parameter_count": "125.1B",
+    "parameters_raw": 125086497008,
+    "min_ram_gb": 69.9,
+    "recommended_ram_gb": 116.5,
+    "min_vram_gb": 64.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 890710,
+    "hf_likes": 471,
+    "release_date": "2026-02-24",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 10000000000
+  },
+  {
+    "name": "mistralai/Mixtral-8x22B-Instruct-v0.1",
+    "provider": "Mistral AI",
+    "parameter_count": "140.6B",
+    "parameters_raw": 140630071296,
+    "min_ram_gb": 78.6,
+    "recommended_ram_gb": 131.0,
+    "min_vram_gb": 72.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 34434,
+    "hf_likes": 748,
+    "release_date": "2024-04-16",
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 39100000000
+  },
+  {
+    "name": "rednote-hilab/dots.llm1.inst",
+    "provider": "rednote-hilab",
+    "parameter_count": "142.8B",
+    "parameters_raw": 142774381696,
+    "min_ram_gb": 79.8,
+    "recommended_ram_gb": 133.0,
+    "min_vram_gb": 73.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "dots1",
+    "hf_downloads": 9356,
+    "hf_likes": 176,
+    "release_date": "2025-05-14"
+  },
+  {
+    "name": "bigscience/bloom",
+    "provider": "bigscience",
+    "parameter_count": "176.2B",
+    "parameters_raw": 176247271424,
+    "min_ram_gb": 98.5,
+    "recommended_ram_gb": 164.1,
+    "min_vram_gb": 90.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "bloom",
+    "hf_downloads": 6538,
+    "hf_likes": 4991,
+    "release_date": "2022-05-19"
+  },
+  {
+    "name": "tiiuae/falcon-180B-chat",
+    "provider": "TII",
+    "parameter_count": "179.5B",
+    "parameters_raw": 179522565120,
+    "min_ram_gb": 100.3,
+    "recommended_ram_gb": 167.2,
+    "min_vram_gb": 92.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "falcon",
+    "hf_downloads": 729,
+    "hf_likes": 546,
+    "release_date": "2023-09-04"
+  },
+  {
+    "name": "MiniMaxAI/MiniMax-M2.5",
+    "provider": "minimaxai",
+    "parameter_count": "228.7B",
+    "parameters_raw": 228703644928,
+    "min_ram_gb": 127.8,
+    "recommended_ram_gb": 213.0,
+    "min_vram_gb": 117.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 196608,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "minimax_m2",
+    "hf_downloads": 642510,
+    "hf_likes": 1344,
+    "release_date": "2026-02-12",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 10000000000
+  },
+  {
+    "name": "MiniMaxAI/MiniMax-M2.7",
+    "provider": "MiniMax",
+    "parameter_count": "230B",
+    "parameters_raw": 230000000000,
+    "min_ram_gb": 128.6,
+    "recommended_ram_gb": 214.4,
+    "min_vram_gb": 117.9,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Latest flagship with enhanced reasoning and coding",
+    "pipeline_tag": "text-generation",
+    "architecture": "minimax",
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 2,
+    "active_parameters": 10000000000,
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2026-03-18"
+  },
+  {
+    "name": "Qwen/Qwen3-235B-A22B",
+    "provider": "Alibaba",
+    "parameter_count": "235.1B",
+    "parameters_raw": 235093634560,
+    "min_ram_gb": 131.4,
+    "recommended_ram_gb": 218.9,
+    "min_vram_gb": 120.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 619449,
+    "hf_likes": 1085,
+    "release_date": "2025-04-27",
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 22000000000
+  },
+  {
+    "name": "baidu/ERNIE-4.5-300B-A47B-Paddle",
+    "provider": "baidu",
+    "parameter_count": "300.5B",
+    "parameters_raw": 300474051776,
+    "min_ram_gb": 167.9,
+    "recommended_ram_gb": 279.8,
+    "min_vram_gb": 153.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "ernie4_5_moe",
+    "hf_downloads": 317,
+    "hf_likes": 13,
+    "release_date": "2025-06-28"
+  },
+  {
+    "name": "XiaomiMiMo/MiMo-V2-Flash",
+    "provider": "xiaomimimo",
+    "parameter_count": "309.8B",
+    "parameters_raw": 309785318400,
+    "min_ram_gb": 173.1,
+    "recommended_ram_gb": 288.5,
+    "min_vram_gb": 158.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "mimo_v2_flash",
+    "hf_downloads": 54392,
+    "hf_likes": 699,
+    "release_date": "2025-12-16"
+  },
+  {
+    "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+    "provider": "Meta",
+    "parameter_count": "401.6B",
+    "parameters_raw": 401583781376,
+    "min_ram_gb": 224.4,
+    "recommended_ram_gb": 374.0,
+    "min_vram_gb": 205.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "llama4",
+    "hf_downloads": 20419,
+    "hf_likes": 476,
+    "release_date": "2025-04-01",
+    "is_moe": true,
+    "num_experts": 16,
+    "active_experts": 1,
+    "active_parameters": 17000000000
+  },
+  {
+    "name": "Qwen/Qwen3.5-397B-A17B",
+    "provider": "Alibaba",
+    "parameter_count": "403.4B",
+    "parameters_raw": 403397928944,
+    "min_ram_gb": 225.4,
+    "recommended_ram_gb": 375.7,
+    "min_vram_gb": 206.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 1024813,
+    "hf_likes": 1413,
+    "release_date": "2026-02-16",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 17000000000
+  },
+  {
+    "name": "meta-llama/Llama-3.1-405B-Instruct",
+    "provider": "Meta",
+    "parameter_count": "405.9B",
+    "parameters_raw": 405853388800,
+    "min_ram_gb": 226.8,
+    "recommended_ram_gb": 378.0,
+    "min_vram_gb": 207.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 173579,
+    "hf_likes": 595,
+    "release_date": "2024-07-16"
+  },
+  {
+    "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "480.2B",
+    "parameters_raw": 480154875392,
+    "min_ram_gb": 268.3,
+    "recommended_ram_gb": 447.2,
+    "min_vram_gb": 245.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 92952,
+    "hf_likes": 1322,
+    "release_date": "2025-07-22",
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 35000000000
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3",
+    "provider": "DeepSeek",
+    "parameter_count": "684.5B",
+    "parameters_raw": 684531386000,
+    "min_ram_gb": 382.5,
+    "recommended_ram_gb": 637.5,
+    "min_vram_gb": 350.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 163840,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 580919,
+    "hf_likes": 4024,
+    "release_date": "2024-12-25",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 37000000000
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1",
+    "provider": "DeepSeek",
+    "parameter_count": "684.5B",
+    "parameters_raw": 684531386000,
+    "min_ram_gb": 382.5,
+    "recommended_ram_gb": 637.5,
+    "min_vram_gb": 350.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 163840,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 2759423,
+    "hf_likes": 13141,
+    "release_date": "2025-01-20",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 37000000000
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3.2-Speciale",
+    "provider": "DeepSeek",
+    "parameter_count": "685B",
+    "parameters_raw": 685000000000,
+    "min_ram_gb": 383.2,
+    "recommended_ram_gb": 638.7,
+    "min_vram_gb": 351.3,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v3",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 37000000000,
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-12-01"
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3.2",
+    "provider": "DeepSeek",
+    "parameter_count": "685.4B",
+    "parameters_raw": 685396921376,
+    "min_ram_gb": 383.0,
+    "recommended_ram_gb": 638.3,
+    "min_vram_gb": 351.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 163840,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v32",
+    "hf_downloads": 964384,
+    "hf_likes": 1370,
+    "release_date": "2025-12-01"
+  },
+  {
+    "name": "zai-org/GLM-5",
+    "provider": "zai-org",
+    "parameter_count": "753.9B",
+    "parameters_raw": 753864139008,
+    "min_ram_gb": 421.3,
+    "recommended_ram_gb": 702.1,
+    "min_vram_gb": 386.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "glm_moe_dsa",
+    "hf_downloads": 280654,
+    "hf_likes": 1951,
+    "release_date": "2026-02-11"
+  },
+  {
+    "name": "moonshotai/Kimi-K2-Instruct",
+    "provider": "moonshotai",
+    "parameter_count": "1026.5B",
+    "parameters_raw": 1026470731056,
+    "min_ram_gb": 573.6,
+    "recommended_ram_gb": 956.0,
+    "min_vram_gb": 525.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "kimi_k2",
+    "hf_downloads": 95190,
+    "hf_likes": 2331,
+    "release_date": "2025-07-11"
+  },
+  {
+    "name": "moonshotai/Kimi-K2.5",
+    "provider": "moonshotai",
+    "parameter_count": "1058.6B",
+    "parameters_raw": 1058589420528,
+    "min_ram_gb": 591.5,
+    "recommended_ram_gb": 985.9,
+    "min_vram_gb": 542.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "kimi_k25",
+    "hf_downloads": 6096616,
+    "hf_likes": 2421,
+    "release_date": "2026-01-01"
+  },
+  {
     "name": "peft-internal-testing/tiny-random-GPT2LMHeadModel",
     "provider": "peft-internal-testing",
     "parameter_count": "83K",
@@ -990,31 +5347,6 @@
     ]
   },
   {
-    "name": "nomic-ai/nomic-embed-text-v1.5",
-    "provider": "Nomic",
-    "parameter_count": "137M",
-    "parameters_raw": 136731648,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "Text embeddings for RAG",
-    "capabilities": [],
-    "pipeline_tag": "sentence-similarity",
-    "architecture": "nomic_bert",
-    "hf_downloads": 10472912,
-    "hf_likes": 788,
-    "release_date": "2024-02-10",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/nomic-embed-text-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "EleutherAI/gpt-neo-125m",
     "provider": "eleutherai",
     "parameter_count": "150M",
@@ -1625,31 +5957,6 @@
     "_discovered": true
   },
   {
-    "name": "BAAI/bge-large-en-v1.5",
-    "provider": "BAAI",
-    "parameter_count": "335M",
-    "parameters_raw": 335142400,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 512,
-    "use_case": "Text embeddings for RAG",
-    "capabilities": [],
-    "pipeline_tag": "feature-extraction",
-    "architecture": "bert",
-    "hf_downloads": 6786889,
-    "hf_likes": 638,
-    "release_date": "2023-09-12",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/bge-large-en-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "ibm-granite/granite-4.0-350m",
     "provider": "ibm-granite",
     "parameter_count": "352M",
@@ -1672,154 +5979,6 @@
       {
         "repo": "unsloth/granite-4.0-350m-GGUF",
         "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-ColBERT-350M",
-    "provider": "Liquid AI",
-    "parameter_count": "353M",
-    "parameters_raw": 353322752,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "sentence-similarity",
-    "architecture": "lfm2",
-    "hf_downloads": 22196,
-    "hf_likes": 125,
-    "release_date": "2025-10-28"
-  },
-  {
-    "name": "LiquidAI/LFM2-350M",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 36160,
-    "hf_likes": 245,
-    "release_date": "2025-07-10",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-350M-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/LFM2-350M-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-350M-Extract",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 1120,
-    "hf_likes": 77,
-    "release_date": "2025-09-03",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-350M-Extract-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-350M-Math",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 638,
-    "hf_likes": 56,
-    "release_date": "2025-08-25",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-350M-Math-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-350M-ENJP-MT",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "translation",
-    "architecture": "lfm2",
-    "hf_downloads": 756,
-    "hf_likes": 87,
-    "release_date": "2025-09-03",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-350M-ENJP-MT-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-350M-PII-Extract-JP",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 902,
-    "hf_likes": 53,
-    "release_date": "2025-09-30",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-350M-PII-Extract-JP-GGUF",
-        "provider": "mradermacher"
       }
     ]
   },
@@ -1896,37 +6055,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-VL-450M",
-    "provider": "Liquid AI",
-    "parameter_count": "451M",
-    "parameters_raw": 450822656,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "lfm2_vl",
-    "hf_downloads": 15610,
-    "hf_likes": 146,
-    "release_date": "2025-08-12",
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/LFM2-VL-450M-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/LFM2-VL-450M-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "lmstudio-community/Qwen3-1.7B-MLX-8bit",
     "provider": "lmstudio-community",
     "parameter_count": "484M",
@@ -1947,38 +6075,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2.5-0.5B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "494M",
-    "parameters_raw": 494032768,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 6221788,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-0.5B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-0.5B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-0.5B",
@@ -2597,66 +6693,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-700M",
-    "provider": "Liquid AI",
-    "parameter_count": "742M",
-    "parameters_raw": 742489344,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 11590,
-    "hf_likes": 109,
-    "release_date": "2025-07-10",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-700M-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3-0.6B",
-    "provider": "Alibaba",
-    "parameter_count": "752M",
-    "parameters_raw": 751632384,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3",
-    "hf_downloads": 13937340,
-    "hf_likes": 1165,
-    "release_date": "2025-04-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-0.6B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-0.6B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-0.6B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3Guard-Gen-0.6B",
     "provider": "Alibaba",
     "parameter_count": "752M",
@@ -2925,60 +6961,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen3.5-0.8B",
-    "provider": "Alibaba",
-    "parameter_count": "873M",
-    "parameters_raw": 873438784,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 2051106,
-    "hf_likes": 467,
-    "release_date": "2026-02-28",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-0.8B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-0.8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-0.8B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "873M",
-    "parameters_raw": 873438784,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 152502,
-    "hf_likes": 61,
-    "release_date": "2026-02-28"
   },
   {
     "name": "lmstudio-community/Qwen3-4B-Thinking-2507-MLX-6bit",
@@ -3414,35 +7396,6 @@
     ]
   },
   {
-    "name": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-    "provider": "Community",
-    "parameter_count": "1.1B",
-    "parameters_raw": 1100048384,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 2048,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 2881521,
-    "hf_likes": 1558,
-    "release_date": "2023-12-30",
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/TinyLlama-1.1B-Chat-v1.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "nm-testing/tinyllama-oneshot-w8w8-test-static-shape-change",
     "provider": "nm-testing",
     "parameter_count": "1.1B",
@@ -3596,214 +7549,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-1.2B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 40711,
-    "hf_likes": 351,
-    "release_date": "2025-07-10",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-1.2B-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-1.2B-Base",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 37002,
-    "hf_likes": 121,
-    "release_date": "2026-01-05",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2.5-1.2B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-1.2B-Instruct",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 289628,
-    "hf_likes": 549,
-    "release_date": "2026-01-06",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2.5-1.2B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/LFM2.5-1.2B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-1.2B-Thinking",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 27300,
-    "hf_likes": 326,
-    "release_date": "2026-01-20",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2.5-1.2B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/LFM2.5-1.2B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-1.2B-JP",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 2471,
-    "hf_likes": 142,
-    "release_date": "2026-01-04",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2.5-1.2B-JP-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-1.2B-Tool",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 363,
-    "hf_likes": 96,
-    "release_date": "2025-09-03",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-1.2B-Tool-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-1.2B-RAG",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 656,
-    "hf_likes": 115,
-    "release_date": "2025-09-03",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-1.2B-RAG-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-1.2B-Extract",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 1508,
-    "hf_likes": 106,
-    "release_date": "2025-08-22",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-1.2B-Extract-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "lmstudio-community/LFM2-1.2B-MLX-bf16",
     "provider": "lmstudio-community",
     "parameter_count": "1.2B",
@@ -3868,31 +7613,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "meta-llama/Llama-3.2-1B",
-    "provider": "Meta",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1235814400,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 1737741,
-    "hf_likes": 2349,
-    "release_date": "2024-09-18",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-3.2-1B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "meta-llama/Llama-3.2-1B-Instruct",
@@ -4141,31 +7861,6 @@
     "_discovered": true
   },
   {
-    "name": "LGAI-EXAONE/EXAONE-4.0-1.2B",
-    "provider": "lgai-exaone",
-    "parameter_count": "1.3B",
-    "parameters_raw": 1279391488,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 65536,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "exaone4",
-    "hf_downloads": 31444,
-    "hf_likes": 177,
-    "release_date": "2025-07-11",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/EXAONE-4.0-1.2B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "lmstudio-community/DeepSeek-R1-0528-Qwen3-8B-MLX-4bit",
     "provider": "lmstudio-community",
     "parameter_count": "1.3B",
@@ -4387,50 +8082,6 @@
     ]
   },
   {
-    "name": "LiquidAI/LFM2-Audio-1.5B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1470308496,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "audio-to-audio",
-    "architecture": "unknown",
-    "hf_downloads": 232,
-    "hf_likes": 346,
-    "release_date": "2025-08-28",
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/LFM2-Audio-1.5B-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-Audio-1.5B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1470308496,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "audio-to-audio",
-    "architecture": "unknown",
-    "hf_downloads": 1053,
-    "hf_likes": 374,
-    "release_date": "2025-12-18"
-  },
-  {
     "name": "allenai/OLMo-2-0425-1B",
     "provider": "allenai",
     "parameter_count": "1.5B",
@@ -4601,73 +8252,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1543714304,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 755964,
-    "hf_likes": 110,
-    "release_date": "2024-09-18",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-1.5B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-1.5B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-1.5B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-1.5B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1543714304,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 10034924,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-1.5B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-1.5B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2-1.5B-Instruct",
@@ -4873,60 +8457,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-VL-1.6B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.6B",
-    "parameters_raw": 1584804000,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "lfm2_vl",
-    "hf_downloads": 5155,
-    "hf_likes": 226,
-    "release_date": "2025-08-12",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-VL-1.6B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-VL-1.6B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.6B",
-    "parameters_raw": 1596625904,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "lfm2_vl",
-    "hf_downloads": 135633,
-    "hf_likes": 264,
-    "release_date": "2026-01-05",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2.5-VL-1.6B-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
     "name": "KiteFishAI/Minnow-Math-1.5B",
     "provider": "kitefishai",
     "parameter_count": "1.6B",
@@ -4945,31 +8475,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "stabilityai/stablelm-2-1_6b-chat",
-    "provider": "Stability AI",
-    "parameter_count": "1.6B",
-    "parameters_raw": 1644515328,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "stablelm",
-    "hf_downloads": 1818,
-    "hf_likes": 34,
-    "release_date": "2024-04-08",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/stablelm-2-1_6b-chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "nanonets/Nanonets-OCR2-1.5B-exp",
@@ -5220,40 +8725,6 @@
     "_discovered": true
   },
   {
-    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
-    "provider": "DeepSeek",
-    "parameter_count": "1.8B",
-    "parameters_raw": 1777088000,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 787869,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
     "provider": "Alibaba",
     "parameter_count": "1.8B",
@@ -5456,41 +8927,6 @@
     "num_experts": 64,
     "active_experts": 6,
     "active_parameters": 277721550
-  },
-  {
-    "name": "Qwen/Qwen3-1.7B",
-    "provider": "Alibaba",
-    "parameter_count": "2.0B",
-    "parameters_raw": 2031739904,
-    "min_ram_gb": 1.1,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 1.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3",
-    "hf_downloads": 7067897,
-    "hf_likes": 437,
-    "release_date": "2025-04-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-1.7B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-1.7B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-1.7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "JetLM/SDAR-1.7B-Chat",
@@ -5942,60 +9378,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen3.5-2B",
-    "provider": "Alibaba",
-    "parameter_count": "2.3B",
-    "parameters_raw": 2274069824,
-    "min_ram_gb": 1.3,
-    "recommended_ram_gb": 2.1,
-    "min_vram_gb": 1.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 1456178,
-    "hf_likes": 231,
-    "release_date": "2026-02-28",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-2B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-2B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-2B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "2.3B",
-    "parameters_raw": 2274069824,
-    "min_ram_gb": 1.3,
-    "recommended_ram_gb": 2.1,
-    "min_vram_gb": 1.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 81008,
-    "hf_likes": 62,
-    "release_date": "2026-02-28"
-  },
-  {
     "name": "huihui-ai/Huihui-Qwen3.5-2B-abliterated",
     "provider": "huihui-ai",
     "parameter_count": "2.3B",
@@ -6341,85 +9723,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-2.6B",
-    "provider": "Liquid AI",
-    "parameter_count": "2.6B",
-    "parameters_raw": 2569272320,
-    "min_ram_gb": 1.4,
-    "recommended_ram_gb": 2.4,
-    "min_vram_gb": 1.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 7291,
-    "hf_likes": 184,
-    "release_date": "2025-09-22",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-2.6B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-2.6B-Exp",
-    "provider": "Liquid AI",
-    "parameter_count": "2.6B",
-    "parameters_raw": 2569272320,
-    "min_ram_gb": 1.4,
-    "recommended_ram_gb": 2.4,
-    "min_vram_gb": 1.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 26317,
-    "hf_likes": 335,
-    "release_date": "2025-12-25",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-2.6B-Exp-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/LFM2-2.6B-Exp-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-2.6B-Transcript",
-    "provider": "Liquid AI",
-    "parameter_count": "2.6B",
-    "parameters_raw": 2569272320,
-    "min_ram_gb": 1.4,
-    "recommended_ram_gb": 2.4,
-    "min_vram_gb": 1.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 327,
-    "hf_likes": 161,
-    "release_date": "2026-01-05",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-2.6B-Transcript-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "AIDC-AI/Ovis2.5-2B",
     "provider": "aidc-ai",
     "parameter_count": "2.6B",
@@ -6438,35 +9741,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "google/gemma-2-2b-it",
-    "provider": "Google",
-    "parameter_count": "2.6B",
-    "parameters_raw": 2614341888,
-    "min_ram_gb": 1.5,
-    "recommended_ram_gb": 2.4,
-    "min_vram_gb": 1.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "gemma2",
-    "hf_downloads": 377256,
-    "hf_likes": 1315,
-    "release_date": "2024-07-16",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/gemma-2-2b-it-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/gemma-2-2b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Efficient-Large-Model/gemma-2-2b-it",
@@ -6772,27 +10046,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-VL-3B",
-    "provider": "Liquid AI",
-    "parameter_count": "3.0B",
-    "parameters_raw": 2998975216,
-    "min_ram_gb": 1.7,
-    "recommended_ram_gb": 2.8,
-    "min_vram_gb": 1.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "lfm2_vl",
-    "hf_downloads": 11922,
-    "hf_likes": 132,
-    "release_date": "2025-10-22"
-  },
-  {
     "name": "bigcode/starcoder2-3b",
     "provider": "BigCode",
     "parameter_count": "3.0B",
@@ -6939,39 +10192,6 @@
     "_discovered": true
   },
   {
-    "name": "HuggingFaceTB/SmolLM3-3B",
-    "provider": "huggingfacetb",
-    "parameter_count": "3.1B",
-    "parameters_raw": 3075098624,
-    "min_ram_gb": 1.7,
-    "recommended_ram_gb": 2.9,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 65536,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "smollm3",
-    "hf_downloads": 1091490,
-    "hf_likes": 924,
-    "release_date": "2025-07-08",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/SmolLM3-3B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/SmolLM3-3B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/SmolLM3-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "HuggingFaceTB/SmolLM3-3B-Base",
     "provider": "huggingfacetb",
     "parameter_count": "3.1B",
@@ -6993,38 +10213,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/SmolLM3-3B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-3B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "3.1B",
-    "parameters_raw": 3085938688,
-    "min_ram_gb": 1.7,
-    "recommended_ram_gb": 2.9,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 7876727,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-3B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-3B-Instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -7174,60 +10362,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "ibm-granite/granite-4.0-h-micro",
-    "provider": "ibm-granite",
-    "parameter_count": "3.2B",
-    "parameters_raw": 3191396096,
-    "min_ram_gb": 1.8,
-    "recommended_ram_gb": 3.0,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "granitemoehybrid",
-    "hf_downloads": 47085,
-    "hf_likes": 142,
-    "release_date": "2025-09-16",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/granite-4.0-h-micro-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/granite-4.0-h-micro-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "meta-llama/Llama-3.2-3B",
-    "provider": "Meta",
-    "parameter_count": "3.2B",
-    "parameters_raw": 3212749824,
-    "min_ram_gb": 1.8,
-    "recommended_ram_gb": 3.0,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 1266644,
-    "hf_likes": 725,
-    "release_date": "2024-09-18",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-3.2-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "meta-llama/Llama-3.2-3B-Instruct",
@@ -7664,42 +10798,6 @@
     "_discovered": true
   },
   {
-    "name": "Qwen/Qwen2.5-VL-3B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3754622976,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.5,
-    "min_vram_gb": 1.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 6467324,
-    "hf_likes": 633,
-    "release_date": "2025-01-26",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-VL-3B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen2.5-VL-3B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-VL-3B-Instruct-AWQ",
     "provider": "Alibaba",
     "parameter_count": "3.8B",
@@ -7850,91 +10948,6 @@
     "num_experts": 16,
     "active_experts": 2,
     "active_parameters": 633693422
-  },
-  {
-    "name": "microsoft/Phi-4-mini-reasoning",
-    "provider": "Microsoft",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3800000000,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.5,
-    "min_vram_gb": 1.9,
-    "quantization": "Q4_K_M",
-    "context_length": 16384,
-    "use_case": "Lightweight reasoning",
-    "pipeline_tag": "text-generation",
-    "architecture": "phi4",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-04-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Phi-4-mini-reasoning-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Phi-4-mini-reasoning-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "microsoft/phi-3-mini-4k-instruct",
-    "provider": "Microsoft",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3821079552,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.6,
-    "min_vram_gb": 2.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "phi3",
-    "hf_downloads": 704829,
-    "hf_likes": 1403,
-    "release_date": "2024-04-22",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/phi-3-mini-4k-instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/phi-3-mini-4k-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "microsoft/Phi-3.5-mini-instruct",
-    "provider": "Microsoft",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3821079552,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.6,
-    "min_vram_gb": 2.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "phi3",
-    "hf_downloads": 946484,
-    "hf_likes": 967,
-    "release_date": "2024-08-16",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Phi-3.5-mini-instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Phi-3.5-mini-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "microsoft/Phi-3-mini-4k-instruct",
@@ -8097,33 +11110,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "google/gemma-3n-E2B-it",
-    "provider": "Google",
-    "parameter_count": "4B",
-    "parameters_raw": 4000000000,
-    "min_ram_gb": 2.2,
-    "recommended_ram_gb": 3.7,
-    "min_vram_gb": 2.1,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Multimodal, on-device (effective 2B)",
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "gemma3n",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-06-25",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-3n-E2B-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-3n-E2B-it-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen3-4B-Instruct-2507",
@@ -8881,60 +11867,6 @@
     "_discovered": true
   },
   {
-    "name": "Qwen/Qwen3.5-4B",
-    "provider": "Alibaba",
-    "parameter_count": "4.7B",
-    "parameters_raw": 4659865088,
-    "min_ram_gb": 2.6,
-    "recommended_ram_gb": 4.3,
-    "min_vram_gb": 2.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 2702718,
-    "hf_likes": 429,
-    "release_date": "2026-02-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-4B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-4B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-4B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "4.7B",
-    "parameters_raw": 4659865088,
-    "min_ram_gb": 2.6,
-    "recommended_ram_gb": 4.3,
-    "min_vram_gb": 2.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 96875,
-    "hf_likes": 54,
-    "release_date": "2026-02-27"
-  },
-  {
     "name": "Tristepin/ue3-qw35-4b-v1",
     "provider": "tristepin",
     "parameter_count": "4.7B",
@@ -9481,25 +12413,6 @@
     "active_parameters": 580405768
   },
   {
-    "name": "microsoft/Phi-4-multimodal-instruct",
-    "provider": "Microsoft",
-    "parameter_count": "5.6B",
-    "parameters_raw": 5574460384,
-    "min_ram_gb": 3.1,
-    "recommended_ram_gb": 5.2,
-    "min_vram_gb": 2.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "automatic-speech-recognition",
-    "architecture": "phi4mm",
-    "hf_downloads": 295822,
-    "hf_likes": 1576,
-    "release_date": "2025-02-24"
-  },
-  {
     "name": "cyankiwi/Qwen3-VL-30B-A3B-Instruct-AWQ-4bit",
     "provider": "cyankiwi",
     "parameter_count": "5.8B",
@@ -9545,31 +12458,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "01-ai/Yi-6B-Chat",
-    "provider": "01.ai",
-    "parameter_count": "6.1B",
-    "parameters_raw": 6061035520,
-    "min_ram_gb": 3.4,
-    "recommended_ram_gb": 5.6,
-    "min_vram_gb": 3.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 27255,
-    "hf_likes": 70,
-    "release_date": "2023-11-22",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Yi-6B-Chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "apolo13x/Qwen3.5-35B-A3B-quantized.w4a16",
@@ -9658,33 +12546,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "lmsys/vicuna-7b-v1.5",
-    "provider": "LMSYS",
-    "parameter_count": "7.0B",
-    "parameters_raw": 6738415616,
-    "min_ram_gb": 3.8,
-    "recommended_ram_gb": 6.3,
-    "min_vram_gb": 3.4,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/vicuna-7b-v1.5-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/vicuna-7b-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "LLM360/Amber",
@@ -9864,31 +12725,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/Llama-2-7b-chat-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "meta-llama/CodeLlama-7b-Instruct-hf",
-    "provider": "Meta",
-    "parameter_count": "6.7B",
-    "parameters_raw": 6738546688,
-    "min_ram_gb": 3.8,
-    "recommended_ram_gb": 6.3,
-    "min_vram_gb": 3.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 1616,
-    "hf_likes": 59,
-    "release_date": "2024-03-13",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-7b-Instruct-hf-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -10092,39 +12928,6 @@
     ]
   },
   {
-    "name": "ibm-granite/granite-4.0-h-tiny",
-    "provider": "ibm-granite",
-    "parameter_count": "6.9B",
-    "parameters_raw": 6939037248,
-    "min_ram_gb": 3.9,
-    "recommended_ram_gb": 6.5,
-    "min_vram_gb": 3.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Lightweight, edge deployment",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "granitemoehybrid",
-    "hf_downloads": 62096,
-    "hf_likes": 198,
-    "release_date": "2025-09-16",
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 964959866,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/granite-4.0-h-tiny-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/granite-4.0-h-tiny-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "EleutherAI/pythia-6.9b",
     "provider": "eleutherai",
     "parameter_count": "7.0B",
@@ -10146,77 +12949,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/pythia-6.9b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "openchat/openchat-3.5-0106",
-    "provider": "OpenChat",
-    "parameter_count": "7.0B",
-    "parameters_raw": 7000000000,
-    "min_ram_gb": 3.9,
-    "recommended_ram_gb": 6.5,
-    "min_vram_gb": 3.6,
-    "quantization": "Q4_K_M",
-    "context_length": 8192,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/openchat-3.5-0106-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/openchat-3.5-0106-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "XiaomiMiMo/MiMo-7B-RL",
-    "provider": "Xiaomi",
-    "parameter_count": "7.0B",
-    "parameters_raw": 7000000000,
-    "min_ram_gb": 3.9,
-    "recommended_ram_gb": 6.5,
-    "min_vram_gb": 3.6,
-    "quantization": "Q4_K_M",
-    "context_length": 32768,
-    "use_case": "Advanced reasoning, math and code",
-    "pipeline_tag": "text-generation",
-    "architecture": "mimo",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-05-01"
-  },
-  {
-    "name": "microsoft/Orca-2-7b",
-    "provider": "Microsoft",
-    "parameter_count": "7.0B",
-    "parameters_raw": 7016400896,
-    "min_ram_gb": 3.9,
-    "recommended_ram_gb": 6.5,
-    "min_vram_gb": 3.6,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Reasoning, step-by-step solutions",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Orca-2-7b-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Orca-2-7b-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -10357,50 +13089,6 @@
     "_discovered": true
   },
   {
-    "name": "bigcode/starcoder2-7b",
-    "provider": "BigCode",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7173923840,
-    "min_ram_gb": 4.0,
-    "recommended_ram_gb": 6.7,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 16384,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "starcoder2",
-    "hf_downloads": 18288,
-    "hf_likes": 210,
-    "release_date": "2024-02-20"
-  },
-  {
-    "name": "tiiuae/falcon-7b-instruct",
-    "provider": "TII",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7217189760,
-    "min_ram_gb": 4.0,
-    "recommended_ram_gb": 6.7,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "falcon",
-    "hf_downloads": 58905,
-    "hf_likes": 1031,
-    "release_date": "2023-04-25",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/falcon-7b-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "tiiuae/falcon-7b",
     "provider": "TII",
     "parameter_count": "7.2B",
@@ -10422,35 +13110,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/falcon-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "HuggingFaceH4/zephyr-7b-beta",
-    "provider": "HuggingFace",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7241732096,
-    "min_ram_gb": 4.0,
-    "recommended_ram_gb": 6.7,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 136490,
-    "hf_likes": 1836,
-    "release_date": "2023-10-26",
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/zephyr-7b-beta-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/zephyr-7b-beta-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -10646,37 +13305,6 @@
     "_discovered": true
   },
   {
-    "name": "mistralai/Mistral-7B-Instruct-v0.3",
-    "provider": "Mistral AI",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7248023552,
-    "min_ram_gb": 4.1,
-    "recommended_ram_gb": 6.8,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "mistral",
-    "hf_downloads": 2210285,
-    "hf_likes": 2489,
-    "release_date": "2024-05-22",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Mistral-7B-Instruct-v0.3-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Mistral-7B-Instruct-v0.3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "allenai/wildguard",
     "provider": "allenai",
     "parameter_count": "7.2B",
@@ -10857,35 +13485,6 @@
     "_discovered": true
   },
   {
-    "name": "tiiuae/Falcon3-7B-Instruct",
-    "provider": "TII",
-    "parameter_count": "7.5B",
-    "parameters_raw": 7455550464,
-    "min_ram_gb": 4.2,
-    "recommended_ram_gb": 6.9,
-    "min_vram_gb": 3.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 24126,
-    "hf_likes": 77,
-    "release_date": "2024-11-29",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Falcon3-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Falcon3-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "apolo13x/Qwen3.5-9B-NVFP4",
     "provider": "apolo13x",
     "parameter_count": "7.5B",
@@ -11046,105 +13645,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2.5-7B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 14881790,
-    "hf_likes": 1180,
-    "release_date": "2024-09-16",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-7B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 2522695,
-    "hf_likes": 678,
-    "release_date": "2024-09-17",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-7B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
-    "provider": "DeepSeek",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 604740,
-    "hf_likes": 800,
-    "release_date": "2025-01-20",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-Coder-7B-Instruct-GPTQ-Int4",
@@ -11727,32 +14227,6 @@
     "_discovered": true
   },
   {
-    "name": "LGAI-EXAONE/EXAONE-Deep-7.8B",
-    "provider": "lgai-exaone",
-    "parameter_count": "7.8B",
-    "parameters_raw": 7818448896,
-    "min_ram_gb": 4.4,
-    "recommended_ram_gb": 7.3,
-    "min_vram_gb": 4.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "exaone",
-    "hf_downloads": 270267,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/EXAONE-Deep-7.8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "XiaomiMiMo/MiMo-7B-Base",
     "provider": "xiaomimimo",
     "parameter_count": "7.8B",
@@ -11867,37 +14341,6 @@
     ]
   },
   {
-    "name": "google/gemma-3n-E4B-it",
-    "provider": "Google",
-    "parameter_count": "8B",
-    "parameters_raw": 8000000000,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Multimodal, on-device (effective 4B)",
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "gemma3n",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-06-25",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-3n-E4B-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-3n-E4B-it-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gemma-3n-E4B-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "allenai/Molmo-7B-D-0924",
     "provider": "allenai",
     "parameter_count": "8.0B",
@@ -11916,79 +14359,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "meta-llama/Llama-3.1-8B",
-    "provider": "Meta",
-    "parameter_count": "8.0B",
-    "parameters_raw": 8030261248,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 1364845,
-    "hf_likes": 2135,
-    "release_date": "2024-07-14"
-  },
-  {
-    "name": "meta-llama/Llama-3.1-8B-Instruct",
-    "provider": "Meta",
-    "parameter_count": "8.0B",
-    "parameters_raw": 8030261248,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 8438089,
-    "hf_likes": 5652,
-    "release_date": "2024-07-18",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3.1-8B-Instruct-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "mistralai/Ministral-8B-Instruct-2410",
-    "provider": "Mistral AI",
-    "parameter_count": "8.0B",
-    "parameters_raw": 8030261248,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Ministral-8B-Instruct-2410-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Ministral-8B-Instruct-2410-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "meta-llama/Meta-Llama-3-8B",
@@ -12605,41 +14975,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen3-8B",
-    "provider": "Alibaba",
-    "parameter_count": "8.2B",
-    "parameters_raw": 8190735360,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.6,
-    "min_vram_gb": 4.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3",
-    "hf_downloads": 9296313,
-    "hf_likes": 1022,
-    "release_date": "2025-04-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-8B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-8B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3-8B-Base",
     "provider": "Alibaba",
     "parameter_count": "8.2B",
@@ -13037,42 +15372,6 @@
       },
       {
         "repo": "mradermacher/UI-TARS-7B-SFT-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-VL-7B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8292166656,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.7,
-    "min_vram_gb": 4.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 4459295,
-    "hf_likes": 1482,
-    "release_date": "2025-01-26",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen2.5-VL-7B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-7B-Instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -13560,35 +15859,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "LiquidAI/LFM2-8B-A1B",
-    "provider": "Liquid AI",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8339929856,
-    "min_ram_gb": 4.7,
-    "recommended_ram_gb": 7.8,
-    "min_vram_gb": 4.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2_moe",
-    "hf_downloads": 48127,
-    "hf_likes": 343,
-    "release_date": "2025-10-07",
-    "is_moe": true,
-    "num_experts": 32,
-    "active_experts": 4,
-    "active_parameters": 1500000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-8B-A1B-GGUF",
-        "provider": "unsloth"
-      }
-    ]
   },
   {
     "name": "xtuner/llava-llama-3-8b-v1_1-transformers",
@@ -14247,25 +16517,6 @@
     "_discovered": true
   },
   {
-    "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
-    "provider": "nvidia",
-    "parameter_count": "8.9B",
-    "parameters_raw": 8888227328,
-    "min_ram_gb": 5.0,
-    "recommended_ram_gb": 8.3,
-    "min_vram_gb": 4.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "nemotron_h",
-    "hf_downloads": 445975,
-    "hf_likes": 487,
-    "release_date": "2025-08-12"
-  },
-  {
     "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Japanese",
     "provider": "nvidia",
     "parameter_count": "8.9B",
@@ -14442,35 +16693,6 @@
     "_discovered": true
   },
   {
-    "name": "google/gemma-2-9b-it",
-    "provider": "Google",
-    "parameter_count": "9.2B",
-    "parameters_raw": 9241705984,
-    "min_ram_gb": 5.2,
-    "recommended_ram_gb": 8.6,
-    "min_vram_gb": 4.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "gemma2",
-    "hf_downloads": 236439,
-    "hf_likes": 781,
-    "release_date": "2024-06-24",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/gemma-2-9b-it-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/gemma-2-9b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "moondream/moondream3-preview",
     "provider": "moondream",
     "parameter_count": "9.3B",
@@ -14565,35 +16787,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "THUDM/glm-4-9b-chat",
-    "provider": "thudm",
-    "parameter_count": "9.4B",
-    "parameters_raw": 9399951392,
-    "min_ram_gb": 5.3,
-    "recommended_ram_gb": 8.8,
-    "min_vram_gb": 4.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "chatglm",
-    "hf_downloads": 163762,
-    "hf_likes": 704,
-    "release_date": "2024-06-04",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/glm-4-9b-chat-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/glm-4-9b-chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "adept/fuyu-8b",
@@ -14720,60 +16913,6 @@
         "provider": "mradermacher"
       }
     ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-9B",
-    "provider": "Alibaba",
-    "parameter_count": "9.7B",
-    "parameters_raw": 9653104368,
-    "min_ram_gb": 5.4,
-    "recommended_ram_gb": 9.0,
-    "min_vram_gb": 4.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 4818944,
-    "hf_likes": 1152,
-    "release_date": "2026-02-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-9B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-9B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-9B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "9.7B",
-    "parameters_raw": 9653104368,
-    "min_ram_gb": 5.4,
-    "recommended_ram_gb": 9.0,
-    "min_vram_gb": 4.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 101941,
-    "hf_likes": 59,
-    "release_date": "2026-02-26"
   },
   {
     "name": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -15132,28 +17271,6 @@
     "_discovered": true
   },
   {
-    "name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
-    "provider": "Meta",
-    "parameter_count": "10.7B",
-    "parameters_raw": 10670220835,
-    "min_ram_gb": 6.0,
-    "recommended_ram_gb": 9.9,
-    "min_vram_gb": 5.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "mllama",
-    "hf_downloads": 254818,
-    "hf_likes": 1583,
-    "release_date": "2024-09-18"
-  },
-  {
     "name": "huihui-ai/Llama-3.2-11B-Vision-Instruct-abliterated",
     "provider": "huihui-ai",
     "parameter_count": "10.7B",
@@ -15175,35 +17292,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "upstage/SOLAR-10.7B-Instruct-v1.0",
-    "provider": "Upstage",
-    "parameter_count": "10.7B",
-    "parameters_raw": 10731524096,
-    "min_ram_gb": 6.0,
-    "recommended_ram_gb": 10.0,
-    "min_vram_gb": 5.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 35845,
-    "hf_likes": 649,
-    "release_date": "2023-12-12",
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/SOLAR-10.7B-Instruct-v1.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "naver-hyperclovax/HyperCLOVAX-SEED-Omni-8B",
@@ -15296,37 +17384,6 @@
     ]
   },
   {
-    "name": "google/gemma-3-12b-it",
-    "provider": "Google",
-    "parameter_count": "12B",
-    "parameters_raw": 12000000000,
-    "min_ram_gb": 6.7,
-    "recommended_ram_gb": 11.2,
-    "min_vram_gb": 6.1,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Multimodal, vision and text",
-    "pipeline_tag": "text-generation",
-    "architecture": "gemma3",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-3-12b-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-3-12b-it-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gemma-3-12b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "google/gemma-3-12b-pt",
     "provider": "Google",
     "parameter_count": "12.2B",
@@ -15397,37 +17454,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "mistralai/Mistral-Nemo-Instruct-2407",
-    "provider": "Mistral AI",
-    "parameter_count": "12.2B",
-    "parameters_raw": 12247076864,
-    "min_ram_gb": 6.8,
-    "recommended_ram_gb": 11.4,
-    "min_vram_gb": 6.3,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Mistral-Nemo-Instruct-2407-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Mistral-Nemo-Instruct-2407-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Mistral-Nemo-Instruct-2407-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "casperhansen/mistral-nemo-instruct-2407-awq",
@@ -15504,87 +17530,6 @@
     ]
   },
   {
-    "name": "microsoft/Orca-2-13b",
-    "provider": "Microsoft",
-    "parameter_count": "13.0B",
-    "parameters_raw": 13015864320,
-    "min_ram_gb": 7.3,
-    "recommended_ram_gb": 12.1,
-    "min_vram_gb": 6.7,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Reasoning, step-by-step solutions",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Orca-2-13b-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Orca-2-13b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "lmsys/vicuna-13b-v1.5",
-    "provider": "LMSYS",
-    "parameter_count": "13.0B",
-    "parameters_raw": 13015864320,
-    "min_ram_gb": 7.3,
-    "recommended_ram_gb": 12.1,
-    "min_vram_gb": 6.7,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/vicuna-13b-v1.5-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/vicuna-13b-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "WizardLMTeam/WizardLM-13B-V1.2",
-    "provider": "WizardLM",
-    "parameter_count": "13.0B",
-    "parameters_raw": 13015864320,
-    "min_ram_gb": 7.3,
-    "recommended_ram_gb": 12.1,
-    "min_vram_gb": 6.7,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/WizardLM-13B-V1.2-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/WizardLM-13B-V1.2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "cais/HarmBench-Llama-2-13b-cls",
     "provider": "cais",
     "parameter_count": "13.0B",
@@ -15606,31 +17551,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/HarmBench-Llama-2-13b-cls-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "meta-llama/CodeLlama-13b-Instruct-hf",
-    "provider": "Meta",
-    "parameter_count": "13.0B",
-    "parameters_raw": 13016028160,
-    "min_ram_gb": 7.3,
-    "recommended_ram_gb": 12.1,
-    "min_vram_gb": 6.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 806,
-    "hf_likes": 27,
-    "release_date": "2024-03-13",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-13b-Instruct-hf-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -15768,81 +17688,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "microsoft/phi-4",
-    "provider": "Microsoft",
-    "parameter_count": "14B",
-    "parameters_raw": 14000000000,
-    "min_ram_gb": 7.8,
-    "recommended_ram_gb": 13.0,
-    "min_vram_gb": 7.2,
-    "quantization": "Q4_K_M",
-    "context_length": 16384,
-    "use_case": "Reasoning, STEM, code generation",
-    "pipeline_tag": "text-generation",
-    "architecture": "phi",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/phi-4-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/phi-4-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/phi-4-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "microsoft/Phi-3-medium-14b-instruct",
-    "provider": "Microsoft",
-    "parameter_count": "14B",
-    "parameters_raw": 14000000000,
-    "min_ram_gb": 7.8,
-    "recommended_ram_gb": 13.0,
-    "min_vram_gb": 7.2,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Balanced performance and size",
-    "pipeline_tag": "text-generation",
-    "architecture": "phi3",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
-  },
-  {
-    "name": "microsoft/Phi-4-reasoning",
-    "provider": "Microsoft",
-    "parameter_count": "14B",
-    "parameters_raw": 14000000000,
-    "min_ram_gb": 7.8,
-    "recommended_ram_gb": 13.0,
-    "min_vram_gb": 7.2,
-    "quantization": "Q4_K_M",
-    "context_length": 32768,
-    "use_case": "Advanced reasoning, math and code",
-    "pipeline_tag": "text-generation",
-    "architecture": "phi4",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-04-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Phi-4-reasoning-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Phi-4-reasoning-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen1.5-14B",
@@ -16085,99 +17930,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen2.5-14B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14770000000,
-    "min_ram_gb": 8.2,
-    "recommended_ram_gb": 13.7,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-14B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-14B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3-14B",
-    "provider": "Alibaba",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14770000000,
-    "min_ram_gb": 8.2,
-    "recommended_ram_gb": 13.7,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-14B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-14B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-14B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-14B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14770033664,
-    "min_ram_gb": 8.3,
-    "recommended_ram_gb": 13.8,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 845050,
-    "hf_likes": 144,
-    "release_date": "2024-11-06",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-14B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-14B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-14B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-14B-Instruct-AWQ",
     "provider": "Alibaba",
     "parameter_count": "14.8B",
@@ -16198,40 +17950,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
-    "provider": "DeepSeek",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14770033664,
-    "min_ram_gb": 8.3,
-    "recommended_ram_gb": 13.8,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 543050,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-Coder-14B-Instruct-AWQ",
@@ -16402,29 +18120,6 @@
     "_discovered": true
   },
   {
-    "name": "WizardLMTeam/WizardCoder-15B-V1.0",
-    "provider": "WizardLM",
-    "parameter_count": "15.5B",
-    "parameters_raw": 15515334656,
-    "min_ram_gb": 8.7,
-    "recommended_ram_gb": 14.5,
-    "min_vram_gb": 7.9,
-    "quantization": "Q4_K_M",
-    "context_length": 8192,
-    "use_case": "Code generation and completion",
-    "pipeline_tag": "text-generation",
-    "architecture": "starcoder",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/WizardCoder-15B-V1.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "nvidia/Qwen3-30B-A3B-NVFP4",
     "provider": "nvidia",
     "parameter_count": "15.6B",
@@ -16501,62 +18196,6 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 1704458782
-  },
-  {
-    "name": "bigcode/starcoder2-15b",
-    "provider": "BigCode",
-    "parameter_count": "15.7B",
-    "parameters_raw": 15700000000,
-    "min_ram_gb": 8.8,
-    "recommended_ram_gb": 14.6,
-    "min_vram_gb": 8.0,
-    "quantization": "Q4_K_M",
-    "context_length": 16384,
-    "use_case": "Code generation and completion",
-    "pipeline_tag": "text-generation",
-    "architecture": "starcoder2",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/starcoder2-15b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
-    "provider": "DeepSeek",
-    "parameter_count": "15.7B",
-    "parameters_raw": 15706484224,
-    "min_ram_gb": 8.8,
-    "recommended_ram_gb": 14.6,
-    "min_vram_gb": 8.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 163840,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v2",
-    "hf_downloads": 367294,
-    "hf_likes": 572,
-    "release_date": "2024-06-14",
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 2400000000,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "deepseek-ai/DeepSeek-V2-Lite-Chat",
@@ -16861,35 +18500,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "inclusionAI/Ling-lite",
-    "provider": "inclusionai",
-    "parameter_count": "16.8B",
-    "parameters_raw": 16801974272,
-    "min_ram_gb": 9.4,
-    "recommended_ram_gb": 15.6,
-    "min_vram_gb": 8.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "bailing_moe",
-    "hf_downloads": 441,
-    "hf_likes": 78,
-    "release_date": "2025-02-28",
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 2336524543,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Ling-lite-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "AxionML/Qwen3.5-27B-NVFP4",
@@ -17446,66 +19056,6 @@
     "active_parameters": 2607900202
   },
   {
-    "name": "LiquidAI/LFM2-24B-A2B",
-    "provider": "Liquid AI",
-    "parameter_count": "23.8B",
-    "parameters_raw": 23843661440,
-    "min_ram_gb": 13.3,
-    "recommended_ram_gb": 22.2,
-    "min_vram_gb": 12.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2_moe",
-    "hf_downloads": 41199,
-    "hf_likes": 302,
-    "release_date": "2026-02-24",
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 4,
-    "active_parameters": 2300000000,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-24B-A2B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "mistralai/Mistral-Small-24B-Instruct-2501",
-    "provider": "Mistral AI",
-    "parameter_count": "24B",
-    "parameters_raw": 24000000000,
-    "min_ram_gb": 13.4,
-    "recommended_ram_gb": 22.4,
-    "min_vram_gb": 12.3,
-    "quantization": "Q4_K_M",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Mistral-Small-24B-Instruct-2501-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Mistral-Small-24B-Instruct-2501-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Mistral-Small-24B-Instruct-2501-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "cyankiwi/Qwen3.5-122B-A10B-AWQ-4bit",
     "provider": "cyankiwi",
     "parameter_count": "24.3B",
@@ -17570,65 +19120,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "google/gemma-4-26B-A4B-it",
-    "provider": "Google",
-    "parameter_count": "26.5B",
-    "parameters_raw": 26544131376,
-    "min_ram_gb": 14.8,
-    "recommended_ram_gb": 24.7,
-    "min_vram_gb": 13.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 24366,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-4-26B-A4B-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-4-26B-A4B-it-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
-  },
-  {
-    "name": "google/gemma-2-27b-it",
-    "provider": "Google",
-    "parameter_count": "27.2B",
-    "parameters_raw": 27227128320,
-    "min_ram_gb": 15.2,
-    "recommended_ram_gb": 25.4,
-    "min_vram_gb": 13.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "gemma2",
-    "hf_downloads": 283589,
-    "hf_likes": 561,
-    "release_date": "2024-06-24",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/gemma-2-27b-it-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/gemma-2-27b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "DavidAU/Qwen3.5-27B-Claude-4.6-OS-Auto-Variable-Thinking",
@@ -17815,41 +19306,6 @@
     "_discovered": true
   },
   {
-    "name": "google/gemma-3-27b-it",
-    "provider": "Google",
-    "parameter_count": "27.4B",
-    "parameters_raw": 27432406640,
-    "min_ram_gb": 15.3,
-    "recommended_ram_gb": 25.5,
-    "min_vram_gb": 14.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "gemma3",
-    "hf_downloads": 957301,
-    "hf_likes": 1943,
-    "release_date": "2025-03-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-3-27b-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-3-27b-it-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gemma-3-27b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "RedHatAI/gemma-3-27b-it-FP8-dynamic",
     "provider": "redhatai",
     "parameter_count": "27.4B",
@@ -17868,38 +19324,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen3.5-27B",
-    "provider": "Alibaba",
-    "parameter_count": "27.8B",
-    "parameters_raw": 27781427952,
-    "min_ram_gb": 15.5,
-    "recommended_ram_gb": 25.9,
-    "min_vram_gb": 14.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 2913948,
-    "hf_likes": 848,
-    "release_date": "2026-02-24",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-27B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-27B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -19118,31 +20542,6 @@
     "_discovered": true
   },
   {
-    "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-    "provider": "nvidia",
-    "parameter_count": "31.6B",
-    "parameters_raw": 31577937344,
-    "min_ram_gb": 17.6,
-    "recommended_ram_gb": 29.4,
-    "min_vram_gb": 16.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "nemotron_h",
-    "hf_downloads": 1030284,
-    "hf_likes": 702,
-    "release_date": "2025-12-04",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "nvidia/Nemotron-Cascade-2-30B-A3B",
     "provider": "nvidia",
     "parameter_count": "31.6B",
@@ -19234,31 +20633,6 @@
       },
       {
         "repo": "mradermacher/EXAONE-3.5-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LGAI-EXAONE/EXAONE-4.0-32B",
-    "provider": "lgai-exaone",
-    "parameter_count": "32.0B",
-    "parameters_raw": 32003216384,
-    "min_ram_gb": 17.9,
-    "recommended_ram_gb": 29.8,
-    "min_vram_gb": 16.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "exaone4",
-    "hf_downloads": 23904,
-    "hf_likes": 281,
-    "release_date": "2025-07-11",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/EXAONE-4.0-32B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -19404,92 +20778,6 @@
     ]
   },
   {
-    "name": "allenai/OLMo-2-0325-32B-Instruct",
-    "provider": "allenai",
-    "parameter_count": "32.2B",
-    "parameters_raw": 32234279936,
-    "min_ram_gb": 18.0,
-    "recommended_ram_gb": 30.0,
-    "min_vram_gb": 16.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "olmo2",
-    "hf_downloads": 16537,
-    "hf_likes": 148,
-    "release_date": "2025-03-12",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/OLMo-2-0325-32B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/OLMo-2-0325-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-32B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "32.5B",
-    "parameters_raw": 32510000000,
-    "min_ram_gb": 18.2,
-    "recommended_ram_gb": 30.3,
-    "min_vram_gb": 16.7,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-32B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "google/gemma-4-31B-it",
-    "provider": "Google",
-    "parameter_count": "32.7B",
-    "parameters_raw": 32682372656,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.4,
-    "min_vram_gb": 16.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 76200,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-4-31B-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-4-31B-it-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3-32B-AWQ",
     "provider": "Alibaba",
     "parameter_count": "32.8B",
@@ -19510,74 +20798,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-32B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.5,
-    "min_vram_gb": 16.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 933747,
-    "hf_likes": 1999,
-    "release_date": "2024-11-06",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-32B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
-    "provider": "DeepSeek",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.5,
-    "min_vram_gb": 16.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 910905,
-    "hf_likes": 1528,
-    "release_date": "2025-01-20",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-32B-Instruct-AWQ",
@@ -19770,36 +20990,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/QwQ-32B",
-    "provider": "Alibaba",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.5,
-    "min_vram_gb": 16.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 67230,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/QwQ-32B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/QwQ-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-Coder-32B",
@@ -20085,33 +21275,6 @@
     ]
   },
   {
-    "name": "meta-llama/CodeLlama-34b-Instruct-hf",
-    "provider": "Meta",
-    "parameter_count": "33.7B",
-    "parameters_raw": 33743970304,
-    "min_ram_gb": 18.9,
-    "recommended_ram_gb": 31.4,
-    "min_vram_gb": 17.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 603,
-    "hf_likes": 19,
-    "release_date": "2024-03-14",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-34b-Instruct-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "codellama/CodeLlama-34b-Instruct-hf",
     "provider": "codellama",
     "parameter_count": "33.7B",
@@ -20135,33 +21298,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/CodeLlama-34b-Instruct-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "01-ai/Yi-34B-Chat",
-    "provider": "01.ai",
-    "parameter_count": "34.4B",
-    "parameters_raw": 34386780160,
-    "min_ram_gb": 19.2,
-    "recommended_ram_gb": 32.0,
-    "min_vram_gb": 17.6,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Multilingual, Chinese/English chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "yi",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Yi-34B-Chat-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Yi-34B-Chat-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -20239,73 +21375,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "CohereForAI/c4ai-command-r-v01",
-    "provider": "Cohere",
-    "parameter_count": "35B",
-    "parameters_raw": 35000000000,
-    "min_ram_gb": 19.5,
-    "recommended_ram_gb": 32.6,
-    "min_vram_gb": 17.9,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "RAG, tool use, agents",
-    "pipeline_tag": "text-generation",
-    "architecture": "cohere",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/c4ai-command-r-v01-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/c4ai-command-r-v01-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-35B-A3B",
-    "provider": "Alibaba",
-    "parameter_count": "36.0B",
-    "parameters_raw": 35951822704,
-    "min_ram_gb": 20.1,
-    "recommended_ram_gb": 33.5,
-    "min_vram_gb": 18.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 3120929,
-    "hf_likes": 1313,
-    "release_date": "2026-02-24",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 3000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-35B-A3B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3.5-35B-A3B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-35B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen3.5-35B-A3B-GPTQ-Int4",
@@ -20712,64 +21781,6 @@
     ]
   },
   {
-    "name": "tiiuae/falcon-40b-instruct",
-    "provider": "TII",
-    "parameter_count": "40.0B",
-    "parameters_raw": 40000000000,
-    "min_ram_gb": 22.4,
-    "recommended_ram_gb": 37.3,
-    "min_vram_gb": 20.5,
-    "quantization": "Q4_K_M",
-    "context_length": 2048,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "falcon",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/falcon-40b-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-    "provider": "Mistral AI",
-    "parameter_count": "46.7B",
-    "parameters_raw": 46702792704,
-    "min_ram_gb": 26.1,
-    "recommended_ram_gb": 43.5,
-    "min_vram_gb": 23.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "mixtral",
-    "hf_downloads": 424985,
-    "hf_likes": 4652,
-    "release_date": "2023-12-10",
-    "is_moe": true,
-    "num_experts": 8,
-    "active_experts": 2,
-    "active_parameters": 12900000000,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Mixtral-8x7B-Instruct-v0.1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Salesforce/xLAM-8x7b-r",
     "provider": "salesforce",
     "parameter_count": "46.7B",
@@ -20799,41 +21810,6 @@
       },
       {
         "repo": "mradermacher/xLAM-8x7b-r-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
-    "provider": "NousResearch",
-    "parameter_count": "46.7B",
-    "parameters_raw": 46702809088,
-    "min_ram_gb": 26.1,
-    "recommended_ram_gb": 43.5,
-    "min_vram_gb": 23.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "mixtral",
-    "hf_downloads": 8968,
-    "hf_likes": 452,
-    "release_date": "2024-01-11",
-    "is_moe": true,
-    "num_experts": 8,
-    "active_experts": 2,
-    "active_parameters": 12900000000,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Nous-Hermes-2-Mixtral-8x7B-DPO-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Nous-Hermes-2-Mixtral-8x7B-DPO-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -21059,62 +22035,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "meta-llama/Llama-3.1-70B-Instruct",
-    "provider": "Meta",
-    "parameter_count": "70.6B",
-    "parameters_raw": 70553706496,
-    "min_ram_gb": 39.4,
-    "recommended_ram_gb": 65.7,
-    "min_vram_gb": 36.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 997370,
-    "hf_likes": 904,
-    "release_date": "2024-07-16"
-  },
-  {
-    "name": "meta-llama/Llama-3.3-70B-Instruct",
-    "provider": "Meta",
-    "parameter_count": "70.6B",
-    "parameters_raw": 70553706496,
-    "min_ram_gb": 39.4,
-    "recommended_ram_gb": 65.7,
-    "min_vram_gb": 36.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 406340,
-    "hf_likes": 2686,
-    "release_date": "2024-11-26",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3.3-70B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Llama-3.3-70B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Llama-3.3-70B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "zerofata/L3.3-GeneticLemonade-Final-v2-70B",
@@ -21377,37 +22297,6 @@
     "_discovered": true
   },
   {
-    "name": "Qwen/Qwen2.5-72B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "72.7B",
-    "parameters_raw": 72706203648,
-    "min_ram_gb": 40.6,
-    "recommended_ram_gb": 67.7,
-    "min_vram_gb": 37.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 677691,
-    "hf_likes": 923,
-    "release_date": "2024-09-16",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-72B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-72B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "huihui-ai/Qwen2.5-72B-Instruct-abliterated",
     "provider": "huihui-ai",
     "parameter_count": "72.7B",
@@ -21596,43 +22485,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen2.5-VL-72B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "73.4B",
-    "parameters_raw": 73410777344,
-    "min_ram_gb": 41.0,
-    "recommended_ram_gb": 68.4,
-    "min_vram_gb": 37.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 96427,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-VL-72B-Instruct-AWQ",
     "provider": "Alibaba",
     "parameter_count": "73.7B",
@@ -21784,41 +22636,6 @@
     "num_experts": 512,
     "active_experts": 10,
     "active_parameters": 5462052829
-  },
-  {
-    "name": "Qwen/Qwen3-Coder-Next",
-    "provider": "Alibaba",
-    "parameter_count": "79.7B",
-    "parameters_raw": 79674391296,
-    "min_ram_gb": 44.5,
-    "recommended_ram_gb": 74.2,
-    "min_vram_gb": 40.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3_next",
-    "hf_downloads": 854743,
-    "hf_likes": 1220,
-    "release_date": "2026-01-30",
-    "is_moe": true,
-    "num_experts": 512,
-    "active_experts": 10,
-    "active_parameters": 3000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-Coder-Next-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-Coder-Next-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen3-Coder-Next-FP8",
@@ -22287,42 +23104,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen3.5-122B-A10B",
-    "provider": "Alibaba",
-    "parameter_count": "125.1B",
-    "parameters_raw": 125086497008,
-    "min_ram_gb": 69.9,
-    "recommended_ram_gb": 116.5,
-    "min_vram_gb": 64.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 821843,
-    "hf_likes": 467,
-    "release_date": "2026-02-24",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 10000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-122B-A10B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-122B-A10B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3.5-122B-A10B-GPTQ-Int4",
     "provider": "Alibaba",
     "parameter_count": "125.1B",
@@ -22399,94 +23180,6 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 9968428637
-  },
-  {
-    "name": "mistralai/Mixtral-8x22B-Instruct-v0.1",
-    "provider": "Mistral AI",
-    "parameter_count": "140.6B",
-    "parameters_raw": 140630071296,
-    "min_ram_gb": 78.6,
-    "recommended_ram_gb": 131.0,
-    "min_vram_gb": 72.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 65536,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "mixtral",
-    "hf_downloads": 34368,
-    "hf_likes": 748,
-    "release_date": "2024-04-16",
-    "is_moe": true,
-    "num_experts": 8,
-    "active_experts": 2,
-    "active_parameters": 39100000000
-  },
-  {
-    "name": "rednote-hilab/dots.llm1.inst",
-    "provider": "rednote-hilab",
-    "parameter_count": "142.8B",
-    "parameters_raw": 142774381696,
-    "min_ram_gb": 79.8,
-    "recommended_ram_gb": 133.0,
-    "min_vram_gb": 73.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "dots1",
-    "hf_downloads": 9261,
-    "hf_likes": 176,
-    "release_date": "2025-05-14",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/dots.llm1.inst-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "bigscience/bloom",
-    "provider": "bigscience",
-    "parameter_count": "176.2B",
-    "parameters_raw": 176247271424,
-    "min_ram_gb": 98.5,
-    "recommended_ram_gb": 164.1,
-    "min_vram_gb": 90.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "bloom",
-    "hf_downloads": 7167,
-    "hf_likes": 4989,
-    "release_date": "2022-05-19"
-  },
-  {
-    "name": "tiiuae/falcon-180B-chat",
-    "provider": "TII",
-    "parameter_count": "179.5B",
-    "parameters_raw": 179522565120,
-    "min_ram_gb": 100.3,
-    "recommended_ram_gb": 167.2,
-    "min_vram_gb": 92.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "falcon",
-    "hf_downloads": 663,
-    "hf_likes": 546,
-    "release_date": "2023-09-04"
   },
   {
     "name": "stepfun-ai/Step-3.5-Flash",
@@ -22635,39 +23328,6 @@
     "active_parameters": 18223715635
   },
   {
-    "name": "MiniMaxAI/MiniMax-M2.5",
-    "provider": "minimaxai",
-    "parameter_count": "228.7B",
-    "parameters_raw": 228703644928,
-    "min_ram_gb": 127.8,
-    "recommended_ram_gb": 213.0,
-    "min_vram_gb": 117.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 196608,
-    "use_case": "Lightweight, edge deployment",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "minimax_m2",
-    "hf_downloads": 622769,
-    "hf_likes": 1330,
-    "release_date": "2026-02-12",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 10000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/MiniMax-M2.5-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/MiniMax-M2.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "MiniMaxAI/MiniMax-M2",
     "provider": "minimaxai",
     "parameter_count": "228.7B",
@@ -22728,62 +23388,6 @@
       {
         "repo": "mradermacher/MiniMax-M2.1-GGUF",
         "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "MiniMaxAI/MiniMax-M2.7",
-    "provider": "MiniMax",
-    "parameter_count": "230B",
-    "parameters_raw": 230000000000,
-    "min_ram_gb": 128.6,
-    "recommended_ram_gb": 214.4,
-    "min_vram_gb": 117.9,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Latest flagship with enhanced reasoning and coding",
-    "pipeline_tag": "text-generation",
-    "architecture": "minimax",
-    "is_moe": true,
-    "num_experts": 32,
-    "active_experts": 2,
-    "active_parameters": 10000000000,
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2026-03-18"
-  },
-  {
-    "name": "Qwen/Qwen3-235B-A22B",
-    "provider": "Alibaba",
-    "parameter_count": "235.1B",
-    "parameters_raw": 235093634560,
-    "min_ram_gb": 131.4,
-    "recommended_ram_gb": 218.9,
-    "min_vram_gb": 120.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3_moe",
-    "hf_downloads": 590265,
-    "hf_likes": 1085,
-    "release_date": "2025-04-27",
-    "is_moe": true,
-    "num_experts": 128,
-    "active_experts": 8,
-    "active_parameters": 22000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-235B-A22B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-235B-A22B-GGUF",
-        "provider": "ggml-org"
       }
     ]
   },
@@ -23065,54 +23669,6 @@
     "_discovered": true
   },
   {
-    "name": "baidu/ERNIE-4.5-300B-A47B-Paddle",
-    "provider": "baidu",
-    "parameter_count": "300.5B",
-    "parameters_raw": 300474051776,
-    "min_ram_gb": 167.9,
-    "recommended_ram_gb": 279.8,
-    "min_vram_gb": 153.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "ernie4_5_moe",
-    "hf_downloads": 320,
-    "hf_likes": 12,
-    "release_date": "2025-06-28"
-  },
-  {
-    "name": "XiaomiMiMo/MiMo-V2-Flash",
-    "provider": "xiaomimimo",
-    "parameter_count": "309.8B",
-    "parameters_raw": 309785318400,
-    "min_ram_gb": 173.1,
-    "recommended_ram_gb": 288.5,
-    "min_vram_gb": 158.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "mimo_v2_flash",
-    "hf_downloads": 51065,
-    "hf_likes": 694,
-    "release_date": "2025-12-16",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/MiMo-V2-Flash-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/MiMo-V2-Flash-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "stepfun-ai/step3",
     "provider": "stepfun-ai",
     "parameter_count": "321.0B",
@@ -23257,41 +23813,6 @@
     "active_parameters": 31617371393
   },
   {
-    "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
-    "provider": "Meta",
-    "parameter_count": "401.6B",
-    "parameters_raw": 401583781376,
-    "min_ram_gb": 224.4,
-    "recommended_ram_gb": 374.0,
-    "min_vram_gb": 205.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "llama4",
-    "hf_downloads": 20387,
-    "hf_likes": 474,
-    "release_date": "2025-04-01",
-    "is_moe": true,
-    "num_experts": 16,
-    "active_experts": 1,
-    "active_parameters": 17000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-4-Maverick-17B-128E-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Llama-4-Maverick-17B-128E-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
     "provider": "Meta",
     "parameter_count": "401.6B",
@@ -23340,42 +23861,6 @@
     "active_parameters": 43930451431
   },
   {
-    "name": "Qwen/Qwen3.5-397B-A17B",
-    "provider": "Alibaba",
-    "parameter_count": "403.4B",
-    "parameters_raw": 403397928944,
-    "min_ram_gb": 225.4,
-    "recommended_ram_gb": 375.7,
-    "min_vram_gb": 206.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 1081165,
-    "hf_likes": 1405,
-    "release_date": "2026-02-16",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 17000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-397B-A17B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-397B-A17B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3.5-397B-A17B-FP8",
     "provider": "Alibaba",
     "parameter_count": "403.4B",
@@ -23406,27 +23891,6 @@
         "provider": "mradermacher"
       }
     ]
-  },
-  {
-    "name": "meta-llama/Llama-3.1-405B-Instruct",
-    "provider": "Meta",
-    "parameter_count": "405.9B",
-    "parameters_raw": 405853388800,
-    "min_ram_gb": 226.8,
-    "recommended_ram_gb": 378.0,
-    "min_vram_gb": 207.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 169125,
-    "hf_likes": 593,
-    "release_date": "2024-07-16"
   },
   {
     "name": "meta-llama/Llama-3.1-405B",
@@ -23469,37 +23933,6 @@
     "_discovered": true
   },
   {
-    "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "480.2B",
-    "parameters_raw": 480154875392,
-    "min_ram_gb": 268.3,
-    "recommended_ram_gb": 447.2,
-    "min_vram_gb": 245.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3_moe",
-    "hf_downloads": 93169,
-    "hf_likes": 1318,
-    "release_date": "2025-07-22",
-    "is_moe": true,
-    "num_experts": 160,
-    "active_experts": 8,
-    "active_parameters": 35000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
     "name": "meituan-longcat/LongCat-Flash-Chat",
     "provider": "meituan-longcat",
     "parameter_count": "561.9B",
@@ -23518,68 +23951,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-V3",
-    "provider": "DeepSeek",
-    "parameter_count": "684.5B",
-    "parameters_raw": 684531386000,
-    "min_ram_gb": 382.5,
-    "recommended_ram_gb": 637.5,
-    "min_vram_gb": 350.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 163840,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v3",
-    "hf_downloads": 575152,
-    "hf_likes": 4020,
-    "release_date": "2024-12-25",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 37000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-V3-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-R1",
-    "provider": "DeepSeek",
-    "parameter_count": "684.5B",
-    "parameters_raw": 684531386000,
-    "min_ram_gb": 382.5,
-    "recommended_ram_gb": 637.5,
-    "min_vram_gb": 350.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 163840,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v3",
-    "hf_downloads": 2588610,
-    "hf_likes": 13125,
-    "release_date": "2025-01-20",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 37000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-GGUF",
-        "provider": "bartowski"
-      }
-    ]
   },
   {
     "name": "deepseek-ai/DeepSeek-R1-0528",
@@ -23642,77 +24013,6 @@
     ]
   },
   {
-    "name": "deepseek-ai/DeepSeek-V3.2-Speciale",
-    "provider": "DeepSeek",
-    "parameter_count": "685B",
-    "parameters_raw": 685000000000,
-    "min_ram_gb": 383.2,
-    "recommended_ram_gb": 638.7,
-    "min_vram_gb": 351.3,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v3",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 37000000000,
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-12-01"
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-V3.2",
-    "provider": "DeepSeek",
-    "parameter_count": "685.4B",
-    "parameters_raw": 685396921376,
-    "min_ram_gb": 383.0,
-    "recommended_ram_gb": 638.3,
-    "min_vram_gb": 351.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 163840,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v32",
-    "hf_downloads": 911552,
-    "hf_likes": 1364,
-    "release_date": "2025-12-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-V3.2-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "zai-org/GLM-5",
-    "provider": "zai-org",
-    "parameter_count": "753.9B",
-    "parameters_raw": 753864139008,
-    "min_ram_gb": 421.3,
-    "recommended_ram_gb": 702.1,
-    "min_vram_gb": 386.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 202752,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "glm_moe_dsa",
-    "hf_downloads": 251608,
-    "hf_likes": 1920,
-    "release_date": "2026-02-11",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-5-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
     "name": "zai-org/GLM-5-FP8",
     "provider": "zai-org",
     "parameter_count": "753.9B",
@@ -23755,31 +24055,6 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 80681570216
-  },
-  {
-    "name": "moonshotai/Kimi-K2-Instruct",
-    "provider": "moonshotai",
-    "parameter_count": "1026.5B",
-    "parameters_raw": 1026470731056,
-    "min_ram_gb": 573.6,
-    "recommended_ram_gb": 956.0,
-    "min_vram_gb": 525.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "kimi_k2",
-    "hf_downloads": 96217,
-    "hf_likes": 2331,
-    "release_date": "2025-07-11",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2-Instruct-GGUF",
-        "provider": "unsloth"
-      }
-    ]
   },
   {
     "name": "moonshotai/Kimi-K2-Instruct-0905",
@@ -23829,33 +24104,6 @@
     "gguf_sources": [
       {
         "repo": "unsloth/Kimi-K2-Thinking-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "moonshotai/Kimi-K2.5",
-    "provider": "moonshotai",
-    "parameter_count": "1058.6B",
-    "parameters_raw": 1058589420528,
-    "min_ram_gb": 591.5,
-    "recommended_ram_gb": 985.9,
-    "min_vram_gb": 542.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "kimi_k25",
-    "hf_downloads": 6190986,
-    "hf_likes": 2410,
-    "release_date": "2026-01-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2.5-GGUF",
         "provider": "unsloth"
       }
     ]

--- a/llmfit-core/data/hf_models.json
+++ b/llmfit-core/data/hf_models.json
@@ -1,5 +1,4362 @@
 [
   {
+    "name": "nomic-ai/nomic-embed-text-v1.5",
+    "provider": "Nomic",
+    "parameter_count": "137M",
+    "parameters_raw": 136731648,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Text embeddings for RAG",
+    "capabilities": [],
+    "pipeline_tag": "sentence-similarity",
+    "architecture": "nomic_bert",
+    "hf_downloads": 10548767,
+    "hf_likes": 791,
+    "release_date": "2024-02-10",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/nomic-embed-text-v1.5-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "BAAI/bge-large-en-v1.5",
+    "provider": "BAAI",
+    "parameter_count": "335M",
+    "parameters_raw": 335142400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 512,
+    "use_case": "Text embeddings for RAG",
+    "capabilities": [],
+    "pipeline_tag": "feature-extraction",
+    "architecture": "bert",
+    "hf_downloads": 6782849,
+    "hf_likes": 641,
+    "release_date": "2023-09-12",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/bge-large-en-v1.5-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-ColBERT-350M",
+    "provider": "Liquid AI",
+    "parameter_count": "353M",
+    "parameters_raw": 353322752,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "sentence-similarity",
+    "architecture": "lfm2",
+    "hf_downloads": 27092,
+    "hf_likes": 127,
+    "release_date": "2025-10-28"
+  },
+  {
+    "name": "LiquidAI/LFM2-350M",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 35470,
+    "hf_likes": 246,
+    "release_date": "2025-07-10",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-350M-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/LFM2-350M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-350M-Extract",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 1199,
+    "hf_likes": 77,
+    "release_date": "2025-09-03",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-350M-Extract-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-350M-Math",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 666,
+    "hf_likes": 57,
+    "release_date": "2025-08-25",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-350M-Math-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-350M-ENJP-MT",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "translation",
+    "architecture": "lfm2",
+    "hf_downloads": 799,
+    "hf_likes": 87,
+    "release_date": "2025-09-03",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-350M-ENJP-MT-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-350M-PII-Extract-JP",
+    "provider": "Liquid AI",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 927,
+    "hf_likes": 54,
+    "release_date": "2025-09-30",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-350M-PII-Extract-JP-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-VL-450M",
+    "provider": "Liquid AI",
+    "parameter_count": "451M",
+    "parameters_raw": 450822656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "lfm2_vl",
+    "hf_downloads": 15337,
+    "hf_likes": 146,
+    "release_date": "2025-08-12",
+    "gguf_sources": [
+      {
+        "repo": "ggml-org/LFM2-VL-450M-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/LFM2-VL-450M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-0.5B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "494M",
+    "parameters_raw": 494032768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 6231939,
+    "hf_likes": 493,
+    "release_date": "2024-09-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-700M",
+    "provider": "Liquid AI",
+    "parameter_count": "742M",
+    "parameters_raw": 742489344,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 11599,
+    "hf_likes": 110,
+    "release_date": "2025-07-10",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-700M-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-0.6B",
+    "provider": "Alibaba",
+    "parameter_count": "752M",
+    "parameters_raw": 751632384,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3",
+    "hf_downloads": 14235258,
+    "hf_likes": 1172,
+    "release_date": "2025-04-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-0.6B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-0.6B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3-0.6B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-0.8B",
+    "provider": "Alibaba",
+    "parameter_count": "873M",
+    "parameters_raw": 873438784,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 2077133,
+    "hf_likes": 472,
+    "release_date": "2026-02-28",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-0.8B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-0.8B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-0.8B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "873M",
+    "parameters_raw": 873438784,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 147054,
+    "hf_likes": 63,
+    "release_date": "2026-02-28"
+  },
+  {
+    "name": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "provider": "Community",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100048384,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 2917542,
+    "hf_likes": 1560,
+    "release_date": "2023-12-30",
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/TinyLlama-1.1B-Chat-v1.0-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-1.2B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 39580,
+    "hf_likes": 352,
+    "release_date": "2025-07-10",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-1.2B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-1.2B-Base",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 28345,
+    "hf_likes": 121,
+    "release_date": "2026-01-05",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2.5-1.2B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-1.2B-Instruct",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 298234,
+    "hf_likes": 551,
+    "release_date": "2026-01-06",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2.5-1.2B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/LFM2.5-1.2B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-1.2B-Thinking",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 27721,
+    "hf_likes": 327,
+    "release_date": "2026-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2.5-1.2B-Thinking-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/LFM2.5-1.2B-Thinking-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-1.2B-JP",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 2481,
+    "hf_likes": 142,
+    "release_date": "2026-01-04",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2.5-1.2B-JP-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-1.2B-Tool",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 428,
+    "hf_likes": 97,
+    "release_date": "2025-09-03",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-1.2B-Tool-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-1.2B-RAG",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 694,
+    "hf_likes": 115,
+    "release_date": "2025-09-03",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-1.2B-RAG-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-1.2B-Extract",
+    "provider": "Liquid AI",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 1390,
+    "hf_likes": 106,
+    "release_date": "2025-08-22",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-1.2B-Extract-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/Llama-3.2-1B",
+    "provider": "Meta",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1672905,
+    "hf_likes": 2352,
+    "release_date": "2024-09-18",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-1B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-4.0-1.2B",
+    "provider": "lgai-exaone",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1279391488,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone4",
+    "hf_downloads": 32631,
+    "hf_likes": 177,
+    "release_date": "2025-07-11",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/EXAONE-4.0-1.2B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-Audio-1.5B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1470308496,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "audio-to-audio",
+    "architecture": "unknown",
+    "hf_downloads": 268,
+    "hf_likes": 346,
+    "release_date": "2025-08-28",
+    "gguf_sources": [
+      {
+        "repo": "ggml-org/LFM2-Audio-1.5B-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-Audio-1.5B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1470308496,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "audio-to-audio",
+    "architecture": "unknown",
+    "hf_downloads": 1038,
+    "hf_likes": 374,
+    "release_date": "2025-12-18"
+  },
+  {
+    "name": "Qwen/Qwen2.5-1.5B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 9788462,
+    "hf_likes": 654,
+    "release_date": "2024-09-17",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-1.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-1.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 707325,
+    "hf_likes": 110,
+    "release_date": "2024-09-18",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-Coder-1.5B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Qwen2.5-Coder-1.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-1.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-VL-1.6B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1584804000,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "lfm2_vl",
+    "hf_downloads": 5012,
+    "hf_likes": 226,
+    "release_date": "2025-08-12",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-VL-1.6B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2.5-VL-1.6B",
+    "provider": "Liquid AI",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1596625904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "lfm2_vl",
+    "hf_downloads": 138277,
+    "hf_likes": 264,
+    "release_date": "2026-01-05",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2.5-VL-1.6B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "stabilityai/stablelm-2-1_6b-chat",
+    "provider": "Stability AI",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1644515328,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "stablelm",
+    "hf_downloads": 1796,
+    "hf_likes": 34,
+    "release_date": "2024-04-08",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/stablelm-2-1_6b-chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "tiiuae/Falcon3-1B-Instruct",
+    "provider": "TII",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1669408768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 10980,
+    "hf_likes": 46,
+    "release_date": "2024-12-14",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Falcon3-1B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Falcon3-1B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+    "provider": "DeepSeek",
+    "parameter_count": "1.8B",
+    "parameters_raw": 1777088000,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 789335,
+    "hf_likes": 1468,
+    "release_date": "2025-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-1.7B",
+    "provider": "Alibaba",
+    "parameter_count": "2.0B",
+    "parameters_raw": 2031739904,
+    "min_ram_gb": 1.1,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3",
+    "hf_downloads": 7527100,
+    "hf_likes": 439,
+    "release_date": "2025-04-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-1.7B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-1.7B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3-1.7B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-2B",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2274069824,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.1,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 1428994,
+    "hf_likes": 236,
+    "release_date": "2026-02-28",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-2B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-2B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-2B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2274069824,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.1,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 79145,
+    "hf_likes": 64,
+    "release_date": "2026-02-28"
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-Deep-2.4B",
+    "provider": "lgai-exaone",
+    "parameter_count": "2.4B",
+    "parameters_raw": 2405327360,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone",
+    "hf_downloads": 1277,
+    "hf_likes": 98,
+    "release_date": "2025-03-12"
+  },
+  {
+    "name": "LiquidAI/LFM2-2.6B",
+    "provider": "Liquid AI",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2569272320,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 7357,
+    "hf_likes": 184,
+    "release_date": "2025-09-22",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-2.6B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-2.6B-Exp",
+    "provider": "Liquid AI",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2569272320,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 25155,
+    "hf_likes": 337,
+    "release_date": "2025-12-25",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-2.6B-Exp-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/LFM2-2.6B-Exp-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-2.6B-Transcript",
+    "provider": "Liquid AI",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2569272320,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2",
+    "hf_downloads": 404,
+    "hf_likes": 162,
+    "release_date": "2026-01-05",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-2.6B-Transcript-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-2-2b-it",
+    "provider": "Google",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2614341888,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "gemma2",
+    "hf_downloads": 377375,
+    "hf_likes": 1320,
+    "release_date": "2024-07-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/gemma-2-2b-it-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/gemma-2-2b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-VL-3B",
+    "provider": "Liquid AI",
+    "parameter_count": "3.0B",
+    "parameters_raw": 2998975216,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.8,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "lfm2_vl",
+    "hf_downloads": 12094,
+    "hf_likes": 132,
+    "release_date": "2025-10-22"
+  },
+  {
+    "name": "HuggingFaceTB/SmolLM3-3B",
+    "provider": "huggingfacetb",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3075098624,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "smollm3",
+    "hf_downloads": 1092647,
+    "hf_likes": 927,
+    "release_date": "2025-07-08",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/SmolLM3-3B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/SmolLM3-3B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/SmolLM3-3B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-3B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3085938688,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 8032389,
+    "hf_likes": 431,
+    "release_date": "2024-09-17",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-3B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-3B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "ibm-granite/granite-4.0-h-micro",
+    "provider": "ibm-granite",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3191396096,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 47860,
+    "hf_likes": 142,
+    "release_date": "2025-09-16",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/granite-4.0-h-micro-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/granite-4.0-h-micro-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/Llama-3.2-3B",
+    "provider": "Meta",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3212749824,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1266035,
+    "hf_likes": 730,
+    "release_date": "2024-09-18",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-3B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "tiiuae/Falcon3-3B-Instruct",
+    "provider": "TII",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3227655168,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 8872,
+    "hf_likes": 28,
+    "release_date": "2024-12-14",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Falcon3-3B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Falcon3-3B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-VL-3B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3754622976,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 6326695,
+    "hf_likes": 635,
+    "release_date": "2025-01-26",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-VL-3B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen2.5-VL-3B-Instruct-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-VL-3B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-4-mini-reasoning",
+    "provider": "Microsoft",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3800000000,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "Q4_K_M",
+    "context_length": 16384,
+    "use_case": "Lightweight reasoning",
+    "pipeline_tag": "text-generation",
+    "architecture": "phi4",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-04-01",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Phi-4-mini-reasoning-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Phi-4-mini-reasoning-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/phi-3-mini-4k-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3821079552,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.6,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "phi3",
+    "hf_downloads": 678067,
+    "hf_likes": 1406,
+    "release_date": "2024-04-22",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/phi-3-mini-4k-instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/phi-3-mini-4k-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-3.5-mini-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3821079552,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.6,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "phi3",
+    "hf_downloads": 738734,
+    "hf_likes": 969,
+    "release_date": "2024-08-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Phi-3.5-mini-instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Phi-3.5-mini-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3n-E2B-it",
+    "provider": "Google",
+    "parameter_count": "4B",
+    "parameters_raw": 4000000000,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.1,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Multimodal, on-device (effective 2B)",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma3n",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-06-25",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3n-E2B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3n-E2B-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-4B",
+    "provider": "Alibaba",
+    "parameter_count": "4.7B",
+    "parameters_raw": 4659865088,
+    "min_ram_gb": 2.6,
+    "recommended_ram_gb": 4.3,
+    "min_vram_gb": 2.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 2755159,
+    "hf_likes": 436,
+    "release_date": "2026-02-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-4B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-4B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-4B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "4.7B",
+    "parameters_raw": 4659865088,
+    "min_ram_gb": 2.6,
+    "recommended_ram_gb": 4.3,
+    "min_vram_gb": 2.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 95699,
+    "hf_likes": 55,
+    "release_date": "2026-02-27"
+  },
+  {
+    "name": "google/gemma-4-E2B-it",
+    "provider": "Google",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5123178051,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "any-to-any",
+    "architecture": "gemma4",
+    "hf_downloads": 167166,
+    "hf_likes": 248,
+    "release_date": "2026-03-02",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-4-E2B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-4-E2B-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-4-multimodal-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "5.6B",
+    "parameters_raw": 5574460384,
+    "min_ram_gb": 3.1,
+    "recommended_ram_gb": 5.2,
+    "min_vram_gb": 2.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "automatic-speech-recognition",
+    "architecture": "phi4mm",
+    "hf_downloads": 282837,
+    "hf_likes": 1577,
+    "release_date": "2025-02-24"
+  },
+  {
+    "name": "01-ai/Yi-6B-Chat",
+    "provider": "01.ai",
+    "parameter_count": "6.1B",
+    "parameters_raw": 6061035520,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 26597,
+    "hf_likes": 70,
+    "release_date": "2023-11-22",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Yi-6B-Chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lmsys/vicuna-7b-v1.5",
+    "provider": "LMSYS",
+    "parameter_count": "7.0B",
+    "parameters_raw": 6738415616,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.3,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/vicuna-7b-v1.5-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/vicuna-7b-v1.5-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/CodeLlama-7b-Instruct-hf",
+    "provider": "Meta",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6738546688,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.3,
+    "min_vram_gb": 3.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1526,
+    "hf_likes": 59,
+    "release_date": "2024-03-13",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/CodeLlama-7b-Instruct-hf-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "ibm-granite/granite-4.0-h-tiny",
+    "provider": "ibm-granite",
+    "parameter_count": "6.9B",
+    "parameters_raw": 6939037248,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 74389,
+    "hf_likes": 198,
+    "release_date": "2025-09-16",
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 964959866,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/granite-4.0-h-tiny-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/granite-4.0-h-tiny-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "openchat/openchat-3.5-0106",
+    "provider": "OpenChat",
+    "parameter_count": "7.0B",
+    "parameters_raw": 7000000000,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/openchat-3.5-0106-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/openchat-3.5-0106-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "XiaomiMiMo/MiMo-7B-RL",
+    "provider": "Xiaomi",
+    "parameter_count": "7.0B",
+    "parameters_raw": 7000000000,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "context_length": 32768,
+    "use_case": "Advanced reasoning, math and code",
+    "pipeline_tag": "text-generation",
+    "architecture": "mimo",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-05-01"
+  },
+  {
+    "name": "microsoft/Orca-2-7b",
+    "provider": "Microsoft",
+    "parameter_count": "7.0B",
+    "parameters_raw": 7016400896,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Reasoning, step-by-step solutions",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Orca-2-7b-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Orca-2-7b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "bigcode/starcoder2-7b",
+    "provider": "BigCode",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7173923840,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "starcoder2",
+    "hf_downloads": 18604,
+    "hf_likes": 210,
+    "release_date": "2024-02-20"
+  },
+  {
+    "name": "tiiuae/falcon-7b-instruct",
+    "provider": "TII",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7217189760,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "falcon",
+    "hf_downloads": 58735,
+    "hf_likes": 1031,
+    "release_date": "2023-04-25",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/falcon-7b-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "HuggingFaceH4/zephyr-7b-beta",
+    "provider": "HuggingFace",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 129252,
+    "hf_likes": 1836,
+    "release_date": "2023-10-26",
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/zephyr-7b-beta-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/zephyr-7b-beta-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Mistral-7B-Instruct-v0.3",
+    "provider": "Mistral AI",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7248023552,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 2189625,
+    "hf_likes": 2496,
+    "release_date": "2024-05-22",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Mistral-7B-Instruct-v0.3-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Mistral-7B-Instruct-v0.3-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "allenai/OLMo-2-1124-7B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "7.3B",
+    "parameters_raw": 7298617344,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "olmo2",
+    "hf_downloads": 17570,
+    "hf_likes": 48,
+    "release_date": "2024-12-18",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/OLMo-2-1124-7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/OLMo-2-1124-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "tiiuae/Falcon3-7B-Instruct",
+    "provider": "TII",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7455550464,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 23516,
+    "hf_likes": 77,
+    "release_date": "2024-11-29",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Falcon3-7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Falcon3-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-7B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 13544700,
+    "hf_likes": 1184,
+    "release_date": "2024-09-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-7B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 2499046,
+    "hf_likes": 678,
+    "release_date": "2024-09-17",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-Coder-7B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Qwen2.5-Coder-7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+    "provider": "DeepSeek",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 613455,
+    "hf_likes": 802,
+    "release_date": "2025-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-7B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-Deep-7.8B",
+    "provider": "lgai-exaone",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7818448896,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone",
+    "hf_downloads": 270744,
+    "hf_likes": 100,
+    "release_date": "2025-03-12",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/EXAONE-Deep-7.8B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-4-E4B-it",
+    "provider": "Google",
+    "parameter_count": "8.0B",
+    "parameters_raw": 7996156490,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.4,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "any-to-any",
+    "architecture": "gemma4",
+    "hf_downloads": 197704,
+    "hf_likes": 345,
+    "release_date": "2026-03-02",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-4-E4B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-4-E4B-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3n-E4B-it",
+    "provider": "Google",
+    "parameter_count": "8B",
+    "parameters_raw": 8000000000,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Multimodal, on-device (effective 4B)",
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma3n",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-06-25",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3n-E4B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3n-E4B-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-3n-E4B-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/Llama-3.1-8B",
+    "provider": "Meta",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1360242,
+    "hf_likes": 2137,
+    "release_date": "2024-07-14"
+  },
+  {
+    "name": "meta-llama/Llama-3.1-8B-Instruct",
+    "provider": "Meta",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 8507661,
+    "hf_likes": 5661,
+    "release_date": "2024-07-18",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Llama-3.1-8B-Instruct-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Ministral-8B-Instruct-2410",
+    "provider": "Mistral AI",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Ministral-8B-Instruct-2410-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Ministral-8B-Instruct-2410-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-8B",
+    "provider": "Alibaba",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8190735360,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3",
+    "hf_downloads": 9315480,
+    "hf_likes": 1025,
+    "release_date": "2025-04-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-8B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-8B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3-8B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-VL-7B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8292166656,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 4399050,
+    "hf_likes": 1484,
+    "release_date": "2025-01-26",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen2.5-VL-7B-Instruct-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-VL-7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-8B-A1B",
+    "provider": "Liquid AI",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8339929856,
+    "min_ram_gb": 4.7,
+    "recommended_ram_gb": 7.8,
+    "min_vram_gb": 4.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2_moe",
+    "hf_downloads": 49084,
+    "hf_likes": 344,
+    "release_date": "2025-10-07",
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 1500000000,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/LFM2-8B-A1B-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+    "provider": "nvidia",
+    "parameter_count": "8.9B",
+    "parameters_raw": 8888227328,
+    "min_ram_gb": 5.0,
+    "recommended_ram_gb": 8.3,
+    "min_vram_gb": 4.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "nemotron_h",
+    "hf_downloads": 461012,
+    "hf_likes": 487,
+    "release_date": "2025-08-12"
+  },
+  {
+    "name": "google/gemma-2-9b-it",
+    "provider": "Google",
+    "parameter_count": "9.2B",
+    "parameters_raw": 9241705984,
+    "min_ram_gb": 5.2,
+    "recommended_ram_gb": 8.6,
+    "min_vram_gb": 4.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "gemma2",
+    "hf_downloads": 219508,
+    "hf_likes": 784,
+    "release_date": "2024-06-24",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/gemma-2-9b-it-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/gemma-2-9b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "THUDM/glm-4-9b-chat",
+    "provider": "thudm",
+    "parameter_count": "9.4B",
+    "parameters_raw": 9399951392,
+    "min_ram_gb": 5.3,
+    "recommended_ram_gb": 8.8,
+    "min_vram_gb": 4.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "chatglm",
+    "hf_downloads": 170011,
+    "hf_likes": 704,
+    "release_date": "2024-06-04",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/glm-4-9b-chat-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/glm-4-9b-chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-9B",
+    "provider": "Alibaba",
+    "parameter_count": "9.7B",
+    "parameters_raw": 9653104368,
+    "min_ram_gb": 5.4,
+    "recommended_ram_gb": 9.0,
+    "min_vram_gb": 4.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 4869308,
+    "hf_likes": 1185,
+    "release_date": "2026-02-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-9B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-9B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-9B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "9.7B",
+    "parameters_raw": 9653104368,
+    "min_ram_gb": 5.4,
+    "recommended_ram_gb": 9.0,
+    "min_vram_gb": 4.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 104575,
+    "hf_likes": 62,
+    "release_date": "2026-02-26"
+  },
+  {
+    "name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    "provider": "Meta",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10670220835,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 9.9,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "mllama",
+    "hf_downloads": 231775,
+    "hf_likes": 1583,
+    "release_date": "2024-09-18"
+  },
+  {
+    "name": "upstage/SOLAR-10.7B-Instruct-v1.0",
+    "provider": "Upstage",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 38534,
+    "hf_likes": 649,
+    "release_date": "2023-12-12",
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/SOLAR-10.7B-Instruct-v1.0-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3-12b-it",
+    "provider": "Google",
+    "parameter_count": "12B",
+    "parameters_raw": 12000000000,
+    "min_ram_gb": 6.7,
+    "recommended_ram_gb": 11.2,
+    "min_vram_gb": 6.1,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Multimodal, vision and text",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma3",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3-12b-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3-12b-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-3-12b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Mistral-Nemo-Instruct-2407",
+    "provider": "Mistral AI",
+    "parameter_count": "12.2B",
+    "parameters_raw": 12247076864,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.4,
+    "min_vram_gb": 6.3,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Mistral-Nemo-Instruct-2407-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Mistral-Nemo-Instruct-2407-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Mistral-Nemo-Instruct-2407-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Orca-2-13b",
+    "provider": "Microsoft",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13015864320,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Reasoning, step-by-step solutions",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Orca-2-13b-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Orca-2-13b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lmsys/vicuna-13b-v1.5",
+    "provider": "LMSYS",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13015864320,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/vicuna-13b-v1.5-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/vicuna-13b-v1.5-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "WizardLMTeam/WizardLM-13B-V1.2",
+    "provider": "WizardLM",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13015864320,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/WizardLM-13B-V1.2-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/WizardLM-13B-V1.2-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/CodeLlama-13b-Instruct-hf",
+    "provider": "Meta",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13016028160,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 258,
+    "hf_likes": 27,
+    "release_date": "2024-03-13",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/CodeLlama-13b-Instruct-hf-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "allenai/OLMo-2-1124-13B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "13.7B",
+    "parameters_raw": 13716198400,
+    "min_ram_gb": 7.7,
+    "recommended_ram_gb": 12.8,
+    "min_vram_gb": 7.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "olmo2",
+    "hf_downloads": 8608,
+    "hf_likes": 47,
+    "release_date": "2024-12-18",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/OLMo-2-1124-13B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/OLMo-2-1124-13B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/phi-4",
+    "provider": "Microsoft",
+    "parameter_count": "14B",
+    "parameters_raw": 14000000000,
+    "min_ram_gb": 7.8,
+    "recommended_ram_gb": 13.0,
+    "min_vram_gb": 7.2,
+    "quantization": "Q4_K_M",
+    "context_length": 16384,
+    "use_case": "Reasoning, STEM, code generation",
+    "pipeline_tag": "text-generation",
+    "architecture": "phi",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/phi-4-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/phi-4-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/phi-4-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-3-medium-14b-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "14B",
+    "parameters_raw": 14000000000,
+    "min_ram_gb": 7.8,
+    "recommended_ram_gb": 13.0,
+    "min_vram_gb": 7.2,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Balanced performance and size",
+    "pipeline_tag": "text-generation",
+    "architecture": "phi3",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
+  },
+  {
+    "name": "microsoft/Phi-4-reasoning",
+    "provider": "Microsoft",
+    "parameter_count": "14B",
+    "parameters_raw": 14000000000,
+    "min_ram_gb": 7.8,
+    "recommended_ram_gb": 13.0,
+    "min_vram_gb": 7.2,
+    "quantization": "Q4_K_M",
+    "context_length": 32768,
+    "use_case": "Advanced reasoning, math and code",
+    "pipeline_tag": "text-generation",
+    "architecture": "phi4",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-04-01",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Phi-4-reasoning-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Phi-4-reasoning-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-14B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770000000,
+    "min_ram_gb": 8.2,
+    "recommended_ram_gb": 13.7,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-14B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-14B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-14B",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770000000,
+    "min_ram_gb": 8.2,
+    "recommended_ram_gb": 13.7,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-14B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-14B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3-14B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-14B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770033664,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 888451,
+    "hf_likes": 145,
+    "release_date": "2024-11-06",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-Coder-14B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Qwen2.5-Coder-14B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-14B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+    "provider": "DeepSeek",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770033664,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 576201,
+    "hf_likes": 621,
+    "release_date": "2025-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-14B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "WizardLMTeam/WizardCoder-15B-V1.0",
+    "provider": "WizardLM",
+    "parameter_count": "15.5B",
+    "parameters_raw": 15515334656,
+    "min_ram_gb": 8.7,
+    "recommended_ram_gb": 14.5,
+    "min_vram_gb": 7.9,
+    "quantization": "Q4_K_M",
+    "context_length": 8192,
+    "use_case": "Code generation and completion",
+    "pipeline_tag": "text-generation",
+    "architecture": "starcoder",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/WizardCoder-15B-V1.0-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "bigcode/starcoder2-15b",
+    "provider": "BigCode",
+    "parameter_count": "15.7B",
+    "parameters_raw": 15700000000,
+    "min_ram_gb": 8.8,
+    "recommended_ram_gb": 14.6,
+    "min_vram_gb": 8.0,
+    "quantization": "Q4_K_M",
+    "context_length": 16384,
+    "use_case": "Code generation and completion",
+    "pipeline_tag": "text-generation",
+    "architecture": "starcoder2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/starcoder2-15b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
+    "provider": "DeepSeek",
+    "parameter_count": "15.7B",
+    "parameters_raw": 15706484224,
+    "min_ram_gb": 8.8,
+    "recommended_ram_gb": 14.6,
+    "min_vram_gb": 8.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 163840,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v2",
+    "hf_downloads": 400985,
+    "hf_likes": 575,
+    "release_date": "2024-06-14",
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2400000000,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "inclusionAI/Ling-lite",
+    "provider": "inclusionai",
+    "parameter_count": "16.8B",
+    "parameters_raw": 16801974272,
+    "min_ram_gb": 9.4,
+    "recommended_ram_gb": 15.6,
+    "min_vram_gb": 8.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "bailing_moe",
+    "hf_downloads": 436,
+    "hf_likes": 78,
+    "release_date": "2025-02-28",
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2336524543,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Ling-lite-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Devstral-Small-2505",
+    "provider": "Mistral AI",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23572403200,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 97867,
+    "hf_likes": 866,
+    "release_date": "2025-05-12",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Devstral-Small-2505-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "LiquidAI/LFM2-24B-A2B",
+    "provider": "Liquid AI",
+    "parameter_count": "23.8B",
+    "parameters_raw": 23843661440,
+    "min_ram_gb": 13.3,
+    "recommended_ram_gb": 22.2,
+    "min_vram_gb": 12.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "lfm2_moe",
+    "hf_downloads": 40933,
+    "hf_likes": 304,
+    "release_date": "2026-02-24",
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 4,
+    "active_parameters": 2300000000,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/LFM2-24B-A2B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Mistral-Small-24B-Instruct-2501",
+    "provider": "Mistral AI",
+    "parameter_count": "24B",
+    "parameters_raw": 24000000000,
+    "min_ram_gb": 13.4,
+    "recommended_ram_gb": 22.4,
+    "min_vram_gb": 12.3,
+    "quantization": "Q4_K_M",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "mistral",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Mistral-Small-24B-Instruct-2501-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Mistral-Small-24B-Instruct-2501-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Mistral-Small-24B-Instruct-2501-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-4-26B-A4B-it",
+    "provider": "Google",
+    "parameter_count": "26.5B",
+    "parameters_raw": 26544131376,
+    "min_ram_gb": 14.8,
+    "recommended_ram_gb": 24.7,
+    "min_vram_gb": 13.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma4",
+    "hf_downloads": 271222,
+    "hf_likes": 388,
+    "release_date": "2026-03-11",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-4-26B-A4B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-4-26B-A4B-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-4-26B-A4B-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-2-27b-it",
+    "provider": "Google",
+    "parameter_count": "27.2B",
+    "parameters_raw": 27227128320,
+    "min_ram_gb": 15.2,
+    "recommended_ram_gb": 25.4,
+    "min_vram_gb": 13.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "gemma2",
+    "hf_downloads": 258287,
+    "hf_likes": 563,
+    "release_date": "2024-06-24",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/gemma-2-27b-it-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/gemma-2-27b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3-27b-it",
+    "provider": "Google",
+    "parameter_count": "27.4B",
+    "parameters_raw": 27432406640,
+    "min_ram_gb": 15.3,
+    "recommended_ram_gb": 25.5,
+    "min_vram_gb": 14.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma3",
+    "hf_downloads": 899424,
+    "hf_likes": 1946,
+    "release_date": "2025-03-01",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3-27b-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3-27b-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-3-27b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-27B",
+    "provider": "Alibaba",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 3004081,
+    "hf_likes": 862,
+    "release_date": "2026-02-24",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-27B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-27B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    "provider": "nvidia",
+    "parameter_count": "31.6B",
+    "parameters_raw": 31577937344,
+    "min_ram_gb": 17.6,
+    "recommended_ram_gb": 29.4,
+    "min_vram_gb": 16.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "nemotron_h",
+    "hf_downloads": 1116073,
+    "hf_likes": 703,
+    "release_date": "2025-12-04",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-Deep-32B",
+    "provider": "lgai-exaone",
+    "parameter_count": "32.0B",
+    "parameters_raw": 32003200000,
+    "min_ram_gb": 17.9,
+    "recommended_ram_gb": 29.8,
+    "min_vram_gb": 16.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone",
+    "hf_downloads": 4682,
+    "hf_likes": 299,
+    "release_date": "2025-03-12",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/EXAONE-Deep-32B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-4.0-32B",
+    "provider": "lgai-exaone",
+    "parameter_count": "32.0B",
+    "parameters_raw": 32003216384,
+    "min_ram_gb": 17.9,
+    "recommended_ram_gb": 29.8,
+    "min_vram_gb": 16.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "exaone4",
+    "hf_downloads": 23440,
+    "hf_likes": 281,
+    "release_date": "2025-07-11",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/EXAONE-4.0-32B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "allenai/OLMo-2-0325-32B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "32.2B",
+    "parameters_raw": 32234279936,
+    "min_ram_gb": 18.0,
+    "recommended_ram_gb": 30.0,
+    "min_vram_gb": 16.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "olmo2",
+    "hf_downloads": 16393,
+    "hf_likes": 148,
+    "release_date": "2025-03-12",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/OLMo-2-0325-32B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/OLMo-2-0325-32B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-32B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "32.5B",
+    "parameters_raw": 32510000000,
+    "min_ram_gb": 18.2,
+    "recommended_ram_gb": 30.3,
+    "min_vram_gb": 16.7,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-32B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-32B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-4-31B-it",
+    "provider": "Google",
+    "parameter_count": "32.7B",
+    "parameters_raw": 32682372656,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.4,
+    "min_vram_gb": 16.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "gemma4",
+    "hf_downloads": 490192,
+    "hf_likes": 964,
+    "release_date": "2026-03-11",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-4-31B-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-4-31B-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-32B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.5,
+    "min_vram_gb": 16.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 957436,
+    "hf_likes": 2000,
+    "release_date": "2024-11-06",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-Coder-32B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-32B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/QwQ-32B",
+    "provider": "Alibaba",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.5,
+    "min_vram_gb": 16.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 69719,
+    "hf_likes": 2886,
+    "release_date": "2025-03-05",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/QwQ-32B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/QwQ-32B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    "provider": "DeepSeek",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.5,
+    "min_vram_gb": 16.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 929875,
+    "hf_likes": 1528,
+    "release_date": "2025-01-20",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "meta-llama/CodeLlama-34b-Instruct-hf",
+    "provider": "Meta",
+    "parameter_count": "33.7B",
+    "parameters_raw": 33743970304,
+    "min_ram_gb": 18.9,
+    "recommended_ram_gb": 31.4,
+    "min_vram_gb": 17.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 595,
+    "hf_likes": 19,
+    "release_date": "2024-03-14",
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/CodeLlama-34b-Instruct-hf-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "01-ai/Yi-34B-Chat",
+    "provider": "01.ai",
+    "parameter_count": "34.4B",
+    "parameters_raw": 34386780160,
+    "min_ram_gb": 19.2,
+    "recommended_ram_gb": 32.0,
+    "min_vram_gb": 17.6,
+    "quantization": "Q4_K_M",
+    "context_length": 4096,
+    "use_case": "Multilingual, Chinese/English chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "yi",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Yi-34B-Chat-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Yi-34B-Chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "CohereForAI/c4ai-command-r-v01",
+    "provider": "Cohere",
+    "parameter_count": "35B",
+    "parameters_raw": 35000000000,
+    "min_ram_gb": 19.5,
+    "recommended_ram_gb": 32.6,
+    "min_vram_gb": 17.9,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "RAG, tool use, agents",
+    "pipeline_tag": "text-generation",
+    "architecture": "cohere",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/c4ai-command-r-v01-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/c4ai-command-r-v01-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-35B-A3B",
+    "provider": "Alibaba",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 3181547,
+    "hf_likes": 1328,
+    "release_date": "2026-02-24",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 3000000000,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3.5-35B-A3B-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3.5-35B-A3B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3.5-35B-A3B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "tiiuae/falcon-40b-instruct",
+    "provider": "TII",
+    "parameter_count": "40.0B",
+    "parameters_raw": 40000000000,
+    "min_ram_gb": 22.4,
+    "recommended_ram_gb": 37.3,
+    "min_vram_gb": 20.5,
+    "quantization": "Q4_K_M",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "pipeline_tag": "text-generation",
+    "architecture": "falcon",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/falcon-40b-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "provider": "Mistral AI",
+    "parameter_count": "46.7B",
+    "parameters_raw": 46702792704,
+    "min_ram_gb": 26.1,
+    "recommended_ram_gb": 43.5,
+    "min_vram_gb": 23.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 433678,
+    "hf_likes": 4654,
+    "release_date": "2023-12-10",
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 12900000000,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Mixtral-8x7B-Instruct-v0.1-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
+    "provider": "NousResearch",
+    "parameter_count": "46.7B",
+    "parameters_raw": 46702809088,
+    "min_ram_gb": 26.1,
+    "recommended_ram_gb": 43.5,
+    "min_vram_gb": 23.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "mixtral",
+    "hf_downloads": 8992,
+    "hf_likes": 452,
+    "release_date": "2024-01-11",
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 12900000000,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/Nous-Hermes-2-Mixtral-8x7B-DPO-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/Nous-Hermes-2-Mixtral-8x7B-DPO-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/Llama-3.3-Nemotron-Super-49B-v1",
+    "provider": "nvidia",
+    "parameter_count": "49.9B",
+    "parameters_raw": 49867145216,
+    "min_ram_gb": 27.9,
+    "recommended_ram_gb": 46.4,
+    "min_vram_gb": 25.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "nemotron-nas",
+    "hf_downloads": 31937,
+    "hf_likes": 321,
+    "release_date": "2025-03-16"
+  },
+  {
+    "name": "meta-llama/Llama-3.1-70B-Instruct",
+    "provider": "Meta",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 1005297,
+    "hf_likes": 905,
+    "release_date": "2024-07-16"
+  },
+  {
+    "name": "meta-llama/Llama-3.3-70B-Instruct",
+    "provider": "Meta",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 401076,
+    "hf_likes": 2688,
+    "release_date": "2024-11-26",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Llama-3.3-70B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Llama-3.3-70B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Llama-3.3-70B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF",
+    "provider": "nvidia",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 10915,
+    "hf_likes": 2063,
+    "release_date": "2024-10-12",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Llama-3.1-Nemotron-70B-Instruct-HF-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Llama-3.1-Nemotron-70B-Instruct-HF-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-72B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "72.7B",
+    "parameters_raw": 72706203648,
+    "min_ram_gb": 40.6,
+    "recommended_ram_gb": 67.7,
+    "min_vram_gb": 37.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 672969,
+    "hf_likes": 924,
+    "release_date": "2024-09-16",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-72B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-72B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2.5-VL-72B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "73.4B",
+    "parameters_raw": 73410777344,
+    "min_ram_gb": 41.0,
+    "recommended_ram_gb": 68.4,
+    "min_vram_gb": 37.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 88913,
+    "hf_likes": 605,
+    "release_date": "2025-01-27",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen2.5-VL-72B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen2.5-VL-72B-Instruct-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-VL-72B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-Coder-Next",
+    "provider": "Alibaba",
+    "parameter_count": "79.7B",
+    "parameters_raw": 79674391296,
+    "min_ram_gb": 44.5,
+    "recommended_ram_gb": 74.2,
+    "min_vram_gb": 40.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3_next",
+    "hf_downloads": 779315,
+    "hf_likes": 1226,
+    "release_date": "2026-01-30",
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 3000000000,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-Coder-Next-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3-Coder-Next-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "CohereForAI/c4ai-command-r-plus-08-2024",
+    "provider": "Cohere",
+    "parameter_count": "103.8B",
+    "parameters_raw": 103810674688,
+    "min_ram_gb": 58.0,
+    "recommended_ram_gb": 96.7,
+    "min_vram_gb": 53.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "cohere",
+    "hf_downloads": 3399,
+    "hf_likes": 282,
+    "release_date": "2024-08-21",
+    "gguf_sources": [
+      {
+        "repo": "bartowski/c4ai-command-r-plus-08-2024-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/c4ai-command-r-plus-08-2024-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "CohereForAI/c4ai-command-a-03-2025",
+    "provider": "Cohere",
+    "parameter_count": "111.1B",
+    "parameters_raw": 111057580032,
+    "min_ram_gb": 62.1,
+    "recommended_ram_gb": 103.4,
+    "min_vram_gb": 56.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "cohere2",
+    "hf_downloads": 4144,
+    "hf_likes": 383,
+    "release_date": "2025-03-11",
+    "gguf_sources": [
+      {
+        "repo": "unsloth/c4ai-command-a-03-2025-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3.5-122B-A10B",
+    "provider": "Alibaba",
+    "parameter_count": "125.1B",
+    "parameters_raw": 125086497008,
+    "min_ram_gb": 69.9,
+    "recommended_ram_gb": 116.5,
+    "min_vram_gb": 64.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 890710,
+    "hf_likes": 471,
+    "release_date": "2026-02-24",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 10000000000
+  },
+  {
+    "name": "mistralai/Mixtral-8x22B-Instruct-v0.1",
+    "provider": "Mistral AI",
+    "parameter_count": "140.6B",
+    "parameters_raw": 140630071296,
+    "min_ram_gb": 78.6,
+    "recommended_ram_gb": 131.0,
+    "min_vram_gb": 72.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 34434,
+    "hf_likes": 748,
+    "release_date": "2024-04-16",
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 39100000000
+  },
+  {
+    "name": "rednote-hilab/dots.llm1.inst",
+    "provider": "rednote-hilab",
+    "parameter_count": "142.8B",
+    "parameters_raw": 142774381696,
+    "min_ram_gb": 79.8,
+    "recommended_ram_gb": 133.0,
+    "min_vram_gb": 73.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "dots1",
+    "hf_downloads": 9356,
+    "hf_likes": 176,
+    "release_date": "2025-05-14"
+  },
+  {
+    "name": "bigscience/bloom",
+    "provider": "bigscience",
+    "parameter_count": "176.2B",
+    "parameters_raw": 176247271424,
+    "min_ram_gb": 98.5,
+    "recommended_ram_gb": 164.1,
+    "min_vram_gb": 90.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "bloom",
+    "hf_downloads": 6538,
+    "hf_likes": 4991,
+    "release_date": "2022-05-19"
+  },
+  {
+    "name": "tiiuae/falcon-180B-chat",
+    "provider": "TII",
+    "parameter_count": "179.5B",
+    "parameters_raw": 179522565120,
+    "min_ram_gb": 100.3,
+    "recommended_ram_gb": 167.2,
+    "min_vram_gb": 92.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "falcon",
+    "hf_downloads": 729,
+    "hf_likes": 546,
+    "release_date": "2023-09-04"
+  },
+  {
+    "name": "MiniMaxAI/MiniMax-M2.5",
+    "provider": "minimaxai",
+    "parameter_count": "228.7B",
+    "parameters_raw": 228703644928,
+    "min_ram_gb": 127.8,
+    "recommended_ram_gb": 213.0,
+    "min_vram_gb": 117.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 196608,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "minimax_m2",
+    "hf_downloads": 642510,
+    "hf_likes": 1344,
+    "release_date": "2026-02-12",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 10000000000
+  },
+  {
+    "name": "MiniMaxAI/MiniMax-M2.7",
+    "provider": "MiniMax",
+    "parameter_count": "230B",
+    "parameters_raw": 230000000000,
+    "min_ram_gb": 128.6,
+    "recommended_ram_gb": 214.4,
+    "min_vram_gb": 117.9,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Latest flagship with enhanced reasoning and coding",
+    "pipeline_tag": "text-generation",
+    "architecture": "minimax",
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 2,
+    "active_parameters": 10000000000,
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2026-03-18"
+  },
+  {
+    "name": "Qwen/Qwen3-235B-A22B",
+    "provider": "Alibaba",
+    "parameter_count": "235.1B",
+    "parameters_raw": 235093634560,
+    "min_ram_gb": 131.4,
+    "recommended_ram_gb": 218.9,
+    "min_vram_gb": 120.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose text generation",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 619449,
+    "hf_likes": 1085,
+    "release_date": "2025-04-27",
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 22000000000
+  },
+  {
+    "name": "baidu/ERNIE-4.5-300B-A47B-Paddle",
+    "provider": "baidu",
+    "parameter_count": "300.5B",
+    "parameters_raw": 300474051776,
+    "min_ram_gb": 167.9,
+    "recommended_ram_gb": 279.8,
+    "min_vram_gb": 153.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "ernie4_5_moe",
+    "hf_downloads": 317,
+    "hf_likes": 13,
+    "release_date": "2025-06-28"
+  },
+  {
+    "name": "XiaomiMiMo/MiMo-V2-Flash",
+    "provider": "xiaomimimo",
+    "parameter_count": "309.8B",
+    "parameters_raw": 309785318400,
+    "min_ram_gb": 173.1,
+    "recommended_ram_gb": 288.5,
+    "min_vram_gb": 158.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "mimo_v2_flash",
+    "hf_downloads": 54392,
+    "hf_likes": 699,
+    "release_date": "2025-12-16"
+  },
+  {
+    "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+    "provider": "Meta",
+    "parameter_count": "401.6B",
+    "parameters_raw": 401583781376,
+    "min_ram_gb": 224.4,
+    "recommended_ram_gb": 374.0,
+    "min_vram_gb": 205.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "llama4",
+    "hf_downloads": 20419,
+    "hf_likes": 476,
+    "release_date": "2025-04-01",
+    "is_moe": true,
+    "num_experts": 16,
+    "active_experts": 1,
+    "active_parameters": 17000000000
+  },
+  {
+    "name": "Qwen/Qwen3.5-397B-A17B",
+    "provider": "Alibaba",
+    "parameter_count": "403.4B",
+    "parameters_raw": 403397928944,
+    "min_ram_gb": 225.4,
+    "recommended_ram_gb": 375.7,
+    "min_vram_gb": 206.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 1024813,
+    "hf_likes": 1413,
+    "release_date": "2026-02-16",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 17000000000
+  },
+  {
+    "name": "meta-llama/Llama-3.1-405B-Instruct",
+    "provider": "Meta",
+    "parameter_count": "405.9B",
+    "parameters_raw": 405853388800,
+    "min_ram_gb": 226.8,
+    "recommended_ram_gb": 378.0,
+    "min_vram_gb": 207.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "llama",
+    "hf_downloads": 173579,
+    "hf_likes": 595,
+    "release_date": "2024-07-16"
+  },
+  {
+    "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "480.2B",
+    "parameters_raw": 480154875392,
+    "min_ram_gb": 268.3,
+    "recommended_ram_gb": 447.2,
+    "min_vram_gb": 245.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 92952,
+    "hf_likes": 1322,
+    "release_date": "2025-07-22",
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 35000000000
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3",
+    "provider": "DeepSeek",
+    "parameter_count": "684.5B",
+    "parameters_raw": 684531386000,
+    "min_ram_gb": 382.5,
+    "recommended_ram_gb": 637.5,
+    "min_vram_gb": 350.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 163840,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 580919,
+    "hf_likes": 4024,
+    "release_date": "2024-12-25",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 37000000000
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1",
+    "provider": "DeepSeek",
+    "parameter_count": "684.5B",
+    "parameters_raw": 684531386000,
+    "min_ram_gb": 382.5,
+    "recommended_ram_gb": 637.5,
+    "min_vram_gb": 350.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 163840,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 2759423,
+    "hf_likes": 13141,
+    "release_date": "2025-01-20",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 37000000000
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3.2-Speciale",
+    "provider": "DeepSeek",
+    "parameter_count": "685B",
+    "parameters_raw": 685000000000,
+    "min_ram_gb": 383.2,
+    "recommended_ram_gb": 638.7,
+    "min_vram_gb": 351.3,
+    "quantization": "Q4_K_M",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v3",
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 37000000000,
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": "2025-12-01"
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3.2",
+    "provider": "DeepSeek",
+    "parameter_count": "685.4B",
+    "parameters_raw": 685396921376,
+    "min_ram_gb": 383.0,
+    "recommended_ram_gb": 638.3,
+    "min_vram_gb": 351.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 163840,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "deepseek_v32",
+    "hf_downloads": 964384,
+    "hf_likes": 1370,
+    "release_date": "2025-12-01"
+  },
+  {
+    "name": "zai-org/GLM-5",
+    "provider": "zai-org",
+    "parameter_count": "753.9B",
+    "parameters_raw": 753864139008,
+    "min_ram_gb": 421.3,
+    "recommended_ram_gb": 702.1,
+    "min_vram_gb": 386.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "glm_moe_dsa",
+    "hf_downloads": 280654,
+    "hf_likes": 1951,
+    "release_date": "2026-02-11"
+  },
+  {
+    "name": "moonshotai/Kimi-K2-Instruct",
+    "provider": "moonshotai",
+    "parameter_count": "1026.5B",
+    "parameters_raw": 1026470731056,
+    "min_ram_gb": 573.6,
+    "recommended_ram_gb": 956.0,
+    "min_vram_gb": 525.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "kimi_k2",
+    "hf_downloads": 95190,
+    "hf_likes": 2331,
+    "release_date": "2025-07-11"
+  },
+  {
+    "name": "moonshotai/Kimi-K2.5",
+    "provider": "moonshotai",
+    "parameter_count": "1058.6B",
+    "parameters_raw": 1058589420528,
+    "min_ram_gb": 591.5,
+    "recommended_ram_gb": 985.9,
+    "min_vram_gb": 542.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "kimi_k25",
+    "hf_downloads": 6096616,
+    "hf_likes": 2421,
+    "release_date": "2026-01-01"
+  },
+  {
     "name": "peft-internal-testing/tiny-random-GPT2LMHeadModel",
     "provider": "peft-internal-testing",
     "parameter_count": "83K",
@@ -990,31 +5347,6 @@
     ]
   },
   {
-    "name": "nomic-ai/nomic-embed-text-v1.5",
-    "provider": "Nomic",
-    "parameter_count": "137M",
-    "parameters_raw": 136731648,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "Text embeddings for RAG",
-    "capabilities": [],
-    "pipeline_tag": "sentence-similarity",
-    "architecture": "nomic_bert",
-    "hf_downloads": 10472912,
-    "hf_likes": 788,
-    "release_date": "2024-02-10",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/nomic-embed-text-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "EleutherAI/gpt-neo-125m",
     "provider": "eleutherai",
     "parameter_count": "150M",
@@ -1625,31 +5957,6 @@
     "_discovered": true
   },
   {
-    "name": "BAAI/bge-large-en-v1.5",
-    "provider": "BAAI",
-    "parameter_count": "335M",
-    "parameters_raw": 335142400,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 512,
-    "use_case": "Text embeddings for RAG",
-    "capabilities": [],
-    "pipeline_tag": "feature-extraction",
-    "architecture": "bert",
-    "hf_downloads": 6786889,
-    "hf_likes": 638,
-    "release_date": "2023-09-12",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/bge-large-en-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "ibm-granite/granite-4.0-350m",
     "provider": "ibm-granite",
     "parameter_count": "352M",
@@ -1672,154 +5979,6 @@
       {
         "repo": "unsloth/granite-4.0-350m-GGUF",
         "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-ColBERT-350M",
-    "provider": "Liquid AI",
-    "parameter_count": "353M",
-    "parameters_raw": 353322752,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "sentence-similarity",
-    "architecture": "lfm2",
-    "hf_downloads": 22196,
-    "hf_likes": 125,
-    "release_date": "2025-10-28"
-  },
-  {
-    "name": "LiquidAI/LFM2-350M",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 36160,
-    "hf_likes": 245,
-    "release_date": "2025-07-10",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-350M-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/LFM2-350M-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-350M-Extract",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 1120,
-    "hf_likes": 77,
-    "release_date": "2025-09-03",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-350M-Extract-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-350M-Math",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 638,
-    "hf_likes": 56,
-    "release_date": "2025-08-25",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-350M-Math-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-350M-ENJP-MT",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "translation",
-    "architecture": "lfm2",
-    "hf_downloads": 756,
-    "hf_likes": 87,
-    "release_date": "2025-09-03",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-350M-ENJP-MT-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-350M-PII-Extract-JP",
-    "provider": "Liquid AI",
-    "parameter_count": "354M",
-    "parameters_raw": 354483968,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 902,
-    "hf_likes": 53,
-    "release_date": "2025-09-30",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-350M-PII-Extract-JP-GGUF",
-        "provider": "mradermacher"
       }
     ]
   },
@@ -1896,37 +6055,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-VL-450M",
-    "provider": "Liquid AI",
-    "parameter_count": "451M",
-    "parameters_raw": 450822656,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "lfm2_vl",
-    "hf_downloads": 15610,
-    "hf_likes": 146,
-    "release_date": "2025-08-12",
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/LFM2-VL-450M-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/LFM2-VL-450M-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "lmstudio-community/Qwen3-1.7B-MLX-8bit",
     "provider": "lmstudio-community",
     "parameter_count": "484M",
@@ -1947,38 +6075,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2.5-0.5B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "494M",
-    "parameters_raw": 494032768,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 6221788,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-0.5B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-0.5B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-0.5B",
@@ -2597,66 +6693,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-700M",
-    "provider": "Liquid AI",
-    "parameter_count": "742M",
-    "parameters_raw": 742489344,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 11590,
-    "hf_likes": 109,
-    "release_date": "2025-07-10",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-700M-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3-0.6B",
-    "provider": "Alibaba",
-    "parameter_count": "752M",
-    "parameters_raw": 751632384,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3",
-    "hf_downloads": 13937340,
-    "hf_likes": 1165,
-    "release_date": "2025-04-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-0.6B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-0.6B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-0.6B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3Guard-Gen-0.6B",
     "provider": "Alibaba",
     "parameter_count": "752M",
@@ -2925,60 +6961,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen3.5-0.8B",
-    "provider": "Alibaba",
-    "parameter_count": "873M",
-    "parameters_raw": 873438784,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 2051106,
-    "hf_likes": 467,
-    "release_date": "2026-02-28",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-0.8B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-0.8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-0.8B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "873M",
-    "parameters_raw": 873438784,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 152502,
-    "hf_likes": 61,
-    "release_date": "2026-02-28"
   },
   {
     "name": "lmstudio-community/Qwen3-4B-Thinking-2507-MLX-6bit",
@@ -3414,35 +7396,6 @@
     ]
   },
   {
-    "name": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-    "provider": "Community",
-    "parameter_count": "1.1B",
-    "parameters_raw": 1100048384,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 2048,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 2881521,
-    "hf_likes": 1558,
-    "release_date": "2023-12-30",
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/TinyLlama-1.1B-Chat-v1.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "nm-testing/tinyllama-oneshot-w8w8-test-static-shape-change",
     "provider": "nm-testing",
     "parameter_count": "1.1B",
@@ -3596,214 +7549,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-1.2B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 40711,
-    "hf_likes": 351,
-    "release_date": "2025-07-10",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-1.2B-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-1.2B-Base",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 37002,
-    "hf_likes": 121,
-    "release_date": "2026-01-05",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2.5-1.2B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-1.2B-Instruct",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 289628,
-    "hf_likes": 549,
-    "release_date": "2026-01-06",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2.5-1.2B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/LFM2.5-1.2B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-1.2B-Thinking",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 27300,
-    "hf_likes": 326,
-    "release_date": "2026-01-20",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2.5-1.2B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/LFM2.5-1.2B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-1.2B-JP",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 2471,
-    "hf_likes": 142,
-    "release_date": "2026-01-04",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2.5-1.2B-JP-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-1.2B-Tool",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 363,
-    "hf_likes": 96,
-    "release_date": "2025-09-03",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-1.2B-Tool-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-1.2B-RAG",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 656,
-    "hf_likes": 115,
-    "release_date": "2025-09-03",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-1.2B-RAG-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-1.2B-Extract",
-    "provider": "Liquid AI",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1170340608,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 1508,
-    "hf_likes": 106,
-    "release_date": "2025-08-22",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-1.2B-Extract-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "lmstudio-community/LFM2-1.2B-MLX-bf16",
     "provider": "lmstudio-community",
     "parameter_count": "1.2B",
@@ -3868,31 +7613,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "meta-llama/Llama-3.2-1B",
-    "provider": "Meta",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1235814400,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 1737741,
-    "hf_likes": 2349,
-    "release_date": "2024-09-18",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-3.2-1B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "meta-llama/Llama-3.2-1B-Instruct",
@@ -4141,31 +7861,6 @@
     "_discovered": true
   },
   {
-    "name": "LGAI-EXAONE/EXAONE-4.0-1.2B",
-    "provider": "lgai-exaone",
-    "parameter_count": "1.3B",
-    "parameters_raw": 1279391488,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 65536,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "exaone4",
-    "hf_downloads": 31444,
-    "hf_likes": 177,
-    "release_date": "2025-07-11",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/EXAONE-4.0-1.2B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "lmstudio-community/DeepSeek-R1-0528-Qwen3-8B-MLX-4bit",
     "provider": "lmstudio-community",
     "parameter_count": "1.3B",
@@ -4387,50 +8082,6 @@
     ]
   },
   {
-    "name": "LiquidAI/LFM2-Audio-1.5B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1470308496,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "audio-to-audio",
-    "architecture": "unknown",
-    "hf_downloads": 232,
-    "hf_likes": 346,
-    "release_date": "2025-08-28",
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/LFM2-Audio-1.5B-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-Audio-1.5B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1470308496,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "audio-to-audio",
-    "architecture": "unknown",
-    "hf_downloads": 1053,
-    "hf_likes": 374,
-    "release_date": "2025-12-18"
-  },
-  {
     "name": "allenai/OLMo-2-0425-1B",
     "provider": "allenai",
     "parameter_count": "1.5B",
@@ -4601,73 +8252,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1543714304,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 755964,
-    "hf_likes": 110,
-    "release_date": "2024-09-18",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-1.5B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-1.5B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-1.5B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-1.5B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1543714304,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 10034924,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-1.5B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-1.5B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2-1.5B-Instruct",
@@ -4873,60 +8457,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-VL-1.6B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.6B",
-    "parameters_raw": 1584804000,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "lfm2_vl",
-    "hf_downloads": 5155,
-    "hf_likes": 226,
-    "release_date": "2025-08-12",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-VL-1.6B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2.5-VL-1.6B",
-    "provider": "Liquid AI",
-    "parameter_count": "1.6B",
-    "parameters_raw": 1596625904,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "lfm2_vl",
-    "hf_downloads": 135633,
-    "hf_likes": 264,
-    "release_date": "2026-01-05",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2.5-VL-1.6B-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
     "name": "KiteFishAI/Minnow-Math-1.5B",
     "provider": "kitefishai",
     "parameter_count": "1.6B",
@@ -4945,31 +8475,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "stabilityai/stablelm-2-1_6b-chat",
-    "provider": "Stability AI",
-    "parameter_count": "1.6B",
-    "parameters_raw": 1644515328,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "stablelm",
-    "hf_downloads": 1818,
-    "hf_likes": 34,
-    "release_date": "2024-04-08",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/stablelm-2-1_6b-chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "nanonets/Nanonets-OCR2-1.5B-exp",
@@ -5220,40 +8725,6 @@
     "_discovered": true
   },
   {
-    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
-    "provider": "DeepSeek",
-    "parameter_count": "1.8B",
-    "parameters_raw": 1777088000,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 787869,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
     "provider": "Alibaba",
     "parameter_count": "1.8B",
@@ -5456,41 +8927,6 @@
     "num_experts": 64,
     "active_experts": 6,
     "active_parameters": 277721550
-  },
-  {
-    "name": "Qwen/Qwen3-1.7B",
-    "provider": "Alibaba",
-    "parameter_count": "2.0B",
-    "parameters_raw": 2031739904,
-    "min_ram_gb": 1.1,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 1.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3",
-    "hf_downloads": 7067897,
-    "hf_likes": 437,
-    "release_date": "2025-04-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-1.7B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-1.7B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-1.7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "JetLM/SDAR-1.7B-Chat",
@@ -5942,60 +9378,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen3.5-2B",
-    "provider": "Alibaba",
-    "parameter_count": "2.3B",
-    "parameters_raw": 2274069824,
-    "min_ram_gb": 1.3,
-    "recommended_ram_gb": 2.1,
-    "min_vram_gb": 1.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 1456178,
-    "hf_likes": 231,
-    "release_date": "2026-02-28",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-2B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-2B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-2B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "2.3B",
-    "parameters_raw": 2274069824,
-    "min_ram_gb": 1.3,
-    "recommended_ram_gb": 2.1,
-    "min_vram_gb": 1.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 81008,
-    "hf_likes": 62,
-    "release_date": "2026-02-28"
-  },
-  {
     "name": "huihui-ai/Huihui-Qwen3.5-2B-abliterated",
     "provider": "huihui-ai",
     "parameter_count": "2.3B",
@@ -6341,85 +9723,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-2.6B",
-    "provider": "Liquid AI",
-    "parameter_count": "2.6B",
-    "parameters_raw": 2569272320,
-    "min_ram_gb": 1.4,
-    "recommended_ram_gb": 2.4,
-    "min_vram_gb": 1.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 7291,
-    "hf_likes": 184,
-    "release_date": "2025-09-22",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-2.6B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-2.6B-Exp",
-    "provider": "Liquid AI",
-    "parameter_count": "2.6B",
-    "parameters_raw": 2569272320,
-    "min_ram_gb": 1.4,
-    "recommended_ram_gb": 2.4,
-    "min_vram_gb": 1.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 26317,
-    "hf_likes": 335,
-    "release_date": "2025-12-25",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-2.6B-Exp-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/LFM2-2.6B-Exp-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LiquidAI/LFM2-2.6B-Transcript",
-    "provider": "Liquid AI",
-    "parameter_count": "2.6B",
-    "parameters_raw": 2569272320,
-    "min_ram_gb": 1.4,
-    "recommended_ram_gb": 2.4,
-    "min_vram_gb": 1.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2",
-    "hf_downloads": 327,
-    "hf_likes": 161,
-    "release_date": "2026-01-05",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-2.6B-Transcript-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "AIDC-AI/Ovis2.5-2B",
     "provider": "aidc-ai",
     "parameter_count": "2.6B",
@@ -6438,35 +9741,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "google/gemma-2-2b-it",
-    "provider": "Google",
-    "parameter_count": "2.6B",
-    "parameters_raw": 2614341888,
-    "min_ram_gb": 1.5,
-    "recommended_ram_gb": 2.4,
-    "min_vram_gb": 1.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "gemma2",
-    "hf_downloads": 377256,
-    "hf_likes": 1315,
-    "release_date": "2024-07-16",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/gemma-2-2b-it-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/gemma-2-2b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Efficient-Large-Model/gemma-2-2b-it",
@@ -6772,27 +10046,6 @@
     "_discovered": true
   },
   {
-    "name": "LiquidAI/LFM2-VL-3B",
-    "provider": "Liquid AI",
-    "parameter_count": "3.0B",
-    "parameters_raw": 2998975216,
-    "min_ram_gb": 1.7,
-    "recommended_ram_gb": 2.8,
-    "min_vram_gb": 1.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "lfm2_vl",
-    "hf_downloads": 11922,
-    "hf_likes": 132,
-    "release_date": "2025-10-22"
-  },
-  {
     "name": "bigcode/starcoder2-3b",
     "provider": "BigCode",
     "parameter_count": "3.0B",
@@ -6939,39 +10192,6 @@
     "_discovered": true
   },
   {
-    "name": "HuggingFaceTB/SmolLM3-3B",
-    "provider": "huggingfacetb",
-    "parameter_count": "3.1B",
-    "parameters_raw": 3075098624,
-    "min_ram_gb": 1.7,
-    "recommended_ram_gb": 2.9,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 65536,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "smollm3",
-    "hf_downloads": 1091490,
-    "hf_likes": 924,
-    "release_date": "2025-07-08",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/SmolLM3-3B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/SmolLM3-3B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/SmolLM3-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "HuggingFaceTB/SmolLM3-3B-Base",
     "provider": "huggingfacetb",
     "parameter_count": "3.1B",
@@ -6993,38 +10213,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/SmolLM3-3B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-3B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "3.1B",
-    "parameters_raw": 3085938688,
-    "min_ram_gb": 1.7,
-    "recommended_ram_gb": 2.9,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 7876727,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-3B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-3B-Instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -7174,60 +10362,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "ibm-granite/granite-4.0-h-micro",
-    "provider": "ibm-granite",
-    "parameter_count": "3.2B",
-    "parameters_raw": 3191396096,
-    "min_ram_gb": 1.8,
-    "recommended_ram_gb": 3.0,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "granitemoehybrid",
-    "hf_downloads": 47085,
-    "hf_likes": 142,
-    "release_date": "2025-09-16",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/granite-4.0-h-micro-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/granite-4.0-h-micro-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "meta-llama/Llama-3.2-3B",
-    "provider": "Meta",
-    "parameter_count": "3.2B",
-    "parameters_raw": 3212749824,
-    "min_ram_gb": 1.8,
-    "recommended_ram_gb": 3.0,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 1266644,
-    "hf_likes": 725,
-    "release_date": "2024-09-18",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-3.2-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "meta-llama/Llama-3.2-3B-Instruct",
@@ -7664,42 +10798,6 @@
     "_discovered": true
   },
   {
-    "name": "Qwen/Qwen2.5-VL-3B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3754622976,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.5,
-    "min_vram_gb": 1.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 6467324,
-    "hf_likes": 633,
-    "release_date": "2025-01-26",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-VL-3B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen2.5-VL-3B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-VL-3B-Instruct-AWQ",
     "provider": "Alibaba",
     "parameter_count": "3.8B",
@@ -7850,91 +10948,6 @@
     "num_experts": 16,
     "active_experts": 2,
     "active_parameters": 633693422
-  },
-  {
-    "name": "microsoft/Phi-4-mini-reasoning",
-    "provider": "Microsoft",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3800000000,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.5,
-    "min_vram_gb": 1.9,
-    "quantization": "Q4_K_M",
-    "context_length": 16384,
-    "use_case": "Lightweight reasoning",
-    "pipeline_tag": "text-generation",
-    "architecture": "phi4",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-04-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Phi-4-mini-reasoning-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Phi-4-mini-reasoning-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "microsoft/phi-3-mini-4k-instruct",
-    "provider": "Microsoft",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3821079552,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.6,
-    "min_vram_gb": 2.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "phi3",
-    "hf_downloads": 704829,
-    "hf_likes": 1403,
-    "release_date": "2024-04-22",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/phi-3-mini-4k-instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/phi-3-mini-4k-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "microsoft/Phi-3.5-mini-instruct",
-    "provider": "Microsoft",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3821079552,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.6,
-    "min_vram_gb": 2.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "phi3",
-    "hf_downloads": 946484,
-    "hf_likes": 967,
-    "release_date": "2024-08-16",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Phi-3.5-mini-instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Phi-3.5-mini-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "microsoft/Phi-3-mini-4k-instruct",
@@ -8097,33 +11110,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "google/gemma-3n-E2B-it",
-    "provider": "Google",
-    "parameter_count": "4B",
-    "parameters_raw": 4000000000,
-    "min_ram_gb": 2.2,
-    "recommended_ram_gb": 3.7,
-    "min_vram_gb": 2.1,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Multimodal, on-device (effective 2B)",
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "gemma3n",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-06-25",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-3n-E2B-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-3n-E2B-it-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen3-4B-Instruct-2507",
@@ -8881,60 +11867,6 @@
     "_discovered": true
   },
   {
-    "name": "Qwen/Qwen3.5-4B",
-    "provider": "Alibaba",
-    "parameter_count": "4.7B",
-    "parameters_raw": 4659865088,
-    "min_ram_gb": 2.6,
-    "recommended_ram_gb": 4.3,
-    "min_vram_gb": 2.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 2702718,
-    "hf_likes": 429,
-    "release_date": "2026-02-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-4B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-4B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-4B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "4.7B",
-    "parameters_raw": 4659865088,
-    "min_ram_gb": 2.6,
-    "recommended_ram_gb": 4.3,
-    "min_vram_gb": 2.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 96875,
-    "hf_likes": 54,
-    "release_date": "2026-02-27"
-  },
-  {
     "name": "Tristepin/ue3-qw35-4b-v1",
     "provider": "tristepin",
     "parameter_count": "4.7B",
@@ -9481,25 +12413,6 @@
     "active_parameters": 580405768
   },
   {
-    "name": "microsoft/Phi-4-multimodal-instruct",
-    "provider": "Microsoft",
-    "parameter_count": "5.6B",
-    "parameters_raw": 5574460384,
-    "min_ram_gb": 3.1,
-    "recommended_ram_gb": 5.2,
-    "min_vram_gb": 2.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "automatic-speech-recognition",
-    "architecture": "phi4mm",
-    "hf_downloads": 295822,
-    "hf_likes": 1576,
-    "release_date": "2025-02-24"
-  },
-  {
     "name": "cyankiwi/Qwen3-VL-30B-A3B-Instruct-AWQ-4bit",
     "provider": "cyankiwi",
     "parameter_count": "5.8B",
@@ -9545,31 +12458,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "01-ai/Yi-6B-Chat",
-    "provider": "01.ai",
-    "parameter_count": "6.1B",
-    "parameters_raw": 6061035520,
-    "min_ram_gb": 3.4,
-    "recommended_ram_gb": 5.6,
-    "min_vram_gb": 3.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 27255,
-    "hf_likes": 70,
-    "release_date": "2023-11-22",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Yi-6B-Chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "apolo13x/Qwen3.5-35B-A3B-quantized.w4a16",
@@ -9658,33 +12546,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "lmsys/vicuna-7b-v1.5",
-    "provider": "LMSYS",
-    "parameter_count": "7.0B",
-    "parameters_raw": 6738415616,
-    "min_ram_gb": 3.8,
-    "recommended_ram_gb": 6.3,
-    "min_vram_gb": 3.4,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/vicuna-7b-v1.5-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/vicuna-7b-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "LLM360/Amber",
@@ -9864,31 +12725,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/Llama-2-7b-chat-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "meta-llama/CodeLlama-7b-Instruct-hf",
-    "provider": "Meta",
-    "parameter_count": "6.7B",
-    "parameters_raw": 6738546688,
-    "min_ram_gb": 3.8,
-    "recommended_ram_gb": 6.3,
-    "min_vram_gb": 3.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 1616,
-    "hf_likes": 59,
-    "release_date": "2024-03-13",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-7b-Instruct-hf-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -10092,39 +12928,6 @@
     ]
   },
   {
-    "name": "ibm-granite/granite-4.0-h-tiny",
-    "provider": "ibm-granite",
-    "parameter_count": "6.9B",
-    "parameters_raw": 6939037248,
-    "min_ram_gb": 3.9,
-    "recommended_ram_gb": 6.5,
-    "min_vram_gb": 3.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Lightweight, edge deployment",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "granitemoehybrid",
-    "hf_downloads": 62096,
-    "hf_likes": 198,
-    "release_date": "2025-09-16",
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 964959866,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/granite-4.0-h-tiny-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/granite-4.0-h-tiny-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "EleutherAI/pythia-6.9b",
     "provider": "eleutherai",
     "parameter_count": "7.0B",
@@ -10146,77 +12949,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/pythia-6.9b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "openchat/openchat-3.5-0106",
-    "provider": "OpenChat",
-    "parameter_count": "7.0B",
-    "parameters_raw": 7000000000,
-    "min_ram_gb": 3.9,
-    "recommended_ram_gb": 6.5,
-    "min_vram_gb": 3.6,
-    "quantization": "Q4_K_M",
-    "context_length": 8192,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/openchat-3.5-0106-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/openchat-3.5-0106-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "XiaomiMiMo/MiMo-7B-RL",
-    "provider": "Xiaomi",
-    "parameter_count": "7.0B",
-    "parameters_raw": 7000000000,
-    "min_ram_gb": 3.9,
-    "recommended_ram_gb": 6.5,
-    "min_vram_gb": 3.6,
-    "quantization": "Q4_K_M",
-    "context_length": 32768,
-    "use_case": "Advanced reasoning, math and code",
-    "pipeline_tag": "text-generation",
-    "architecture": "mimo",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-05-01"
-  },
-  {
-    "name": "microsoft/Orca-2-7b",
-    "provider": "Microsoft",
-    "parameter_count": "7.0B",
-    "parameters_raw": 7016400896,
-    "min_ram_gb": 3.9,
-    "recommended_ram_gb": 6.5,
-    "min_vram_gb": 3.6,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Reasoning, step-by-step solutions",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Orca-2-7b-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Orca-2-7b-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -10357,50 +13089,6 @@
     "_discovered": true
   },
   {
-    "name": "bigcode/starcoder2-7b",
-    "provider": "BigCode",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7173923840,
-    "min_ram_gb": 4.0,
-    "recommended_ram_gb": 6.7,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 16384,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "starcoder2",
-    "hf_downloads": 18288,
-    "hf_likes": 210,
-    "release_date": "2024-02-20"
-  },
-  {
-    "name": "tiiuae/falcon-7b-instruct",
-    "provider": "TII",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7217189760,
-    "min_ram_gb": 4.0,
-    "recommended_ram_gb": 6.7,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "falcon",
-    "hf_downloads": 58905,
-    "hf_likes": 1031,
-    "release_date": "2023-04-25",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/falcon-7b-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "tiiuae/falcon-7b",
     "provider": "TII",
     "parameter_count": "7.2B",
@@ -10422,35 +13110,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/falcon-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "HuggingFaceH4/zephyr-7b-beta",
-    "provider": "HuggingFace",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7241732096,
-    "min_ram_gb": 4.0,
-    "recommended_ram_gb": 6.7,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 136490,
-    "hf_likes": 1836,
-    "release_date": "2023-10-26",
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/zephyr-7b-beta-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/zephyr-7b-beta-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -10646,37 +13305,6 @@
     "_discovered": true
   },
   {
-    "name": "mistralai/Mistral-7B-Instruct-v0.3",
-    "provider": "Mistral AI",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7248023552,
-    "min_ram_gb": 4.1,
-    "recommended_ram_gb": 6.8,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "mistral",
-    "hf_downloads": 2210285,
-    "hf_likes": 2489,
-    "release_date": "2024-05-22",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Mistral-7B-Instruct-v0.3-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Mistral-7B-Instruct-v0.3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "allenai/wildguard",
     "provider": "allenai",
     "parameter_count": "7.2B",
@@ -10857,35 +13485,6 @@
     "_discovered": true
   },
   {
-    "name": "tiiuae/Falcon3-7B-Instruct",
-    "provider": "TII",
-    "parameter_count": "7.5B",
-    "parameters_raw": 7455550464,
-    "min_ram_gb": 4.2,
-    "recommended_ram_gb": 6.9,
-    "min_vram_gb": 3.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 24126,
-    "hf_likes": 77,
-    "release_date": "2024-11-29",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Falcon3-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Falcon3-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "apolo13x/Qwen3.5-9B-NVFP4",
     "provider": "apolo13x",
     "parameter_count": "7.5B",
@@ -11046,105 +13645,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2.5-7B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 14881790,
-    "hf_likes": 1180,
-    "release_date": "2024-09-16",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-7B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 2522695,
-    "hf_likes": 678,
-    "release_date": "2024-09-17",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-7B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
-    "provider": "DeepSeek",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 604740,
-    "hf_likes": 800,
-    "release_date": "2025-01-20",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-Coder-7B-Instruct-GPTQ-Int4",
@@ -11727,32 +14227,6 @@
     "_discovered": true
   },
   {
-    "name": "LGAI-EXAONE/EXAONE-Deep-7.8B",
-    "provider": "lgai-exaone",
-    "parameter_count": "7.8B",
-    "parameters_raw": 7818448896,
-    "min_ram_gb": 4.4,
-    "recommended_ram_gb": 7.3,
-    "min_vram_gb": 4.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "exaone",
-    "hf_downloads": 270267,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/EXAONE-Deep-7.8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "XiaomiMiMo/MiMo-7B-Base",
     "provider": "xiaomimimo",
     "parameter_count": "7.8B",
@@ -11867,37 +14341,6 @@
     ]
   },
   {
-    "name": "google/gemma-3n-E4B-it",
-    "provider": "Google",
-    "parameter_count": "8B",
-    "parameters_raw": 8000000000,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Multimodal, on-device (effective 4B)",
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "gemma3n",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-06-25",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-3n-E4B-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-3n-E4B-it-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gemma-3n-E4B-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "allenai/Molmo-7B-D-0924",
     "provider": "allenai",
     "parameter_count": "8.0B",
@@ -11916,79 +14359,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "meta-llama/Llama-3.1-8B",
-    "provider": "Meta",
-    "parameter_count": "8.0B",
-    "parameters_raw": 8030261248,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 1364845,
-    "hf_likes": 2135,
-    "release_date": "2024-07-14"
-  },
-  {
-    "name": "meta-llama/Llama-3.1-8B-Instruct",
-    "provider": "Meta",
-    "parameter_count": "8.0B",
-    "parameters_raw": 8030261248,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 8438089,
-    "hf_likes": 5652,
-    "release_date": "2024-07-18",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3.1-8B-Instruct-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "mistralai/Ministral-8B-Instruct-2410",
-    "provider": "Mistral AI",
-    "parameter_count": "8.0B",
-    "parameters_raw": 8030261248,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Ministral-8B-Instruct-2410-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Ministral-8B-Instruct-2410-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "meta-llama/Meta-Llama-3-8B",
@@ -12605,41 +14975,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen3-8B",
-    "provider": "Alibaba",
-    "parameter_count": "8.2B",
-    "parameters_raw": 8190735360,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.6,
-    "min_vram_gb": 4.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3",
-    "hf_downloads": 9296313,
-    "hf_likes": 1022,
-    "release_date": "2025-04-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-8B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-8B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3-8B-Base",
     "provider": "Alibaba",
     "parameter_count": "8.2B",
@@ -13037,42 +15372,6 @@
       },
       {
         "repo": "mradermacher/UI-TARS-7B-SFT-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-VL-7B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8292166656,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.7,
-    "min_vram_gb": 4.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 4459295,
-    "hf_likes": 1482,
-    "release_date": "2025-01-26",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen2.5-VL-7B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-7B-Instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -13560,35 +15859,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "LiquidAI/LFM2-8B-A1B",
-    "provider": "Liquid AI",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8339929856,
-    "min_ram_gb": 4.7,
-    "recommended_ram_gb": 7.8,
-    "min_vram_gb": 4.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2_moe",
-    "hf_downloads": 48127,
-    "hf_likes": 343,
-    "release_date": "2025-10-07",
-    "is_moe": true,
-    "num_experts": 32,
-    "active_experts": 4,
-    "active_parameters": 1500000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/LFM2-8B-A1B-GGUF",
-        "provider": "unsloth"
-      }
-    ]
   },
   {
     "name": "xtuner/llava-llama-3-8b-v1_1-transformers",
@@ -14247,25 +16517,6 @@
     "_discovered": true
   },
   {
-    "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
-    "provider": "nvidia",
-    "parameter_count": "8.9B",
-    "parameters_raw": 8888227328,
-    "min_ram_gb": 5.0,
-    "recommended_ram_gb": 8.3,
-    "min_vram_gb": 4.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "nemotron_h",
-    "hf_downloads": 445975,
-    "hf_likes": 487,
-    "release_date": "2025-08-12"
-  },
-  {
     "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Japanese",
     "provider": "nvidia",
     "parameter_count": "8.9B",
@@ -14442,35 +16693,6 @@
     "_discovered": true
   },
   {
-    "name": "google/gemma-2-9b-it",
-    "provider": "Google",
-    "parameter_count": "9.2B",
-    "parameters_raw": 9241705984,
-    "min_ram_gb": 5.2,
-    "recommended_ram_gb": 8.6,
-    "min_vram_gb": 4.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "gemma2",
-    "hf_downloads": 236439,
-    "hf_likes": 781,
-    "release_date": "2024-06-24",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/gemma-2-9b-it-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/gemma-2-9b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "moondream/moondream3-preview",
     "provider": "moondream",
     "parameter_count": "9.3B",
@@ -14565,35 +16787,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "THUDM/glm-4-9b-chat",
-    "provider": "thudm",
-    "parameter_count": "9.4B",
-    "parameters_raw": 9399951392,
-    "min_ram_gb": 5.3,
-    "recommended_ram_gb": 8.8,
-    "min_vram_gb": 4.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "chatglm",
-    "hf_downloads": 163762,
-    "hf_likes": 704,
-    "release_date": "2024-06-04",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/glm-4-9b-chat-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/glm-4-9b-chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "adept/fuyu-8b",
@@ -14720,60 +16913,6 @@
         "provider": "mradermacher"
       }
     ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-9B",
-    "provider": "Alibaba",
-    "parameter_count": "9.7B",
-    "parameters_raw": 9653104368,
-    "min_ram_gb": 5.4,
-    "recommended_ram_gb": 9.0,
-    "min_vram_gb": 4.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 4818944,
-    "hf_likes": 1152,
-    "release_date": "2026-02-27",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-9B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-9B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-9B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "9.7B",
-    "parameters_raw": 9653104368,
-    "min_ram_gb": 5.4,
-    "recommended_ram_gb": 9.0,
-    "min_vram_gb": 4.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 101941,
-    "hf_likes": 59,
-    "release_date": "2026-02-26"
   },
   {
     "name": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -15132,28 +17271,6 @@
     "_discovered": true
   },
   {
-    "name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
-    "provider": "Meta",
-    "parameter_count": "10.7B",
-    "parameters_raw": 10670220835,
-    "min_ram_gb": 6.0,
-    "recommended_ram_gb": 9.9,
-    "min_vram_gb": 5.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "mllama",
-    "hf_downloads": 254818,
-    "hf_likes": 1583,
-    "release_date": "2024-09-18"
-  },
-  {
     "name": "huihui-ai/Llama-3.2-11B-Vision-Instruct-abliterated",
     "provider": "huihui-ai",
     "parameter_count": "10.7B",
@@ -15175,35 +17292,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "upstage/SOLAR-10.7B-Instruct-v1.0",
-    "provider": "Upstage",
-    "parameter_count": "10.7B",
-    "parameters_raw": 10731524096,
-    "min_ram_gb": 6.0,
-    "recommended_ram_gb": 10.0,
-    "min_vram_gb": 5.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 35845,
-    "hf_likes": 649,
-    "release_date": "2023-12-12",
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/SOLAR-10.7B-Instruct-v1.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "naver-hyperclovax/HyperCLOVAX-SEED-Omni-8B",
@@ -15296,37 +17384,6 @@
     ]
   },
   {
-    "name": "google/gemma-3-12b-it",
-    "provider": "Google",
-    "parameter_count": "12B",
-    "parameters_raw": 12000000000,
-    "min_ram_gb": 6.7,
-    "recommended_ram_gb": 11.2,
-    "min_vram_gb": 6.1,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Multimodal, vision and text",
-    "pipeline_tag": "text-generation",
-    "architecture": "gemma3",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-3-12b-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-3-12b-it-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gemma-3-12b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "google/gemma-3-12b-pt",
     "provider": "Google",
     "parameter_count": "12.2B",
@@ -15397,37 +17454,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "mistralai/Mistral-Nemo-Instruct-2407",
-    "provider": "Mistral AI",
-    "parameter_count": "12.2B",
-    "parameters_raw": 12247076864,
-    "min_ram_gb": 6.8,
-    "recommended_ram_gb": 11.4,
-    "min_vram_gb": 6.3,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Mistral-Nemo-Instruct-2407-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Mistral-Nemo-Instruct-2407-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Mistral-Nemo-Instruct-2407-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "casperhansen/mistral-nemo-instruct-2407-awq",
@@ -15504,87 +17530,6 @@
     ]
   },
   {
-    "name": "microsoft/Orca-2-13b",
-    "provider": "Microsoft",
-    "parameter_count": "13.0B",
-    "parameters_raw": 13015864320,
-    "min_ram_gb": 7.3,
-    "recommended_ram_gb": 12.1,
-    "min_vram_gb": 6.7,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Reasoning, step-by-step solutions",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Orca-2-13b-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Orca-2-13b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "lmsys/vicuna-13b-v1.5",
-    "provider": "LMSYS",
-    "parameter_count": "13.0B",
-    "parameters_raw": 13015864320,
-    "min_ram_gb": 7.3,
-    "recommended_ram_gb": 12.1,
-    "min_vram_gb": 6.7,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/vicuna-13b-v1.5-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/vicuna-13b-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "WizardLMTeam/WizardLM-13B-V1.2",
-    "provider": "WizardLM",
-    "parameter_count": "13.0B",
-    "parameters_raw": 13015864320,
-    "min_ram_gb": 7.3,
-    "recommended_ram_gb": 12.1,
-    "min_vram_gb": 6.7,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/WizardLM-13B-V1.2-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/WizardLM-13B-V1.2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "cais/HarmBench-Llama-2-13b-cls",
     "provider": "cais",
     "parameter_count": "13.0B",
@@ -15606,31 +17551,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/HarmBench-Llama-2-13b-cls-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "meta-llama/CodeLlama-13b-Instruct-hf",
-    "provider": "Meta",
-    "parameter_count": "13.0B",
-    "parameters_raw": 13016028160,
-    "min_ram_gb": 7.3,
-    "recommended_ram_gb": 12.1,
-    "min_vram_gb": 6.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 806,
-    "hf_likes": 27,
-    "release_date": "2024-03-13",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-13b-Instruct-hf-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -15768,81 +17688,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "microsoft/phi-4",
-    "provider": "Microsoft",
-    "parameter_count": "14B",
-    "parameters_raw": 14000000000,
-    "min_ram_gb": 7.8,
-    "recommended_ram_gb": 13.0,
-    "min_vram_gb": 7.2,
-    "quantization": "Q4_K_M",
-    "context_length": 16384,
-    "use_case": "Reasoning, STEM, code generation",
-    "pipeline_tag": "text-generation",
-    "architecture": "phi",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/phi-4-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/phi-4-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/phi-4-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "microsoft/Phi-3-medium-14b-instruct",
-    "provider": "Microsoft",
-    "parameter_count": "14B",
-    "parameters_raw": 14000000000,
-    "min_ram_gb": 7.8,
-    "recommended_ram_gb": 13.0,
-    "min_vram_gb": 7.2,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Balanced performance and size",
-    "pipeline_tag": "text-generation",
-    "architecture": "phi3",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
-  },
-  {
-    "name": "microsoft/Phi-4-reasoning",
-    "provider": "Microsoft",
-    "parameter_count": "14B",
-    "parameters_raw": 14000000000,
-    "min_ram_gb": 7.8,
-    "recommended_ram_gb": 13.0,
-    "min_vram_gb": 7.2,
-    "quantization": "Q4_K_M",
-    "context_length": 32768,
-    "use_case": "Advanced reasoning, math and code",
-    "pipeline_tag": "text-generation",
-    "architecture": "phi4",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-04-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Phi-4-reasoning-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Phi-4-reasoning-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen1.5-14B",
@@ -16085,99 +17930,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen2.5-14B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14770000000,
-    "min_ram_gb": 8.2,
-    "recommended_ram_gb": 13.7,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-14B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-14B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3-14B",
-    "provider": "Alibaba",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14770000000,
-    "min_ram_gb": 8.2,
-    "recommended_ram_gb": 13.7,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-14B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-14B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-14B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-14B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14770033664,
-    "min_ram_gb": 8.3,
-    "recommended_ram_gb": 13.8,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 845050,
-    "hf_likes": 144,
-    "release_date": "2024-11-06",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-14B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-14B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-14B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-14B-Instruct-AWQ",
     "provider": "Alibaba",
     "parameter_count": "14.8B",
@@ -16198,40 +17950,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
-    "provider": "DeepSeek",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14770033664,
-    "min_ram_gb": 8.3,
-    "recommended_ram_gb": 13.8,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 543050,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-Coder-14B-Instruct-AWQ",
@@ -16402,29 +18120,6 @@
     "_discovered": true
   },
   {
-    "name": "WizardLMTeam/WizardCoder-15B-V1.0",
-    "provider": "WizardLM",
-    "parameter_count": "15.5B",
-    "parameters_raw": 15515334656,
-    "min_ram_gb": 8.7,
-    "recommended_ram_gb": 14.5,
-    "min_vram_gb": 7.9,
-    "quantization": "Q4_K_M",
-    "context_length": 8192,
-    "use_case": "Code generation and completion",
-    "pipeline_tag": "text-generation",
-    "architecture": "starcoder",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/WizardCoder-15B-V1.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "nvidia/Qwen3-30B-A3B-NVFP4",
     "provider": "nvidia",
     "parameter_count": "15.6B",
@@ -16501,62 +18196,6 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 1704458782
-  },
-  {
-    "name": "bigcode/starcoder2-15b",
-    "provider": "BigCode",
-    "parameter_count": "15.7B",
-    "parameters_raw": 15700000000,
-    "min_ram_gb": 8.8,
-    "recommended_ram_gb": 14.6,
-    "min_vram_gb": 8.0,
-    "quantization": "Q4_K_M",
-    "context_length": 16384,
-    "use_case": "Code generation and completion",
-    "pipeline_tag": "text-generation",
-    "architecture": "starcoder2",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/starcoder2-15b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
-    "provider": "DeepSeek",
-    "parameter_count": "15.7B",
-    "parameters_raw": 15706484224,
-    "min_ram_gb": 8.8,
-    "recommended_ram_gb": 14.6,
-    "min_vram_gb": 8.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 163840,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v2",
-    "hf_downloads": 367294,
-    "hf_likes": 572,
-    "release_date": "2024-06-14",
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 2400000000,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "deepseek-ai/DeepSeek-V2-Lite-Chat",
@@ -16861,35 +18500,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "inclusionAI/Ling-lite",
-    "provider": "inclusionai",
-    "parameter_count": "16.8B",
-    "parameters_raw": 16801974272,
-    "min_ram_gb": 9.4,
-    "recommended_ram_gb": 15.6,
-    "min_vram_gb": 8.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "bailing_moe",
-    "hf_downloads": 441,
-    "hf_likes": 78,
-    "release_date": "2025-02-28",
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 2336524543,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Ling-lite-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "AxionML/Qwen3.5-27B-NVFP4",
@@ -17446,66 +19056,6 @@
     "active_parameters": 2607900202
   },
   {
-    "name": "LiquidAI/LFM2-24B-A2B",
-    "provider": "Liquid AI",
-    "parameter_count": "23.8B",
-    "parameters_raw": 23843661440,
-    "min_ram_gb": 13.3,
-    "recommended_ram_gb": 22.2,
-    "min_vram_gb": 12.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "lfm2_moe",
-    "hf_downloads": 41199,
-    "hf_likes": 302,
-    "release_date": "2026-02-24",
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 4,
-    "active_parameters": 2300000000,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/LFM2-24B-A2B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "mistralai/Mistral-Small-24B-Instruct-2501",
-    "provider": "Mistral AI",
-    "parameter_count": "24B",
-    "parameters_raw": 24000000000,
-    "min_ram_gb": 13.4,
-    "recommended_ram_gb": 22.4,
-    "min_vram_gb": 12.3,
-    "quantization": "Q4_K_M",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "mistral",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Mistral-Small-24B-Instruct-2501-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Mistral-Small-24B-Instruct-2501-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Mistral-Small-24B-Instruct-2501-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "cyankiwi/Qwen3.5-122B-A10B-AWQ-4bit",
     "provider": "cyankiwi",
     "parameter_count": "24.3B",
@@ -17570,65 +19120,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "google/gemma-4-26B-A4B-it",
-    "provider": "Google",
-    "parameter_count": "26.5B",
-    "parameters_raw": 26544131376,
-    "min_ram_gb": 14.8,
-    "recommended_ram_gb": 24.7,
-    "min_vram_gb": 13.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 24366,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-4-26B-A4B-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-4-26B-A4B-it-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
-  },
-  {
-    "name": "google/gemma-2-27b-it",
-    "provider": "Google",
-    "parameter_count": "27.2B",
-    "parameters_raw": 27227128320,
-    "min_ram_gb": 15.2,
-    "recommended_ram_gb": 25.4,
-    "min_vram_gb": 13.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "gemma2",
-    "hf_downloads": 283589,
-    "hf_likes": 561,
-    "release_date": "2024-06-24",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/gemma-2-27b-it-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/gemma-2-27b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "DavidAU/Qwen3.5-27B-Claude-4.6-OS-Auto-Variable-Thinking",
@@ -17815,41 +19306,6 @@
     "_discovered": true
   },
   {
-    "name": "google/gemma-3-27b-it",
-    "provider": "Google",
-    "parameter_count": "27.4B",
-    "parameters_raw": 27432406640,
-    "min_ram_gb": 15.3,
-    "recommended_ram_gb": 25.5,
-    "min_vram_gb": 14.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "gemma3",
-    "hf_downloads": 957301,
-    "hf_likes": 1943,
-    "release_date": "2025-03-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-3-27b-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-3-27b-it-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gemma-3-27b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "RedHatAI/gemma-3-27b-it-FP8-dynamic",
     "provider": "redhatai",
     "parameter_count": "27.4B",
@@ -17868,38 +19324,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen3.5-27B",
-    "provider": "Alibaba",
-    "parameter_count": "27.8B",
-    "parameters_raw": 27781427952,
-    "min_ram_gb": 15.5,
-    "recommended_ram_gb": 25.9,
-    "min_vram_gb": 14.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5",
-    "hf_downloads": 2913948,
-    "hf_likes": 848,
-    "release_date": "2026-02-24",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-27B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-27B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -19118,31 +20542,6 @@
     "_discovered": true
   },
   {
-    "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-    "provider": "nvidia",
-    "parameter_count": "31.6B",
-    "parameters_raw": 31577937344,
-    "min_ram_gb": 17.6,
-    "recommended_ram_gb": 29.4,
-    "min_vram_gb": 16.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "nemotron_h",
-    "hf_downloads": 1030284,
-    "hf_likes": 702,
-    "release_date": "2025-12-04",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "nvidia/Nemotron-Cascade-2-30B-A3B",
     "provider": "nvidia",
     "parameter_count": "31.6B",
@@ -19234,31 +20633,6 @@
       },
       {
         "repo": "mradermacher/EXAONE-3.5-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "LGAI-EXAONE/EXAONE-4.0-32B",
-    "provider": "lgai-exaone",
-    "parameter_count": "32.0B",
-    "parameters_raw": 32003216384,
-    "min_ram_gb": 17.9,
-    "recommended_ram_gb": 29.8,
-    "min_vram_gb": 16.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "exaone4",
-    "hf_downloads": 23904,
-    "hf_likes": 281,
-    "release_date": "2025-07-11",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/EXAONE-4.0-32B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -19404,92 +20778,6 @@
     ]
   },
   {
-    "name": "allenai/OLMo-2-0325-32B-Instruct",
-    "provider": "allenai",
-    "parameter_count": "32.2B",
-    "parameters_raw": 32234279936,
-    "min_ram_gb": 18.0,
-    "recommended_ram_gb": 30.0,
-    "min_vram_gb": 16.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "olmo2",
-    "hf_downloads": 16537,
-    "hf_likes": 148,
-    "release_date": "2025-03-12",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/OLMo-2-0325-32B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/OLMo-2-0325-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-32B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "32.5B",
-    "parameters_raw": 32510000000,
-    "min_ram_gb": 18.2,
-    "recommended_ram_gb": 30.3,
-    "min_vram_gb": 16.7,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-32B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "google/gemma-4-31B-it",
-    "provider": "Google",
-    "parameter_count": "32.7B",
-    "parameters_raw": 32682372656,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.4,
-    "min_vram_gb": 16.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 76200,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gemma-4-31B-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gemma-4-31B-it-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3-32B-AWQ",
     "provider": "Alibaba",
     "parameter_count": "32.8B",
@@ -19510,74 +20798,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-32B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.5,
-    "min_vram_gb": 16.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 933747,
-    "hf_likes": 1999,
-    "release_date": "2024-11-06",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-32B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-32B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
-    "provider": "DeepSeek",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.5,
-    "min_vram_gb": 16.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 910905,
-    "hf_likes": 1528,
-    "release_date": "2025-01-20",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-32B-Instruct-AWQ",
@@ -19770,36 +20990,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/QwQ-32B",
-    "provider": "Alibaba",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.5,
-    "min_vram_gb": 16.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 67230,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/QwQ-32B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/QwQ-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-Coder-32B",
@@ -20085,33 +21275,6 @@
     ]
   },
   {
-    "name": "meta-llama/CodeLlama-34b-Instruct-hf",
-    "provider": "Meta",
-    "parameter_count": "33.7B",
-    "parameters_raw": 33743970304,
-    "min_ram_gb": 18.9,
-    "recommended_ram_gb": 31.4,
-    "min_vram_gb": 17.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 603,
-    "hf_likes": 19,
-    "release_date": "2024-03-14",
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-34b-Instruct-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "codellama/CodeLlama-34b-Instruct-hf",
     "provider": "codellama",
     "parameter_count": "33.7B",
@@ -20135,33 +21298,6 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/CodeLlama-34b-Instruct-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "01-ai/Yi-34B-Chat",
-    "provider": "01.ai",
-    "parameter_count": "34.4B",
-    "parameters_raw": 34386780160,
-    "min_ram_gb": 19.2,
-    "recommended_ram_gb": 32.0,
-    "min_vram_gb": 17.6,
-    "quantization": "Q4_K_M",
-    "context_length": 4096,
-    "use_case": "Multilingual, Chinese/English chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "yi",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Yi-34B-Chat-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Yi-34B-Chat-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -20239,73 +21375,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "CohereForAI/c4ai-command-r-v01",
-    "provider": "Cohere",
-    "parameter_count": "35B",
-    "parameters_raw": 35000000000,
-    "min_ram_gb": 19.5,
-    "recommended_ram_gb": 32.6,
-    "min_vram_gb": 17.9,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "RAG, tool use, agents",
-    "pipeline_tag": "text-generation",
-    "architecture": "cohere",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/c4ai-command-r-v01-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/c4ai-command-r-v01-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3.5-35B-A3B",
-    "provider": "Alibaba",
-    "parameter_count": "36.0B",
-    "parameters_raw": 35951822704,
-    "min_ram_gb": 20.1,
-    "recommended_ram_gb": 33.5,
-    "min_vram_gb": 18.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 3120929,
-    "hf_likes": 1313,
-    "release_date": "2026-02-24",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 3000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-35B-A3B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3.5-35B-A3B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-35B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen3.5-35B-A3B-GPTQ-Int4",
@@ -20712,64 +21781,6 @@
     ]
   },
   {
-    "name": "tiiuae/falcon-40b-instruct",
-    "provider": "TII",
-    "parameter_count": "40.0B",
-    "parameters_raw": 40000000000,
-    "min_ram_gb": 22.4,
-    "recommended_ram_gb": 37.3,
-    "min_vram_gb": 20.5,
-    "quantization": "Q4_K_M",
-    "context_length": 2048,
-    "use_case": "Instruction following, chat",
-    "pipeline_tag": "text-generation",
-    "architecture": "falcon",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/falcon-40b-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-    "provider": "Mistral AI",
-    "parameter_count": "46.7B",
-    "parameters_raw": 46702792704,
-    "min_ram_gb": 26.1,
-    "recommended_ram_gb": 43.5,
-    "min_vram_gb": 23.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "mixtral",
-    "hf_downloads": 424985,
-    "hf_likes": 4652,
-    "release_date": "2023-12-10",
-    "is_moe": true,
-    "num_experts": 8,
-    "active_experts": 2,
-    "active_parameters": 12900000000,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Mixtral-8x7B-Instruct-v0.1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Salesforce/xLAM-8x7b-r",
     "provider": "salesforce",
     "parameter_count": "46.7B",
@@ -20799,41 +21810,6 @@
       },
       {
         "repo": "mradermacher/xLAM-8x7b-r-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
-    "provider": "NousResearch",
-    "parameter_count": "46.7B",
-    "parameters_raw": 46702809088,
-    "min_ram_gb": 26.1,
-    "recommended_ram_gb": 43.5,
-    "min_vram_gb": 23.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "mixtral",
-    "hf_downloads": 8968,
-    "hf_likes": 452,
-    "release_date": "2024-01-11",
-    "is_moe": true,
-    "num_experts": 8,
-    "active_experts": 2,
-    "active_parameters": 12900000000,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Nous-Hermes-2-Mixtral-8x7B-DPO-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Nous-Hermes-2-Mixtral-8x7B-DPO-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -21059,62 +22035,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "meta-llama/Llama-3.1-70B-Instruct",
-    "provider": "Meta",
-    "parameter_count": "70.6B",
-    "parameters_raw": 70553706496,
-    "min_ram_gb": 39.4,
-    "recommended_ram_gb": 65.7,
-    "min_vram_gb": 36.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 997370,
-    "hf_likes": 904,
-    "release_date": "2024-07-16"
-  },
-  {
-    "name": "meta-llama/Llama-3.3-70B-Instruct",
-    "provider": "Meta",
-    "parameter_count": "70.6B",
-    "parameters_raw": 70553706496,
-    "min_ram_gb": 39.4,
-    "recommended_ram_gb": 65.7,
-    "min_vram_gb": 36.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 406340,
-    "hf_likes": 2686,
-    "release_date": "2024-11-26",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3.3-70B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Llama-3.3-70B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Llama-3.3-70B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "zerofata/L3.3-GeneticLemonade-Final-v2-70B",
@@ -21377,37 +22297,6 @@
     "_discovered": true
   },
   {
-    "name": "Qwen/Qwen2.5-72B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "72.7B",
-    "parameters_raw": 72706203648,
-    "min_ram_gb": 40.6,
-    "recommended_ram_gb": 67.7,
-    "min_vram_gb": 37.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen2",
-    "hf_downloads": 677691,
-    "hf_likes": 923,
-    "release_date": "2024-09-16",
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-72B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-72B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "huihui-ai/Qwen2.5-72B-Instruct-abliterated",
     "provider": "huihui-ai",
     "parameter_count": "72.7B",
@@ -21596,43 +22485,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen2.5-VL-72B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "73.4B",
-    "parameters_raw": 73410777344,
-    "min_ram_gb": 41.0,
-    "recommended_ram_gb": 68.4,
-    "min_vram_gb": 37.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 96427,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-VL-72B-Instruct-AWQ",
     "provider": "Alibaba",
     "parameter_count": "73.7B",
@@ -21784,41 +22636,6 @@
     "num_experts": 512,
     "active_experts": 10,
     "active_parameters": 5462052829
-  },
-  {
-    "name": "Qwen/Qwen3-Coder-Next",
-    "provider": "Alibaba",
-    "parameter_count": "79.7B",
-    "parameters_raw": 79674391296,
-    "min_ram_gb": 44.5,
-    "recommended_ram_gb": 74.2,
-    "min_vram_gb": 40.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3_next",
-    "hf_downloads": 854743,
-    "hf_likes": 1220,
-    "release_date": "2026-01-30",
-    "is_moe": true,
-    "num_experts": 512,
-    "active_experts": 10,
-    "active_parameters": 3000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-Coder-Next-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-Coder-Next-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen3-Coder-Next-FP8",
@@ -22287,42 +23104,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen3.5-122B-A10B",
-    "provider": "Alibaba",
-    "parameter_count": "125.1B",
-    "parameters_raw": 125086497008,
-    "min_ram_gb": 69.9,
-    "recommended_ram_gb": 116.5,
-    "min_vram_gb": 64.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 821843,
-    "hf_likes": 467,
-    "release_date": "2026-02-24",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 10000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-122B-A10B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-122B-A10B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3.5-122B-A10B-GPTQ-Int4",
     "provider": "Alibaba",
     "parameter_count": "125.1B",
@@ -22399,94 +23180,6 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 9968428637
-  },
-  {
-    "name": "mistralai/Mixtral-8x22B-Instruct-v0.1",
-    "provider": "Mistral AI",
-    "parameter_count": "140.6B",
-    "parameters_raw": 140630071296,
-    "min_ram_gb": 78.6,
-    "recommended_ram_gb": 131.0,
-    "min_vram_gb": 72.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 65536,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "mixtral",
-    "hf_downloads": 34368,
-    "hf_likes": 748,
-    "release_date": "2024-04-16",
-    "is_moe": true,
-    "num_experts": 8,
-    "active_experts": 2,
-    "active_parameters": 39100000000
-  },
-  {
-    "name": "rednote-hilab/dots.llm1.inst",
-    "provider": "rednote-hilab",
-    "parameter_count": "142.8B",
-    "parameters_raw": 142774381696,
-    "min_ram_gb": 79.8,
-    "recommended_ram_gb": 133.0,
-    "min_vram_gb": 73.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "dots1",
-    "hf_downloads": 9261,
-    "hf_likes": 176,
-    "release_date": "2025-05-14",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/dots.llm1.inst-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "bigscience/bloom",
-    "provider": "bigscience",
-    "parameter_count": "176.2B",
-    "parameters_raw": 176247271424,
-    "min_ram_gb": 98.5,
-    "recommended_ram_gb": 164.1,
-    "min_vram_gb": 90.3,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "bloom",
-    "hf_downloads": 7167,
-    "hf_likes": 4989,
-    "release_date": "2022-05-19"
-  },
-  {
-    "name": "tiiuae/falcon-180B-chat",
-    "provider": "TII",
-    "parameter_count": "179.5B",
-    "parameters_raw": 179522565120,
-    "min_ram_gb": 100.3,
-    "recommended_ram_gb": 167.2,
-    "min_vram_gb": 92.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "falcon",
-    "hf_downloads": 663,
-    "hf_likes": 546,
-    "release_date": "2023-09-04"
   },
   {
     "name": "stepfun-ai/Step-3.5-Flash",
@@ -22635,39 +23328,6 @@
     "active_parameters": 18223715635
   },
   {
-    "name": "MiniMaxAI/MiniMax-M2.5",
-    "provider": "minimaxai",
-    "parameter_count": "228.7B",
-    "parameters_raw": 228703644928,
-    "min_ram_gb": 127.8,
-    "recommended_ram_gb": 213.0,
-    "min_vram_gb": 117.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 196608,
-    "use_case": "Lightweight, edge deployment",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "minimax_m2",
-    "hf_downloads": 622769,
-    "hf_likes": 1330,
-    "release_date": "2026-02-12",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 10000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/MiniMax-M2.5-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/MiniMax-M2.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "MiniMaxAI/MiniMax-M2",
     "provider": "minimaxai",
     "parameter_count": "228.7B",
@@ -22728,62 +23388,6 @@
       {
         "repo": "mradermacher/MiniMax-M2.1-GGUF",
         "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "MiniMaxAI/MiniMax-M2.7",
-    "provider": "MiniMax",
-    "parameter_count": "230B",
-    "parameters_raw": 230000000000,
-    "min_ram_gb": 128.6,
-    "recommended_ram_gb": 214.4,
-    "min_vram_gb": 117.9,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Latest flagship with enhanced reasoning and coding",
-    "pipeline_tag": "text-generation",
-    "architecture": "minimax",
-    "is_moe": true,
-    "num_experts": 32,
-    "active_experts": 2,
-    "active_parameters": 10000000000,
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2026-03-18"
-  },
-  {
-    "name": "Qwen/Qwen3-235B-A22B",
-    "provider": "Alibaba",
-    "parameter_count": "235.1B",
-    "parameters_raw": 235093634560,
-    "min_ram_gb": 131.4,
-    "recommended_ram_gb": 218.9,
-    "min_vram_gb": 120.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose text generation",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3_moe",
-    "hf_downloads": 590265,
-    "hf_likes": 1085,
-    "release_date": "2025-04-27",
-    "is_moe": true,
-    "num_experts": 128,
-    "active_experts": 8,
-    "active_parameters": 22000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-235B-A22B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-235B-A22B-GGUF",
-        "provider": "ggml-org"
       }
     ]
   },
@@ -23065,54 +23669,6 @@
     "_discovered": true
   },
   {
-    "name": "baidu/ERNIE-4.5-300B-A47B-Paddle",
-    "provider": "baidu",
-    "parameter_count": "300.5B",
-    "parameters_raw": 300474051776,
-    "min_ram_gb": 167.9,
-    "recommended_ram_gb": 279.8,
-    "min_vram_gb": 153.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "ernie4_5_moe",
-    "hf_downloads": 320,
-    "hf_likes": 12,
-    "release_date": "2025-06-28"
-  },
-  {
-    "name": "XiaomiMiMo/MiMo-V2-Flash",
-    "provider": "xiaomimimo",
-    "parameter_count": "309.8B",
-    "parameters_raw": 309785318400,
-    "min_ram_gb": 173.1,
-    "recommended_ram_gb": 288.5,
-    "min_vram_gb": 158.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "mimo_v2_flash",
-    "hf_downloads": 51065,
-    "hf_likes": 694,
-    "release_date": "2025-12-16",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/MiMo-V2-Flash-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/MiMo-V2-Flash-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "stepfun-ai/step3",
     "provider": "stepfun-ai",
     "parameter_count": "321.0B",
@@ -23257,41 +23813,6 @@
     "active_parameters": 31617371393
   },
   {
-    "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
-    "provider": "Meta",
-    "parameter_count": "401.6B",
-    "parameters_raw": 401583781376,
-    "min_ram_gb": 224.4,
-    "recommended_ram_gb": 374.0,
-    "min_vram_gb": 205.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "llama4",
-    "hf_downloads": 20387,
-    "hf_likes": 474,
-    "release_date": "2025-04-01",
-    "is_moe": true,
-    "num_experts": 16,
-    "active_experts": 1,
-    "active_parameters": 17000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-4-Maverick-17B-128E-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Llama-4-Maverick-17B-128E-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
     "provider": "Meta",
     "parameter_count": "401.6B",
@@ -23340,42 +23861,6 @@
     "active_parameters": 43930451431
   },
   {
-    "name": "Qwen/Qwen3.5-397B-A17B",
-    "provider": "Alibaba",
-    "parameter_count": "403.4B",
-    "parameters_raw": 403397928944,
-    "min_ram_gb": 225.4,
-    "recommended_ram_gb": 375.7,
-    "min_vram_gb": 206.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 1081165,
-    "hf_likes": 1405,
-    "release_date": "2026-02-16",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 17000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3.5-397B-A17B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3.5-397B-A17B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen3.5-397B-A17B-FP8",
     "provider": "Alibaba",
     "parameter_count": "403.4B",
@@ -23406,27 +23891,6 @@
         "provider": "mradermacher"
       }
     ]
-  },
-  {
-    "name": "meta-llama/Llama-3.1-405B-Instruct",
-    "provider": "Meta",
-    "parameter_count": "405.9B",
-    "parameters_raw": 405853388800,
-    "min_ram_gb": 226.8,
-    "recommended_ram_gb": 378.0,
-    "min_vram_gb": 207.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "llama",
-    "hf_downloads": 169125,
-    "hf_likes": 593,
-    "release_date": "2024-07-16"
   },
   {
     "name": "meta-llama/Llama-3.1-405B",
@@ -23469,37 +23933,6 @@
     "_discovered": true
   },
   {
-    "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "480.2B",
-    "parameters_raw": 480154875392,
-    "min_ram_gb": 268.3,
-    "recommended_ram_gb": 447.2,
-    "min_vram_gb": 245.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "text-generation",
-    "architecture": "qwen3_moe",
-    "hf_downloads": 93169,
-    "hf_likes": 1318,
-    "release_date": "2025-07-22",
-    "is_moe": true,
-    "num_experts": 160,
-    "active_experts": 8,
-    "active_parameters": 35000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
     "name": "meituan-longcat/LongCat-Flash-Chat",
     "provider": "meituan-longcat",
     "parameter_count": "561.9B",
@@ -23518,68 +23951,6 @@
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-V3",
-    "provider": "DeepSeek",
-    "parameter_count": "684.5B",
-    "parameters_raw": 684531386000,
-    "min_ram_gb": 382.5,
-    "recommended_ram_gb": 637.5,
-    "min_vram_gb": 350.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 163840,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v3",
-    "hf_downloads": 575152,
-    "hf_likes": 4020,
-    "release_date": "2024-12-25",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 37000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-V3-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-R1",
-    "provider": "DeepSeek",
-    "parameter_count": "684.5B",
-    "parameters_raw": 684531386000,
-    "min_ram_gb": 382.5,
-    "recommended_ram_gb": 637.5,
-    "min_vram_gb": 350.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 163840,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v3",
-    "hf_downloads": 2588610,
-    "hf_likes": 13125,
-    "release_date": "2025-01-20",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 37000000000,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-GGUF",
-        "provider": "bartowski"
-      }
-    ]
   },
   {
     "name": "deepseek-ai/DeepSeek-R1-0528",
@@ -23642,77 +24013,6 @@
     ]
   },
   {
-    "name": "deepseek-ai/DeepSeek-V3.2-Speciale",
-    "provider": "DeepSeek",
-    "parameter_count": "685B",
-    "parameters_raw": 685000000000,
-    "min_ram_gb": 383.2,
-    "recommended_ram_gb": 638.7,
-    "min_vram_gb": 351.3,
-    "quantization": "Q4_K_M",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v3",
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 37000000000,
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": "2025-12-01"
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-V3.2",
-    "provider": "DeepSeek",
-    "parameter_count": "685.4B",
-    "parameters_raw": 685396921376,
-    "min_ram_gb": 383.0,
-    "recommended_ram_gb": 638.3,
-    "min_vram_gb": 351.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 163840,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "deepseek_v32",
-    "hf_downloads": 911552,
-    "hf_likes": 1364,
-    "release_date": "2025-12-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-V3.2-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "zai-org/GLM-5",
-    "provider": "zai-org",
-    "parameter_count": "753.9B",
-    "parameters_raw": 753864139008,
-    "min_ram_gb": 421.3,
-    "recommended_ram_gb": 702.1,
-    "min_vram_gb": 386.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 202752,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "glm_moe_dsa",
-    "hf_downloads": 251608,
-    "hf_likes": 1920,
-    "release_date": "2026-02-11",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-5-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
     "name": "zai-org/GLM-5-FP8",
     "provider": "zai-org",
     "parameter_count": "753.9B",
@@ -23755,31 +24055,6 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 80681570216
-  },
-  {
-    "name": "moonshotai/Kimi-K2-Instruct",
-    "provider": "moonshotai",
-    "parameter_count": "1026.5B",
-    "parameters_raw": 1026470731056,
-    "min_ram_gb": 573.6,
-    "recommended_ram_gb": 956.0,
-    "min_vram_gb": 525.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "kimi_k2",
-    "hf_downloads": 96217,
-    "hf_likes": 2331,
-    "release_date": "2025-07-11",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2-Instruct-GGUF",
-        "provider": "unsloth"
-      }
-    ]
   },
   {
     "name": "moonshotai/Kimi-K2-Instruct-0905",
@@ -23829,33 +24104,6 @@
     "gguf_sources": [
       {
         "repo": "unsloth/Kimi-K2-Thinking-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "moonshotai/Kimi-K2.5",
-    "provider": "moonshotai",
-    "parameter_count": "1058.6B",
-    "parameters_raw": 1058589420528,
-    "min_ram_gb": 591.5,
-    "recommended_ram_gb": 985.9,
-    "min_vram_gb": 542.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "image-text-to-text",
-    "architecture": "kimi_k25",
-    "hf_downloads": 6190986,
-    "hf_likes": 2410,
-    "release_date": "2026-01-01",
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2.5-GGUF",
         "provider": "unsloth"
       }
     ]

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -2254,7 +2254,11 @@ const OLLAMA_MAPPINGS: &[(&str, &str)] = &[
     ("mistral-7b-instruct-v0.2", "mistral:7b"),
     ("mistral-nemo-instruct-2407", "mistral-nemo"),
     ("mistral-small-24b-instruct-2501", "mistral-small:24b"),
+    ("mistral-small-3.1-24b-instruct-2503", "mistral-small3.1"),
     ("mistral-large-instruct-2407", "mistral-large"),
+    ("mistral-large-instruct-2411", "mistral-large2.1"),
+    ("pixtral-12b-2409", "pixtral"),
+    ("devstral-small-2505", "devstral"),
     ("mixtral-8x7b-instruct-v0.1", "mixtral:8x7b"),
     ("mixtral-8x22b-instruct-v0.1", "mixtral:8x22b"),
     // Qwen 2 / 2.5
@@ -2274,8 +2278,10 @@ const OLLAMA_MAPPINGS: &[(&str, &str)] = &[
     ("qwen2.5-coder-7b-instruct", "qwen2.5-coder:7b"),
     ("qwen2.5-coder-1.5b-instruct", "qwen2.5-coder:1.5b"),
     ("qwen2.5-coder-0.5b-instruct", "qwen2.5-coder:0.5b"),
+    ("qwen2.5-vl-72b-instruct", "qwen2.5vl:72b"),
     ("qwen2.5-vl-7b-instruct", "qwen2.5vl:7b"),
     ("qwen2.5-vl-3b-instruct", "qwen2.5vl:3b"),
+    ("qwq-32b", "qwq"),
     // Qwen 3
     ("qwen3-235b-a22b", "qwen3:235b"),
     ("qwen3-32b", "qwen3:32b"),
@@ -2302,6 +2308,9 @@ const OLLAMA_MAPPINGS: &[(&str, &str)] = &[
     ("deepseek-r1-distill-qwen-32b", "deepseek-r1:32b"),
     ("deepseek-r1-distill-qwen-14b", "deepseek-r1:14b"),
     ("deepseek-r1-distill-qwen-7b", "deepseek-r1:7b"),
+    ("deepseek-r1-distill-qwen-1.5b", "deepseek-r1:1.5b"),
+    ("deepseek-r1-distill-llama-70b", "deepseek-r1:70b"),
+    ("deepseek-r1-distill-llama-8b", "deepseek-r1:8b"),
     ("deepseek-coder-v2-lite-instruct", "deepseek-coder-v2:16b"),
     // Community / other
     ("tinyllama-1.1b-chat-v1.0", "tinyllama"),
@@ -2313,6 +2322,8 @@ const OLLAMA_MAPPINGS: &[(&str, &str)] = &[
     ("falcon-7b-instruct", "falcon:7b"),
     ("falcon-40b-instruct", "falcon:40b"),
     ("falcon-180b-chat", "falcon:180b"),
+    ("falcon3-1b-instruct", "falcon3:1b"),
+    ("falcon3-3b-instruct", "falcon3:3b"),
     ("falcon3-7b-instruct", "falcon3:7b"),
     ("openchat-3.5-0106", "openchat:7b"),
     ("vicuna-7b-v1.5", "vicuna:7b"),
@@ -2321,6 +2332,8 @@ const OLLAMA_MAPPINGS: &[(&str, &str)] = &[
     ("solar-10.7b-instruct-v1.0", "solar:10.7b"),
     ("zephyr-7b-beta", "zephyr:7b"),
     ("c4ai-command-r-v01", "command-r"),
+    ("c4ai-command-r-plus-08-2024", "command-r-plus"),
+    ("c4ai-command-a-03-2025", "command-a"),
     (
         "nous-hermes-2-mixtral-8x7b-dpo",
         "nous-hermes2-mixtral:8x7b",
@@ -2328,6 +2341,7 @@ const OLLAMA_MAPPINGS: &[(&str, &str)] = &[
     ("hermes-3-llama-3.1-8b", "hermes3:8b"),
     ("nomic-embed-text-v1.5", "nomic-embed-text"),
     ("bge-large-en-v1.5", "bge-large"),
+    ("smollm2-1.7b-instruct", "smollm2:1.7b"),
     ("smollm2-135m-instruct", "smollm2:135m"),
     ("smollm2-135m", "smollm2:135m"),
     // Google Gemma 3n
@@ -2338,6 +2352,17 @@ const OLLAMA_MAPPINGS: &[(&str, &str)] = &[
     ("phi-4-mini-reasoning", "phi4-mini-reasoning"),
     // DeepSeek V3.2 Speciale (no local Ollama tag yet, maps to v3)
     ("deepseek-v3.2-speciale", "deepseek-v3"),
+    // NVIDIA Nemotron Llama fine-tunes
+    ("llama-3.1-nemotron-70b-instruct-hf", "nemotron:70b"),
+    ("llama-3.3-nemotron-super-49b-v1", "nemotron:49b"),
+    // EXAONE Deep reasoning models
+    ("exaone-deep-2.4b", "exaone-deep:2.4b"),
+    ("exaone-deep-7.8b", "exaone-deep:7.8b"),
+    ("exaone-deep-32b", "exaone-deep:32b"),
+    // OLMo 2
+    ("olmo-2-1124-7b-instruct", "olmo2:7b"),
+    ("olmo-2-1124-13b-instruct", "olmo2:13b"),
+    ("olmo-2-0325-32b-instruct", "olmo2:32b"),
     // Liquid AI LFM2
     ("lfm2-350m", "lfm2:350m"),
     ("lfm2-700m", "lfm2:700m"),

--- a/scripts/scrape_docker_models.py
+++ b/scripts/scrape_docker_models.py
@@ -59,7 +59,11 @@ OLLAMA_MAPPINGS = {
     "mistral-7b-instruct-v0.2": "mistral:7b",
     "mistral-nemo-instruct-2407": "mistral-nemo",
     "mistral-small-24b-instruct-2501": "mistral-small:24b",
+    "mistral-small-3.1-24b-instruct-2503": "mistral-small3.1",
     "mistral-large-instruct-2407": "mistral-large",
+    "mistral-large-instruct-2411": "mistral-large2.1",
+    "pixtral-12b-2409": "pixtral",
+    "devstral-small-2505": "devstral",
     "mixtral-8x7b-instruct-v0.1": "mixtral:8x7b",
     "mixtral-8x22b-instruct-v0.1": "mixtral:8x22b",
     # Qwen 2 / 2.5
@@ -79,8 +83,10 @@ OLLAMA_MAPPINGS = {
     "qwen2.5-coder-7b-instruct": "qwen2.5-coder:7b",
     "qwen2.5-coder-1.5b-instruct": "qwen2.5-coder:1.5b",
     "qwen2.5-coder-0.5b-instruct": "qwen2.5-coder:0.5b",
+    "qwen2.5-vl-72b-instruct": "qwen2.5vl:72b",
     "qwen2.5-vl-7b-instruct": "qwen2.5vl:7b",
     "qwen2.5-vl-3b-instruct": "qwen2.5vl:3b",
+    "qwq-32b": "qwq",
     # Qwen 3
     "qwen3-235b-a22b": "qwen3:235b",
     "qwen3-32b": "qwen3:32b",
@@ -107,6 +113,9 @@ OLLAMA_MAPPINGS = {
     "deepseek-r1-distill-qwen-32b": "deepseek-r1:32b",
     "deepseek-r1-distill-qwen-14b": "deepseek-r1:14b",
     "deepseek-r1-distill-qwen-7b": "deepseek-r1:7b",
+    "deepseek-r1-distill-qwen-1.5b": "deepseek-r1:1.5b",
+    "deepseek-r1-distill-llama-70b": "deepseek-r1:70b",
+    "deepseek-r1-distill-llama-8b": "deepseek-r1:8b",
     "deepseek-coder-v2-lite-instruct": "deepseek-coder-v2:16b",
     # Community / other
     "tinyllama-1.1b-chat-v1.0": "tinyllama",
@@ -118,6 +127,8 @@ OLLAMA_MAPPINGS = {
     "falcon-7b-instruct": "falcon:7b",
     "falcon-40b-instruct": "falcon:40b",
     "falcon-180b-chat": "falcon:180b",
+    "falcon3-1b-instruct": "falcon3:1b",
+    "falcon3-3b-instruct": "falcon3:3b",
     "falcon3-7b-instruct": "falcon3:7b",
     "openchat-3.5-0106": "openchat:7b",
     "vicuna-7b-v1.5": "vicuna:7b",
@@ -126,10 +137,13 @@ OLLAMA_MAPPINGS = {
     "solar-10.7b-instruct-v1.0": "solar:10.7b",
     "zephyr-7b-beta": "zephyr:7b",
     "c4ai-command-r-v01": "command-r",
+    "c4ai-command-r-plus-08-2024": "command-r-plus",
+    "c4ai-command-a-03-2025": "command-a",
     "nous-hermes-2-mixtral-8x7b-dpo": "nous-hermes2-mixtral:8x7b",
     "hermes-3-llama-3.1-8b": "hermes3:8b",
     "nomic-embed-text-v1.5": "nomic-embed-text",
     "bge-large-en-v1.5": "bge-large",
+    "smollm2-1.7b-instruct": "smollm2:1.7b",
     "smollm2-135m-instruct": "smollm2:135m",
     "smollm2-135m": "smollm2:135m",
     # Google Gemma 3n
@@ -140,6 +154,17 @@ OLLAMA_MAPPINGS = {
     "phi-4-mini-reasoning": "phi4-mini-reasoning",
     # DeepSeek V3.2 Speciale
     "deepseek-v3.2-speciale": "deepseek-v3",
+    # NVIDIA Nemotron Llama fine-tunes
+    "llama-3.1-nemotron-70b-instruct-hf": "nemotron:70b",
+    "llama-3.3-nemotron-super-49b-v1": "nemotron:49b",
+    # EXAONE Deep reasoning models
+    "exaone-deep-2.4b": "exaone-deep:2.4b",
+    "exaone-deep-7.8b": "exaone-deep:7.8b",
+    "exaone-deep-32b": "exaone-deep:32b",
+    # OLMo 2
+    "olmo-2-1124-7b-instruct": "olmo2:7b",
+    "olmo-2-1124-13b-instruct": "olmo2:13b",
+    "olmo-2-0325-32b-instruct": "olmo2:32b",
     # Liquid AI LFM2
     "lfm2-350m": "lfm2:350m",
     "lfm2-700m": "lfm2:700m",

--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -54,11 +54,17 @@ TARGET_MODELS = [
     "mistralai/Mixtral-8x7B-Instruct-v0.1",
     "mistralai/Mixtral-8x22B-Instruct-v0.1",
     "mistralai/Mistral-Large-Instruct-2407",
+    "mistralai/Mistral-Large-Instruct-2411",
     "mistralai/Mistral-Small-24B-Instruct-2501",
     "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
     "mistralai/Ministral-8B-Instruct-2410",
     "mistralai/Mistral-Nemo-Instruct-2407",
+    "mistralai/Pixtral-12B-2409",           # Vision-language model
+    "mistralai/Devstral-Small-2505",        # Coding agent model (May 2025)
     # Qwen
+    "Qwen/Qwen2.5-0.5B-Instruct",
+    "Qwen/Qwen2.5-1.5B-Instruct",
+    "Qwen/Qwen2.5-3B-Instruct",
     "Qwen/Qwen2.5-7B-Instruct",
     "Qwen/Qwen2.5-14B-Instruct",
     "Qwen/Qwen2.5-32B-Instruct",
@@ -69,6 +75,8 @@ TARGET_MODELS = [
     "Qwen/Qwen2.5-Coder-32B-Instruct",    # NEW: Large coder
     "Qwen/Qwen2.5-VL-3B-Instruct",        # NEW: Vision-language 3B
     "Qwen/Qwen2.5-VL-7B-Instruct",        # NEW: Vision-language 7B
+    "Qwen/Qwen2.5-VL-72B-Instruct",       # Vision-language 72B
+    "Qwen/QwQ-32B",                        # Popular open reasoning model
     "Qwen/Qwen3-0.6B",
     "Qwen/Qwen3-1.7B",
     "Qwen/Qwen3-4B",
@@ -117,13 +125,19 @@ TARGET_MODELS = [
     "google/gemma-4-31B-it",
     "google/gemma-4-26B-A4B-it",
     # DeepSeek
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
     "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
     "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
     "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
     "deepseek-ai/DeepSeek-V3",
     "deepseek-ai/DeepSeek-R1",
     # Cohere
     "CohereForAI/c4ai-command-r-v01",
+    "CohereForAI/c4ai-command-r-plus-08-2024",
+    "CohereForAI/c4ai-command-a-03-2025",
     # 01.ai Yi family
     "01-ai/Yi-6B-Chat",  # NEW: Popular multilingual 6B
     "01-ai/Yi-34B-Chat",  # NEW: Popular multilingual 34B
@@ -133,6 +147,8 @@ TARGET_MODELS = [
     "tiiuae/falcon-7b-instruct",  # NEW: Popular UAE model
     "tiiuae/falcon-40b-instruct",
     "tiiuae/falcon-180B-chat",
+    "tiiuae/Falcon3-1B-Instruct",
+    "tiiuae/Falcon3-3B-Instruct",
     "tiiuae/Falcon3-7B-Instruct",
     "tiiuae/Falcon3-10B-Instruct",
     # HuggingFace Zephyr
@@ -159,6 +175,8 @@ TARGET_MODELS = [
     "ibm-granite/granite-4.0-h-micro",
     "ibm-granite/granite-4.0-h-small",
     # Allen Institute OLMo
+    "allenai/OLMo-2-1124-7B-Instruct",
+    "allenai/OLMo-2-1124-13B-Instruct",
     "allenai/OLMo-2-0325-32B-Instruct",
     # Zhipu GLM
     "THUDM/glm-4-9b-chat",
@@ -226,16 +244,23 @@ TARGET_MODELS = [
     "XiaomiMiMo/MiMo-V2-Flash",
     "XiaomiMiMo/MiMo-7B-RL",
     # NVIDIA Nemotron
+    "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF",  # Popular fine-tune
+    "nvidia/Llama-3.3-Nemotron-Super-49B-v1",      # Newer Nemotron
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
     "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
     # Microsoft Phi-4 reasoning family
     "microsoft/Phi-4-reasoning",
     "microsoft/Phi-4-mini-reasoning",
     "microsoft/Phi-4-multimodal-instruct",
+    # LG AI EXAONE Deep (reasoning)
+    "LGAI-EXAONE/EXAONE-Deep-2.4B",
+    "LGAI-EXAONE/EXAONE-Deep-7.8B",
+    "LGAI-EXAONE/EXAONE-Deep-32B",
     # LG AI EXAONE 4.0
     "LGAI-EXAONE/EXAONE-4.0-32B",
     "LGAI-EXAONE/EXAONE-4.0-1.2B",
-    # HuggingFace SmolLM3
+    # HuggingFace SmolLM
+    "HuggingFaceTB/SmolLM2-1.7B-Instruct",
     "HuggingFaceTB/SmolLM3-3B",
     # Google Gemma 3n (effective parameter models)
     "google/gemma-3n-E4B-it",


### PR DESCRIPTION
## Summary

- Adds 13 net-new curated models to `TARGET_MODELS` in `scripts/scrape_hf_models.py`
- Expands `OLLAMA_MAPPINGS` in `llmfit-core/src/providers.rs` and `scripts/scrape_docker_models.py` to cover all new models
- Regenerates `data/hf_models.json` (976 models, up from 963)

## New models added

| Provider | Model | Notes |
|----------|-------|-------|
| Mistral | `Pixtral-12B-2409` | Vision-language |
| Mistral | `Devstral-Small-2505` | Coding agent |
| Mistral | `Mistral-Large-Instruct-2411` | Latest large model |
| Qwen | `QwQ-32B` | Popular open reasoning model |
| Qwen | `Qwen2.5-VL-72B-Instruct` | Large vision-language |
| Qwen | `Qwen2.5-0.5B/1.5B/3B-Instruct` | Small/edge variants |
| DeepSeek | `R1-Distill-Qwen-1.5B` & `R1-Distill-Qwen-14B` | Missing R1 distill sizes |
| DeepSeek | `R1-Distill-Llama-8B` & `R1-Distill-Llama-70B` | Llama-based R1 distills |
| Cohere | `c4ai-command-r-plus-08-2024` | Updated Command R+ |
| Cohere | `c4ai-command-a-03-2025` | Command A |
| NVIDIA | `Llama-3.1-Nemotron-70B-Instruct-HF` | Popular fine-tune |
| NVIDIA | `Llama-3.3-Nemotron-Super-49B-v1` | Newer Nemotron |
| LGAI-EXAONE | `EXAONE-Deep-2.4B/7.8B/32B` | Reasoning series |
| Falcon | `Falcon3-1B` & `Falcon3-3B` | Smaller variants |
| AllenAI | `OLMo-2-1124-7B/13B-Instruct` | Smaller OLMo 2 sizes |
| HuggingFace | `SmolLM2-1.7B-Instruct` | Popular small model |

## Provider mapping updates

Both `OLLAMA_MAPPINGS` in `providers.rs` and the Python `scrape_docker_models.py` are kept in sync with all new models. Also added missing mappings for `mistral-small-3.1`, `qwq-32b`, `qwen2.5-vl-72b`, and several DeepSeek R1 distill sizes.

## Test plan

- [ ] Run `python3 scripts/scrape_hf_models.py` — should complete without errors
- [ ] Run `python3 -m json.tool data/hf_models.json` — should pass JSON validation
- [ ] Run `cargo check` — should compile cleanly
- [ ] Spot-check a few new models in the TUI: `cargo run -- search "qwq"`, `cargo run -- search "devstral"`