### PR TITLE
docs: clarify select mode help label

### DIFF
--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2919,7 +2919,7 @@ fn draw_help_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         ("  c", "Compare marked models"),
         ("  x", "Clear marked models"),
         ("  v", "Visual select mode"),
-        ("  V", "Column select mode"),
+        ("  V", "Select mode actions"),
         ("", ""),
         ("General", ""),
         ("  h", "This help screen"),


### PR DESCRIPTION
## Summary
- clarify the help popup label for `V`
- replace the vague `Column select mode` wording with `Select mode actions`
- better match the current Select-mode behavior, where columns can trigger different actions instead of acting like a passive mode switch

## Testing
- cargo test -p llmfit select_mode_status -- --nocapture
- git diff --check
