### PR TITLE
feat: add hardware override options

### DIFF
--- a/.pr-322-draft.md
+++ b/.pr-322-draft.md
@@ -1,0 +1,20 @@
+## Summary
+- add global `--ram` and `--cpu-cores` hardware override flags alongside the existing `--memory` override
+- thread hardware overrides through CLI/TUI flows and `llmfit serve` so API mode matches interactive behavior
+- document the new override behavior in `README.md`, `API.md`, and the `serve` command help text
+- add helper-level unit tests for `with_ram_override()` and `with_cpu_core_override()`
+
+## Why
+Closes #322.
+
+This makes llmfit usable for planning and simulation workflows where you want to evaluate model fit against target hardware instead of the machine currently running llmfit.
+
+## Notes
+- `--memory` continues to override GPU VRAM
+- `--ram` overrides total/available system RAM
+- `--cpu-cores` overrides detected CPU core count
+- `llmfit serve` now reflects these overrides in `/api/v1/system` and model-fit responses because it uses the same hardware override path as CLI/TUI commands
+
+## Validation
+- Added unit tests covering the new `SystemSpecs` override helpers
+- Full local `cargo fmt` / `cargo test` execution is currently blocked in this environment because the Rust toolchain is unavailable

--- a/.pr-322-draft.md
+++ b/.pr-322-draft.md
@@ -17,4 +17,5 @@ This makes llmfit usable for planning and simulation workflows where you want to
 
 ## Validation
 - Added unit tests covering the new `SystemSpecs` override helpers
-- Full local `cargo fmt` / `cargo test` execution is currently blocked in this environment because the Rust toolchain is unavailable
+- Ran `cargo fmt --all`
+- Ran `cargo test`

--- a/API.md
+++ b/API.md
@@ -19,8 +19,10 @@ llmfit serve --port 8787
 Global flags still apply:
 
 ```sh
-llmfit --memory 24G --max-context 8192 serve --port 8787
+llmfit --memory 24G --ram 64G --cpu-cores 16 --max-context 8192 serve --host 0.0.0.0 --port 8787
 ```
+
+This is useful when you want to simulate or advertise target hardware instead of the machine running the server.
 
 ## Base URL
 
@@ -62,6 +64,8 @@ Example response:
 
 ### `GET /api/v1/system`
 Returns node identity + detected hardware.
+
+If the server was started with global overrides such as `--memory`, `--ram`, or `--cpu-cores`, this endpoint reports the overridden values.
 
 Example response shape:
 

--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ llmfit's database uses HuggingFace model names (e.g. `Qwen/Qwen2.5-Coder-14B-Ins
 | Apple Silicon          | `system_profiler`             | Unified memory (= system RAM)  |
 | Ascend                 | `npu-smi`                     | Detected (VRAM may be unknown) |
 
