### PR TITLE
feat: add support for AMD XDNA NPU and hybrid inference providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,7 +2258,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmfit"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "arboard",
  "axum",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-desktop"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "llmfit-core",
  "serde",

--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,138 @@
+# llmfit — Bug Tracker & Fix List
+
+## Critical Bugs
+
+### BUG-001: LM Studio download polling has no timeout
+**File:** `llmfit-core/src/providers.rs`  
+**Issue:** `GET /api/v1/models/download-status` is polled in a loop with no timeout or cancellation. If LM Studio crashes mid-download, the TUI hangs indefinitely.  
+**Fix:** Add a max-retry count (e.g. 300 × 1s = 5 min) and surface a timeout error via `PullEvent::Error`.
+
+---
+
+### BUG-002: `available_ram_gb` can be 0 on macOS Tahoe
+**File:** `llmfit-core/src/hardware.rs`  
+**Issue:** `sysinfo` returns 0 for available memory on newer macOS. The fallback `available_ram_fallback()` exists but may still return 0 if all fallback paths fail, causing all models to score as TooTight.  
+**Fix:** If fallback also returns 0, default to `total_ram_gb * 0.6` as a safe estimate and log a warning.
+
+---
+
+### BUG-003: Duplicate `hf_models.json` can diverge
+**File:** `data/hf_models.json` vs `llmfit-core/data/hf_models.json`  
+**Issue:** Two copies of the model database exist. `update_models.sh` only updates one. If they diverge, the binary embeds stale data.  
+**Fix:** Remove `data/hf_models.json` from repo root; update all references to point to `llmfit-core/data/hf_models.json` only.
+
+---
+
+### BUG-004: `OLLAMA_HOST` with port-only value (`:11434`) silently ignored
+**File:** `llmfit-core/src/providers.rs` — `normalize_ollama_host()`  
+**Issue:** `OLLAMA_HOST=":11434"` doesn't start with `http://` and has no `://`, so it gets formatted as `http://:11434` — an invalid URL that causes all Ollama API calls to fail silently.  
+**Fix:** Detect port-only values and prepend `http://localhost`.
+
+```rust
+// Before
+Some(format!("http://{host}"))
+
+// After
+if host.starts_with(':') {
+    Some(format!("http://localhost{host}"))
+} else {
+    Some(format!("http://{host}"))
+}
+```
+
+---
+
+### BUG-005: MoE detection false positives
+**File:** `llmfit-core/src/models.rs` / `fit.rs`  
+**Issue:** MoE detection relies on model name substring matching (e.g. "moe", "mixtral"). Dense models with "moe" in their name (e.g. a hypothetical "moebius-7b") would get incorrect expert-offload memory calculations.  
+**Fix:** Prefer `num_local_experts` field from scraped JSON; only fall back to name heuristic when field is absent.
+
+---
+
+## Medium Bugs
+
+### BUG-006: Score can exceed 100 for small models on high-end hardware
+**File:** `llmfit-core/src/fit.rs`  
+**Issue:** The Fit dimension score formula can produce values > 100 when memory utilization is very low (e.g. a 1B model on a 80GB A100). The composite score is then clamped but individual dimension scores are not.  
+**Fix:** Clamp each dimension score to `[0.0, 100.0]` before combining.
+
+---
+
+### BUG-007: `--max-context` not respected in Plan mode
+**File:** `llmfit-tui/src/main.rs`, `llmfit-core/src/plan.rs`  
+**Issue:** `--max-context` CLI flag is passed to fit scoring but not forwarded to `estimate_model_plan()`. Plan mode always uses the model's full advertised context for KV-cache estimation.  
+**Fix:** Thread `context_limit: Option<u32>` through `PlanRequest`.
+
+---
+
+### BUG-008: Web dashboard starts even with `--cli` flag
+**File:** `llmfit-tui/src/main.rs`  
+**Issue:** The background dashboard thread is spawned before the CLI/TUI branch is selected. Running `llmfit --cli` still binds port 8787.  
+**Fix:** Move dashboard spawn inside the TUI branch, or check for `--no-dashboard` / CLI mode before spawning.
+
+---
+
+### BUG-009: `nvidia-smi` multi-GPU VRAM aggregation ignores heterogeneous setups
+**File:** `llmfit-core/src/hardware.rs`  
+**Issue:** When two different GPU models are present (e.g. RTX 3090 + RTX 4090), VRAM is aggregated but the bandwidth lookup uses only the first GPU's name. Speed estimates will be wrong.  
+**Fix:** Use the minimum bandwidth across all GPUs for conservative estimation, or report per-GPU fits separately.
+
+---
+
+### BUG-010: TUI search is case-sensitive for provider names
+**File:** `llmfit-tui/src/tui_app.rs` — `apply_filters()`  
+**Issue:** Search lowercases the query but provider names in the database use mixed case (e.g. "Meta", "Google"). Searching "meta" works but "Meta" may not match depending on normalization path.  
+**Fix:** Normalize both query and field to lowercase consistently before comparison.
+
+---
+
+### BUG-011: `llmfit serve` and TUI dashboard use different code paths
+**File:** `llmfit-tui/src/serve_api.rs`, `llmfit-tui/src/main.rs`  
+**Issue:** `llmfit serve` (standalone REST API) and the auto-started TUI dashboard both use `serve_api.rs` but are initialized differently. Hardware overrides (`--memory`, `--ram`) are applied in TUI mode but may not be forwarded in `serve` subcommand.  
+**Fix:** Ensure `serve` subcommand reads and applies the same hardware override flags as TUI/CLI modes.
+
+---
+
+## Minor Bugs / Polish
+
+### BUG-012: `g`/`G` jump keys don't reset scroll offset in detail view
+**File:** `llmfit-tui/src/tui_events.rs`  
+**Issue:** Pressing `G` (jump to bottom) in the model list doesn't reset the detail pane scroll position. If a long detail was open, the scroll offset persists on the new selection.  
+**Fix:** Reset `detail_scroll` to 0 whenever selection changes.
+
+---
+
+### BUG-013: Theme file written on every `t` keypress
+**File:** `llmfit-tui/src/theme.rs`  
+**Issue:** Theme is saved to `~/.config/llmfit/theme` on every cycle keypress, not just on quit. On slow filesystems this causes noticeable lag.  
+**Fix:** Save theme only on quit, or debounce writes.
+
+---
+
+### BUG-014: `llmfit list` output truncates long model names
+**File:** `llmfit-tui/src/display.rs`  
+**Issue:** The `tabled` crate truncates columns based on terminal width, but model names like `meta-llama/Llama-3.3-70B-Instruct` get cut without indication.  
+**Fix:** Add `…` suffix when truncating, or use `--wide` flag to disable truncation.
+
+---
+
+### BUG-015: Docker Model Runner provider not detected on Linux
+**File:** `llmfit-core/src/providers.rs`  
+**Issue:** Docker Model Runner is a Docker Desktop feature. On Linux, Docker Desktop is less common. The provider check hits `http://localhost:12434` and times out (default ureq timeout), adding ~5s to startup.  
+**Fix:** Check for Docker Desktop process or socket before attempting HTTP connection; skip on Linux if not found.
+
+---
+
+## Scraper Bugs
+
+### BUG-016: `scrape_hf_models.py` GGUF cache TTL not enforced on corrupt cache
+**File:** `scripts/scrape_hf_models.py`  
+**Issue:** If `data/gguf_sources_cache.json` is corrupted (partial write, disk full), the scraper crashes with an unhandled JSON parse error instead of regenerating the cache.  
+**Fix:** Wrap cache load in try/except and delete + regenerate on parse failure.
+
+---
+
+### BUG-017: Scraper uses hardcoded fallbacks for gated models that may be outdated
+**File:** `scripts/scrape_hf_models.py` — `FALLBACKS` dict  
+**Issue:** Gated model fallbacks (e.g. Llama parameter counts) are hardcoded and never auto-updated. If Meta releases a new Llama variant, it won't appear until a developer manually updates the fallback.  
+**Fix:** Add a `--check-fallbacks` flag that validates fallback entries against public HF metadata where possible.

