### PR TITLE
docs: update select status action label

### DIFF
--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2503,7 +2503,7 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             ];
             let col_name = header_names.get(app.select_column).unwrap_or(&"");
             (
-                format!(" ←/→:column  ↑↓:nav  Enter:filter [{}]  Esc:exit", col_name),
+                format!(" ←/→:column  ↑↓:nav  Enter:action [{}]  Esc:exit", col_name),
                 "SELECT".to_string(),
             )
         }


### PR DESCRIPTION
## Summary
- update the Select-mode status bar wording from `Enter:filter` to `Enter:action`
- match the current behavior, where focused columns can trigger different actions instead of only filters
- keep the in-app status text aligned with fresh-base Select-mode behavior

## Testing
- cargo test -p llmfit select_mode_status -- --nocapture
- git diff --check
