### PR TITLE
docs: surface use-case and capability popup keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `t`                        | Cycle color theme (saved automatically)                               |
 | `p`                        | Open Plan mode for selected model (hardware planning)                 |
 | `P`                        | Open provider filter popup                                            |
-| `U`                        | Open use-case filter popup                                            |
-| `C`                        | Open capability filter popup                                          |
+| `U`                        | Open use-case filter popup (`Space`/`Enter` toggle, `a` all)          |
+| `C`                        | Open capability filter popup (`Space`/`Enter` toggle, `a` all)        |
 | `L`                        | Open license filter popup                                             |
 | `R`                        | Open runtime/backend filter popup (llama.cpp, MLX, vLLM)             |
 | `h`                        | Open help popup (all key bindings)                                    |

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2292,7 +2292,7 @@ fn draw_use_case_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         .collect();
 
     let active_count = app.selected_use_cases.iter().filter(|&&s| s).count();
-    let title = format!(" Use Cases ({}/{}) ", active_count, total);
+    let title = format!(" Use Cases ({}/{}) • Space toggle • a all ", active_count, total);
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -2375,7 +2375,7 @@ fn draw_capability_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         .collect();
 
     let active_count = app.selected_capabilities.iter().filter(|&&s| s).count();
-    let title = format!(" Capabilities ({}/{}) ", active_count, total);
+    let title = format!(" Capabilities ({}/{}) • Space toggle • a all ", active_count, total);
 
     let block = Block::default()
         .borders(Borders::ALL)


### PR DESCRIPTION
## Summary
- surface the existing `Space`/`Enter` toggle and `a` select-all shortcuts directly in the Use Case and Capability popup titles
- document those same keys in the README shortcut table so users can discover them without reading the source
- continue issue #346's narrowing improvements by exposing existing fast-filter controls instead of adding new filtering logic

## Testing
- cargo test -p llmfit --quiet
- git diff --check
