### PR TITLE
fix: include provider host in download errors

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -94,6 +94,10 @@ impl OllamaProvider {
         Self::default()
     }
 
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
     /// Build the full API URL for a given endpoint path.
     fn api_url(&self, path: &str) -> String {
         format!("{}/api/{}", self.base_url.trim_end_matches('/'), path)
@@ -1177,6 +1181,10 @@ impl DockerModelRunnerProvider {
         Self::default()
     }
 
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
     fn models_url(&self) -> String {
         format!("{}/v1/models", self.base_url.trim_end_matches('/'))
     }
@@ -1345,6 +1353,10 @@ impl Default for LmStudioProvider {
 impl LmStudioProvider {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
     }
 
     fn models_url(&self) -> String {

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1723,7 +1723,8 @@ impl App {
                 self.pull_active = Some(handle);
             }
             Err(e) => {
-                self.pull_status = Some(format!("Pull failed: {}", e));
+                self.pull_status =
+                    Some(format!("Pull failed via {}: {}", self.ollama.base_url(), e));
             }
         }
     }
@@ -1771,7 +1772,11 @@ impl App {
                 self.pull_active = Some(handle);
             }
             Err(e) => {
-                self.pull_status = Some(format!("Docker pull failed: {}", e));
+                self.pull_status = Some(format!(
+                    "Docker pull failed via {}: {}",
+                    self.docker_mr.base_url(),
+                    e
+                ));
             }
         }
     }
@@ -1790,7 +1795,11 @@ impl App {
                 self.pull_active = Some(handle);
             }
             Err(e) => {
-                self.pull_status = Some(format!("LM Studio download failed: {}", e));
+                self.pull_status = Some(format!(
+                    "LM Studio download failed via {}: {}",
+                    self.lmstudio.base_url(),
+                    e
+                ));
             }
         }
     }


### PR DESCRIPTION
## Summary
- expose the configured base URL for Ollama, Docker Model Runner, and LM Studio providers
- include that host in TUI download-start failure messages so errors like `Connection refused` tell users which endpoint failed
- keep the change scoped to startup error reporting rather than redesigning the pull stack

## Testing
- cargo test -p llmfit --quiet
- git diff --check
