### PR TITLE
docs: clarify plan shortcut wording again

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `v`                        | Enter Visual mode (select multiple models)                            |
 | `V`                        | Enter Select mode (column-based filtering)                            |
 | `t`                        | Cycle color theme (saved automatically)                               |
-| `p`                        | Open Plan mode for selected model (hardware planning)                 |
+| `p`                        | Open Plan mode for the selected model configuration                   |
 | `P`                        | Open provider filter popup                                            |
 | `U`                        | Open use-case filter popup                                            |
 | `C`                        | Open capability filter popup                                          |


### PR DESCRIPTION
## Summary
- tighten the top-level README shortcut wording for `p` on the current `origin/main` base
- describe Plan mode as operating on the selected model configuration so the first shortcut table matches the detailed planning section below
- reduce another small wording drift between the top-level docs and the deeper mode docs

## Testing
- git diff --check
