### PR TITLE
docs: surface quant and mode popup keys

### DIFF
--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2701,7 +2701,7 @@ fn draw_quant_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         .collect();
 
     let active_count = app.selected_quants.iter().filter(|&&s| s).count();
-    let title = format!(" Quant ({}/{}) ", active_count, total);
+    let title = format!(" Quant ({}/{}) • Space toggle • a all ", active_count, total);
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -2776,7 +2776,7 @@ fn draw_run_mode_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         .collect();
 
     let active_count = app.selected_run_modes.iter().filter(|&&s| s).count();
-    let title = format!(" Run Mode ({}/{}) ", active_count, total);
+    let title = format!(" Run Mode ({}/{}) • Space toggle • a all ", active_count, total);
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -2856,7 +2856,7 @@ fn draw_params_bucket_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         .collect();
 
     let active_count = app.selected_params_buckets.iter().filter(|&&s| s).count();
-    let title = format!(" Params ({}/{}) ", active_count, total);
+    let title = format!(" Params ({}/{}) • Space toggle • a all ", active_count, total);
 
     let block = Block::default()
         .borders(Borders::ALL)


### PR DESCRIPTION
## Summary
- surface the existing `Space` toggle and `a` all/none shortcuts directly in the Quant, Run Mode, and Params popup titles
- make another set of built-in multi-select filters self-discoverable without changing the underlying filtering logic
- continue issue #346's narrowing improvements by making popup interactions more consistent across the TUI

## Testing
- cargo test -p llmfit --quiet
- git diff --check
