### PR TITLE
docs: update select mode docs for disk noop

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The multi-compare view displays a table where rows are attributes (Score, tok/s,
 
 #### Select mode (`V`)
 
-Column-based filtering. Press `V` (shift-v) to enter Select mode, then use `h`/`l` or arrow keys to move between column headers. The active column is visually highlighted. Press `Enter` or `Space` to activate the appropriate filter for that column:
+Column-based narrowing. Press `V` (shift-v) to enter Select mode, then use `h`/`l` or arrow keys to move between column headers. The active column is visually highlighted. Press `Enter` or `Space` to trigger that column's current action — depending on the column this may open a filter popup, start search, change sorting, or do nothing (`Disk`):
 
 | Column                        | Filter action                                                             |
 |-------------------------------|---------------------------------------------------------------------------|
@@ -152,7 +152,14 @@ Column-based filtering. Press `V` (shift-v) to enter Select mode, then use `h`/`
 | Model                         | Enter search mode                                                         |
 | Provider                      | Open provider popup                                                       |
 | Params                        | Open parameter-size bucket popup (<3B, 3-7B, 7-14B, 14-30B, 30-70B, 70B+) |
-| Score, tok/s, Mem%, Ctx, Date | Sort by that column                                                       |
+| Score                        | Sort by score                                                             |
+| tok/s                        | Sort by throughput                                                        |
+| Quant                        | Open quantization popup                                                   |
+| Disk                         | No Select-mode action yet                                                 |
+| Mode                         | Open run-mode popup (GPU, MoE, CPU+GPU, CPU)                              |
+| Mem%                         | Sort by memory utilization                                                |
+| Ctx                          | Sort by context length                                                    |
+| Date                         | Sort by release date                                                      |
 | Quant                         | Open quantization popup                                                   |
 | Mode                          | Open run-mode popup (GPU, MoE, CPU+GPU, CPU)                              |
 | Fit                           | Cycle fit filter                                                          |


### PR DESCRIPTION
## Summary
- update the Select mode intro so it no longer implies every column activates a filter
- explain that a column action may open a filter, start search, change sorting, or do nothing (`Disk`)
- explicitly document the current `Disk` no-op behavior in the Select mode column-action table when that older combined sort row is present

## Testing
- git diff --check
