### PR TITLE
ci: fix Release workflow not firing for release-please tags (#424)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,21 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
-      - "!v*-mac"
+  # Fires when release-please (or a maintainer) publishes a GitHub Release.
+  # Using the `release` event instead of `push: tags` is necessary because
+  # tags created by the release-please workflow use GITHUB_TOKEN, which by
+  # design does not trigger downstream workflows — that caused v0.9.4 to
+  # ship with no binary assets (see issue #424).
+  release:
+    types: [published]
+  # Manual backfill: run against a specific existing tag (e.g. v0.9.4) to
+  # upload assets to an already-published release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build and attach assets to (e.g. v0.9.4)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -63,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -91,7 +104,7 @@ jobs:
       - name: Package
         shell: bash
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${{ inputs.tag || github.ref_name }}"
           ASSET_NAME="${BINARY}-${TAG}-${{ matrix.target }}"
           STAGING="${RUNNER_TEMP}/${ASSET_NAME}"
           mkdir -p "${STAGING}"
@@ -144,6 +157,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: |
             artifacts/**/*.tar.gz
@@ -156,6 +170,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -183,7 +199,7 @@ jobs:
 
       - name: Download release assets and update formula
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           VERSION="${TAG#v}"
 
@@ -244,5 +260,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/llmfit.rb
-          git commit -m "Update llmfit to ${GITHUB_REF_NAME}"
+          git commit -m "Update llmfit to ${TAG}"
           git push


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/release.yml` trigger from `push: tags` to `release: published`, so the workflow actually fires when release-please publishes a release
- Add a `workflow_dispatch` input (`tag`) so any existing tag can be backfilled with binaries and a homebrew update

## Why v0.9.4 had no assets
release-please creates tags and the GitHub Release using `GITHUB_TOKEN`. By design, anything `GITHUB_TOKEN` does **does not trigger further workflow runs**, so `push: tags` never fired for v0.9.4 — the release was published with only notes. v0.9.3 worked because that tag happened to be pushed manually.

Reacting to the `release: published` event sidesteps that restriction: release-please's publish step will fire this workflow on future releases.

## Backfilling v0.9.4
Because v0.9.4 is already published, re-merging won't retroactively fire anything. After this PR lands:

1. Go to Actions → Release → **Run workflow**
2. Pick branch `main`, enter `v0.9.4` in the `tag` input
3. The job will check out the v0.9.4 tag, build all targets, upload assets to the existing release, and update the Homebrew tap

## Test plan
- [ ] Merge and confirm next release-please release auto-populates assets
- [ ] Manually dispatch against `v0.9.4` and verify the 16 expected assets appear on the release, matching the shape of v0.9.3
- [ ] Confirm the Homebrew tap commit lands with v0.9.4 SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)