### PR TITLE
docs: clarify force-runtime scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ llmfit recommend --json --use-case coding --limit 3
 llmfit recommend --force-runtime llamacpp
 llmfit recommend --force-runtime llamacpp --use-case coding --limit 3
 
+# `--force-runtime` changes the analysis/scoring path, not the provider/download catalog.
+# A model still needs a compatible format/runtime path (for example GGUF for llama.cpp)
+# to become downloadable or launchable through the local provider flows.
+
 # Plan required hardware for a specific model configuration
 llmfit plan "Qwen/Qwen3-4B-MLX-4bit" --context 8192
 llmfit plan "Qwen/Qwen3-4B-MLX-4bit" --context 8192 --quant mlx-4bit


### PR DESCRIPTION
## Summary
- clarify in the README that `--force-runtime` changes the analysis/scoring path rather than rewriting the provider/download catalog for a model
- explain that a model still needs a compatible format/runtime path (for example GGUF for llama.cpp) to become downloadable or launchable through the local provider flows
- make the `force-runtime does nothing` complaint in issue #271 easier to interpret against the current behavior

## Testing
- git diff --check
