### PR TITLE
docs: mention Ocean theme in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Plan mode shows estimates for:
 
 ### Themes
 
-Press `t` to cycle through 10 built-in color themes. Your selection is saved automatically to `~/.config/llmfit/theme` and restored on next launch.
+Press `t` to cycle through 10 built-in color themes. Your selection is saved automatically to `~/.config/llmfit/theme` and restored on next launch. Themes now include `Ocean`, a blue option inspired by the default macOS Terminal background.
 
 | Theme                    | Description                                       |
 |--------------------------|---------------------------------------------------|


### PR DESCRIPTION
## Summary
- mention the new `Ocean` theme explicitly in the README theme section instead of leaving it hidden behind the generic `t` cycling description
- explain that Ocean is the blue theme inspired by the default macOS Terminal background
- follow up the new theme work in issue #344 with a small discoverability improvement

## Testing
- git diff --check
