### PR TITLE
docs: add uv install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ brew install llmfit
 port install llmfit
 ```
 
+### uv / PyPI
+```sh
+uv tool run llmfit
+```
+
+Or install the published Python package explicitly:
+
+```sh
+uv tool install llmfit
+# or: pip install llmfit
+```
+
 #### Quick install
 ```sh
 curl -fsSL https://llmfit.axjns.dev/install.sh | sh


### PR DESCRIPTION
$## Summary\n- add `uv tool run llmfit` as a documented installation / execution path\n- mention `uv tool install llmfit` and `pip install llmfit` for users who prefer the published Python package\n- make the README reflect the install method described in issue #318\n\n## Testing\n- git diff --check