### PR TITLE
fix: use generic select action label

### DIFF
--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2503,7 +2503,7 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             ];
             let col_name = header_names.get(app.select_column).unwrap_or(&"");
             (
-                format!(" ←/→:column  ↑↓:nav  Enter:filter [{}]  Esc:exit", col_name),
+                format!(" ←/→:column  ↑↓:nav  Enter:action [{}]  Esc:exit", col_name),
                 "SELECT".to_string(),
             )
         }


### PR DESCRIPTION
## Summary
- change the Select-mode status bar label from `Enter:filter` to `Enter:action`
- match the current Select-mode behavior, where columns may trigger search, sorting, popups, or no-op (`Disk`), not only filters
- keep the status text accurate on fresh-base builds without changing any keybindings or logic

## Testing
- cargo test -p llmfit select_mode_status -- --nocapture
- git diff --check