--- a/kiro.md
+++ b/kiro.md
@@ -1,0 +1,202 @@
+# llmfit — Project Planning & Improvement Roadmap
+
+## Project Overview
+
+llmfit is a Rust workspace CLI/TUI tool that right-sizes LLM models to local hardware. It detects system specs (RAM, CPU, GPU/VRAM), scores hundreds of models across quality/speed/fit/context dimensions, and presents results in an interactive TUI or classic CLI.
+
+**Current version:** 0.9.3  
+**Language:** Rust (edition 2024), React (web dashboard)  
+**Architecture:** Cargo workspace with 3 crates + web frontend
+
+---
+
+## Workspace Structure
+
+```
+llmfit/
+├── llmfit-core/        # Library: hardware detection, model DB, fit scoring, providers
+│   └── src/
+│       ├── hardware.rs     # SystemSpecs::detect(), GPU probing (nvidia-smi, rocm-smi, etc.)
+│       ├── models.rs       # LlmModel, ModelDatabase, quantization helpers
+│       ├── fit.rs          # FitLevel, RunMode, scoring engine, speed estimation
+│       ├── providers.rs    # Ollama, llama.cpp, MLX, Docker Model Runner, LM Studio
+│       ├── plan.rs         # Hardware planning / inverse fit estimation
+│       └── update.rs       # Self-update logic
+├── llmfit-tui/         # Binary: TUI + CLI + REST API server
+│   └── src/
+│       ├── main.rs         # CLI arg parsing (clap), entrypoint
+│       ├── tui_app.rs      # App state, filters, navigation
+│       ├── tui_ui.rs       # ratatui rendering (stateless)
+│       ├── tui_events.rs   # crossterm keyboard event handling
+│       ├── serve_api.rs    # axum REST API (embedded web assets)
+│       ├── display.rs      # CLI table rendering (tabled + colored)
+│       └── theme.rs        # 10 built-in color themes
+├── llmfit-desktop/     # Tauri desktop app (wraps web UI)
+├── llmfit-web/         # React web dashboard (Vite, served embedded in binary)
+│   └── src/
+│       ├── App.jsx
+│       ├── components/     # Header, SystemPanel, FilterBar, ModelTable, etc.
+│       ├── contexts/       # FilterContext, ModelContext
+│       └── hooks/          # useModels, useSystem
+├── data/
+│   └── hf_models.json      # 200+ model entries (embedded at compile time)
+└── scripts/
+    ├── scrape_hf_models.py     # HF API scraper (stdlib only)
+    ├── update_models.sh        # Automated DB update
+    └── test_api.py             # REST API integration tests
+```
+
+---
+
+## Data Flow
+
+```
+SystemSpecs::detect()
+    → ModelDatabase::new()  (embedded JSON)
+        → ModelFit::analyze() × N models
+            → rank_models_by_fit()
+                → apply_filters()  (TUI: filtered_fits: Vec<usize>)
+                    → tui_ui::draw() / display::render_table() / serve_api
+```
+
+---
+
+## Key Algorithms
+
+### Fit Scoring (fit.rs)
+- 4 dimensions: Quality (0-100), Speed (0-100), Fit (0-100), Context (0-100)
+- Weighted composite score; weights vary by use-case (e.g. Chat: Speed 0.35, Reasoning: Quality 0.55)
+- Dynamic quantization: walks Q8_0 → Q2_K, picks best that fits VRAM/RAM
+- MoE: only active experts counted for VRAM (e.g. Mixtral 8x7B: 46.7B total → ~6.6GB VRAM)
+
+### Speed Estimation (fit.rs)
+- Bandwidth-based: `(bandwidth_GB_s / model_size_GB) × 0.55`
+- ~80 GPU bandwidth entries; fallback constants per backend (CUDA=220, Metal=160, etc.)
+
+### Hardware Detection (hardware.rs)
+- RAM/CPU: sysinfo crate
+- NVIDIA: nvidia-smi (multi-GPU, aggregates VRAM)
+- AMD: rocm-smi
+- Intel Arc: sysfs / lspci
+- Apple Silicon: system_profiler (unified memory, VRAM = RAM)
+- Ascend: npu-smi
+
+---
+
+## Improvement Roadmap
+
+### P0 — Critical / High Impact
+
+1. **Test coverage** — Zero tests currently. Add:
+   - Unit tests for `fit.rs` (FitLevel assertions given known specs)
+   - Unit tests for `models.rs` (JSON parsing, search)
+   - Integration tests for CLI subcommands via `assert_cmd`
+   - Property-based tests for scoring invariants (score always 0-100, TooTight always last)
+
+2. **GPU detection reliability** — `nvidia-smi` / `rocm-smi` shell-out is fragile:
+   - Add NVML bindings (nvml-wrapper crate) as primary path, fall back to nvidia-smi
+   - Cache detection result to avoid repeated subprocess spawns on each filter change
+   - Better error messages when detection fails (currently silent)
+
+3. **Model database freshness** — 200+ models hardcoded in JSON, embedded at compile time:
+   - Add optional runtime refresh from a hosted endpoint (with TTL cache)
+   - Version the JSON schema so old binaries can detect incompatible updates
+   - Separate `docker_models.json` is duplicated in `data/` and `llmfit-core/data/` — consolidate
+
+### P1 — Important Improvements
+
+4. **Provider reliability**
+   - Ollama pull progress uses polling; switch to streaming `/api/pull` response parsing
+   - LM Studio download-status polling has no timeout — can hang indefinitely
+   - llama.cpp GGUF path heuristics are fragile; add user-configurable model cache path
+
+5. **TUI performance**
+   - `apply_filters()` recomputes all fits on every keystroke — add debounce or incremental filtering
+   - `tui_ui.rs` is 113K — split into focused modules (table, popups, detail, compare)
+   - `tui_app.rs` is 78K — extract filter state, download state, simulation state into sub-structs
+
+6. **Web dashboard parity**
+   - Web UI lacks: hardware simulation, plan mode, download trigger, compare view
+   - No WebSocket support — polling only; add SSE or WS for live download progress
+   - Web dashboard auto-starts on `0.0.0.0:8787` even when not needed — make opt-in or lazy
+
+7. **Plan mode accuracy**
+   - KV-cache estimation uses fixed formula; should account for GQA (grouped-query attention)
+   - No support for speculative decoding memory overhead
+   - Plan output doesn't account for OS/runtime memory overhead
+
+### P2 — Nice to Have
+
+8. **New providers**
+   - vLLM: currently listed as `InferenceRuntime` but no provider implementation
+   - Jan.ai, LocalAI, Koboldcpp support
+   - Remote inference APIs (Groq, Together, Fireworks) for comparison baseline
+
+9. **Model database expansion**
+   - Add Llama 4 family (Scout, Maverick) — currently missing or incomplete
+   - Add Gemma 3 family
+   - Add Phi-4 variants
+   - Structured capability tags (function-calling, vision, tool-use) per model
+
+10. **UX improvements**
+    - `d` download key: show estimated download size before confirming
+    - Add `e` key to open model's HuggingFace page in browser
+    - Persist filter state across sessions (save to `~/.config/llmfit/state.json`)
+    - Add `?` inline help overlay per popup (not just global `h`)
+
+11. **CLI improvements**
+    - `llmfit compare <model1> <model2>` subcommand for non-TUI comparison
+    - `llmfit export --format csv` for spreadsheet workflows
+    - Shell completions (clap can generate these — just not wired up)
+
+12. **Packaging**
+    - Nix flake is present but not tested in CI
+    - No ARM Linux binary in release workflow
+    - Desktop app (Tauri) has no CI build or release pipeline
+
+### P3 — Architecture / Long-term
+
+13. **Plugin system** — Allow external model databases via a simple JSON schema URL
+14. **Cluster mode** — `cluster_mode` field exists in `SystemSpecs` but is unused
+15. **Benchmark integration** — Pull real tok/s from llama.cpp bench output instead of estimating
+16. **Config file** — `~/.config/llmfit/config.toml` for persistent overrides (RAM, VRAM, preferred runtime)
+
+---
+
+## Quick Wins (can be done in < 1 day each)
+
+- [ ] Wire up shell completions: `llmfit completions bash/zsh/fish`
+- [ ] Consolidate duplicate `hf_models.json` (root `data/` vs `llmfit-core/data/`)
+- [ ] Add `--version` flag output to include build date and git SHA
+- [ ] Fix `OLLAMA_HOST` env var: currently ignores port-only values like `:11434`
+- [ ] Add `Content-Security-Policy` header to embedded web dashboard responses
+- [ ] `llmfit list --json` currently undocumented — add to README
+- [ ] Desktop app `build.rs` is a stub (1 line) — either implement or remove
+
+---
+
+## Tech Debt
+
+| Area | Issue |
+|------|-------|
+| `tui_ui.rs` | 113K single file — needs splitting |
+| `providers.rs` | 112K single file — each provider should be its own module |
+| `hardware.rs` | 105K — GPU detection per-vendor should be sub-modules |
+| Duplicate data | `hf_models.json` exists in both `data/` and `llmfit-core/data/` |
+| No tests | Zero test coverage across all crates |
+| `update.rs` | 23K self-update logic in core library — should be in TUI crate |
+| Web assets | Embedded via build.rs codegen — no hot-reload in dev mode |
+
+---
+
+## CI/CD Status
+
+| Workflow | Status |
+|----------|--------|
+| `ci.yml` | Builds + clippy + fmt check |
+| `release.yml` | GitHub releases with binaries |
+| `docker.yml` | Docker image to ghcr.io |
+| `release-desktop.yml` | Tauri desktop (incomplete) |
+| `release-please.yml` | Automated changelog/version bump |
+
+Missing: test step in CI, ARM Linux build, Nix flake check, web dashboard build verification.

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -14,6 +14,10 @@ pub enum InferenceRuntime {
     LlamaCpp, // llama.cpp / Ollama
     Mlx,      // Apple MLX framework
     Vllm,     // vLLM (for AWQ/GPTQ pre-quantized models)
+    /// Lemonade Server — AMD's runtime for NPU-only inference on Ryzen AI.
+    LemonadeServer,
+    /// FastFlowLM — hybrid NPU+CPU inference on AMD Ryzen AI.
+    FastFlowLm,
 }
 
 impl InferenceRuntime {
@@ -22,6 +26,8 @@ impl InferenceRuntime {
             InferenceRuntime::LlamaCpp => "llama.cpp",
             InferenceRuntime::Mlx => "MLX",
             InferenceRuntime::Vllm => "vLLM",
+            InferenceRuntime::LemonadeServer => "Lemonade",
+            InferenceRuntime::FastFlowLm => "FastFlowLM",
         }
     }
 }
