### PR TITLE
feat(tui): add runtime filter popup

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -27,6 +27,7 @@ pub enum InputMode {
     RunModePopup,
     ParamsBucketPopup,
     LicensePopup,
+    RuntimePopup,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -310,6 +311,11 @@ pub struct App {
     pub selected_licenses: Vec<bool>,
     pub license_cursor: usize,
 
+    // Runtime/Backend filter (popup)
+    pub runtimes: Vec<String>,
+    pub selected_runtimes: Vec<bool>,
+    pub runtime_cursor: usize,
+
     // Theme
     pub theme: Theme,
 
@@ -450,6 +456,16 @@ impl App {
         }
         let selected_licenses = vec![true; model_licenses.len()];
 
+        // Extract unique runtimes using InferenceRuntime labels
+        let model_runtimes: Vec<String> = {
+            let mut set = std::collections::BTreeSet::new();
+            for f in &all_fits {
+                set.insert(f.runtime.label().to_string());
+            }
+            set.into_iter().collect()
+        };
+        let selected_runtimes = vec![true; model_runtimes.len()];
+
         let filtered_count = all_fits.len();
 
         let (download_capability_tx, download_capability_rx) = mpsc::channel();
@@ -542,6 +558,9 @@ impl App {
             licenses: model_licenses,
             selected_licenses,
             license_cursor: 0,
+            runtimes: model_runtimes,
+            selected_runtimes,
+            runtime_cursor: 0,
             theme: Theme::load(),
             backend_hidden_count,
         };
@@ -707,6 +726,20 @@ impl App {
                     }
                 };
 
+                // Runtime filter
+                let matches_runtime = {
+                    let all_selected = self.selected_runtimes.iter().all(|&s| s);
+                    if all_selected {
+                        true
+                    } else {
+                        let rt_label = fit.runtime.label();
+                        self.runtimes
+                            .iter()
+                            .zip(self.selected_runtimes.iter())
+                            .any(|(r, &sel)| sel && r == rt_label)
+                    }
+                };
+
                 matches_search
                     && matches_provider
                     && matches_use_case
@@ -718,6 +751,7 @@ impl App {
                     && matches_params_bucket
                     && matches_tp
                     && matches_license
+                    && matches_runtime
             })
             .map(|(i, _)| i)
             .collect();
@@ -1480,6 +1514,45 @@ impl App {
         let all_selected = self.selected_licenses.iter().all(|&s| s);
         let new_val = !all_selected;
         for s in &mut self.selected_licenses {
+            *s = new_val;
+        }
+        self.apply_filters();
+    }
+
+    // ── Runtime popup ───────────────────────────────────────────
+
+    pub fn open_runtime_popup(&mut self) {
+        self.input_mode = InputMode::RuntimePopup;
+    }
+
+    pub fn close_runtime_popup(&mut self) {
+        self.input_mode = InputMode::Normal;
+    }
+
+    pub fn runtime_popup_up(&mut self) {
+        if self.runtime_cursor > 0 {
+            self.runtime_cursor -= 1;
+        }
+    }
+
+    pub fn runtime_popup_down(&mut self) {
+        if self.runtime_cursor + 1 < self.runtimes.len() {
+            self.runtime_cursor += 1;
+        }
+    }
+
+    pub fn runtime_popup_toggle(&mut self) {
+        if self.runtime_cursor < self.selected_runtimes.len() {
+            self.selected_runtimes[self.runtime_cursor] =
+                !self.selected_runtimes[self.runtime_cursor];
+            self.apply_filters();
+        }
+    }
+
+    pub fn runtime_popup_select_all(&mut self) {
+        let all_selected = self.selected_runtimes.iter().all(|&s| s);
+        let new_val = !all_selected;
+        for s in &mut self.selected_runtimes {
             *s = new_val;
         }
         self.apply_filters();

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -29,6 +29,7 @@ pub fn handle_events(app: &mut App) -> std::io::Result<bool> {
             InputMode::RunModePopup => handle_run_mode_popup_mode(app, key),
             InputMode::ParamsBucketPopup => handle_params_bucket_popup_mode(app, key),
             InputMode::LicensePopup => handle_license_popup_mode(app, key),
+            InputMode::RuntimePopup => handle_runtime_popup_mode(app, key),
         }
         return Ok(true);
     }
@@ -97,6 +98,7 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char('U') => app.open_use_case_popup(),
         KeyCode::Char('C') => app.open_capability_popup(),
         KeyCode::Char('L') => app.open_license_popup(),
+        KeyCode::Char('B') => app.open_runtime_popup(),
 
         // Installed-first sort toggle (any provider)
         KeyCode::Char('i')
@@ -337,6 +339,21 @@ fn handle_license_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char(' ') | KeyCode::Enter => app.license_popup_toggle(),
 
         KeyCode::Char('a') => app.license_popup_select_all(),
