### PR TITLE
fix: add Gemma 4 GGUF mappings

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1846,6 +1846,10 @@ const LLAMACPP_GGUF_MAPPINGS: &[(&str, &str)] = &[
         "bartowski/Mixtral-8x7B-Instruct-v0.1-GGUF",
     ),
     // Google Gemma
+    ("gemma-4-e4b-it", "bartowski/gemma-4-E4B-it-GGUF"),
+    ("gemma-4-e2b-it", "bartowski/gemma-4-E2B-it-GGUF"),
+    ("gemma-4-31b-it", "bartowski/gemma-4-31B-it-GGUF"),
+    ("gemma-4-26b-a4b-it", "bartowski/gemma-4-26B-A4B-it-GGUF"),
     ("gemma-3-12b-it", "bartowski/gemma-3-12b-it-GGUF"),
     ("gemma-2-27b-it", "bartowski/gemma-2-27b-it-GGUF"),
     ("gemma-2-9b-it", "bartowski/gemma-2-9b-it-GGUF"),
@@ -2778,6 +2782,22 @@ mod tests {
         // Models with hardcoded mappings should be found
         assert!(lookup_gguf_repo("meta-llama/Llama-3.1-8B-Instruct").is_some());
         assert!(lookup_gguf_repo("deepseek-r1").is_some());
+        assert_eq!(
+            lookup_gguf_repo("google/gemma-4-E2B-it"),
+            Some("bartowski/gemma-4-E2B-it-GGUF")
+        );
+        assert_eq!(
+            lookup_gguf_repo("google/gemma-4-E4B-it"),
+            Some("bartowski/gemma-4-E4B-it-GGUF")
+        );
+        assert_eq!(
+            lookup_gguf_repo("google/gemma-4-31B-it"),
+            Some("bartowski/gemma-4-31B-it-GGUF")
+        );
+        assert_eq!(
+            lookup_gguf_repo("google/gemma-4-26B-A4B-it"),
+            Some("bartowski/gemma-4-26B-A4B-it-GGUF")
+        );
     }
 
     #[test]


### PR DESCRIPTION
$## Summary\n- add hardcoded llama.cpp GGUF mappings for Gemma 4 E2B and E4B instruct models\n- add explicit mappings for the existing Gemma 4 31B and 26B A4B instruct variants too\n- extend the provider mapping test to lock the Gemma 4 coverage in\n\n## Testing\n- cargo test -p llmfit-core test_lookup_gguf_repo_known_mappings -- --nocapture\n- cargo test -p llmfit-core test_gguf_pull_tag_known -- --nocapture