### PR TITLE
docs: clarify current hardware override scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ llmfit --memory=24G recommend --json
 
 Accepted suffixes: `G`/`GB`/`GiB` (gigabytes), `M`/`MB`/`MiB` (megabytes), `T`/`TB`/`TiB` (terabytes). Case-insensitive. If no GPU was detected, the override creates a synthetic GPU entry so models are scored for GPU inference.
 
+If you want to sanity-check a different machine profile before buying or provisioning hardware, `--memory` is the current supported override path. It lets you answer "what if I had a different VRAM budget?" for fit, recommendation, and planning flows without pretending llmfit already supports a full custom CPU/GPU/RAM profile editor.
+
 ### Context-length cap for estimation
 
 Use `--max-context` to cap context length used for memory estimation (without changing each model's advertised maximum context):


### PR DESCRIPTION
## Summary
- clarify that `--memory` is the current supported override path for simulating a different VRAM budget in fit/recommend/plan flows
- explain that this helps with machine-sizing what-if checks without overclaiming support for a full custom CPU/GPU/RAM profile editor
- make issue #322 easier to reason about from the current implementation boundary

## Testing
- git diff --check
