### PR TITLE
feat: default TUI to runnable models

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cargo build --release
 llmfit
 ```
 
-Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRAM, backend) are shown at the top. Models are listed in a scrollable table sorted by composite score. Each row shows the model's score, estimated tok/s, best quantization for your hardware, run mode, memory usage, and use-case category.
+Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRAM, backend) are shown at the top. Models are listed in a scrollable table sorted by composite score. Each row shows the model's score, estimated tok/s, best quantization for your hardware, run mode, memory usage, and use-case category. By default, the initial view starts on the **Runnable** fit filter so obviously non-runnable rows do not flood the first screen; press `f` to cycle back to **All** if you want the full database view.
 
 | Key                        | Action                                                                |
 |----------------------------|-----------------------------------------------------------------------|

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -486,7 +486,7 @@ impl App {
             selected_use_cases,
             capabilities: model_capabilities,
             selected_capabilities,
-            fit_filter: FitFilter::All,
+            fit_filter: FitFilter::Runnable,
             availability_filter: AvailabilityFilter::All,
             tp_filter: TpFilter::All,
             installed_first: false,


### PR DESCRIPTION
## Summary
- change the initial TUI fit filter from `All` to `Runnable` so first-time users are not immediately flooded with obviously non-runnable rows
- document that default in the README and point users at `f` if they want to cycle back to the full database view
- address the first-run narrowing concern in issue #346 with a small behavioral change instead of a larger filtering redesign

## Testing
- cargo test -p llmfit --quiet
- git diff --check
