### PR TITLE
Docs: Describe Python-based install options in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If Scoop is not installed, follow the [Scoop installation guide](https://scoop.s
 brew install llmfit
 ```
 
-### MacPorts
+#### MacPorts
 ```sh
 port install llmfit
 ```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Downloads the latest release binary from GitHub and installs it to `/usr/local/b
 curl -fsSL https://llmfit.axjns.dev/install.sh | sh -s -- --local
 ```
 
+### uv / pip
+To install or update llmfit:
+```sh
+uv tool install -U llmfit
+```
+
+To run without installing:
+```sh
+uvx llmfit
+```
+
+You can also install llmfit as a Python package in the normal way with tools such as pip or uv.
+Python packaging is done in a separate repository: [llmfit-pypi](https://github.com/JEHoctor/llmfit-pypi).
+
 ### Docker / Podman
 ```sh
 docker run ghcr.io/alexsjones/llmfit

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ uvx llmfit
 ```
 
 You can also install llmfit as a Python package in the normal way with tools such as pip or uv.
-Python packaging is done in a separate repository: [llmfit-pypi](https://github.com/JEHoctor/llmfit-pypi).
 
 ### Docker / Podman
 ```sh


### PR DESCRIPTION
This addresses #318.

Python packaging is described as an install method. Install via `uv tool install -U` and `uvx` are described. Install as a python package in a venv or uv project is only mentioned and not demonstrated. For those who want that (and it's not the typical llmfit user) it will be easy to deduce how; it's completely standard.

I linked to the packaging repo because someone looking for the packaging code might have a hard time finding it otherwise. The only other line of breadcrumbs to find this info would be to visit the llmfit page on pypi and see the link to the packaging source.

### Incidental change: I made the header size equal between MacPorts and Homebrew