### PR TITLE
docs: surface download popup cancel hint

### DIFF
--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2438,7 +2438,7 @@ fn draw_download_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) 
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(tc.accent_secondary))
-        .title(" Download With ")
+        .title(" Download With • Enter confirm • Esc cancel ")
         .title_style(
             Style::default()
                 .fg(tc.accent_secondary)


### PR DESCRIPTION
## Summary
- surface `Enter confirm` and `Esc cancel` directly in the download-provider popup title instead of relying only on the status-bar hint
- make the current download-provider picker flow easier to understand at the point of use
- continue issue #344's cancellation/discoverability cleanup with a small in-product UX improvement

## Testing
- cargo test -p llmfit --quiet
- git diff --check
