### PR TITLE
docs: add Windows offline install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ scoop install llmfit
 
 If Scoop is not installed, follow the [Scoop installation guide](https://scoop.sh/).
 
+For restricted Windows environments, the GitHub release workflow also publishes standalone Windows `.zip` archives. Those are the better fit for offline or PowerShell-restricted installs: download the matching release artifact on a connected machine, copy it over, extract it, and run the bundled `llmfit.exe` directly.
+
 ### macOS / Linux
 
 #### Homebrew


### PR DESCRIPTION
## Summary
- document that the release workflow already publishes standalone Windows `.zip` archives alongside the Scoop installation path
- point restricted/offline Windows users at those release artifacts as the practical install route when Scoop or PowerShell setup is not an option
- make issue #201 easier to resolve from the current release process without inventing a new installer format first

## Testing
- git diff --check
