### PR TITLE
feat(recommend): add --output-llamacpp flag + fix llama.cpp CLI args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,7 +2258,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmfit"
-version = "0.9.3"
+version = "0.9.5"
 dependencies = [
  "arboard",
  "axum",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-core"
-version = "0.9.3"
+version = "0.9.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-desktop"
-version = "0.9.3"
+version = "0.9.5"
 dependencies = [
  "llmfit-core",
  "serde",

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -498,6 +498,77 @@ pub fn display_json_fits(specs: &SystemSpecs, fits: &[ModelFit]) {
     );
 }
 
+/// Serialize system specs + model fits to JSON with llama.cpp commands and print to stdout.
+pub fn display_json_fits_with_llamacpp(specs: &SystemSpecs, fits: &[ModelFit]) {
+    use llmfit_core::fit::InferenceRuntime;
+
+    let models: Vec<serde_json::Value> = fits
+        .iter()
+        .map(|fit| {
+            let mut json = fit_to_json(fit);
+
+            // Add llama.cpp command for llama.cpp-compatible models
+            if fit.runtime == InferenceRuntime::LlamaCpp {
+                if let Some(cmd) = generate_llamacpp_command(fit) {
+                    json.as_object_mut().unwrap().insert(
+                        "llamacpp_command".to_string(),
+                        serde_json::Value::String(cmd),
+                    );
+                }
+            }
+
+            json
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "system": system_json(specs),
+        "models": models,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("JSON serialization failed")
+    );
+}
+
+/// Generate a llama.cpp command string for a model fit.
+fn generate_llamacpp_command(fit: &ModelFit) -> Option<String> {
+    // Get the GGUF source repo if available
+    let repo = fit.model.gguf_sources.first().map(|s| &s.repo);
+
+    // Construct the model filename from the model name and quant
+    let model_name = fit.model.name.replace('/', "-");
+    let quant = &fit.best_quant;
+    let context = fit.model.context_length;
+
+    // Build the command with proper quoting
+    let mut cmd = String::new();
+
+    // If we have a GGUF source and the model is not installed, include download command
+    if !fit.installed {
+        if let Some(repo) = repo {
+            cmd.push_str(&format!("llmfit download \"{}\" --quant {}\n", repo, quant));
+        }
+    }
+
+    // Construct the expected local filename
+    // The filename format depends on the GGUF source, but typically: ModelName-QuantLevel.gguf
+    let gguf_filename = format!("{}-{}.gguf", model_name, quant);
+    let model_path = format!("~/.cache/llmfit/models/{}", gguf_filename);
+
+    // Add the llama-cli command
+    cmd.push_str(&format!(
+        "llama-cli -m \"{}\" -ngl all -c {} -cnv",
+        model_path, context
+    ));
+
+    if cmd.is_empty() {
+        None
+    } else {
+        Some(cmd)
+    }
+}
+
 /// Serialize diff output via serde derives (new diff-only path).
 pub fn display_json_diff_fits(specs: &SystemSpecs, fits: &[ModelFit]) {
     #[derive(serde::Serialize)]

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -536,36 +536,22 @@ fn generate_llamacpp_command(fit: &ModelFit) -> Option<String> {
     // Get the GGUF source repo if available
     let repo = fit.model.gguf_sources.first().map(|s| &s.repo);
 
-    // Construct the model filename from the model name and quant
-    let model_name = fit.model.name.replace('/', "-");
     let quant = &fit.best_quant;
     let context = fit.model.context_length;
 
-    // Build the command with proper quoting
-    let mut cmd = String::new();
-
-    // If we have a GGUF source and the model is not installed, include download command
-    if !fit.installed {
-        if let Some(repo) = repo {
-            cmd.push_str(&format!("llmfit download \"{}\" --quant {}\n", repo, quant));
-        }
-    }
-
-    // Construct the expected local filename
-    // The filename format depends on the GGUF source, but typically: ModelName-QuantLevel.gguf
-    let gguf_filename = format!("{}-{}.gguf", model_name, quant);
-    let model_path = format!("~/.cache/llmfit/models/{}", gguf_filename);
-
-    // Add the llama-cli command
-    cmd.push_str(&format!(
-        "llama-cli -m \"{}\" -ngl all -c {} -cnv",
-        model_path, context
-    ));
-
-    if cmd.is_empty() {
-        None
+    // Use the -hf option with HuggingFace repo to let llama-cli handle model
+    // downloading/caching. This avoids path guessing issues and works for both
+    // installed and non-installed models. llama-cli automatically downloads
+    // to its own cache if the model isn't present locally.
+    if let Some(repo) = repo {
+        // Format: llama-cli -hf repo/name:QuantLevel -ngl all -c context -cnv
+        // The :QuantLevel suffix tells llama-cli which quantization file to use
+        Some(format!(
+            "llama-cli -hf \"{}:{}\" -ngl all -c {} -cnv",
+            repo, quant, context
+        ))
     } else {
-        Some(cmd)
+        None
     }
 }
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -547,7 +547,7 @@ fn generate_llamacpp_command(fit: &ModelFit) -> Option<String> {
         // Format: llama-cli -hf repo/name:QuantLevel -ngl all -c context -cnv
         // The :QuantLevel suffix tells llama-cli which quantization file to use
         Some(format!(
-            "llama-cli -hf \"{}:{}\" -ngl all -c {} -cnv",
+            "llama-cli -hf {}:{} -ngl all -c {} -cnv",
             repo, quant, context
         ))
     } else {

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -420,12 +420,13 @@ AGENT USAGE:
   llmfit recommend --runtime mlx --capability vision
   llmfit recommend --force-runtime llamacpp  # get llama.cpp results on Apple Silicon
   llmfit recommend --license apache-2.0,mit
+  llmfit recommend --output-llamacpp  # include llama.cpp commands in output
 
   JSON output is the default. Fields: { system: {...}, models: [{ name,
   provider, parameter_count, fit_level, run_mode, score, score_components
   { quality, speed, fit, context }, estimated_tps, disk_size_gb,
   memory_required_gb, memory_available_gb, utilization_pct, best_quant,
-  use_case, license, runtime, capabilities }] }")]
+  use_case, license, runtime, capabilities, llamacpp_command (when --output-llamacpp) }] }")]
     Recommend {
         /// Limit number of recommendations
         #[arg(short = 'n', long, default_value = "5")]
@@ -459,6 +460,10 @@ AGENT USAGE:
         /// Output as JSON (default for recommend)
         #[arg(long, default_value = "true")]
         json: bool,
+
+        /// Include exact llama.cpp commands in output for llama.cpp-compatible models
+        #[arg(long)]
+        output_llamacpp: bool,
     },
 
     /// Download a GGUF model from HuggingFace for use with llama.cpp
@@ -598,9 +603,9 @@ AGENT USAGE:
         #[arg(long, default_value = "8080")]
         port: u16,
 
-        /// Number of GPU layers to offload (-1 = all)
-        #[arg(long, short = 'g', default_value = "-1")]
-        ngl: i32,
+        /// GPU layers to offload: 'all', 'auto', or a number
+        #[arg(long, short = 'g', default_value = "all")]
+        ngl: String,
 
         /// Context size in tokens
         #[arg(long, short = 'c', default_value = "4096")]
@@ -1122,6 +1127,7 @@ fn run_recommend(
     capability: Option<String>,
     license: Option<String>,
     json: bool,
+    output_llamacpp: bool,
     overrides: &HardwareOverrides,
     context_limit: Option<u32>,
 ) {
@@ -1254,7 +1260,11 @@ fn run_recommend(
     fits.truncate(limit);
 
     if json {
-        display::display_json_fits(&specs, &fits);
+        if output_llamacpp {
+            display::display_json_fits_with_llamacpp(&specs, &fits);
+        } else {
+            display::display_json_fits(&specs, &fits);
+        }
     } else {
         if !fits.is_empty() {
             specs.display();
@@ -1609,7 +1619,7 @@ fn run_hf_search(query: &str, limit: usize) {
     println!("To list files: llmfit download <repository> --list");
 }
 
-fn run_model(model: &str, server: bool, port: u16, ngl: i32, ctx_size: u32) {
+fn run_model(model: &str, server: bool, port: u16, ngl: &str, ctx_size: u32) {
     use llmfit_core::providers::LlamaCppProvider;
 
     let provider = LlamaCppProvider::new();
@@ -1661,7 +1671,7 @@ fn run_model(model: &str, server: bool, port: u16, ngl: i32, ctx_size: u32) {
                 "--port",
                 &port.to_string(),
                 "-ngl",
-                &ngl.to_string(),
+                ngl,
                 "-c",
                 &ctx_size.to_string(),
             ])
@@ -1691,7 +1701,7 @@ fn run_model(model: &str, server: bool, port: u16, ngl: i32, ctx_size: u32) {
                 "-m",
                 model_path.to_str().unwrap_or(""),
                 "-ngl",
-                &ngl.to_string(),
+                ngl,
                 "-c",
                 &ctx_size.to_string(),
                 "-cnv",
@@ -1889,6 +1899,7 @@ fn main() {
                 capability,
                 license,
                 json,
+                output_llamacpp,
             } => {
                 run_recommend(
                     limit,
@@ -1899,6 +1910,7 @@ fn main() {
                     capability,
                     license,
                     json,
+                    output_llamacpp,
                     &overrides,
                     context_limit,
                 );
@@ -1934,7 +1946,7 @@ fn main() {
                 ngl,
                 ctx_size,
             } => {
-                run_model(&model, server, port, ngl, ctx_size);
+                run_model(&model, server, port, &ngl, ctx_size);
             }
 
             Commands::Serve { host, port } => {

--- a/llmfit-web/package-lock.json
+++ b/llmfit-web/package-lock.json
@@ -79,7 +79,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -429,7 +428,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -453,7 +451,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1256,27 +1253,6 @@
         "win32"
       ]
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -1331,13 +1307,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1535,29 +1504,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1611,7 +1557,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1770,13 +1715,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
@@ -1982,7 +1920,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -2070,16 +2007,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -2208,21 +2135,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2238,7 +2150,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2251,7 +2162,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2259,13 +2169,6 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2560,7 +2463,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
- Add --output-llamacpp flag to recommend command to include llama.cpp commands in JSON output for compatible models
- Fix -ngl argument to use documented values ('all', 'auto', or number) instead of undocumented -1 value
- Change ngl parameter from i32 to String type for proper llama.cpp compatibility

The llama.cpp CLI now uses:
- "auto" → n_gpu_layers = -1 (auto-detect)
- "all" → n_gpu_layers = -2 (offload everything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)