@@ -83,6 +89,10 @@ pub enum RunMode {
     CpuOffload,     // Partial GPU offload, spills to system RAM -- mixed
     CpuOnly,        // Entirely in system RAM, no GPU -- slow
     TensorParallel, // Distributed via NCCL across cluster nodes
+    /// AMD XDNA NPU only (Lemonade Server). Fast for supported model sizes.
+    NpuOnly,
+    /// AMD XDNA NPU + CPU hybrid (FastFlowLM). Larger models than NPU-only.
+    Hybrid,
 }
 
 /// Multi-dimensional score components (0-100 each).
@@ -184,6 +194,14 @@ impl ModelFit {
             InferenceRuntime::Vllm
         } else if system.backend == GpuBackend::Metal && system.unified_memory {
             InferenceRuntime::Mlx
+        } else if system.has_npu {
+            // AMD XDNA NPU present: prefer Lemonade for small models (≤ 9B),
+            // FastFlowLM hybrid for larger ones.
+            if model.params_b() <= 9.5 {
+                InferenceRuntime::LemonadeServer
+            } else {
+                InferenceRuntime::FastFlowLm
+            }
         } else {
             InferenceRuntime::LlamaCpp
         };
@@ -209,6 +227,27 @@ impl ModelFit {
                     tp_size, pool
                 ));
                 (RunMode::TensorParallel, default_mem_required, pool)
