### PR TITLE
docs: surface provider popup bulk keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `V`                        | Enter Select mode (column-based filtering)                            |
 | `t`                        | Cycle color theme (saved automatically)                               |
 | `p`                        | Open Plan mode for selected model (hardware planning)                 |
-| `P`                        | Open provider filter popup                                            |
+| `P`                        | Open provider filter popup (`Space`/`Enter` toggle, `a` all, `c` clear) |
 | `U`                        | Open use-case filter popup                                            |
 | `C`                        | Open capability filter popup                                          |
 | `L`                        | Open license filter popup                                             |

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2190,7 +2190,7 @@ fn draw_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         .collect();
 
     let active_count = app.selected_providers.iter().filter(|&&s| s).count();
-    let title = format!(" Providers ({}/{}) ", active_count, total);
+    let title = format!(" Providers ({}/{}) • Space toggle • a all • c clear ", active_count, total);
 
     let block = Block::default()
         .borders(Borders::ALL)


### PR DESCRIPTION
## Summary
- surface the existing provider-popup bulk actions directly in the TUI by adding `Space toggle`, `a all`, and `c clear` to the popup title
- document those same keys in the README shortcut table so users can discover them without reading the source
- improve issue #346's narrowing workflow without adding any new controls or changing the underlying provider filter behavior

## Testing
- cargo test -p llmfit --quiet
- git diff --check
