### PR TITLE
docs: fix README sort shortcut list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `Ctrl-U`                   | Clear search                                                          |
 | `f`                        | Cycle fit filter: All, Runnable, Perfect, Good, Marginal              |
 | `a`                        | Cycle availability filter: All, GGUF Avail, Installed                 |
-| `s`                        | Cycle sort column: Score, Params, Mem%, Ctx, Date, Use Case           |
+| `s`                        | Cycle sort column: Score, tok/s, Params, Mem%, Ctx, Date, Use Case    |
 | `v`                        | Enter Visual mode (select multiple models)                            |
 | `V`                        | Enter Select mode (column-based filtering)                            |
 | `t`                        | Cycle color theme (saved automatically)                               |


### PR DESCRIPTION
## Summary
- fix the top-level README shortcut table so the `s` sort-cycle entry matches the current implementation
- add the missing `tok/s` sort option to the documented cycle order
- keep the README aligned with the current `SortColumn` behavior in the TUI/core code

## Testing
- git diff --check
