### PR TITLE
fix(providers): prevent argument injection in hf and docker subproces…

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -507,9 +507,12 @@ impl ModelProvider for MlxProvider {
                 percent: None,
             });
 
-            // Download from Hugging Face using their CLI tool
+            // Download from Hugging Face using their CLI tool.
+            // `--` terminates option parsing so a repo id beginning with `-`
+            // (reachable via the unauthenticated localhost /api/v1/download
+            // endpoint) cannot be misinterpreted as a flag like --local-dir.
             let result = std::process::Command::new(&hf_bin)
-                .args(["download", &repo_for_thread])
+                .args(["download", "--", &repo_for_thread])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output();
@@ -1464,8 +1467,10 @@ impl ModelProvider for DockerModelRunnerProvider {
                 percent: None,
             });
 
+            // `--` terminates option parsing so a tag beginning with `-`
+            // cannot inject docker CLI flags.
             let result = std::process::Command::new("docker")
-                .args(["model", "pull", &tag])
+                .args(["model", "pull", "--", &tag])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .output();


### PR DESCRIPTION
…s calls

MlxProvider::start_pull and DockerModelRunnerProvider::start_pull pass the user-supplied model tag directly as a positional argument:

  Command::new(&hf_bin).args(["download", &repo_for_thread])
  Command::new("docker").args(["model", "pull", &tag])

A tag beginning with `-` is parsed as a flag by the invoked CLI rather than a positional argument. For example, a model tag of "--local-dir/x" reaches `hf download --local-dir/x`. Impact is bounded to single-arg flag injection (no shell is involved, args are passed via execve), but the model tag is reachable from the unauthenticated POST /api/v1/download endpoint — loopback-restricted but any local process can hit it.

Insert `--` to terminate option parsing before the positional argument. Both the hf CLI (Python argparse) and docker CLI (spf13/cobra) honour this convention.

Co-Authored-By: gregkh_clanker_t1000