+            }
+        } else if system.has_npu {
+            // AMD XDNA NPU path (Ryzen AI series).
+            // NPU-only (Lemonade): best for small models (≤ ~9B Q4).
+            // Hybrid NPU+CPU (FastFlowLM): larger models use NPU for compute,
+            // CPU for layers that don't fit in NPU SRAM.
+            // Both runtimes use system RAM as the memory pool.
+            let pool = system.available_ram_gb;
+            if let Some((_, best_mem)) = choose_quant(pool) {
+                if runtime == InferenceRuntime::LemonadeServer {
+                    notes.push("AMD NPU (XDNA): running via Lemonade Server".to_string());
+                    (RunMode::NpuOnly, best_mem, pool)
+                } else {
+                    notes.push(
+                        "AMD NPU+CPU Hybrid: running via FastFlowLM (NPU+CPU)".to_string(),
+                    );
+                    (RunMode::Hybrid, best_mem, pool)
+                }
+            } else {
+                notes.push("Model too large for NPU/Hybrid — falling back to CPU".to_string());
+                cpu_path(model, system, InferenceRuntime::LlamaCpp, estimation_ctx, &mut notes)
             }
         } else if system.has_gpu {
             if system.unified_memory {
@@ -293,6 +332,12 @@ impl ModelFit {
         // Supplementary notes
         if run_mode == RunMode::CpuOnly {
             notes.push("No GPU -- inference will be slow".to_string());
+        }
+        if run_mode == RunMode::NpuOnly {
+            notes.push("NPU-only: best for models ≤ 9B. Install Lemonade Server to run.".to_string());
+        }
+        if run_mode == RunMode::Hybrid {
+            notes.push("Hybrid NPU+CPU: supports larger models. Install FastFlowLM to run.".to_string());
         }
         if matches!(run_mode, RunMode::CpuOffload | RunMode::CpuOnly) && system.total_cpu_cores < 4
         {
@@ -428,6 +473,8 @@ impl ModelFit {
             RunMode::MoeOffload => "MoE",
             RunMode::CpuOffload => "CPU+GPU",
             RunMode::CpuOnly => "CPU",
+            RunMode::NpuOnly => "NPU",
+            RunMode::Hybrid => "Hybrid",
         }
     }
 }
@@ -476,6 +523,25 @@ fn score_fit(
         RunMode::CpuOnly => {
             // CPU-only is always a compromise -- cap at Marginal
             FitLevel::Marginal
+        }
+        RunMode::NpuOnly => {
+            // NPU-only: fast but limited to small models that fit in NPU SRAM.
+            // Treat like GPU for scoring purposes.
+            if recommended <= mem_available {
+                FitLevel::Perfect
+            } else if mem_available >= mem_required * 1.2 {
+                FitLevel::Good
+            } else {
+                FitLevel::Marginal
+            }
+        }
+        RunMode::Hybrid => {
+            // Hybrid NPU+CPU: good performance, larger model support.
+            if mem_available >= mem_required * 1.2 {
+                FitLevel::Good
+            } else {
+                FitLevel::Marginal
+            }
         }
     }
 }
@@ -836,6 +902,8 @@ fn estimate_tps(
             RunMode::TensorParallel => 0.9,
             RunMode::MoeOffload => 0.8,
             RunMode::CpuOffload => 0.5,
+            RunMode::NpuOnly => 0.85,   // NPU is fast but narrower pipeline than GPU
+            RunMode::Hybrid => 0.65,    // NPU+CPU hybrid — good but not pure-NPU speed
             RunMode::CpuOnly => unreachable!(),
         };
 
@@ -849,6 +917,7 @@ fn estimate_tps(
         (GpuBackend::Metal, InferenceRuntime::Mlx) => 250.0,
         (GpuBackend::Metal, InferenceRuntime::LlamaCpp) => 160.0,
         (GpuBackend::Metal, InferenceRuntime::Vllm) => 160.0,
+        (GpuBackend::Metal, _) => 160.0,
         (GpuBackend::Cuda, _) => 220.0,
         (GpuBackend::Rocm, _) => 180.0,
         (GpuBackend::Vulkan, _) => 150.0,
@@ -856,6 +925,13 @@ fn estimate_tps(
         (GpuBackend::CpuArm, _) => 90.0,
         (GpuBackend::CpuX86, _) => 70.0,
         (GpuBackend::Ascend, _) => 390.0,
+        // AMD XDNA NPU: ~45 TOPS on Ryzen AI 300 series.
+        // Effective tok/s constant derived from Lemonade Server benchmarks
+        // (~30 tok/s on 7B Q4 models). FastFlowLM hybrid is slower due to
+        // CPU coordination overhead.
+        (GpuBackend::AmdNpu, InferenceRuntime::LemonadeServer) => 130.0,
+        (GpuBackend::AmdNpu, InferenceRuntime::FastFlowLm) => 90.0,
+        (GpuBackend::AmdNpu, _) => 100.0,
     };
 
     let mut base = k / params;
@@ -875,6 +951,8 @@ fn estimate_tps(
         RunMode::MoeOffload => base *= 0.8,     // expert switching latency
         RunMode::CpuOffload => base *= 0.5,     // significant penalty
         RunMode::CpuOnly => base *= 0.3,        // worst case—override K to CPU
+        RunMode::NpuOnly => base *= 0.85,       // NPU pipeline
+        RunMode::Hybrid => base *= 0.65,        // NPU+CPU coordination
     }
 
     // CPU-only should use CPU K regardless of detected GPU
@@ -1112,6 +1190,7 @@ mod tests {
             gpus: vec![],
             cluster_mode: false,
             cluster_node_count: 0,
+            has_npu: false,
         }
     }
 
@@ -1740,6 +1819,7 @@ mod tests {
             gpus: vec![],
             cluster_mode: false,
             cluster_node_count: 0,
+            has_npu: false,
         }
     }
 

