### PR TITLE
fix: resolve a build warning for an unused variable

### DIFF
--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -395,7 +395,7 @@ async fn runtimes(State(_state): State<Arc<AppState>>) -> Json<serde_json::Value
     Json(serde_json::json!({ "runtimes": runtimes, "warnings": warnings }))
 }
 
-async fn installed(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
+async fn installed(State(_state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     let mut set = tokio::task::JoinSet::new();
 
     set.spawn_blocking(|| {


### PR DESCRIPTION
the state variable is never used in the installed() function, so the compiler properly warns it should be marked as such, just like is done in the runtimes() function.