### PR TITLE
docs: clarify model database inclusion boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,8 @@ The scraper writes `data/hf_models.json`, which is baked into the binary via `in
 
 By default, the scraper enriches models with known GGUF download sources from providers like [unsloth](https://huggingface.co/unsloth) and [bartowski](https://huggingface.co/bartowski). Results are cached in `data/gguf_sources_cache.json` (7-day TTL) to avoid repeated API calls. Use `--no-gguf-sources` to skip enrichment for a faster scrape.
 
+Inclusion rule of thumb: llmfit's database is centered on models that can be mapped onto its current local-runtime workflows (Hugging Face repos, GGUF/MLX variants, and runtime-specific pull mappings). Hosted aliases or provider-only catalog names that do not have a stable local Hugging Face / GGUF / MLX path today are usually discussed first rather than being added directly as database entries.
+
 ---
 
 ## Project structure


### PR DESCRIPTION
## Summary
- add a README note explaining that llmfit's model database is centered on models that map onto current local-runtime workflows
- clarify that hosted aliases or provider-only catalog names without a stable local Hugging Face / GGUF / MLX path are usually discussed first instead of being added directly
- make future model-addition requests like provider-side aliases easier to triage without overpromising support

## Testing
- git diff --check
