### PR TITLE
feat: add rahimdzx/AraCode-7B-GGUF Arabic coding model

### DIFF
--- a/data/hf_models.json
+++ b/data/hf_models.json
@@ -25257,5 +25257,24 @@
     "hf_downloads": 0,
     "hf_likes": 0,
     "release_date": null
+  },
+  {
+    "name": "rahimdzx/AraCode-7B-GGUF",
+    "provider": "rahimdzx",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "coding",
+    "capabilities": ["coding"],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
   }
 ]

--- a/llmfit-core/data/hf_models.json
+++ b/llmfit-core/data/hf_models.json
@@ -25257,5 +25257,24 @@
     "hf_downloads": 0,
     "hf_likes": 0,
     "release_date": null
+  },
+  {
+    "name": "rahimdzx/AraCode-7B-GGUF",
+    "provider": "rahimdzx",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "coding",
+    "capabilities": ["coding"],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen2",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
   }
 ]

--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -262,6 +262,8 @@ TARGET_MODELS = [
     "shoumenchougou/RWKV7-G1f-2.9B-GGUF",
     "shoumenchougou/RWKV7-G1f-7.2B-GGUF",
     "shoumenchougou/RWKV7-G1f-13.3B-GGUF",
+    # AraCode — Arabic-specialized coding model (GGUF native)
+    "rahimdzx/AraCode-7B-GGUF",
 ]
 
 # Bytes-per-parameter for different quantization levels
@@ -2214,6 +2216,18 @@ def main():
             "use_case": "General purpose text generation",
             "capabilities": [],
             "pipeline_tag": "text-generation", "architecture": "rwkv",
+            "hf_downloads": 0, "hf_likes": 0, "release_date": None,
+        },
+        # AraCode-7B-GGUF: GGUF-native repo — no safetensors metadata, fallback required
+        {
+            "name": "rahimdzx/AraCode-7B-GGUF",
+            "provider": "rahimdzx", "parameter_count": "7.6B",
+            "parameters_raw": 7_615_616_512,
+            "min_ram_gb": 4.3, "recommended_ram_gb": 7.1, "min_vram_gb": 3.9,
+            "quantization": "Q4_K_M", "format": "gguf", "context_length": 32768,
+            "use_case": "coding",
+            "capabilities": ["coding"],
+            "pipeline_tag": "text-generation", "architecture": "qwen2",
             "hf_downloads": 0, "hf_likes": 0, "release_date": None,
         },
     ]


### PR DESCRIPTION
## Summary

- Adds `rahimdzx/AraCode-7B-GGUF` to the curated `TARGET_MODELS` list in `scripts/scrape_hf_models.py`
- Adds a hardcoded `FALLBACK` entry — GGUF-native repos have no safetensors metadata so the scraper returns `None`; the fallback guarantees the record is always emitted
- Regenerated `data/hf_models.json` and `llmfit-core/data/hf_models.json` via the scraper

## Model details

| Field | Value |
|---|---|
| HuggingFace ID | `rahimdzx/AraCode-7B-GGUF` |
| Architecture | qwen2 |
| Parameters | 7.6B |
| Format | GGUF |
| Quantization | Q4_K_M (~4.68 GB) |
| Context | 32768 tokens |
| Use case | coding |
| Languages | Arabic + English |
| License | Apache-2.0 |

This is the first open-source Arabic-specialized code explanation and generation model.

## Test plan

- [x] `scrape_hf_models.py` runs without errors
- [x] `rahimdzx/AraCode-7B-GGUF` present in `data/hf_models.json` with correct fields
- [ ] `llmfit list | grep -i aracode` returns the model
- [ ] `llmfit info "AraCode-7B-GGUF"` shows correct params and quantization