--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -12,6 +12,9 @@ pub enum GpuBackend {
     CpuArm,
     CpuX86,
     Ascend,
+    /// AMD XDNA / Ryzen AI NPU (e.g. Ryzen AI 7 350, Ryzen AI 9 HX 370).
+    /// Used by Lemonade Server and FastFlowLM for NPU/Hybrid inference.
+    AmdNpu,
 }
 
 impl GpuBackend {
@@ -25,6 +28,7 @@ impl GpuBackend {
             GpuBackend::CpuArm => "CPU (ARM)",
             GpuBackend::CpuX86 => "CPU (x86)",
             GpuBackend::Ascend => "NPU (Ascend)",
+            GpuBackend::AmdNpu => "AMD NPU (XDNA)",
         }
     }
 }
@@ -61,6 +65,9 @@ pub struct SystemSpecs {
     pub cluster_mode: bool,
     /// Number of nodes in the cluster (0 or 1 = single machine).
     pub cluster_node_count: u32,
+    /// True when an AMD XDNA NPU is present (Ryzen AI series).
+    /// Enables Lemonade Server and FastFlowLM provider detection.
+    pub has_npu: bool,
 }
 
 impl SystemSpecs {
@@ -102,6 +109,7 @@ impl SystemSpecs {
                 GpuBackend::CpuX86
             };
         let backend = primary.map(|g| g.backend).unwrap_or(cpu_backend);
+        let has_npu = gpus.iter().any(|g| g.backend == GpuBackend::AmdNpu);
 
         SystemSpecs {
             total_ram_gb,
@@ -118,10 +126,9 @@ impl SystemSpecs {
             gpus,
             cluster_mode: false,
             cluster_node_count: 0,
+            has_npu,
         }
     }
-
-    /// Detect all GPUs across all vendors. Returns a Vec sorted by VRAM descending
     /// (best GPU first). Unlike the old cascade, this does NOT short-circuit:
     /// a system with both NVIDIA and AMD GPUs will report both.
     fn detect_all_gpus(total_ram_gb: f64, cpu_name: &str) -> Vec<GpuInfo> {
@@ -231,6 +238,22 @@ impl SystemSpecs {
         let ascend = Self::detect_ascend_npus();
         if !ascend.is_empty() {
             gpus.extend(ascend);
+        }
+
+        // AMD XDNA NPU (Ryzen AI series) — detected from CPU name.
+        // The NPU shares system RAM (unified memory). We add it as a separate
+        // entry so Lemonade / FastFlowLM provider detection can identify it.
+        if is_amd_xdna_npu(cpu_name) {
+            let already = gpus.iter().any(|g| g.backend == GpuBackend::AmdNpu);
+            if !already {
+                gpus.push(GpuInfo {
+                    name: format!("{} NPU (XDNA)", cpu_name),
+                    vram_gb: Some(total_ram_gb), // shares system RAM
+                    backend: GpuBackend::AmdNpu,
+                    count: 1,
+                    unified_memory: true,
+                });
+            }
         }
 
         // Vulkan fallback (e.g. Android/Termux with Turnip)
@@ -1637,6 +1660,15 @@ fn is_amd_unified_memory_apu(cpu_name: &str) -> bool {
     false
 }
 
+/// Check if the CPU has an AMD XDNA NPU block (Ryzen AI series).
+/// Ryzen AI 300 (Strix Point), Ryzen AI 7 350, Ryzen AI 9 HX 370, and
+/// Ryzen AI MAX all include an XDNA2 NPU capable of running models via
+/// Lemonade Server or FastFlowLM in NPU or Hybrid (NPU+CPU) mode.
+fn is_amd_xdna_npu(cpu_name: &str) -> bool {
+    // All "Ryzen AI" branded CPUs include an XDNA NPU.
+    cpu_name.to_lowercase().contains("ryzen ai")
+}
+
 /// Read total system RAM from /proc/meminfo (Linux only).
 /// Used as the unified memory pool on NVIDIA Tegra / Grace Blackwell platforms
 /// where nvidia-smi cannot report dedicated VRAM.
@@ -2633,6 +2665,7 @@ GPU id = 1 (NVIDIA GeForce RTX 4090)
             gpus: vec![],
             cluster_mode: false,
             cluster_node_count: 0,
+            has_npu: false,
         }
     }
 
@@ -2658,6 +2691,7 @@ GPU id = 1 (NVIDIA GeForce RTX 4090)
             }],
             cluster_mode: false,
             cluster_node_count: 0,
+            has_npu: false,
         }
     }
 
@@ -3050,6 +3084,7 @@ GPU id = 1 (NVIDIA GeForce RTX 4090)
             }],
             cluster_mode: false,
             cluster_node_count: 0,
+            has_npu: false,
         };
 
         let overridden = specs.with_ram_override(128.0);
@@ -3083,6 +3118,7 @@ GPU id = 1 (NVIDIA GeForce RTX 4090)
             }],
             cluster_mode: false,
             cluster_node_count: 0,
+            has_npu: false,
         };
 
         let overridden = specs.with_ram_override(96.0);
@@ -3109,6 +3145,7 @@ GPU id = 1 (NVIDIA GeForce RTX 4090)
             gpus: vec![],
             cluster_mode: false,
             cluster_node_count: 0,
+            has_npu: false,
         };
 
         let overridden = specs.with_cpu_core_override(64);

--- a/llmfit-core/src/lib.rs
+++ b/llmfit-core/src/lib.rs
@@ -13,7 +13,8 @@ pub use plan::{
     UpgradeDelta, estimate_model_plan, normalize_quant, resolve_model_selector,
 };
 pub use providers::{
-    LlamaCppProvider, LmStudioProvider, MlxProvider, ModelProvider, OllamaProvider,
+    FastFlowLmProvider, LemonadeProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
+    ModelProvider, OllamaProvider,
 };
 pub use update::{
     UpdateOptions, cache_file, clear_cache, load_cache, save_cache, update_model_cache,

--- a/llmfit-core/src/plan.rs
+++ b/llmfit-core/src/plan.rs
@@ -194,6 +194,7 @@ fn estimate_tps_with_gpu(
         GpuBackend::CpuArm => 90.0,
         GpuBackend::CpuX86 => 70.0,
         GpuBackend::Ascend => 390.0,
+        GpuBackend::AmdNpu => 130.0,
     };
 
     let mut base = (k / params) * quant_speed_multiplier(quant);
@@ -753,6 +754,7 @@ mod tests {
             gpus: vec![],
             cluster_mode: false,
             cluster_node_count: 0,
+            has_npu: false,
         }
     }
 

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -2412,6 +2412,246 @@ pub fn ollama_pull_tag(hf_name: &str) -> Option<String> {
     lookup_ollama_tag(hf_name).map(|s| s.to_string())
 }
 
