### PR TITLE
docs: update help select mode entry

### DIFF
--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2919,7 +2919,7 @@ fn draw_help_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         ("  c", "Compare marked models"),
         ("  x", "Clear marked models"),
         ("  v", "Visual select mode"),
-        ("  V", "Column select mode"),
+        ("  V", "Select mode actions"),
         ("", ""),
         ("General", ""),
         ("  h", "This help screen"),


### PR DESCRIPTION
## Summary
- update the help popup entry for `V`
- replace the outdated `Column select mode` wording with `Select mode actions`
- keep the in-app help aligned with the current Select-mode behavior on fresh-base builds

## Testing
- cargo test -p llmfit select_mode_status -- --nocapture
- git diff --check
