### PR TITLE
fix: add full row nav in select mode

### DIFF
--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -185,8 +185,14 @@ fn handle_select_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Enter | KeyCode::Char(' ') => app.activate_select_column_filter(),
 
         // Row navigation (still works in select mode)
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => app.half_page_up(),
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => app.half_page_down(),
         KeyCode::Up | KeyCode::Char('k') => app.move_up(),
         KeyCode::Down | KeyCode::Char('j') => app.move_down(),
+        KeyCode::PageUp => app.page_up(),
+        KeyCode::PageDown => app.page_down(),
+        KeyCode::Home | KeyCode::Char('g') => app.home(),
+        KeyCode::End | KeyCode::Char('G') => app.end(),
 
         _ => {}
     }


### PR DESCRIPTION
## Summary
- add the missing row-navigation keys to Select mode
- support `Ctrl-U`, `Ctrl-D`, `PageUp`, `PageDown`, `Home`, and `End` in addition to the existing `↑↓/jk`
- keep Select mode row navigation consistent with Normal and Visual modes while preserving existing column navigation and actions

## Testing
- cargo test -p llmfit -- --nocapture
- git diff --check
