### PR TITLE
docs: add half-page shortcuts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `Up` / `Down` or `j` / `k` | Navigate models                                                       |
 | `/`                        | Enter search mode (partial match on name, provider, params, use case) |
 | `Esc` or `Enter`           | Exit search mode                                                      |
-| `Ctrl-U`                   | Clear search                                                          |
+| `Ctrl-U`                   | Half-page up in table views; clear search/current field while editing |
+| `Ctrl-D`                   | Half-page down in table views                                         |
 | `f`                        | Cycle fit filter: All, Runnable, Perfect, Good, Marginal              |
 | `a`                        | Cycle availability filter: All, GGUF Avail, Installed                 |
 | `s`                        | Cycle sort column: Score, Params, Mem%, Ctx, Date, Use Case           |


### PR DESCRIPTION
## Summary
- add the existing `Ctrl-D` half-page-down shortcut to the top-level README shortcut table
- clarify that `Ctrl-U` means half-page-up in table views while still acting as a clear shortcut in search/editing contexts
- make the top-level navigation docs better match the current TUI event handling

## Testing
- git diff --check
