### PR TITLE
fix: correct select-mode disk status label

### DIFF
--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2498,12 +2498,13 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
         }
         InputMode::Select => {
             let header_names = [
-                "", "Inst", "Model", "Provider", "Params", "Score", "tok/s*", "Quant", "Mode",
+                "", "Inst", "Model", "Provider", "Params", "Score", "tok/s*", "Quant", "Disk", "Mode",
                 "Mem %", "Ctx", "Date", "Fit", "Use Case",
             ];
             let col_name = header_names.get(app.select_column).unwrap_or(&"");
+            let action = if *col_name == "Disk" { "noop" } else { "action" };
             (
-                format!(" ←/→:column  ↑↓:nav  Enter:filter [{}]  Esc:exit", col_name),
+                format!(" ←/→:column  ↑↓:nav  Enter:{} [{}]  Esc:exit", action, col_name),
                 "SELECT".to_string(),
             )
         }


### PR DESCRIPTION
## Summary
- fix the Select mode status-bar column-name mapping so it includes the `Disk` column instead of shifting later labels left by one slot
- show `Enter:noop [Disk]` on the Disk column so users understand that this column currently has no Select-mode action
- keep the change scoped to the status/help text rather than changing any filtering behavior

## Testing
- cargo test -p llmfit --quiet
- git diff --check