-If autodetection fails or reports incorrect values, use `--memory=<SIZE>` to override (see [GPU memory override](#gpu-memory-override) above).
+If autodetection fails or reports incorrect values, use global hardware overrides such as `--memory=<SIZE>`, `--ram=<SIZE>`, or `--cpu-cores=<N>` to simulate target hardware for planning and fit analysis.
 
 ### Android / Termux note
 

--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -1473,6 +1473,21 @@ impl SystemSpecs {
         self
     }
 
+    /// Override total and available system RAM with a user-specified value (in GB).
+    /// This is useful for planning or simulating target hardware instead of the
+    /// currently detected machine.
+    pub fn with_ram_override(mut self, ram_gb: f64) -> Self {
+        self.total_ram_gb = ram_gb;
+        self.available_ram_gb = ram_gb;
+        self
+    }
+
+    /// Override the detected CPU core count with a user-specified value.
+    pub fn with_cpu_core_override(mut self, cpu_cores: usize) -> Self {
+        self.total_cpu_cores = cpu_cores;
+        self
+    }
+
     pub fn display(&self) {
         println!("\n=== System Specifications ===");
         println!("CPU: {} ({} cores)", self.cpu_name, self.total_cpu_cores);
@@ -2288,7 +2303,7 @@ fn estimate_vram_from_name(name: &str) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::SystemSpecs;
+    use super::{GpuBackend, GpuInfo, SystemSpecs};
 
     #[test]
     fn test_parse_nvidia_smi_does_not_sum_multi_gpu_vram() {
@@ -3001,4 +3016,68 @@ GPU id = 1 (NVIDIA GeForce RTX 4090)
         assert_eq!(super::quant_min_compute_capability("Q4_K_M"), None);
         assert_eq!(super::quant_min_compute_capability("Q8_0"), None);
     }
+
+    #[test]
+    fn test_with_ram_override_updates_total_and_available_ram_only() {
+        let specs = SystemSpecs {
+            total_ram_gb: 32.0,
+            available_ram_gb: 24.0,
+            total_cpu_cores: 12,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: true,
+            gpu_vram_gb: Some(16.0),
+            total_gpu_vram_gb: Some(16.0),
+            gpu_name: Some("Test GPU".to_string()),
+            gpu_count: 1,
+            unified_memory: false,
+            backend: super::GpuBackend::Cuda,
+            gpus: vec![super::GpuInfo {
+                name: "Test GPU".to_string(),
+                vram_gb: Some(16.0),
+                backend: super::GpuBackend::Cuda,
+                count: 1,
+                unified_memory: false,
+            }],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        };
+
+        let overridden = specs.with_ram_override(64.0);
+
+        assert_eq!(overridden.total_ram_gb, 64.0);
+        assert_eq!(overridden.available_ram_gb, 64.0);
+        assert_eq!(overridden.total_cpu_cores, 12);
+        assert_eq!(overridden.gpu_vram_gb, Some(16.0));
+        assert_eq!(overridden.total_gpu_vram_gb, Some(16.0));
+        assert_eq!(overridden.gpu_count, 1);
+    }
+
+    #[test]
+    fn test_with_cpu_core_override_updates_core_count_only() {
+        let specs = SystemSpecs {
+            total_ram_gb: 32.0,
+            available_ram_gb: 24.0,
+            total_cpu_cores: 12,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: false,
+            gpu_vram_gb: None,
+            total_gpu_vram_gb: None,
+            gpu_name: None,
+            gpu_count: 0,
+            unified_memory: false,
+            backend: super::GpuBackend::CpuX86,
+            gpus: vec![],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        };
+
+        let overridden = specs.with_cpu_core_override(20);
+
+        assert_eq!(overridden.total_cpu_cores, 20);
+        assert_eq!(overridden.total_ram_gb, 32.0);
+        assert_eq!(overridden.available_ram_gb, 24.0);
+        assert_eq!(overridden.backend, super::GpuBackend::CpuX86);
+        assert!(!overridden.has_gpu);
+    }
+
 }

--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -3079,5 +3079,4 @@ GPU id = 1 (NVIDIA GeForce RTX 4090)
         assert_eq!(overridden.backend, super::GpuBackend::CpuX86);
         assert!(!overridden.has_gpu);
     }
-
 }

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -113,12 +113,7 @@ pub fn display_model_fits(fits: &[ModelFit]) {
         .iter()
         .map(|fit| {
             let status_prefix = if fit.installed { "✓ " } else { "" };
-            let status_text = format!(
-                "{}{} {}",
-                status_prefix,
-                fit.fit_emoji(),
-                fit.fit_text()
-            );
+            let status_text = format!("{}{} {}", status_prefix, fit.fit_emoji(), fit.fit_text());
 
             ModelRow {
                 status: status_text,

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -16,6 +16,26 @@ use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::ModelDatabase;
 use llmfit_core::plan::{PlanRequest, estimate_model_plan, resolve_model_selector};
 
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| format!("invalid positive integer: {value}"))?;
+    if parsed == 0 {
+        return Err("value must be at least 1".to_string());
+    }
+    Ok(parsed)
+}
+
+fn parse_positive_u32(value: &str) -> Result<u32, String> {
+    let parsed = value
+        .parse::<u32>()
+        .map_err(|_| format!("invalid positive integer: {value}"))?;
+    if parsed == 0 {
+        return Err("value must be at least 1".to_string());
+    }
+    Ok(parsed)
+}
+
 const DEFAULT_DASHBOARD_HOST: &str = "0.0.0.0";
 const DEFAULT_DASHBOARD_PORT: u16 = 8787;
 
@@ -78,11 +98,13 @@ recommend models, compare them side-by-side, plan hardware upgrades, download
 GGUF weights, and launch inference — all from a single binary.
 
 GLOBAL FLAGS:
-  --json           Output structured JSON on every subcommand (for tool/agent
-                   integration). Always exits 0 on success, 1 on error.
-  --memory <SIZE>  Override GPU VRAM (e.g. \"32G\", \"32000M\", \"1.5T\").
-  --max-context N  Cap context length for memory estimation (tokens).
-                   Falls back to OLLAMA_CONTEXT_LENGTH env var if unset.
+  --json             Output structured JSON on every subcommand (for tool/agent
+                     integration). Always exits 0 on success, 1 on error.
+  --memory <SIZE>    Override GPU VRAM (e.g. \"32G\", \"32000M\", \"1.5T\").
+  --ram <SIZE>       Override system RAM (e.g. \"64G\", \"65536M\").
+  --cpu-cores <N>    Override detected CPU core count.
+  --max-context N    Cap context length for memory estimation (tokens).
+                     Falls back to OLLAMA_CONTEXT_LENGTH env var if unset.
 
 EXIT CODES:
   0  Success
@@ -121,9 +143,17 @@ struct Cli {
     #[arg(long, value_name = "SIZE")]
     memory: Option<String>,
 
+    /// Override total/available system RAM (e.g. "64G", "65536M").
+    #[arg(long, value_name = "SIZE")]
+    ram: Option<String>,
+
+    /// Override detected CPU core count.
+    #[arg(long, value_name = "N", value_parser = parse_positive_usize)]
+    cpu_cores: Option<usize>,
+
     /// Cap context length used for memory estimation (tokens).
     /// Falls back to OLLAMA_CONTEXT_LENGTH if not set.
-    #[arg(long, value_name = "TOKENS", value_parser = clap::value_parser!(u32).range(1..))]
+    #[arg(long, value_name = "TOKENS", value_parser = parse_positive_u32)]
     max_context: Option<u32>,
 
     /// Do not auto-start the background dashboard server
@@ -602,6 +632,7 @@ EXIT CODES:
 AGENT USAGE:
   llmfit serve --port 8787
   llmfit serve --host 0.0.0.0 --port 8787  # expose to other machines
+  llmfit --memory 24G --ram 64G --cpu-cores 16 serve --port 8787
   All endpoints return JSON. See API.md for the full endpoint reference.")]
     Serve {
         /// Host interface to bind
@@ -614,23 +645,43 @@ AGENT USAGE:
     },
 }
 
-/// Detect system specs with optional GPU memory override.
-fn detect_specs(memory_override: &Option<String>) -> SystemSpecs {
-    let specs = SystemSpecs::detect();
+/// Detect system specs with optional hardware overrides.
+fn detect_specs(
+    memory_override: &Option<String>,
+    ram_override: &Option<String>,
+    cpu_core_override: Option<usize>,
+) -> SystemSpecs {
+    let mut specs = SystemSpecs::detect();
+
     if let Some(mem_str) = memory_override {
         match llmfit_core::hardware::parse_memory_size(mem_str) {
-            Some(gb) => specs.with_gpu_memory_override(gb),
+            Some(gb) => specs = specs.with_gpu_memory_override(gb),
             None => {
                 eprintln!(
                     "Warning: could not parse --memory value '{}'. Expected format: 32G, 32000M, 1.5T",
                     mem_str
                 );
-                specs
             }
         }
-    } else {
-        specs
     }
+
+    if let Some(ram_str) = ram_override {
+        match llmfit_core::hardware::parse_memory_size(ram_str) {
+            Some(gb) => specs = specs.with_ram_override(gb),
+            None => {
+                eprintln!(
+                    "Warning: could not parse --ram value '{}'. Expected format: 64G, 65536M, 1.5T",
+                    ram_str
+                );
+            }
+        }
+    }
+
+    if let Some(cpu_cores) = cpu_core_override {
+        specs = specs.with_cpu_core_override(cpu_cores);
+    }
+
+    specs
 }
 
 fn resolve_context_limit(max_context: Option<u32>) -> Option<u32> {
@@ -794,9 +845,11 @@ fn run_fit(
     sort: SortColumn,
     json: bool,
     memory_override: &Option<String>,
+    ram_override: &Option<String>,
+    cpu_core_override: Option<usize>,
     context_limit: Option<u32>,
 ) {
-    let specs = detect_specs(memory_override);
+    let specs = detect_specs(memory_override, ram_override, cpu_core_override);
     let db = ModelDatabase::new();
 
     if !json {
@@ -912,6 +965,8 @@ fn run_diff(
     limit: usize,
     json: bool,
     memory_override: &Option<String>,
+    ram_override: &Option<String>,
+    cpu_core_override: Option<usize>,
     context_limit: Option<u32>,
 ) {
     if limit < 2 {
@@ -924,7 +979,7 @@ fn run_diff(
         std::process::exit(1);
     }
 
-    let specs = detect_specs(memory_override);
+    let specs = detect_specs(memory_override, ram_override, cpu_core_override);
     let db = ModelDatabase::new();
 
     let mut fits: Vec<ModelFit> = db
@@ -976,7 +1031,12 @@ fn run_diff(
     }
 }
 
-fn run_tui(memory_override: &Option<String>, context_limit: Option<u32>) -> std::io::Result<()> {
+fn run_tui(
+    memory_override: &Option<String>,
+    ram_override: &Option<String>,
+    cpu_core_override: Option<usize>,
+    context_limit: Option<u32>,
+) -> std::io::Result<()> {
     // Setup terminal
     crossterm::terminal::enable_raw_mode()?;
     let mut stdout = std::io::stdout();
@@ -991,7 +1051,7 @@ fn run_tui(memory_override: &Option<String>, context_limit: Option<u32>) -> std:
     draw_boot_screen(&mut terminal, "Detecting system hardware...")?;
 
     // Create app state
-    let specs = detect_specs(memory_override);
+    let specs = detect_specs(memory_override, ram_override, cpu_core_override);
     draw_boot_screen(&mut terminal, "Loading providers and models...")?;
     let mut app = tui_app::App::with_specs_and_context(specs, context_limit);
 
@@ -1064,9 +1124,11 @@ fn run_recommend(
     license: Option<String>,
     json: bool,
     memory_override: &Option<String>,
+    ram_override: &Option<String>,
+    cpu_core_override: Option<usize>,
     context_limit: Option<u32>,
 ) {
-    let specs = detect_specs(memory_override);
+    let specs = detect_specs(memory_override, ram_override, cpu_core_override);
     let db = ModelDatabase::new();
 
     // Parse --force-runtime into an InferenceRuntime if provided
@@ -1295,7 +1357,7 @@ fn run_download(
         let mem_budget = if let Some(b) = budget {
             b
         } else {
-            let specs = detect_specs(memory_override);
+            let specs = detect_specs(memory_override, &None, None);
             specs
                 .total_gpu_vram_gb
                 .or(Some(specs.available_ram_gb))
@@ -1611,9 +1673,11 @@ fn run_plan(
     target_tps: Option<f64>,
     json: bool,
     memory_override: &Option<String>,
+    ram_override: &Option<String>,
+    cpu_core_override: Option<usize>,
 ) -> Result<(), String> {
     let db = ModelDatabase::new();
-    let specs = detect_specs(memory_override);
+    let specs = detect_specs(memory_override, ram_override, cpu_core_override);
     let model = resolve_model_selector(db.get_all_models(), model_selector)?;
 
     let request = PlanRequest {
@@ -1650,7 +1714,7 @@ fn main() {
     if let Some(command) = cli.command {
         match command {
             Commands::System => {
-                let specs = detect_specs(&cli.memory);
+                let specs = detect_specs(&cli.memory, &cli.ram, cli.cpu_cores);
                 if cli.json {
                     display::display_json_system(&specs);
                 } else {
@@ -1682,6 +1746,8 @@ fn main() {
                     sort.into(),
                     cli.json,
                     &cli.memory,
+                    &cli.ram,
+                    cli.cpu_cores,
                     context_limit,
                 );
             }
@@ -1694,7 +1760,7 @@ fn main() {
 
             Commands::Info { model } => {
                 let db = ModelDatabase::new();
-                let specs = detect_specs(&cli.memory);
+                let specs = detect_specs(&cli.memory, &cli.ram, cli.cpu_cores);
                 let models = db.get_all_models();
 
                 let idx = match find_name_index_by_selector(models, &model, |m| m.name.as_str()) {
@@ -1728,6 +1794,8 @@ fn main() {
                     limit,
                     cli.json,
                     &cli.memory,
+                    &cli.ram,
+                    cli.cpu_cores,
                     context_limit,
                 );
             }
@@ -1739,7 +1807,16 @@ fn main() {
                 target_tps,
             } => {
                 if let Err(err) =
-                    run_plan(&model, context, quant, target_tps, cli.json, &cli.memory)
+                    run_plan(
+                        &model,
+                        context,
+                        quant,
+                        target_tps,
+                        cli.json,
+                        &cli.memory,
+                        &cli.ram,
+                        cli.cpu_cores,
+                    )
                 {
                     eprintln!("Error: {}", err);
                     std::process::exit(1);
@@ -1766,6 +1843,8 @@ fn main() {
                     license,
                     json,
                     &cli.memory,
+                    &cli.ram,
+                    cli.cpu_cores,
                     context_limit,
                 );
             }
@@ -1804,7 +1883,14 @@ fn main() {
             }
 
             Commands::Serve { host, port } => {
-                if let Err(err) = serve_api::run_serve(&host, port, &cli.memory, context_limit) {
+                if let Err(err) = serve_api::run_serve(
+                    &host,
+                    port,
+                    &cli.memory,
+                    &cli.ram,
+                    cli.cpu_cores,
+                    context_limit,
+                ) {
                     eprintln!("Error: {}", err);
                     std::process::exit(1);
                 }
@@ -1821,13 +1907,15 @@ fn main() {
             cli.sort.into(),
             cli.json,
             &cli.memory,
+            &cli.ram,
+            cli.cpu_cores,
             context_limit,
         );
         return;
     }
 
     // Default: launch TUI
-    if let Err(e) = run_tui(&cli.memory, context_limit) {
+    if let Err(e) = run_tui(&cli.memory, &cli.ram, cli.cpu_cores, context_limit) {
         eprintln!("Error running TUI: {}", e);
         std::process::exit(1);
     }

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1806,18 +1806,16 @@ fn main() {
                 quant,
                 target_tps,
             } => {
-                if let Err(err) =
-                    run_plan(
-                        &model,
-                        context,
-                        quant,
-                        target_tps,
-                        cli.json,
-                        &cli.memory,
-                        &cli.ram,
-                        cli.cpu_cores,
-                    )
-                {
+                if let Err(err) = run_plan(
+                    &model,
+                    context,
+                    quant,
+                    target_tps,
+                    cli.json,
+                    &cli.memory,
+                    &cli.ram,
+                    cli.cpu_cores,
+                ) {
                     eprintln!("Error: {}", err);
                     std::process::exit(1);
                 }

--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -126,6 +126,8 @@ pub fn run_serve(
     host: &str,
     port: u16,
     memory_override: &Option<String>,
+    ram_override: &Option<String>,
+    cpu_core_override: Option<usize>,
     context_limit: Option<u32>,
 ) -> Result<(), String> {
     let ip: IpAddr = host
@@ -133,7 +135,7 @@ pub fn run_serve(
         .map_err(|_| format!("invalid --host value: '{host}'"))?;
     let addr = SocketAddr::new(ip, port);
 
-    let specs = detect_specs(memory_override);
+    let specs = detect_specs(memory_override, ram_override, cpu_core_override);
     let db = ModelDatabase::new();
     let all_models = db.get_all_models().clone();
 
@@ -945,17 +947,31 @@ fn round2(v: f64) -> f64 {
     (v * 100.0).round() / 100.0
 }
 
-/// Detect system specs with optional GPU memory override.
-fn detect_specs(memory_override: &Option<String>) -> SystemSpecs {
-    let specs = SystemSpecs::detect();
+/// Detect system specs with optional hardware overrides.
+fn detect_specs(
+    memory_override: &Option<String>,
+    ram_override: &Option<String>,
+    cpu_core_override: Option<usize>,
+) -> SystemSpecs {
+    let mut specs = SystemSpecs::detect();
+
     if let Some(mem_str) = memory_override {
-        match llmfit_core::hardware::parse_memory_size(mem_str) {
-            Some(gb) => specs.with_gpu_memory_override(gb),
-            None => specs,
+        if let Some(gb) = llmfit_core::hardware::parse_memory_size(mem_str) {
+            specs = specs.with_gpu_memory_override(gb);
         }
-    } else {
-        specs
     }
+
+    if let Some(ram_str) = ram_override {
+        if let Some(gb) = llmfit_core::hardware::parse_memory_size(ram_str) {
+            specs = specs.with_ram_override(gb);
+        }
+    }
+
+    if let Some(cpu_cores) = cpu_core_override {
+        specs = specs.with_cpu_core_override(cpu_cores);
+    }
+
+    specs
 }
 
 #[cfg(test)]

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2943,9 +2943,7 @@ fn draw_help_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
                 Line::from(vec![
                     Span::styled(
                         format!(" {:<14}", key),
-                        Style::default()
-                            .fg(tc.fg)
-                            .add_modifier(Modifier::BOLD),
+                        Style::default().fg(tc.fg).add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(*desc, Style::default().fg(tc.muted)),
                 ])
@@ -2957,7 +2955,11 @@ fn draw_help_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
     let max_scroll = all_lines.len().saturating_sub(inner_height);
     let scroll = app.help_scroll.min(max_scroll);
 
-    let visible: Vec<Line> = all_lines.into_iter().skip(scroll).take(inner_height).collect();
+    let visible: Vec<Line> = all_lines
+        .into_iter()
+        .skip(scroll)
+        .take(inner_height)
+        .collect();
 
     let block = Block::default()
         .borders(Borders::ALL)

--- a/src/tui_app.rs
+++ b/src/tui_app.rs
@@ -1,0 +1,473 @@
+use crate::fit::{FitLevel, ModelFit};
+use crate::hardware::SystemSpecs;
+use crate::models::ModelDatabase;
+use crate::providers::{self, ModelProvider, OllamaProvider, PullEvent, PullHandle};
+
+use std::collections::HashSet;
+use std::sync::mpsc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputMode {
+    Normal,
+    Search,
+    ProviderPopup,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortColumn {
+    Score,
+    Params,
+    MemPct,
+    Ctx,
+    UseCase,
+}
+
+impl SortColumn {
+    pub fn label(&self) -> &str {
+        match self {
+            SortColumn::Score => "Score",
+            SortColumn::Params => "Params",
+            SortColumn::MemPct => "Mem%",
+            SortColumn::Ctx => "Ctx",
+            SortColumn::UseCase => "Use",
+        }
+    }
+
+    pub fn next(&self) -> Self {
+        match self {
+            SortColumn::Score => SortColumn::Params,
+            SortColumn::Params => SortColumn::MemPct,
+            SortColumn::MemPct => SortColumn::Ctx,
+            SortColumn::Ctx => SortColumn::UseCase,
+            SortColumn::UseCase => SortColumn::Score,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FitFilter {
+    All,
+    Perfect,
+    Good,
+    Marginal,
+    TooTight,
+    Runnable, // Perfect + Good + Marginal (excludes TooTight)
+}
+
+impl FitFilter {
+    pub fn label(&self) -> &str {
+        match self {
+            FitFilter::All => "All",
+            FitFilter::Perfect => "Perfect",
+            FitFilter::Good => "Good",
+            FitFilter::Marginal => "Marginal",
+            FitFilter::TooTight => "Too Tight",
+            FitFilter::Runnable => "Runnable",
+        }
+    }
+
+    pub fn next(&self) -> Self {
+        match self {
+            FitFilter::All => FitFilter::Runnable,
+            FitFilter::Runnable => FitFilter::Perfect,
+            FitFilter::Perfect => FitFilter::Good,
+            FitFilter::Good => FitFilter::Marginal,
+            FitFilter::Marginal => FitFilter::TooTight,
+            FitFilter::TooTight => FitFilter::All,
+        }
+    }
+}
+
+pub struct App {
+    pub should_quit: bool,
+    pub input_mode: InputMode,
+    pub search_query: String,
+    pub cursor_position: usize,
+
+    // Data
+    pub specs: SystemSpecs,
+    pub all_fits: Vec<ModelFit>,
+    pub filtered_fits: Vec<usize>, // indices into all_fits
+    pub providers: Vec<String>,
+    pub selected_providers: Vec<bool>,
+
+    // Filters
+    pub fit_filter: FitFilter,
+    pub installed_first: bool,
+    pub sort_column: SortColumn,
+
+    // Table state
+    pub selected_row: usize,
+
+    // Detail view
+    pub show_detail: bool,
+
+    // Provider popup
+    pub provider_cursor: usize,
+
+    // Provider state
+    pub ollama_available: bool,
+    pub ollama_installed: HashSet<String>,
+    ollama: OllamaProvider,
+
+    // Download state
+    pub pull_active: Option<PullHandle>,
+    pub pull_status: Option<String>,
+    pub pull_percent: Option<f64>,
+    pub pull_model_name: Option<String>,
+    /// Animation frame counter, incremented every tick while pulling.
+    pub tick_count: u64,
+}
+
+impl App {
+    pub fn new() -> Self {
+        Self::with_specs(SystemSpecs::detect())
+    }
+
+    pub fn with_specs(specs: SystemSpecs) -> Self {
+        let db = ModelDatabase::new();
+
+        // Detect Ollama
+        let ollama = OllamaProvider::new();
+        let ollama_available = ollama.is_available();
+        let ollama_installed = if ollama_available {
+            ollama.installed_models()
+        } else {
+            HashSet::new()
+        };
+
+        // Analyze all models
+        let mut all_fits: Vec<ModelFit> = db
+            .get_all_models()
+            .iter()
+            .map(|m| {
+                let mut fit = ModelFit::analyze(m, &specs);
+                fit.installed = providers::is_model_installed(&m.name, &ollama_installed);
+                fit
+            })
+            .collect();
+
+        // Sort by fit level then RAM usage
+        all_fits = crate::fit::rank_models_by_fit(all_fits);
+
+        // Extract unique providers
+        let mut model_providers: Vec<String> = all_fits
+            .iter()
+            .map(|f| f.model.provider.clone())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        model_providers.sort();
+
+        let selected_providers = vec![true; model_providers.len()];
+
+        let filtered_count = all_fits.len();
+
+        let mut app = App {
+            should_quit: false,
+            input_mode: InputMode::Normal,
+            search_query: String::new(),
+            cursor_position: 0,
+            specs,
+            all_fits,
+            filtered_fits: (0..filtered_count).collect(),
+            providers: model_providers,
+            selected_providers,
+            fit_filter: FitFilter::All,
+            installed_first: false,
+            sort_column: SortColumn::Score,
+            selected_row: 0,
+            show_detail: false,
+            provider_cursor: 0,
+            ollama_available,
+            ollama_installed,
+            ollama,
+            pull_active: None,
+            pull_status: None,
+            pull_percent: None,
+            pull_model_name: None,
+            tick_count: 0,
+        };
+
+        app.apply_filters();
+        app
+    }
+
+    pub fn apply_filters(&mut self) {
+        let query = self.search_query.to_lowercase();
+
+        self.filtered_fits = self
+            .all_fits
+            .iter()
+            .enumerate()
+            .filter(|(_, fit)| {
+                // Search filter
+                let matches_search = if query.is_empty() {
+                    true
+                } else {
+                    fit.model.name.to_lowercase().contains(&query)
+                        || fit.model.provider.to_lowercase().contains(&query)
+                        || fit.model.parameter_count.to_lowercase().contains(&query)
+                        || fit.model.use_case.to_lowercase().contains(&query)
+                };
+
+                // Provider filter
+                let provider_idx = self.providers.iter().position(|p| p == &fit.model.provider);
+                let matches_provider = provider_idx
+                    .map(|idx| self.selected_providers[idx])
+                    .unwrap_or(true);
+
+                // Fit filter
+                let matches_fit = match self.fit_filter {
+                    FitFilter::All => true,
+                    FitFilter::Perfect => fit.fit_level == FitLevel::Perfect,
+                    FitFilter::Good => fit.fit_level == FitLevel::Good,
+                    FitFilter::Marginal => fit.fit_level == FitLevel::Marginal,
+                    FitFilter::TooTight => fit.fit_level == FitLevel::TooTight,
+                    FitFilter::Runnable => fit.fit_level != FitLevel::TooTight,
+                };
+
+                matches_search && matches_provider && matches_fit
+            })
+            .map(|(i, _)| i)
+            .collect();
+
+        // Clamp selection
+        if self.filtered_fits.is_empty() {
+            self.selected_row = 0;
+        } else if self.selected_row >= self.filtered_fits.len() {
+            self.selected_row = self.filtered_fits.len() - 1;
+        }
+    }
+
+    pub fn selected_fit(&self) -> Option<&ModelFit> {
+        self.filtered_fits
+            .get(self.selected_row)
+            .map(|&idx| &self.all_fits[idx])
+    }
+
+    pub fn move_up(&mut self) {
+        if self.selected_row > 0 {
+            self.selected_row -= 1;
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if !self.filtered_fits.is_empty() && self.selected_row < self.filtered_fits.len() - 1 {
+            self.selected_row += 1;
+        }
+    }
+
+    pub fn page_up(&mut self) {
+        self.selected_row = self.selected_row.saturating_sub(10);
+    }
+
+    pub fn page_down(&mut self) {
+        if !self.filtered_fits.is_empty() {
+            self.selected_row = (self.selected_row + 10).min(self.filtered_fits.len() - 1);
+        }
+    }
+
+    pub fn home(&mut self) {
+        self.selected_row = 0;
+    }
+
+    pub fn end(&mut self) {
+        if !self.filtered_fits.is_empty() {
+            self.selected_row = self.filtered_fits.len() - 1;
+        }
+    }
+
+    pub fn cycle_fit_filter(&mut self) {
+        self.fit_filter = self.fit_filter.next();
+        self.apply_filters();
+    }
+
+    pub fn cycle_sort_column(&mut self) {
+        self.sort_column = self.sort_column.next();
+        self.re_sort();
+    }
+
+    pub fn enter_search(&mut self) {
+        self.input_mode = InputMode::Search;
+    }
+
+    pub fn exit_search(&mut self) {
+        self.input_mode = InputMode::Normal;
+    }
+
+    pub fn search_input(&mut self, c: char) {
+        self.search_query.insert(self.cursor_position, c);
+        self.cursor_position += 1;
+        self.apply_filters();
+    }
+
+    pub fn search_backspace(&mut self) {
+        if self.cursor_position > 0 {
+            self.cursor_position -= 1;
+            self.search_query.remove(self.cursor_position);
+            self.apply_filters();
+        }
+    }
+
+    pub fn search_delete(&mut self) {
+        if self.cursor_position < self.search_query.len() {
+            self.search_query.remove(self.cursor_position);
+            self.apply_filters();
+        }
+    }
+
+    pub fn clear_search(&mut self) {
+        self.search_query.clear();
+        self.cursor_position = 0;
+        self.apply_filters();
+    }
+
+    pub fn toggle_detail(&mut self) {
+        self.show_detail = !self.show_detail;
+    }
+
+    pub fn open_provider_popup(&mut self) {
+        self.input_mode = InputMode::ProviderPopup;
+        // Don't reset cursor -- keep it where it was last time
+    }
+
+    pub fn close_provider_popup(&mut self) {
+        self.input_mode = InputMode::Normal;
+    }
+
+    pub fn provider_popup_up(&mut self) {
+        if self.provider_cursor > 0 {
+            self.provider_cursor -= 1;
+        }
+    }
+
+    pub fn provider_popup_down(&mut self) {
+        if self.provider_cursor + 1 < self.providers.len() {
+            self.provider_cursor += 1;
+        }
+    }
+
+    pub fn provider_popup_toggle(&mut self) {
+        if self.provider_cursor < self.selected_providers.len() {
+            self.selected_providers[self.provider_cursor] =
+                !self.selected_providers[self.provider_cursor];
+            self.apply_filters();
+        }
+    }
+
+    pub fn provider_popup_select_all(&mut self) {
+        let all_selected = self.selected_providers.iter().all(|&s| s);
+        let new_val = !all_selected;
+        for s in &mut self.selected_providers {
+            *s = new_val;
+        }
+        self.apply_filters();
+    }
+
+    pub fn provider_popup_deselect_all(&mut self) {
+        for s in &mut self.selected_providers {
+            *s = false;
+        }
+        self.apply_filters();
+    }
+
+    pub fn toggle_installed_first(&mut self) {
+        self.installed_first = !self.installed_first;
+        self.re_sort();
+    }
+
+    /// Re-sort all_fits using current sort column and installed_first preference, then refilter.
+    fn re_sort(&mut self) {
+        let fits = std::mem::take(&mut self.all_fits);
+        self.all_fits =
+            crate::fit::rank_models_by_fit_opts_col(fits, self.installed_first, self.sort_column);
+        self.apply_filters();
+    }
+
+    /// Start pulling the currently selected model via Ollama.
+    pub fn start_download(&mut self) {
+        if !self.ollama_available {
+            self.pull_status = Some("Ollama is not running".to_string());
+            return;
+        }
+        if self.pull_active.is_some() {
+            return; // already pulling
+        }
+        let Some(fit) = self.selected_fit() else {
+            return;
+        };
+        if fit.installed {
+            self.pull_status = Some("Already installed".to_string());
+            return;
+        }
+        let Some(tag) = providers::ollama_pull_tag(&fit.model.name) else {
+            self.pull_status = Some("Not available in Ollama".to_string());
+            return;
+        };
+        let model_name = fit.model.name.clone();
+        match self.ollama.start_pull(&tag) {
+            Ok(handle) => {
+                self.pull_model_name = Some(model_name);
+                self.pull_status = Some(format!("Pulling {}...", tag));
+                self.pull_percent = Some(0.0);
+                self.pull_active = Some(handle);
+            }
+            Err(e) => {
+                self.pull_status = Some(format!("Pull failed: {}", e));
+            }
+        }
+    }
+
+    /// Poll the active pull for progress. Called each TUI tick.
+    pub fn tick_pull(&mut self) {
+        if self.pull_active.is_some() {
+            self.tick_count = self.tick_count.wrapping_add(1);
+        }
+        let Some(handle) = &self.pull_active else {
+            return;
+        };
+        // Drain all available events
+        loop {
+            match handle.receiver.try_recv() {
+                Ok(PullEvent::Progress { status, percent }) => {
+                    if let Some(p) = percent {
+                        self.pull_percent = Some(p);
+                    }
+                    self.pull_status = Some(status);
+                }
+                Ok(PullEvent::Done) => {
+                    self.pull_status = Some("Download complete!".to_string());
+                    self.pull_percent = None;
+                    self.pull_active = None;
+                    // Refresh installed models
+                    self.refresh_installed();
+                    return;
+                }
+                Ok(PullEvent::Error(e)) => {
+                    self.pull_status = Some(format!("Error: {}", e));
+                    self.pull_percent = None;
+                    self.pull_active = None;
+                    return;
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.pull_status = Some("Pull ended".to_string());
+                    self.pull_percent = None;
+                    self.pull_active = None;
+                    self.refresh_installed();
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Re-query Ollama for installed models and update all_fits.
+    pub fn refresh_installed(&mut self) {
+        self.ollama_installed = self.ollama.installed_models();
+        for fit in &mut self.all_fits {
+            fit.installed = providers::is_model_installed(&fit.model.name, &self.ollama_installed);
+        }
+        self.re_sort();
+    }
+}

--- a/src/tui_events.rs
+++ b/src/tui_events.rs
@@ -1,0 +1,110 @@
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use std::time::Duration;
+
+use crate::tui_app::{App, InputMode};
+
+/// Poll for and handle events. Returns true if an event was processed.
+pub fn handle_events(app: &mut App) -> std::io::Result<bool> {
+    // Always tick the pull progress (non-blocking)
+    app.tick_pull();
+
+    if event::poll(Duration::from_millis(50))?
+        && let Event::Key(key) = event::read()?
+    {
+        // Only handle Press events (ignore Release on some platforms)
+        if key.kind != KeyEventKind::Press {
+            return Ok(false);
+        }
+        match app.input_mode {
+            InputMode::Normal => handle_normal_mode(app, key),
+            InputMode::Search => handle_search_mode(app, key),
+            InputMode::ProviderPopup => handle_provider_popup_mode(app, key),
+        }
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn handle_normal_mode(app: &mut App, key: KeyEvent) {
+    match key.code {
+        // Quit
+        KeyCode::Char('q') | KeyCode::Esc => {
+            if app.show_detail {
+                app.show_detail = false;
+            } else {
+                app.should_quit = true;
+            }
+        }
+
+        // Navigation
+        KeyCode::Up | KeyCode::Char('k') => app.move_up(),
+        KeyCode::Down | KeyCode::Char('j') => app.move_down(),
+        KeyCode::PageUp => app.page_up(),
+        KeyCode::PageDown => app.page_down(),
+        KeyCode::Home | KeyCode::Char('g') => app.home(),
+        KeyCode::End | KeyCode::Char('G') => app.end(),
+
+        // Search
+        KeyCode::Char('/') => app.enter_search(),
+
+        // Fit filter
+        KeyCode::Char('f') => app.cycle_fit_filter(),
+
+        // Sort column
+        KeyCode::Char('s') => app.cycle_sort_column(),
+
+        // Provider popup
+        KeyCode::Char('p') => app.open_provider_popup(),
+
+        // Installed-first sort toggle (Ollama only)
+        KeyCode::Char('i') if app.ollama_available => app.toggle_installed_first(),
+
+        // Download model via Ollama
+        KeyCode::Char('d') if app.ollama_available => app.start_download(),
+
+        // Refresh installed models
+        KeyCode::Char('r') if app.ollama_available => app.refresh_installed(),
+
+        // Detail view
+        KeyCode::Enter => app.toggle_detail(),
+
+        _ => {}
+    }
+}
+
+fn handle_search_mode(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Esc | KeyCode::Enter => app.exit_search(),
+
+        KeyCode::Backspace => app.search_backspace(),
+        KeyCode::Delete => app.search_delete(),
+
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            app.clear_search();
+        }
+
+        KeyCode::Char(c) => app.search_input(c),
+
+        // Allow navigation while searching
+        KeyCode::Up => app.move_up(),
+        KeyCode::Down => app.move_down(),
+
+        _ => {}
+    }
+}
+
+fn handle_provider_popup_mode(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('p') | KeyCode::Char('q') => app.close_provider_popup(),
+
+        KeyCode::Up | KeyCode::Char('k') => app.provider_popup_up(),
+        KeyCode::Down | KeyCode::Char('j') => app.provider_popup_down(),
+
+        KeyCode::Char(' ') | KeyCode::Enter => app.provider_popup_toggle(),
+
+        KeyCode::Char('a') => app.provider_popup_select_all(),
+        KeyCode::Char('c') => app.provider_popup_deselect_all(),
+
+        _ => {}
+    }
+}

--- a/src/tui_ui.rs
+++ b/src/tui_ui.rs
@@ -1,0 +1,980 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style, Stylize},
+    text::{Line, Span},
+    widgets::{
+        Block, Borders, Cell, Clear, Paragraph, Row, Scrollbar, ScrollbarOrientation,
+        ScrollbarState, Table, TableState, Wrap,
+    },
+};
+
+use crate::fit::FitLevel;
+use crate::hardware::is_running_in_wsl;
+use crate::providers;
+use crate::tui_app::{App, FitFilter, InputMode, SortColumn};
+
+pub fn draw(frame: &mut Frame, app: &mut App) {
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // system info bar
+            Constraint::Length(3), // search + filters
+            Constraint::Min(10),   // main table
+            Constraint::Length(1), // status bar
+        ])
+        .split(frame.area());
+
+    draw_system_bar(frame, app, outer[0]);
+    draw_search_and_filters(frame, app, outer[1]);
+
+    if app.show_detail {
+        draw_detail(frame, app, outer[2]);
+    } else {
+        draw_table(frame, app, outer[2]);
+    }
+
+    draw_status_bar(frame, app, outer[3]);
+
+    // Draw provider popup on top if active
+    if app.input_mode == InputMode::ProviderPopup {
+        draw_provider_popup(frame, app);
+    }
+}
+
+fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect) {
+    let gpu_info = if app.specs.gpus.is_empty() {
+        format!("GPU: none ({})", app.specs.backend.label())
+    } else {
+        // Show the primary GPU (best VRAM, used for fit scoring) in full.
+        // If there are additional GPUs, append "+N more".
+        let primary = &app.specs.gpus[0];
+        let backend = primary.backend.label();
+        let primary_str = if primary.unified_memory {
+            format!(
+                "{} ({:.1} GB shared, {})",
+                primary.name,
+                primary.vram_gb.unwrap_or(0.0),
+                backend
+            )
+        } else {
+            match primary.vram_gb {
+                Some(vram) if vram > 0.0 => {
+                    if primary.count > 1 {
+                        format!(
+                            "{} x{} ({:.1} GB, {})",
+                            primary.name, primary.count, vram, backend
+                        )
+                    } else {
+                        format!("{} ({:.1} GB, {})", primary.name, vram, backend)
+                    }
+                }
+                Some(_) => format!("{} (shared, {})", primary.name, backend),
+                None => format!("{} ({})", primary.name, backend),
+            }
+        };
+        let extra = app.specs.gpus.len() - 1;
+        if extra > 0 {
+            format!("GPU: {} +{} more", primary_str, extra)
+        } else {
+            format!("GPU: {}", primary_str)
+        }
+    };
+
+    let ollama_info = if app.ollama_available {
+        format!("Ollama: ✓ ({} installed)", app.ollama_installed.len() / 2)
+    } else {
+        "Ollama: ✗".to_string()
+    };
+    let ollama_color = if app.ollama_available {
+        Color::Green
+    } else {
+        Color::DarkGray
+    };
+
+    let text = Line::from(vec![
+        Span::styled(" CPU: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!(
+                "{} ({} cores)",
+                app.specs.cpu_name, app.specs.total_cpu_cores
+            ),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled("  │  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("RAM: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!(
+                "{:.1} GB avail / {:.1} GB total{}",
+                app.specs.available_ram_gb,
+                app.specs.total_ram_gb,
+                if is_running_in_wsl() { " (WSL)" } else { "" }
+            ),
+            Style::default().fg(Color::Cyan),
+        ),
+        Span::styled("  │  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(gpu_info, Style::default().fg(Color::Yellow)),
+        Span::styled("  │  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(ollama_info, Style::default().fg(ollama_color)),
+    ]);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(" llmfit ")
+        .title_style(
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let paragraph = Paragraph::new(text).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Min(30),    // search
+            Constraint::Length(24), // provider summary
+            Constraint::Length(18), // sort column
+            Constraint::Length(20), // fit filter
+        ])
+        .split(area);
+
+    // Search box
+    let search_style = match app.input_mode {
+        InputMode::Search => Style::default().fg(Color::Yellow),
+        InputMode::Normal | InputMode::ProviderPopup => Style::default().fg(Color::DarkGray),
+    };
+
+    let search_text = if app.search_query.is_empty() && app.input_mode == InputMode::Normal {
+        Line::from(Span::styled(
+            "Press / to search...",
+            Style::default().fg(Color::DarkGray),
+        ))
+    } else {
+        Line::from(Span::styled(
+            &app.search_query,
+            Style::default().fg(Color::White),
+        ))
+    };
+
+    let search_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(search_style)
+        .title(" Search ")
+        .title_style(search_style);
+
+    let search = Paragraph::new(search_text).block(search_block);
+    frame.render_widget(search, chunks[0]);
+
+    if app.input_mode == InputMode::Search {
+        frame.set_cursor_position((
+            chunks[0].x + app.cursor_position as u16 + 1,
+            chunks[0].y + 1,
+        ));
+    }
+
+    // Provider filter summary (press 'p' to open popup)
+    let active_count = app.selected_providers.iter().filter(|&&s| s).count();
+    let total_count = app.providers.len();
+    let provider_text = if active_count == total_count {
+        "All".to_string()
+    } else {
+        format!("{}/{}", active_count, total_count)
+    };
+    let provider_color = if active_count == total_count {
+        Color::Green
+    } else if active_count == 0 {
+        Color::Red
+    } else {
+        Color::Yellow
+    };
+
+    let provider_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(" Providers (p) ")
+        .title_style(Style::default().fg(Color::DarkGray));
+
+    let providers = Paragraph::new(Line::from(Span::styled(
+        format!(" {}", provider_text),
+        Style::default().fg(provider_color),
+    )))
+    .block(provider_block);
+    frame.render_widget(providers, chunks[1]);
+
+    // Sort column
+    let sort_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(" Sort [s] ")
+        .title_style(Style::default().fg(Color::DarkGray));
+
+    let sort_text = Paragraph::new(Line::from(Span::styled(
+        format!(" {}", app.sort_column.label()),
+        Style::default().fg(Color::Cyan),
+    )))
+    .block(sort_block);
+    frame.render_widget(sort_text, chunks[2]);
+
+    // Fit filter
+    let fit_style = match app.fit_filter {
+        FitFilter::All => Style::default().fg(Color::White),
+        FitFilter::Runnable => Style::default().fg(Color::Green),
+        FitFilter::Perfect => Style::default().fg(Color::Green),
+        FitFilter::Good => Style::default().fg(Color::Yellow),
+        FitFilter::Marginal => Style::default().fg(Color::Magenta),
+        FitFilter::TooTight => Style::default().fg(Color::Red),
+    };
+
+    let fit_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(" Fit [f] ")
+        .title_style(Style::default().fg(Color::DarkGray));
+
+    let fit_text = Paragraph::new(Line::from(Span::styled(app.fit_filter.label(), fit_style)))
+        .block(fit_block);
+    frame.render_widget(fit_text, chunks[3]);
+}
+
+fn fit_color(level: FitLevel) -> Color {
+    match level {
+        FitLevel::Perfect => Color::Green,
+        FitLevel::Good => Color::Yellow,
+        FitLevel::Marginal => Color::Magenta,
+        FitLevel::TooTight => Color::Red,
+    }
+}
+
+fn fit_indicator(level: FitLevel) -> &'static str {
+    match level {
+        FitLevel::Perfect => "●",
+        FitLevel::Good => "●",
+        FitLevel::Marginal => "●",
+        FitLevel::TooTight => "●",
+    }
+}
+
+/// Build a compact animated download indicator for the "Inst" column.
+/// Shows a block-character progress bar when percentage is known,
+/// or an animated spinner when waiting.
+fn pull_indicator(percent: Option<f64>, tick: u64) -> String {
+    const SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    let spin = SPINNER[(tick as usize / 3) % SPINNER.len()];
+
+    match percent {
+        Some(pct) => {
+            // 3-char block bar: each char = ~33%, using ░▒▓█
+            const BLOCKS: &[char] = &[' ', '░', '▒', '▓', '█'];
+            let filled = pct / 100.0 * 3.0; // 0..3
+            let mut bar = String::with_capacity(5);
+            bar.push(spin);
+            for i in 0..3 {
+                let level = (filled - i as f64).clamp(0.0, 1.0);
+                let idx = (level * 4.0).round() as usize;
+                bar.push(BLOCKS[idx]);
+            }
+            bar
+        }
+        None => format!(" {} ", spin),
+    }
+}
+
+fn draw_table(frame: &mut Frame, app: &mut App, area: Rect) {
+    let sort_col = app.sort_column;
+    let header_names = [
+        "", "Inst", "Model", "Provider", "Params", "Score", "tok/s", "Quant", "Mode", "Mem %",
+        "Ctx", "Fit", "Use Case",
+    ];
+    // Column indices that correspond to each SortColumn variant
+    let sort_col_idx = match sort_col {
+        SortColumn::Score => 5,
+        SortColumn::Params => 4,
+        SortColumn::MemPct => 9,
+        SortColumn::Ctx => 10,
+        SortColumn::UseCase => 12,
+    };
+    let header_cells = header_names.iter().enumerate().map(|(i, h)| {
+        if i == sort_col_idx {
+            Cell::from(format!("{} ▼", h)).style(
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )
+        } else {
+            Cell::from(*h).style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )
+        }
+    });
+    let header = Row::new(header_cells).height(1);
+
+    let rows: Vec<Row> = app
+        .filtered_fits
+        .iter()
+        .map(|&idx| {
+            let fit = &app.all_fits[idx];
+            let color = fit_color(fit.fit_level);
+
+            let mode_color = match fit.run_mode {
+                crate::fit::RunMode::Gpu => Color::Green,
+                crate::fit::RunMode::MoeOffload => Color::Cyan,
+                crate::fit::RunMode::CpuOffload => Color::Yellow,
+                crate::fit::RunMode::CpuOnly => Color::DarkGray,
+            };
+
+            let score_color = if fit.score >= 70.0 {
+                Color::Green
+            } else if fit.score >= 50.0 {
+                Color::Yellow
+            } else {
+                Color::Red
+            };
+
+            let tps_text = if fit.estimated_tps >= 100.0 {
+                format!("{:.0}", fit.estimated_tps)
+            } else if fit.estimated_tps >= 10.0 {
+                format!("{:.1}", fit.estimated_tps)
+            } else {
+                format!("{:.1}", fit.estimated_tps)
+            };
+
+            let is_pulling = app.pull_active.is_some()
+                && app.pull_model_name.as_deref() == Some(&fit.model.name);
+            let has_ollama = providers::has_ollama_mapping(&fit.model.name);
+
+            let installed_icon = if fit.installed {
+                " ✓".to_string()
+            } else if is_pulling {
+                pull_indicator(app.pull_percent, app.tick_count)
+            } else if !has_ollama {
+                " —".to_string()
+            } else {
+                " ".to_string()
+            };
+            let installed_color = if fit.installed {
+                Color::Green
+            } else if is_pulling {
+                Color::Yellow
+            } else if !has_ollama {
+                Color::DarkGray
+            } else {
+                Color::DarkGray
+            };
+
+            let row_style = if is_pulling {
+                Style::default().bg(Color::Rgb(50, 50, 0))
+            } else {
+                Style::default()
+            };
+
+            Row::new(vec![
+                Cell::from(fit_indicator(fit.fit_level)).style(Style::default().fg(color)),
+                Cell::from(installed_icon).style(Style::default().fg(installed_color)),
+                Cell::from(fit.model.name.clone()).style(Style::default().fg(Color::White)),
+                Cell::from(fit.model.provider.clone()).style(Style::default().fg(Color::DarkGray)),
+                Cell::from(fit.model.parameter_count.clone())
+                    .style(Style::default().fg(Color::White)),
+                Cell::from(format!("{:.0}", fit.score)).style(Style::default().fg(score_color)),
+                Cell::from(tps_text).style(Style::default().fg(Color::White)),
+                Cell::from(fit.best_quant.clone()).style(Style::default().fg(Color::DarkGray)),
+                Cell::from(fit.run_mode_text().to_string()).style(Style::default().fg(mode_color)),
+                Cell::from(format!("{:.0}%", fit.utilization_pct))
+                    .style(Style::default().fg(color)),
+                Cell::from(format!("{}k", fit.model.context_length / 1000))
+                    .style(Style::default().fg(Color::DarkGray)),
+                Cell::from(fit.fit_text().to_string()).style(Style::default().fg(color)),
+                Cell::from(fit.use_case.label().to_string())
+                    .style(Style::default().fg(Color::DarkGray)),
+            ])
+            .style(row_style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(2),  // indicator
+        Constraint::Length(5),  // installed / pull %
+        Constraint::Min(20),    // model name
+        Constraint::Length(12), // provider
+        Constraint::Length(8),  // params
+        Constraint::Length(6),  // score
+        Constraint::Length(6),  // tok/s
+        Constraint::Length(7),  // quant
+        Constraint::Length(7),  // mode
+        Constraint::Length(6),  // mem %
+        Constraint::Length(5),  // ctx
+        Constraint::Length(10), // fit
+        Constraint::Min(10),    // use case
+    ];
+
+    let count_text = format!(
+        " Models ({}/{}) ",
+        app.filtered_fits.len(),
+        app.all_fits.len()
+    );
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray))
+                .title(count_text)
+                .title_style(Style::default().fg(Color::White)),
+        )
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::Rgb(40, 40, 70))
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    let mut state = TableState::default();
+    if !app.filtered_fits.is_empty() {
+        state.select(Some(app.selected_row));
+    }
+
+    frame.render_stateful_widget(table, area, &mut state);
+
+    // Scrollbar
+    if app.filtered_fits.len() > (area.height as usize).saturating_sub(3) {
+        let mut scrollbar_state =
+            ScrollbarState::new(app.filtered_fits.len()).position(app.selected_row);
+        frame.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(Some("↑"))
+                .end_symbol(Some("↓")),
+            area,
+            &mut scrollbar_state,
+        );
+    }
+}
+
+fn draw_detail(frame: &mut Frame, app: &App, area: Rect) {
+    let fit = match app.selected_fit() {
+        Some(f) => f,
+        None => {
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .title(" No model selected ");
+            frame.render_widget(block, area);
+            return;
+        }
+    };
+
+    let color = fit_color(fit.fit_level);
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Model:       ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&fit.model.name, Style::default().fg(Color::White).bold()),
+        ]),
+        Line::from(vec![
+            Span::styled("  Provider:    ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&fit.model.provider, Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Parameters:  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                &fit.model.parameter_count,
+                Style::default().fg(Color::White),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Quantization:", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!(" {}", fit.model.quantization),
+                Style::default().fg(Color::White),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Best Quant:  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!(" {} (for this hardware)", fit.best_quant),
+                Style::default().fg(Color::Green),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Context:     ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{} tokens", fit.model.context_length),
+                Style::default().fg(Color::White),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Use Case:    ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&fit.model.use_case, Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Category:    ", Style::default().fg(Color::DarkGray)),
+            Span::styled(fit.use_case.label(), Style::default().fg(Color::Cyan)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Installed:   ", Style::default().fg(Color::DarkGray)),
+            if fit.installed {
+                Span::styled("✓ Yes (Ollama)", Style::default().fg(Color::Green).bold())
+            } else if app.ollama_available {
+                Span::styled(
+                    "✗ No  (press d to pull)",
+                    Style::default().fg(Color::DarkGray),
+                )
+            } else {
+                Span::styled("- Ollama not running", Style::default().fg(Color::DarkGray))
+            },
+        ]),
+    ];
+
+    // Scoring section
+    let score_color = if fit.score >= 70.0 {
+        Color::Green
+    } else if fit.score >= 50.0 {
+        Color::Yellow
+    } else {
+        Color::Red
+    };
+    lines.extend_from_slice(&[
+        Line::from(""),
+        Line::from(Span::styled(
+            "  ── Score Breakdown ──",
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Overall:     ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.1} / 100", fit.score),
+                Style::default().fg(score_color).bold(),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Quality:     ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.0}", fit.score_components.quality),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled("  Speed: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.0}", fit.score_components.speed),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled("  Fit: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.0}", fit.score_components.fit),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled("  Context: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.0}", fit.score_components.context),
+                Style::default().fg(Color::White),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Est. Speed:  ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.1} tok/s", fit.estimated_tps),
+                Style::default().fg(Color::White),
+            ),
+        ]),
+    ]);
+
+    // MoE Architecture section
+    if fit.model.is_moe {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  ── MoE Architecture ──",
+            Style::default().fg(Color::Cyan),
+        )));
+        lines.push(Line::from(""));
+
+        if let (Some(num_experts), Some(active_experts)) =
+            (fit.model.num_experts, fit.model.active_experts)
+        {
+            lines.push(Line::from(vec![
+                Span::styled("  Experts:     ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!(
+                        "{} active / {} total per token",
+                        active_experts, num_experts
+                    ),
+                    Style::default().fg(Color::Cyan),
+                ),
+            ]));
+        }
+
+        if let Some(active_vram) = fit.model.moe_active_vram_gb() {
+            lines.push(Line::from(vec![
+                Span::styled("  Active VRAM: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("{:.1} GB", active_vram),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::styled(
+                    format!(
+                        "  (vs {:.1} GB full model)",
+                        fit.model.min_vram_gb.unwrap_or(0.0)
+                    ),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]));
+        }
+
+        if let Some(offloaded) = fit.moe_offloaded_gb {
+            lines.push(Line::from(vec![
+                Span::styled("  Offloaded:   ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("{:.1} GB inactive experts in RAM", offloaded),
+                    Style::default().fg(Color::Yellow),
+                ),
+            ]));
+        }
+
+        if fit.run_mode == crate::fit::RunMode::MoeOffload {
+            lines.push(Line::from(vec![
+                Span::styled("  Strategy:    ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    "Expert offloading (active in VRAM, inactive in RAM)",
+                    Style::default().fg(Color::Green),
+                ),
+            ]));
+        } else if fit.run_mode == crate::fit::RunMode::Gpu {
+            lines.push(Line::from(vec![
+                Span::styled("  Strategy:    ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    "All experts loaded in VRAM (optimal)",
+                    Style::default().fg(Color::Green),
+                ),
+            ]));
+        }
+    }
+
+    lines.extend_from_slice(&[
+        Line::from(""),
+        Line::from(Span::styled(
+            "  ── System Fit ──",
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Fit Level:   ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{} {}", fit_indicator(fit.fit_level), fit.fit_text()),
+                Style::default().fg(color).bold(),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Run Mode:    ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                fit.run_mode_text(),
+                Style::default().fg(Color::White).bold(),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  -- Memory --",
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+    ]);
+
+    if let Some(vram) = fit.model.min_vram_gb {
+        let vram_label = if app.specs.has_gpu {
+            if app.specs.unified_memory {
+                if let Some(sys_vram) = app.specs.gpu_vram_gb {
+                    format!("  (shared: {:.1} GB)", sys_vram)
+                } else {
+                    "  (shared memory)".to_string()
+                }
+            } else if let Some(sys_vram) = app.specs.gpu_vram_gb {
+                format!("  (system: {:.1} GB)", sys_vram)
+            } else {
+                "  (system: unknown)".to_string()
+            }
+        } else {
+            "  (no GPU)".to_string()
+        };
+        lines.push(Line::from(vec![
+            Span::styled("  Min VRAM:    ", Style::default().fg(Color::DarkGray)),
+            Span::styled(format!("{:.1} GB", vram), Style::default().fg(Color::White)),
+            Span::styled(vram_label, Style::default().fg(Color::DarkGray)),
+        ]));
+    }
+
+    lines.extend_from_slice(&[
+        Line::from(vec![
+            Span::styled("  Min RAM:     ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.1} GB", fit.model.min_ram_gb),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled(
+                format!("  (system: {:.1} GB avail)", app.specs.available_ram_gb),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Rec RAM:     ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.1} GB", fit.model.recommended_ram_gb),
+                Style::default().fg(Color::White),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Mem Usage:   ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.1}%", fit.utilization_pct),
+                Style::default().fg(color),
+            ),
+            Span::styled(
+                format!(
+                    "  ({:.1} / {:.1} GB)",
+                    fit.memory_required_gb, fit.memory_available_gb
+                ),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]),
+    ]);
+
+    lines.push(Line::from(""));
+    if !fit.notes.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  ── Notes ──",
+            Style::default().fg(Color::Cyan),
+        )));
+        lines.push(Line::from(""));
+        for note in &fit.notes {
+            lines.push(Line::from(Span::styled(
+                format!("  {}", note),
+                Style::default().fg(Color::White),
+            )));
+        }
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(format!(" {} ", fit.model.name))
+        .title_style(Style::default().fg(Color::White).bold());
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn draw_provider_popup(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+
+    // Size the popup: width fits longest provider name, height fits up to 20 rows
+    let max_name_len = app.providers.iter().map(|p| p.len()).max().unwrap_or(10);
+    let popup_width = (max_name_len as u16 + 10).min(area.width.saturating_sub(4)); // "[x] name" + padding
+    let popup_height = (app.providers.len() as u16 + 2).min(area.height.saturating_sub(4)); // +2 for border
+
+    // Center the popup
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    // Clear the area behind the popup
+    frame.render_widget(Clear, popup_area);
+
+    // Build the list of provider lines
+    let inner_height = popup_height.saturating_sub(2) as usize; // minus borders
+    let total = app.providers.len();
+
+    // Scroll so the cursor is always visible
+    let scroll_offset = if app.provider_cursor >= inner_height {
+        app.provider_cursor - inner_height + 1
+    } else {
+        0
+    };
+
+    let lines: Vec<Line> = app
+        .providers
+        .iter()
+        .enumerate()
+        .skip(scroll_offset)
+        .take(inner_height)
+        .map(|(i, name)| {
+            let checkbox = if app.selected_providers[i] {
+                "[x]"
+            } else {
+                "[ ]"
+            };
+            let is_cursor = i == app.provider_cursor;
+
+            let style = if is_cursor {
+                if app.selected_providers[i] {
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD)
+                        .bg(Color::DarkGray)
+                } else {
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD)
+                        .bg(Color::DarkGray)
+                }
+            } else if app.selected_providers[i] {
+                Style::default().fg(Color::Green)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+
+            Line::from(Span::styled(format!(" {} {}", checkbox, name), style))
+        })
+        .collect();
+
+    let active_count = app.selected_providers.iter().filter(|&&s| s).count();
+    let title = format!(" Providers ({}/{}) ", active_count, total);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow))
+        .title(title)
+        .title_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, popup_area);
+}
+
+fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
+    // If a download is in progress, show the progress bar
+    if let Some(status) = &app.pull_status {
+        let progress_text = if let Some(pct) = app.pull_percent {
+            format!(" {} [{:.0}%] ", status, pct)
+        } else {
+            format!(" {} ", status)
+        };
+
+        let (keys, mode_text) = match app.input_mode {
+            InputMode::Normal => {
+                let detail_key = if app.show_detail {
+                    "Enter:table"
+                } else {
+                    "Enter:detail"
+                };
+                let ollama_keys = if app.ollama_available {
+                    let installed_key = if app.installed_first {
+                        "i:all"
+                    } else {
+                        "i:installed↑"
+                    };
+                    format!("  {}  d:pull  r:refresh", installed_key)
+                } else {
+                    String::new()
+                };
+                (
+                    format!(
+                        " ↑↓/jk:nav  {}  /:search  f:fit  s:sort{}  p:providers  q:quit",
+                        detail_key, ollama_keys,
+                    ),
+                    "NORMAL",
+                )
+            }
+            InputMode::Search => (
+                "  Type to search  Esc:done  Ctrl-U:clear".to_string(),
+                "SEARCH",
+            ),
+            InputMode::ProviderPopup => (
+                "  ↑↓/jk:nav  Space:toggle  a:all/none  c:clear  Esc:close".to_string(),
+                "PROVIDERS",
+            ),
+        };
+
+        // Split into two lines: keys + progress
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Min(20),
+                Constraint::Length(progress_text.len() as u16 + 2),
+            ])
+            .split(area);
+
+        let status_line = Line::from(vec![
+            Span::styled(
+                format!(" {} ", mode_text),
+                Style::default().fg(Color::Black).bg(Color::Green).bold(),
+            ),
+            Span::styled(keys, Style::default().fg(Color::DarkGray)),
+        ]);
+        frame.render_widget(Paragraph::new(status_line), chunks[0]);
+
+        let pull_color = if app.pull_active.is_some() {
+            Color::Yellow
+        } else {
+            Color::Green
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                progress_text,
+                Style::default().fg(pull_color),
+            ))),
+            chunks[1],
+        );
+        return;
+    }
+
+    let (keys, mode_text) = match app.input_mode {
+        InputMode::Normal => {
+            let detail_key = if app.show_detail {
+                "Enter:table"
+            } else {
+                "Enter:detail"
+            };
+            let ollama_keys = if app.ollama_available {
+                let installed_key = if app.installed_first {
+                    "i:all"
+                } else {
+                    "i:installed↑"
+                };
+                format!("  {}  d:pull  r:refresh", installed_key)
+            } else {
+                String::new()
+            };
+            (
+                format!(
+                    " ↑↓/jk:nav  {}  /:search  f:fit  s:sort{}  p:providers  q:quit",
+                    detail_key, ollama_keys,
+                ),
+                "NORMAL",
+            )
+        }
+        InputMode::Search => (
+            "  Type to search  Esc:done  Ctrl-U:clear".to_string(),
+            "SEARCH",
+        ),
+        InputMode::ProviderPopup => (
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "PROVIDERS",
+        ),
+    };
+
+    let status_line = Line::from(vec![
+        Span::styled(
+            format!(" {} ", mode_text),
+            Style::default().fg(Color::Black).bg(Color::Green).bold(),
+        ),
+        Span::styled(keys, Style::default().fg(Color::DarkGray)),
+    ]);
+
+    frame.render_widget(Paragraph::new(status_line), area);
+}
+
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max_len - 1])
+    }
+}


### PR DESCRIPTION
## Summary
- add global `--ram` and `--cpu-cores` hardware override flags alongside the existing `--memory` override
- thread hardware overrides through CLI/TUI flows and `llmfit serve` so API mode matches interactive behavior
- document the new override behavior in `README.md`, `API.md`, and the `serve` command help text
- add helper-level unit tests for `with_ram_override()` and `with_cpu_core_override()`

## Why
Closes #322.

This makes llmfit usable for planning and simulation workflows where you want to evaluate model fit against target hardware instead of the machine currently running llmfit.

## Notes
- `--memory` continues to override GPU VRAM
- `--ram` overrides total/available system RAM
- `--cpu-cores` overrides detected CPU core count
- `llmfit serve` now reflects these overrides in `/api/v1/system` and model-fit responses because it uses the same hardware override path as CLI/TUI commands

## Validation
- Added unit tests covering the new `SystemSpecs` override helpers
- Ran `cargo fmt --all`
- Ran `cargo test`