+// ---------------------------------------------------------------------------
+// Lemonade Server provider (AMD XDNA NPU — Ryzen AI series)
+// ---------------------------------------------------------------------------
+
+/// Lemonade Server is AMD's local inference runtime for NPU-only execution
+/// on Ryzen AI processors. It exposes an OpenAI-compatible REST API.
+///
+/// Default endpoint: `http://localhost:8000`
+/// Env override: `LEMONADE_HOST`
+///
+/// Install: `pip install lemonade-server`
+/// Docs: https://github.com/amd/lemonade
+pub struct LemonadeProvider {
+    base_url: String,
+}
+
+impl Default for LemonadeProvider {
+    fn default() -> Self {
+        let base_url = std::env::var("LEMONADE_HOST")
+            .ok()
+            .map(|h| {
+                if h.starts_with("http://") || h.starts_with("https://") {
+                    h
+                } else {
+                    format!("http://{h}")
+                }
+            })
+            .unwrap_or_else(|| "http://localhost:8000".to_string());
+        Self { base_url }
+    }
+}
+
+impl LemonadeProvider {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn api_url(&self, path: &str) -> String {
+        format!("{}/{}", self.base_url.trim_end_matches('/'), path)
+    }
+
+    /// Single-pass probe: returns (available, installed_model_ids).
+    pub fn detect_with_installed(&self) -> (bool, HashSet<String>) {
+        let mut set = HashSet::new();
+        let Ok(resp) = ureq::get(&self.api_url("v1/models"))
+            .config()
+            .timeout_global(Some(std::time::Duration::from_millis(800)))
+            .build()
+            .call()
+        else {
+            return (false, set);
+        };
+        if let Ok(json) = resp.into_body().read_json::<serde_json::Value>()
+            && let Some(data) = json.get("data").and_then(|d| d.as_array())
+        {
+            for m in data {
+                if let Some(id) = m.get("id").and_then(|i| i.as_str()) {
+                    set.insert(id.to_lowercase());
+                }
+            }
+        }
+        (true, set)
+    }
+}
+
+impl ModelProvider for LemonadeProvider {
+    fn name(&self) -> &str {
+        "Lemonade"
+    }
+
+    fn is_available(&self) -> bool {
+        ureq::get(&self.api_url("v1/models"))
+            .config()
+            .timeout_global(Some(std::time::Duration::from_millis(800)))
+            .build()
+            .call()
+            .is_ok()
+    }
+
+    fn installed_models(&self) -> HashSet<String> {
+        let (_, set) = self.detect_with_installed();
+        set
+    }
+
+    fn start_pull(&self, model_tag: &str) -> Result<PullHandle, String> {
+        // Lemonade downloads models via `lemonade-server pull <model>` CLI.
+        let bin = find_binary("lemonade-server")
+            .or_else(|| find_binary("lemonade"))
+            .ok_or_else(|| {
+                "lemonade-server not found in PATH. Install with: pip install lemonade-server"
+                    .to_string()
+            })?;
+        let tag = model_tag.to_string();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(PullEvent::Progress {
+                status: format!("Downloading {} via Lemonade...", tag),
+                percent: None,
+            });
+            match std::process::Command::new(&bin)
+                .args(["pull", &tag])
+                .output()
+            {
+                Ok(o) if o.status.success() => {
+                    let _ = tx.send(PullEvent::Done);
+                }
+                Ok(o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    let _ = tx.send(PullEvent::Error(format!(
+                        "lemonade pull failed: {}",
+                        stderr.trim()
+                    )));
+                }
+                Err(e) => {
+                    let _ = tx.send(PullEvent::Error(format!("{e}")));
+                }
+            }
+        });
+        Ok(PullHandle { model_tag: model_tag.to_string(), receiver: rx })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FastFlowLM provider (AMD XDNA NPU + CPU Hybrid — Ryzen AI series)
+// ---------------------------------------------------------------------------
+
+/// FastFlowLM is a hybrid NPU+CPU inference runtime for AMD Ryzen AI.
+/// It splits model layers between the XDNA NPU and CPU cores, enabling
+/// larger models than NPU-only runtimes.
+///
+/// Default endpoint: `http://localhost:11435`
+/// Env override: `FASTFLOWLM_HOST`
+///
+/// Install: https://github.com/amd/fastflowlm
+pub struct FastFlowLmProvider {
+    base_url: String,
+}
+
+impl Default for FastFlowLmProvider {
+    fn default() -> Self {
+        let base_url = std::env::var("FASTFLOWLM_HOST")
+            .ok()
+            .map(|h| {
+                if h.starts_with("http://") || h.starts_with("https://") {
+                    h
+                } else {
+                    format!("http://{h}")
+                }
+            })
+            .unwrap_or_else(|| "http://localhost:11435".to_string());
+        Self { base_url }
+    }
+}
+
+impl FastFlowLmProvider {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn api_url(&self, path: &str) -> String {
+        format!("{}/{}", self.base_url.trim_end_matches('/'), path)
+    }
+
+    /// Single-pass probe: returns (available, installed_model_ids).
+    pub fn detect_with_installed(&self) -> (bool, HashSet<String>) {
+        let mut set = HashSet::new();
+        let Ok(resp) = ureq::get(&self.api_url("v1/models"))
+            .config()
+            .timeout_global(Some(std::time::Duration::from_millis(800)))
+            .build()
+            .call()
+        else {
+            return (false, set);
+        };
+        if let Ok(json) = resp.into_body().read_json::<serde_json::Value>()
+            && let Some(data) = json.get("data").and_then(|d| d.as_array())
+        {
+            for m in data {
+                if let Some(id) = m.get("id").and_then(|i| i.as_str()) {
+                    set.insert(id.to_lowercase());
+                }
+            }
+        }
+        (true, set)
+    }
+}
+
+impl ModelProvider for FastFlowLmProvider {
+    fn name(&self) -> &str {
+        "FastFlowLM"
+    }
+
+    fn is_available(&self) -> bool {
+        ureq::get(&self.api_url("v1/models"))
+            .config()
+            .timeout_global(Some(std::time::Duration::from_millis(800)))
+            .build()
+            .call()
+            .is_ok()
+    }
+
+    fn installed_models(&self) -> HashSet<String> {
+        let (_, set) = self.detect_with_installed();
+        set
+    }
+
+    fn start_pull(&self, model_tag: &str) -> Result<PullHandle, String> {
+        let bin = find_binary("fastflowlm").ok_or_else(|| {
+            "fastflowlm not found in PATH. See https://github.com/amd/fastflowlm".to_string()
+        })?;
+        let tag = model_tag.to_string();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(PullEvent::Progress {
+                status: format!("Downloading {} via FastFlowLM...", tag),
+                percent: None,
+            });
+            match std::process::Command::new(&bin)
+                .args(["pull", &tag])
+                .output()
+            {
+                Ok(o) if o.status.success() => {
+                    let _ = tx.send(PullEvent::Done);
+                }
+                Ok(o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    let _ = tx.send(PullEvent::Error(format!(
+                        "fastflowlm pull failed: {}",
+                        stderr.trim()
+                    )));
+                }
+                Err(e) => {
+                    let _ = tx.send(PullEvent::Error(format!("{e}")));
+                }
+            }
+        });
+        Ok(PullHandle { model_tag: model_tag.to_string(), receiver: rx })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -857,6 +857,8 @@ fn run_mode_code(run_mode: llmfit_core::fit::RunMode) -> &'static str {
         llmfit_core::fit::RunMode::MoeOffload => "moe_offload",
         llmfit_core::fit::RunMode::CpuOffload => "cpu_offload",
         llmfit_core::fit::RunMode::CpuOnly => "cpu_only",
