### PR TITLE
docs: clarify select-mode intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The multi-compare view displays a table where rows are attributes (Score, tok/s,
 
 #### Select mode (`V`)
 
-Column-based filtering. Press `V` (shift-v) to enter Select mode, then use `h`/`l` or arrow keys to move between column headers. The active column is visually highlighted. Press `Enter` or `Space` to activate the appropriate filter for that column:
+Column-based narrowing. Press `V` (shift-v) to enter Select mode, then use `h`/`l` or arrow keys to move between column headers. The active column is visually highlighted. Press `Enter` or `Space` to trigger that column's current action — depending on the column this may open a filter popup, start search, change the sort column, or do nothing (`Disk`).
 
 | Column                        | Filter action                                                             |
 |-------------------------------|---------------------------------------------------------------------------|


### PR DESCRIPTION
## Summary
- update the Select mode intro text so it matches the current behavior more precisely
- clarify that pressing `Enter`/`Space` on a column may open a filter, start search, change sorting, or do nothing (`Disk`), rather than always activating a filter
- keep the README aligned with the more detailed column-action table added for issue #346

## Testing
- git diff --check
