### PR TITLE
fix: restore disk label in select mode status

### DIFF
--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2498,7 +2498,7 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
         }
         InputMode::Select => {
             let header_names = [
-                "", "Inst", "Model", "Provider", "Params", "Score", "tok/s*", "Quant", "Mode",
+                "", "Inst", "Model", "Provider", "Params", "Score", "tok/s*", "Quant", "Disk", "Mode",
                 "Mem %", "Ctx", "Date", "Fit", "Use Case",
             ];
             let col_name = header_names.get(app.select_column).unwrap_or(&"");


### PR DESCRIPTION
## Summary
- restore the missing `Disk` header entry in the Select-mode status label mapping
- keep the status bar aligned with the visible table columns when the `Disk` column is focused
- prevent the following `Mode`, `Mem %`, `Ctx`, `Date`, `Fit`, and `Use Case` labels from shifting left by one column in fresh-base builds

## Testing
- cargo test -p llmfit select_mode_status -- --nocapture
- git diff --check