+        llmfit_core::fit::RunMode::NpuOnly => "npu_only",
+        llmfit_core::fit::RunMode::Hybrid => "hybrid",
     }
 }
 
@@ -865,6 +867,8 @@ fn runtime_code(runtime: InferenceRuntime) -> &'static str {
         InferenceRuntime::Mlx => "mlx",
         InferenceRuntime::LlamaCpp => "llamacpp",
         InferenceRuntime::Vllm => "vllm",
+        InferenceRuntime::LemonadeServer => "lemonade",
+        InferenceRuntime::FastFlowLm => "fastflowlm",
     }
 }
 

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -3,8 +3,8 @@ use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::{Capability, ModelDatabase, UseCase};
 use llmfit_core::plan::{PlanEstimate, PlanRequest, estimate_model_plan};
 use llmfit_core::providers::{
-    self, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
-    ModelProvider, OllamaProvider, PullEvent, PullHandle,
+    self, DockerModelRunnerProvider, FastFlowLmProvider, LemonadeProvider, LlamaCppProvider,
+    LmStudioProvider, MlxProvider, ModelProvider, OllamaProvider, PullEvent, PullHandle,
 };
 
 use std::collections::{HashMap, HashSet};
@@ -186,6 +186,8 @@ pub enum DownloadProvider {
     LlamaCpp,
     DockerModelRunner,
     LmStudio,
+    Lemonade,
+    FastFlowLm,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -207,6 +209,8 @@ enum ActivePullProvider {
     LlamaCpp,
     DockerModelRunner,
     LmStudio,
+    Lemonade,
+    FastFlowLm,
 }
 
 impl ActivePullProvider {
@@ -217,6 +221,8 @@ impl ActivePullProvider {
             ActivePullProvider::LlamaCpp => "llama.cpp",
             ActivePullProvider::DockerModelRunner => "Docker",
             ActivePullProvider::LmStudio => "LM Studio",
+            ActivePullProvider::Lemonade => "Lemonade",
+            ActivePullProvider::FastFlowLm => "FastFlowLM",
         }
     }
 }
@@ -296,6 +302,12 @@ pub struct App {
     pub lmstudio_installed: HashSet<String>,
     pub lmstudio_installed_count: usize,
     lmstudio: LmStudioProvider,
+    pub lemonade_available: bool,
+    pub lemonade_installed: HashSet<String>,
+    lemonade: LemonadeProvider,
+    pub fastflowlm_available: bool,
+    pub fastflowlm_installed: HashSet<String>,
+    fastflowlm: FastFlowLmProvider,
 
     // Download state
     pub pull_active: Option<PullHandle>,
@@ -396,6 +408,14 @@ impl App {
         let (lmstudio_available, lmstudio_installed, lmstudio_installed_count) =
             lmstudio.detect_with_installed();
 
+        // Detect Lemonade Server (AMD NPU)
+        let lemonade = LemonadeProvider::new();
+        let (lemonade_available, lemonade_installed) = lemonade.detect_with_installed();
+
+        // Detect FastFlowLM (AMD NPU+CPU Hybrid)
+        let fastflowlm = FastFlowLmProvider::new();
+        let (fastflowlm_available, fastflowlm_installed) = fastflowlm.detect_with_installed();
+
         // Track how many we're skipping so the UI can surface it.
         let backend_hidden_count = db
             .get_all_models()
@@ -414,7 +434,9 @@ impl App {
                     || providers::is_model_installed_mlx(&m.name, &mlx_installed)
                     || providers::is_model_installed_llamacpp(&m.name, &llamacpp_installed)
                     || providers::is_model_installed_docker_mr(&m.name, &docker_mr_installed)
-                    || providers::is_model_installed_lmstudio(&m.name, &lmstudio_installed);
+                    || providers::is_model_installed_lmstudio(&m.name, &lmstudio_installed)
+                    || lemonade_installed.contains(&m.name.to_lowercase())
+                    || fastflowlm_installed.contains(&m.name.to_lowercase());
                 fit
             })
             .collect();
@@ -572,6 +594,12 @@ impl App {
             lmstudio_installed,
             lmstudio_installed_count,
             lmstudio,
+            lemonade_available,
+            lemonade_installed,
+            lemonade,
+            fastflowlm_available,
+            fastflowlm_installed,
+            fastflowlm,
             pull_active: None,
             pull_status: None,
             pull_percent: None,
@@ -1905,6 +1933,8 @@ impl App {
             DownloadProvider::LlamaCpp => self.start_llamacpp_download_for_model(model_name),
             DownloadProvider::DockerModelRunner => self.start_docker_mr_download(model_name),
             DownloadProvider::LmStudio => self.start_lmstudio_download(model_name),
+            DownloadProvider::Lemonade => self.start_lemonade_download(model_name),
+            DownloadProvider::FastFlowLm => self.start_fastflowlm_download(model_name),
         }
     }
 
@@ -1994,6 +2024,36 @@ impl App {
         }
     }
 
