### PR TITLE
feat: add clear-all to multi-select popups

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1228,6 +1228,13 @@ impl App {
         self.apply_filters();
     }
 
+    pub fn use_case_popup_clear_all(&mut self) {
+        for s in &mut self.selected_use_cases {
+            *s = false;
+        }
+        self.apply_filters();
+    }
+
     pub fn open_capability_popup(&mut self) {
         self.input_mode = InputMode::CapabilityPopup;
     }
@@ -1261,6 +1268,13 @@ impl App {
         let new_val = !all_selected;
         for s in &mut self.selected_capabilities {
             *s = new_val;
+        }
+        self.apply_filters();
+    }
+
+    pub fn capability_popup_clear_all(&mut self) {
+        for s in &mut self.selected_capabilities {
+            *s = false;
         }
         self.apply_filters();
     }
@@ -1432,6 +1446,13 @@ impl App {
         self.apply_filters();
     }
 
+    pub fn quant_popup_clear_all(&mut self) {
+        for s in &mut self.selected_quants {
+            *s = false;
+        }
+        self.apply_filters();
+    }
+
     // ── RunMode popup ───────────────────────────────────────────
 
     pub fn close_run_mode_popup(&mut self) {
@@ -1467,6 +1488,13 @@ impl App {
         self.apply_filters();
     }
 
+    pub fn run_mode_popup_clear_all(&mut self) {
+        for s in &mut self.selected_run_modes {
+            *s = false;
+        }
+        self.apply_filters();
+    }
+
     // ── Params bucket popup ─────────────────────────────────────
 
     pub fn close_params_bucket_popup(&mut self) {
@@ -1498,6 +1526,13 @@ impl App {
         let new_val = !all_selected;
         for s in &mut self.selected_params_buckets {
             *s = new_val;
+        }
+        self.apply_filters();
+    }
+
+    pub fn params_bucket_popup_clear_all(&mut self) {
+        for s in &mut self.selected_params_buckets {
+            *s = false;
         }
         self.apply_filters();
     }
@@ -1541,6 +1576,13 @@ impl App {
         self.apply_filters();
     }
 
+    pub fn license_popup_clear_all(&mut self) {
+        for s in &mut self.selected_licenses {
+            *s = false;
+        }
+        self.apply_filters();
+    }
+
     pub fn open_runtime_popup(&mut self) {
         self.input_mode = InputMode::RuntimePopup;
     }
@@ -1574,6 +1616,13 @@ impl App {
         let new_val = !all_selected;
         for s in &mut self.selected_runtimes {
             *s = new_val;
+        }
+        self.apply_filters();
+    }
+
+    pub fn runtime_popup_clear_all(&mut self) {
+        for s in &mut self.selected_runtimes {
+            *s = false;
         }
         self.apply_filters();
     }

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -256,6 +256,7 @@ fn handle_use_case_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char(' ') | KeyCode::Enter => app.use_case_popup_toggle(),
 
         KeyCode::Char('a') => app.use_case_popup_select_all(),
+        KeyCode::Char('c') => app.use_case_popup_clear_all(),
 
         _ => {}
     }
@@ -271,6 +272,7 @@ fn handle_capability_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char(' ') | KeyCode::Enter => app.capability_popup_toggle(),
 
         KeyCode::Char('a') => app.capability_popup_select_all(),
+        KeyCode::Char('c') => app.capability_popup_clear_all(),
 
         _ => {}
     }
@@ -296,6 +298,7 @@ fn handle_quant_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char(' ') | KeyCode::Enter => app.quant_popup_toggle(),
 
         KeyCode::Char('a') => app.quant_popup_select_all(),
+        KeyCode::Char('c') => app.quant_popup_clear_all(),
 
         _ => {}
     }
@@ -311,6 +314,7 @@ fn handle_run_mode_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char(' ') | KeyCode::Enter => app.run_mode_popup_toggle(),
 
         KeyCode::Char('a') => app.run_mode_popup_select_all(),
+        KeyCode::Char('c') => app.run_mode_popup_clear_all(),
 
         _ => {}
     }
@@ -326,6 +330,7 @@ fn handle_params_bucket_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char(' ') | KeyCode::Enter => app.params_bucket_popup_toggle(),
 
         KeyCode::Char('a') => app.params_bucket_popup_select_all(),
+        KeyCode::Char('c') => app.params_bucket_popup_clear_all(),
 
         _ => {}
     }
@@ -341,6 +346,7 @@ fn handle_license_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char(' ') | KeyCode::Enter => app.license_popup_toggle(),
 
         KeyCode::Char('a') => app.license_popup_select_all(),
+        KeyCode::Char('c') => app.license_popup_clear_all(),
 
         _ => {}
     }
@@ -356,6 +362,7 @@ fn handle_runtime_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char(' ') | KeyCode::Enter => app.runtime_popup_toggle(),
 
         KeyCode::Char('a') => app.runtime_popup_select_all(),
+        KeyCode::Char('c') => app.runtime_popup_clear_all(),
 
         _ => {}
     }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2517,15 +2517,15 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             "PLAN".to_string(),
         ),
         InputMode::ProviderPopup => (
-            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  c:clear  Esc:close".to_string(),
             "PROVIDERS".to_string(),
         ),
         InputMode::UseCasePopup => (
-            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  c:clear  Esc:close".to_string(),
             "USE CASES".to_string(),
         ),
         InputMode::CapabilityPopup => (
-            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  c:clear  Esc:close".to_string(),
             "CAPABILITIES".to_string(),
         ),
         InputMode::DownloadProviderPopup => (
@@ -2533,23 +2533,23 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             "DOWNLOAD".to_string(),
         ),
         InputMode::QuantPopup => (
-            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  c:clear  Esc:close".to_string(),
             "QUANT".to_string(),
         ),
         InputMode::RunModePopup => (
-            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  c:clear  Esc:close".to_string(),
             "RUN MODE".to_string(),
         ),
         InputMode::ParamsBucketPopup => (
-            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  c:clear  Esc:close".to_string(),
             "PARAMS".to_string(),
         ),
         InputMode::LicensePopup => (
-            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  c:clear  Esc:close".to_string(),
             "LICENSE".to_string(),
         ),
         InputMode::RuntimePopup => (
-            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "  ↑↓/jk:navigate  Space:toggle  a:all/none  c:clear  Esc:close".to_string(),
             "RUNTIME".to_string(),
         ),
         InputMode::HelpPopup => (


### PR DESCRIPTION
## Summary
- add an explicit `c` clear-all action to the multi-select Use Case, Capability, Quant, Run Mode, Params, License, and Runtime popups
- update the popup titles and status-bar help text so the new clear action is visible and consistent with the existing `a` all/none and `Space` toggle controls
- continue issue #346's narrowing improvements with a real interaction upgrade instead of another docs-only change

## Testing
- cargo test -p llmfit --quiet
- git diff --check
