### PR TITLE
docs: surface license and runtime popup keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `P`                        | Open provider filter popup                                            |
 | `U`                        | Open use-case filter popup                                            |
 | `C`                        | Open capability filter popup                                          |
-| `L`                        | Open license filter popup                                             |
-| `R`                        | Open runtime/backend filter popup (llama.cpp, MLX, vLLM)             |
+| `L`                        | Open license filter popup (`Space`/`Enter` toggle, `a` all)           |
+| `R`                        | Open runtime/backend filter popup (`Space`/`Enter` toggle, `a` all)   |
 | `h`                        | Open help popup (all key bindings)                                    |
 | `m`                        | Mark selected model for compare                                       |
 | `c`                        | Open compare view (marked vs selected)                                |

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -3032,7 +3032,7 @@ fn draw_runtime_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         .collect();
 
     let active_count = app.selected_runtimes.iter().filter(|&&s| s).count();
-    let title = format!(" Runtime ({}/{}) ", active_count, total);
+    let title = format!(" Runtime ({}/{}) • Space toggle • a all ", active_count, total);
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -3107,7 +3107,7 @@ fn draw_license_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         .collect();
 
     let active_count = app.selected_licenses.iter().filter(|&&s| s).count();
-    let title = format!(" License ({}/{}) ", active_count, total);
+    let title = format!(" License ({}/{}) • Space toggle • a all ", active_count, total);
 
     let block = Block::default()
         .borders(Borders::ALL)


### PR DESCRIPTION
## Summary
- surface the existing `Space`/`Enter` toggle and `a` select-all shortcuts directly in the License and Runtime popup titles
- document those same keys in the README shortcut table so users can discover them without reading the source
- continue issue #346's narrowing improvements by making another pair of existing fast-filter controls visible in the UI

## Testing
- cargo test -p llmfit --quiet
- git diff --check
