### PR TITLE
docs: show how to reproduce recommendation inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,15 @@ llmfit plan "Qwen/Qwen2.5-Coder-0.5B-Instruct" --context 8192 --json
 - per-path feasibility (`gpu`, `cpu_offload`, `cpu_only`)
 - upgrade deltas
 
+To reproduce a specific recommendation with explicit llama.cpp-style assumptions, take the recommended model name and rerun it through `plan` with the context, quantization, and target throughput you care about:
+
+```sh
+llmfit recommend --use-case coding --limit 5
+llmfit plan "Qwen/Qwen2.5-Coder-7B-Instruct" --context 8192 --quant Q4_K_M --target-tps 15 --json
+```
+
+That gives you a stable machine-readable record of the exact request parameters behind the feasibility result, which is a better fit for scripts and benchmarking notes than relying on the interactive TUI alone.
+
 ---
 
 ## How it works


### PR DESCRIPTION
$## Summary\n- add a README example showing how to take a recommended model and rerun it through `llmfit plan` with explicit context, quantization, and target throughput inputs\n- explain that `plan --json` gives a stable machine-readable record of those assumptions for scripts and benchmarking notes\n- make the recommendation-to-reproduction workflow easier to discover without digging through CLI help\n\n## Testing\n- git diff --check