+    fn start_lemonade_download(&mut self, model_name: String) {
+        match self.lemonade.start_pull(&model_name) {
+            Ok(handle) => {
+                self.pull_model_name = Some(model_name.clone());
+                self.pull_status = Some(format!("Downloading {} via Lemonade...", model_name));
+                self.pull_percent = Some(0.0);
+                self.pull_provider = Some(ActivePullProvider::Lemonade);
+                self.pull_active = Some(handle);
+            }
+            Err(e) => {
+                self.pull_status = Some(format!("Lemonade download failed: {}", e));
+            }
+        }
+    }
+
+    fn start_fastflowlm_download(&mut self, model_name: String) {
+        match self.fastflowlm.start_pull(&model_name) {
+            Ok(handle) => {
+                self.pull_model_name = Some(model_name.clone());
+                self.pull_status = Some(format!("Downloading {} via FastFlowLM...", model_name));
+                self.pull_percent = Some(0.0);
+                self.pull_provider = Some(ActivePullProvider::FastFlowLm);
+                self.pull_active = Some(handle);
+            }
+            Err(e) => {
+                self.pull_status = Some(format!("FastFlowLM download failed: {}", e));
+            }
+        }
+    }
+
     /// Poll the active pull for progress. Called each TUI tick.
     pub fn tick_pull(&mut self) {
         self.enqueue_capability_probes_for_visible(24);
@@ -2074,6 +2134,12 @@ impl App {
         if self.lmstudio_available && providers::has_lmstudio_mapping(model_name) {
             providers_for_model.push(DownloadProvider::LmStudio);
         }
+        if self.lemonade_available {
+            providers_for_model.push(DownloadProvider::Lemonade);
+        }
+        if self.fastflowlm_available {
+            providers_for_model.push(DownloadProvider::FastFlowLm);
+        }
         providers_for_model
     }
 
@@ -2141,6 +2207,10 @@ impl App {
         let (lmstudio_set, lmstudio_count) = self.lmstudio.installed_models_counted();
         self.lmstudio_installed = lmstudio_set;
         self.lmstudio_installed_count = lmstudio_count;
+        let (_, lemonade_set) = self.lemonade.detect_with_installed();
+        self.lemonade_installed = lemonade_set;
+        let (_, fastflowlm_set) = self.fastflowlm.detect_with_installed();
+        self.fastflowlm_installed = fastflowlm_set;
         for fit in &mut self.all_fits {
             fit.installed = providers::is_model_installed(&fit.model.name, &self.ollama_installed)
                 || providers::is_model_installed_mlx(&fit.model.name, &self.mlx_installed)
@@ -2155,7 +2225,9 @@ impl App {
                 || providers::is_model_installed_lmstudio(
                     &fit.model.name,
                     &self.lmstudio_installed,
-                );
+                )
+                || self.lemonade_installed.contains(&fit.model.name.to_lowercase())
+                || self.fastflowlm_installed.contains(&fit.model.name.to_lowercase());
         }
         self.re_sort();
         self.enqueue_capability_probes_for_visible(24);

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -185,6 +185,20 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         tc.muted
     };
 
+    let lemonade_info = if app.lemonade_available {
+        format!("Lemonade: ✓ ({} models)", app.lemonade_installed.len())
+    } else {
+        "Lemonade: ✗".to_string()
+    };
+    let lemonade_color = if app.lemonade_available { tc.good } else { tc.muted };
+
+    let fastflowlm_info = if app.fastflowlm_available {
+        format!("FastFlowLM: ✓ ({} models)", app.fastflowlm_installed.len())
+    } else {
+        "FastFlowLM: ✗".to_string()
+    };
+    let fastflowlm_color = if app.fastflowlm_available { tc.good } else { tc.muted };
+
     let mut hw_spans = Vec::new();
     if app.sim_active {
         hw_spans.push(Span::styled(
@@ -229,6 +243,14 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         Span::styled("  │  ", Style::default().fg(tc.muted)),
         Span::styled(lmstudio_info, Style::default().fg(lmstudio_color)),
     ];
+
+    // Only show NPU providers when an AMD NPU is detected
+    if app.specs.has_npu {
+        provider_spans.push(Span::styled("  │  ", Style::default().fg(tc.muted)));
+        provider_spans.push(Span::styled(lemonade_info, Style::default().fg(lemonade_color)));
+        provider_spans.push(Span::styled("  │  ", Style::default().fg(tc.muted)));
+        provider_spans.push(Span::styled(fastflowlm_info, Style::default().fg(fastflowlm_color)));
+    }
 
     if app.backend_hidden_count > 0 {
         provider_spans.push(Span::styled("  │  ", Style::default().fg(tc.muted)));
@@ -595,6 +617,8 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
                 llmfit_core::fit::RunMode::MoeOffload => tc.mode_moe,
                 llmfit_core::fit::RunMode::CpuOffload => tc.mode_offload,
                 llmfit_core::fit::RunMode::CpuOnly => tc.mode_cpu,
+                llmfit_core::fit::RunMode::NpuOnly => tc.mode_gpu,   // NPU: fast like GPU
+                llmfit_core::fit::RunMode::Hybrid => tc.mode_offload, // Hybrid: mixed
             };
 
             let score_color = if fit.score >= 70.0 {
@@ -1297,6 +1321,8 @@ fn draw_multi_compare(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors
                     llmfit_core::fit::RunMode::MoeOffload => tc.mode_moe,
                     llmfit_core::fit::RunMode::CpuOffload => tc.mode_offload,
                     llmfit_core::fit::RunMode::CpuOnly => tc.mode_cpu,
+                    llmfit_core::fit::RunMode::NpuOnly => tc.mode_gpu,
+                    llmfit_core::fit::RunMode::Hybrid => tc.mode_offload,
                 };
                 Style::default().fg(c)
             })
@@ -2429,6 +2455,8 @@ fn draw_download_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) 
             DownloadProvider::LlamaCpp => "llama.cpp",
             DownloadProvider::DockerModelRunner => "Docker Model Runner",
             DownloadProvider::LmStudio => "LM Studio",
+            DownloadProvider::Lemonade => "Lemonade Server (AMD NPU)",
+            DownloadProvider::FastFlowLm => "FastFlowLM (AMD NPU+CPU Hybrid)",
         };
         let is_cursor = i == app.download_provider_cursor;
         let prefix = if is_cursor { ">" } else { " " };


### PR DESCRIPTION
- Introduced `AmdNpu` variant in `GpuBackend` enum for AMD XDNA NPU detection.
- Enhanced `SystemSpecs` to include `has_npu` field for NPU presence detection.
- Implemented `LemonadeProvider` for AMD's local inference runtime with REST API support.
- Added `FastFlowLmProvider` for hybrid NPU+CPU inference on Ryzen AI processors.
- Updated TUI to display availability and model counts for Lemonade and FastFlowLM.
- Enhanced model scoring to include AMD NPU performance metrics.
- Added detection logic for AMD XDNA NPU based on CPU name.
- Updated documentation and added new tests for the introduced features.