### PR TITLE
refactor: use dirs crate for platform-correct config and cache paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,6 +2375,7 @@ dependencies = [
 name = "llmfit-core"
 version = "0.9.14"
 dependencies = [
+ "dirs",
  "http",
  "serde",
  "serde_json",

--- a/llmfit-core/Cargo.toml
+++ b/llmfit-core/Cargo.toml
@@ -18,3 +18,4 @@ sysinfo = "0.38"
 http = "1"
 ureq = { version = "3.2", features = ["json"] }
 which = "8.0.2"
+dirs = "6.0"

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -467,11 +467,8 @@ fn scan_hf_cache_for_mlx() -> HashSet<String> {
 fn dirs_hf_cache() -> std::path::PathBuf {
     if let Ok(cache) = std::env::var("HF_HOME") {
         std::path::PathBuf::from(cache).join("hub")
-    } else if let Ok(home) = std::env::var("HOME") {
-        std::path::PathBuf::from(home)
-            .join(".cache")
-            .join("huggingface")
-            .join("hub")
+    } else if let Some(cache) = dirs::cache_dir() {
+        cache.join("huggingface").join("hub")
     } else {
         std::path::PathBuf::from("/tmp/.cache/huggingface/hub")
     }
@@ -1235,11 +1232,8 @@ fn parse_repo_gguf_entries(entries: Vec<serde_json::Value>) -> Vec<(String, u64)
 pub fn llamacpp_models_dir() -> PathBuf {
     if let Ok(dir) = std::env::var("LLMFIT_MODELS_DIR") {
         PathBuf::from(dir)
-    } else if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-        PathBuf::from(home)
-            .join(".cache")
-            .join("llmfit")
-            .join("models")
+    } else if let Some(cache) = dirs::cache_dir() {
+        cache.join("llmfit").join("models")
     } else {
         PathBuf::from(".llmfit").join("models")
     }
@@ -1261,8 +1255,8 @@ fn find_binary(name: &str) -> Option<String> {
         PathBuf::from("/usr/local/bin"),
         PathBuf::from("/opt/llama.cpp/build/bin"),
     ];
-    if let Ok(home) = std::env::var("HOME") {
-        common_dirs.push(PathBuf::from(home).join(".local").join("bin"));
+    if let Some(home) = dirs::home_dir() {
+        common_dirs.push(home.join(".local").join("bin"));
     }
     for dir in common_dirs {
         let candidate = dir.join(name);

--- a/llmfit-core/src/update.rs
+++ b/llmfit-core/src/update.rs
@@ -29,21 +29,9 @@ struct CacheEnvelope {
 }
 
 /// Returns the llmfit data directory.
-/// `~/.llmfit` on Linux/macOS, `%APPDATA%\llmfit` on Windows.
+/// Uses the platform-appropriate data directory via the `dirs` crate.
 pub fn cache_dir() -> Option<PathBuf> {
-    #[cfg(target_os = "windows")]
-    {
-        std::env::var("APPDATA")
-            .ok()
-            .map(|p| PathBuf::from(p).join("llmfit"))
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .ok()
-            .map(|p| PathBuf::from(p).join(".llmfit"))
-    }
+    Some(dirs::data_dir()?.join("llmfit"))
 }
 
 /// Full path to the cached model list JSON file.

--- a/llmfit-tui/src/theme.rs
+++ b/llmfit-tui/src/theme.rs
@@ -63,17 +63,9 @@ impl Theme {
         }
     }
 
-    /// Path to the config file: ~/.config/llmfit/theme
+    /// Path to the config file: `<config_dir>/llmfit/theme`
     fn config_path() -> Option<PathBuf> {
-        let home = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .ok()?;
-        Some(
-            PathBuf::from(home)
-                .join(".config")
-                .join("llmfit")
-                .join("theme"),
-        )
+        Some(dirs::config_dir()?.join("llmfit").join("theme"))
     }
 
     /// Save the current theme to disk.


### PR DESCRIPTION
Replace manual HOME/USERPROFILE/APPDATA env var lookups with the dirs crate across the codebase:
- theme.rs: config_path() uses dirs::config_dir()
- update.rs: cache_dir() uses dirs::data_dir()
- providers.rs: dirs_hf_cache() uses dirs::cache_dir()
- providers.rs: llamacpp_models_dir() uses dirs::cache_dir()
- providers.rs: find_binary() uses dirs::home_dir()

This handles macOS ~/Library/Application Support, Linux XDG, and Windows AppData correctly without platform-specific branching.