### PR TITLE
docs: clarify llama.cpp detection configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,8 +592,14 @@ llmfit integrates with [llama.cpp](https://github.com/ggml-org/llama.cpp) as a r
 
 Requirements:
 
-- `llama-cli` or `llama-server` available in `PATH` (for runtime detection)
+- `llama-cli` or `llama-server` available in `PATH` (for runtime detection), or set `LLAMA_CPP_PATH` to the directory that contains those binaries
 - network access to Hugging Face for GGUF downloads
+
+Detection notes:
+
+- if llmfit cannot find `llama-cli` / `llama-server` in `PATH`, it falls back to probing a local `llama-server` health endpoint on `http://localhost:$LLAMA_SERVER_PORT/health`
+- `LLAMA_SERVER_PORT` defaults to `8080`; if your server is running elsewhere (for example `8000` on Jetson setups), export `LLAMA_SERVER_PORT=8000` before launching llmfit
+- if you built llama.cpp from source into a non-standard directory, export `LLAMA_CPP_PATH=/path/to/llama.cpp/build/bin`
 
 How it works:
 


### PR DESCRIPTION
$## Summary\n- document that llmfit can detect llama.cpp either via `PATH`/`LLAMA_CPP_PATH` or by probing a local `llama-server` health endpoint\n- clarify that `LLAMA_SERVER_PORT` defaults to `8080` and should be set explicitly when the server is running on a different port such as `8000`\n- add a non-standard source-build example for `LLAMA_CPP_PATH` so Jetson-style installs are easier to wire up\n\n## Testing\n- git diff --check