### PR TITLE
test: cover list --json cli output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +322,17 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -899,6 +925,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -2261,6 +2293,7 @@ name = "llmfit"
 version = "0.9.2"
 dependencies = [
  "arboard",
+ "assert_cmd",
  "axum",
  "clap",
  "colored",
@@ -3127,6 +3160,33 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -4511,6 +4571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "termwiz"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5115,6 +5181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/llmfit-tui/Cargo.toml
+++ b/llmfit-tui/Cargo.toml
@@ -30,5 +30,6 @@ axum = "0.8"
 tokio = { version = "1.50", features = ["rt-multi-thread", "signal", "net"] }
 
 [dev-dependencies]
+assert_cmd = "2.0"
 http-body-util = "0.1"
 tower = "0.5"

--- a/llmfit-tui/tests/list_json.rs
+++ b/llmfit-tui/tests/list_json.rs
@@ -1,0 +1,39 @@
+use assert_cmd::Command;
+
+#[test]
+fn list_json_outputs_parseable_json_instead_of_table() {
+    let assert = Command::cargo_bin("llmfit")
+        .expect("llmfit binary should build for integration test")
+        .args(["list", "--json"])
+        .assert()
+        .success();
+
+    let output = assert.get_output();
+    let stdout = String::from_utf8(output.stdout.clone()).expect("stdout should be valid UTF-8");
+
+    assert!(
+        !stdout.contains("=== Available LLM Models ==="),
+        "list --json should not render the table header"
+    );
+    assert!(
+        !stdout.contains("╭────────"),
+        "list --json should not render table borders"
+    );
+
+    let models: serde_json::Value =
+        serde_json::from_str(&stdout).expect("list --json should emit valid JSON");
+    let models = models
+        .as_array()
+        .expect("list --json should emit a top-level JSON array");
+
+    assert!(
+        !models.is_empty(),
+        "model database should not be empty in list --json output"
+    );
+    assert!(
+        models
+            .iter()
+            .all(|model| model.get("name").and_then(|name| name.as_str()).is_some()),
+        "every JSON model entry should include a string name"
+    );
+}


### PR DESCRIPTION
## Summary
- add an integration test for `llmfit list --json`
- assert the command emits parseable JSON instead of the ASCII table renderer
- lock in the behavior reported in #147 so future refactors do not regress it

## Testing
- cargo test -p llmfit --test list_json

Closes #147
