### PR TITLE
docs: sync compare and quit shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,16 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `R`                        | Open runtime/backend filter popup (llama.cpp, MLX, vLLM)             |
 | `h`                        | Open help popup (all key bindings)                                    |
 | `m`                        | Mark selected model for compare                                       |
-| `c`                        | Open compare view (marked vs selected)                                |
-| `x`                        | Clear compare mark                                                    |
+| `c`                        | Open compare view for marked models                                   |
+| `x`                        | Clear marked models                                                   |
 | `i`                        | Toggle installed-first sorting (any detected runtime provider)        |
 | `d`                        | Download selected model (provider picker when multiple are available) |
 | `r`                        | Refresh installed models from runtime providers                       |
+| `y`                        | Copy selected model name                                              |
 | `Enter`                    | Toggle detail view for selected model                                 |
 | `PgUp` / `PgDn`            | Scroll by 10                                                          |
 | `g` / `G`                  | Jump to top / bottom                                                  |
-| `q`                        | Quit                                                                  |
+| `q` / `Esc`                | Quit / close popup                                                    |
 
 ### Vim-like modes
 


### PR DESCRIPTION
## Summary
- sync the top-level README compare/quit rows with the current in-product help text
- update `c` to "Open compare view for marked models", `x` to "Clear marked models", add the missing `y` copy-model-name shortcut, and change `q` to `q / Esc`
- reduce one more visible docs drift between the first shortcut table and the built-in help screen

## Testing
- git diff --check
