### PR TITLE
fix(tui): bind auto-spawned dashboard to loopback by default

### DIFF
--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -28,7 +28,12 @@ fn parse_positive_usize(value: &str) -> Result<usize, String> {
     Ok(parsed)
 }
 
-const DEFAULT_DASHBOARD_HOST: &str = "0.0.0.0";
+// Bind the auto-spawned dashboard to loopback only. The explicit `llmfit
+// serve --host` command already defaults to 127.0.0.1, but the silently-
+// auto-spawned dashboard previously bound 0.0.0.0 — exposing /api/v1/system,
+// /api/v1/installed, and the web UI to the LAN without the user knowing a
+// server was running. Set LLMFIT_DASHBOARD_HOST=0.0.0.0 to opt back in.
+const DEFAULT_DASHBOARD_HOST: &str = "127.0.0.1";
 const DEFAULT_DASHBOARD_PORT: u16 = 8787;
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]


### PR DESCRIPTION
The explicit `llmfit serve` subcommand correctly defaults --host to 127.0.0.1, and its docstring documents that default. But the dashboard auto-spawned silently when launching the TUI used DEFAULT_DASHBOARD_HOST = "0.0.0.0", binding all interfaces.

This exposes /api/v1/system (CPU model, RAM, GPU name and VRAM), /api/v1/installed (locally-pulled models), and the web UI to anyone on the LAN — without the user knowing a network service was started at all. The download/plan endpoints have a loopback source-IP check, but the read endpoints do not.

Align the auto-spawn default with the explicit serve default. Users who intentionally want LAN exposure can set LLMFIT_DASHBOARD_HOST=0.0.0.0.

Co-Authored-By: gregkh_clanker_t1000