+
+        _ => {}
+    }
+}
+
+fn handle_runtime_popup_mode(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('B') | KeyCode::Char('q') => app.close_runtime_popup(),
+
+        KeyCode::Up | KeyCode::Char('k') => app.runtime_popup_up(),
+        KeyCode::Down | KeyCode::Char('j') => app.runtime_popup_down(),
+
+        KeyCode::Char(' ') | KeyCode::Enter => app.runtime_popup_toggle(),
+
+        KeyCode::Char('a') => app.runtime_popup_select_all(),
 
         _ => {}
     }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -71,6 +71,8 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_params_bucket_popup(frame, app, &tc);
     } else if app.input_mode == InputMode::LicensePopup {
         draw_license_popup(frame, app, &tc);
+    } else if app.input_mode == InputMode::RuntimePopup {
+        draw_runtime_popup(frame, app, &tc);
     }
 }
 
@@ -276,7 +278,8 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         | InputMode::QuantPopup
         | InputMode::RunModePopup
         | InputMode::ParamsBucketPopup
-        | InputMode::LicensePopup => Style::default().fg(tc.muted),
+        | InputMode::LicensePopup
+        | InputMode::RuntimePopup => Style::default().fg(tc.muted),
     };
 
     let search_text = if app.search_query.is_empty() && app.input_mode == InputMode::Normal {
@@ -2483,6 +2486,10 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
             "LICENSE".to_string(),
         ),
+        InputMode::RuntimePopup => (
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "RUNTIME".to_string(),
+        ),
     }
 }
 
@@ -2859,6 +2866,81 @@ fn draw_license_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 
     let active_count = app.selected_licenses.iter().filter(|&&s| s).count();
     let title = format!(" License ({}/{}) ", active_count, total);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(tc.accent_secondary))
+        .title(title)
+        .title_style(
+            Style::default()
+                .fg(tc.accent_secondary)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, popup_area);
+}
+
+fn draw_runtime_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
+    let area = frame.area();
+
+    let max_name_len = app.runtimes.iter().map(|r| r.len()).max().unwrap_or(10);
+    let popup_width = (max_name_len as u16 + 10).min(area.width.saturating_sub(4));
+    let popup_height = (app.runtimes.len() as u16 + 2).min(area.height.saturating_sub(4));
+
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(Clear, popup_area);
+
+    let inner_height = popup_height.saturating_sub(2) as usize;
+    let total = app.runtimes.len();
+
+    let scroll_offset = if app.runtime_cursor >= inner_height {
+        app.runtime_cursor - inner_height + 1
+    } else {
+        0
+    };
+
+    let lines: Vec<Line> = app
+        .runtimes
+        .iter()
+        .enumerate()
+        .skip(scroll_offset)
+        .take(inner_height)
+        .map(|(i, name)| {
+            let checkbox = if app.selected_runtimes[i] {
+                "[x]"
+            } else {
+                "[ ]"
+            };
+            let is_cursor = i == app.runtime_cursor;
+
+            let style = if is_cursor {
+                if app.selected_runtimes[i] {
+                    Style::default()
+                        .fg(tc.good)
+                        .add_modifier(Modifier::BOLD)
+                        .bg(tc.highlight_bg)
+                } else {
+                    Style::default()
+                        .fg(tc.fg)
+                        .add_modifier(Modifier::BOLD)
+                        .bg(tc.highlight_bg)
+                }
+            } else if app.selected_runtimes[i] {
+                Style::default().fg(tc.good)
+            } else {
+                Style::default().fg(tc.muted)
+            };
+
+            Line::from(Span::styled(format!(" {} {}", checkbox, name), style))
+        })
+        .collect();
+
+    let active_count = app.selected_runtimes.iter().filter(|&&s| s).count();
+    let title = format!(" Runtime ({}/{}) ", active_count, total);
 
     let block = Block::default()
         .borders(Borders::ALL)


### PR DESCRIPTION
## Summary

Adds a runtime/backend filter popup to the TUI, accessible via the **B** key. Follows the exact pattern of the existing filter popups (Quant, RunMode, Params, License).

- Added `RuntimePopup` InputMode variant
- Added runtime filter state derived from `InferenceRuntime::label()` (reuses core enum, no duplicate strings)
- Added B keybind to toggle the popup, with matching event handler
- Added filtering logic in `apply_filters` matching the existing popup pattern
- Added `draw_runtime_popup` draw function in tui_ui.rs

The API already has `RuntimeFilter` (serve_api.rs:718) but the TUI lacked a corresponding popup.

## Testing

`cargo clippy --all-targets --all-features` passes (all warnings are pre-existing).

Fixes #197

This contribution was developed with AI assistance (Claude Code).