### PR TITLE
docs: clarify compare shortcut wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `R`                        | Open runtime/backend filter popup (llama.cpp, MLX, vLLM)             |
 | `h`                        | Open help popup (all key bindings)                                    |
 | `m`                        | Mark selected model for compare                                       |
-| `c`                        | Open compare view (marked vs selected)                                |
-| `x`                        | Clear compare mark                                                    |
+| `c`                        | Open compare view for marked models                                   |
+| `x`                        | Clear marked models                                                   |
 | `i`                        | Toggle installed-first sorting (any detected runtime provider)        |
 | `d`                        | Download selected model (provider picker when multiple are available) |
 | `r`                        | Refresh installed models from runtime providers                       |


### PR DESCRIPTION
## Summary
- tighten the top-level compare shortcut wording in the README so it matches the current compare/mark model behavior more closely
- describe `c` as opening the compare view for marked models instead of the vaguer `marked vs selected` phrasing
- describe `x` as clearing marked models, matching the current help text and event handling

## Testing
- git diff --check
