### PR TITLE
docs: clarify select-mode column actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,22 @@ The multi-compare view displays a table where rows are attributes (Score, tok/s,
 
 Column-based filtering. Press `V` (shift-v) to enter Select mode, then use `h`/`l` or arrow keys to move between column headers. The active column is visually highlighted. Press `Enter` or `Space` to activate the appropriate filter for that column:
 
-| Column                        | Filter action                                                             |
-|-------------------------------|---------------------------------------------------------------------------|
-| Inst                          | Cycle availability filter                                                 |
-| Model                         | Enter search mode                                                         |
-| Provider                      | Open provider popup                                                       |
-| Params                        | Open parameter-size bucket popup (<3B, 3-7B, 7-14B, 14-30B, 30-70B, 70B+) |
-| Score, tok/s, Mem%, Ctx, Date | Sort by that column                                                       |
-| Quant                         | Open quantization popup                                                   |
-| Mode                          | Open run-mode popup (GPU, MoE, CPU+GPU, CPU)                              |
-| Fit                           | Cycle fit filter                                                          |
-| Use Case                      | Open use-case popup                                                       |
+| Column   | Filter action                                                             |
+|----------|---------------------------------------------------------------------------|
+| Inst     | Cycle availability filter                                                 |
+| Model    | Enter search mode                                                         |
+| Provider | Open provider popup                                                       |
+| Params   | Open parameter-size bucket popup (<3B, 3-7B, 7-14B, 14-30B, 30-70B, 70B+) |
+| Score    | Sort by score                                                             |
+| tok/s    | Sort by throughput                                                        |
+| Quant    | Open quantization popup                                                   |
+| Disk     | No Select-mode action yet                                                 |
+| Mode     | Open run-mode popup (GPU, MoE, CPU+GPU, CPU)                              |
+| Mem%     | Sort by memory utilization                                                |
+| Ctx      | Sort by context length                                                    |
+| Date     | Sort by release date                                                      |
+| Fit      | Cycle fit filter                                                          |
+| Use Case | Open use-case popup                                                       |
 
 Row navigation (`j`/`k`) still works in Select mode so you can see the effect of filters as you apply them. Press `Esc` to return to Normal mode.
 


### PR DESCRIPTION
## Summary
- rewrite the Select mode column table so it matches the current per-column behavior in `activate_select_column_filter`
- split the shared sort-row description into explicit `Score`, `tok/s`, `Mem%`, `Ctx`, and `Date` entries
- make it explicit that `Disk` currently has no Select-mode action instead of leaving that column undocumented

## Testing
- git diff --check
