### PR TITLE
Add TurboQuant+ fit filter to TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,7 +2258,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmfit"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "arboard",
  "axum",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-core"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-desktop"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "llmfit-core",
  "serde",

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -110,11 +110,11 @@ pub struct ModelFit {
     pub moe_offloaded_gb: Option<f64>, // GB of inactive experts offloaded to RAM
     pub score: f64,                    // weighted composite score 0-100
     pub score_components: ScoreComponents,
-    pub estimated_tps: f64,        // baseline estimated tokens per second
-    pub best_quant: String,        // best quantization for this hardware
-    pub use_case: UseCase,         // inferred use case category
-    pub runtime: InferenceRuntime, // inference runtime (MLX or llama.cpp)
-    pub installed: bool,           // model found in a local runtime provider
+    pub estimated_tps: f64,         // baseline estimated tokens per second
+    pub best_quant: String,         // best quantization for this hardware
+    pub use_case: UseCase,          // inferred use case category
+    pub runtime: InferenceRuntime,  // inference runtime (MLX or llama.cpp)
+    pub installed: bool,            // model found in a local runtime provider
     pub fits_with_turboquant: bool, // TooTight at fp16 KV but fits with TurboQuant KV
 }
 
@@ -383,9 +383,8 @@ impl ModelFit {
 
         // Check if a TooTight model would fit with TurboQuant KV compression.
         // Only compute on CUDA systems — TurboQuant requires vLLM + CUDA.
-        let fits_with_turboquant = fit_level == FitLevel::TooTight
-            && system.backend == GpuBackend::Cuda
-            && {
+        let fits_with_turboquant =
+            fit_level == FitLevel::TooTight && system.backend == GpuBackend::Cuda && {
                 let tq_mem = model.estimate_memory_gb_with_kv(
                     best_quant,
                     estimation_ctx,

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -381,15 +381,18 @@ impl ModelFit {
             ));
         }
 
-        // Check if a TooTight model would fit with TurboQuant KV compression
-        let fits_with_turboquant = fit_level == FitLevel::TooTight && {
-            let tq_mem = model.estimate_memory_gb_with_kv(
-                best_quant,
-                estimation_ctx,
-                KvQuant::TurboQuant,
-            );
-            tq_mem <= mem_available
-        };
+        // Check if a TooTight model would fit with TurboQuant KV compression.
+        // Only compute on CUDA systems — TurboQuant requires vLLM + CUDA.
+        let fits_with_turboquant = fit_level == FitLevel::TooTight
+            && system.backend == GpuBackend::Cuda
+            && {
+                let tq_mem = model.estimate_memory_gb_with_kv(
+                    best_quant,
+                    estimation_ctx,
+                    KvQuant::TurboQuant,
+                );
+                tq_mem <= mem_available
+            };
 
         ModelFit {
             model: model.clone(),

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -1,5 +1,5 @@
 use crate::hardware::{GpuBackend, SystemSpecs};
-use crate::models::{self, LlmModel, UseCase};
+use crate::models::{self, KvQuant, LlmModel, UseCase};
 
 /// Default context window cap used for memory estimation when no explicit
 /// `--max-context` is provided. Most runtimes (llama.cpp, Ollama) default to
@@ -115,6 +115,7 @@ pub struct ModelFit {
     pub use_case: UseCase,         // inferred use case category
     pub runtime: InferenceRuntime, // inference runtime (MLX or llama.cpp)
     pub installed: bool,           // model found in a local runtime provider
+    pub fits_with_turboquant: bool, // TooTight at fp16 KV but fits with TurboQuant KV
 }
 
 impl ModelFit {
@@ -380,6 +381,16 @@ impl ModelFit {
             ));
         }
 
+        // Check if a TooTight model would fit with TurboQuant KV compression
+        let fits_with_turboquant = fit_level == FitLevel::TooTight && {
+            let tq_mem = model.estimate_memory_gb_with_kv(
+                best_quant,
+                estimation_ctx,
+                KvQuant::TurboQuant,
+            );
+            tq_mem <= mem_available
+        };
+
         ModelFit {
             model: model.clone(),
             fit_level,
@@ -396,6 +407,7 @@ impl ModelFit {
             use_case,
             runtime,
             installed: false, // set later by App after provider detection
+            fits_with_turboquant,
         }
     }
 

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -2021,6 +2021,7 @@ mod tests {
             use_case: llmfit_core::models::UseCase::General,
             runtime: InferenceRuntime::LlamaCpp,
             installed: false,
+            fits_with_turboquant: false,
         }
     }
 

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -93,7 +93,8 @@ pub enum FitFilter {
     Good,
     Marginal,
     TooTight,
-    Runnable, // Perfect + Good + Marginal (excludes TooTight)
+    TurboQuantFit, // TooTight at fp16 but fits with TurboQuant KV compression
+    Runnable,      // Perfect + Good + Marginal (excludes TooTight)
 }
 
 impl FitFilter {
@@ -104,6 +105,7 @@ impl FitFilter {
             FitFilter::Good => "Good",
             FitFilter::Marginal => "Marginal",
             FitFilter::TooTight => "Too Tight",
+            FitFilter::TurboQuantFit => "TQ+ Fit",
             FitFilter::Runnable => "Runnable",
         }
     }
@@ -114,6 +116,7 @@ impl FitFilter {
             "Good" => FitFilter::Good,
             "Marginal" => FitFilter::Marginal,
             "Too Tight" => FitFilter::TooTight,
+            "TQ+ Fit" => FitFilter::TurboQuantFit,
             "Runnable" => FitFilter::Runnable,
             _ => FitFilter::All,
         }
@@ -126,7 +129,8 @@ impl FitFilter {
             FitFilter::Perfect => FitFilter::Good,
             FitFilter::Good => FitFilter::Marginal,
             FitFilter::Marginal => FitFilter::TooTight,
-            FitFilter::TooTight => FitFilter::All,
+            FitFilter::TooTight => FitFilter::TurboQuantFit,
+            FitFilter::TurboQuantFit => FitFilter::All,
         }
     }
 }
@@ -846,6 +850,7 @@ impl App {
                     FitFilter::Good => fit.fit_level == FitLevel::Good,
                     FitFilter::Marginal => fit.fit_level == FitLevel::Marginal,
                     FitFilter::TooTight => fit.fit_level == FitLevel::TooTight,
+                    FitFilter::TurboQuantFit => fit.fits_with_turboquant,
                     FitFilter::Runnable => fit.fit_level != FitLevel::TooTight,
                 };
 

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -1883,7 +1883,7 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             Style::default().fg(tc.good).add_modifier(Modifier::BOLD),
         )));
         right_lines.push(Line::from(Span::styled(
-            "  (github.com/CG-8663/turboquant-tinygrad-bridge)",
+            "  (github.com/0xSero/turboquant)",
             Style::default().fg(tc.muted),
         )));
     }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -430,6 +430,7 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         FitFilter::Good => Style::default().fg(tc.warning),
         FitFilter::Marginal => Style::default().fg(tc.fit_marginal),
         FitFilter::TooTight => Style::default().fg(tc.error),
+        FitFilter::TurboQuantFit => Style::default().fg(tc.good),
     };
 
     let fit_block = Block::default()

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -1825,7 +1825,8 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     lines.push(Line::from(disk_spans));
 
     // Build right-pane content (GGUF sources + notes)
-    let has_right_pane = !fit.model.gguf_sources.is_empty() || !fit.notes.is_empty();
+    let has_right_pane =
+        !fit.model.gguf_sources.is_empty() || !fit.notes.is_empty() || fit.fits_with_turboquant;
 
     let mut right_lines: Vec<Line> = vec![Line::from("")];
 
@@ -1872,6 +1873,18 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
                 Style::default().fg(tc.fg),
             )));
         }
+    }
+
+    if fit.fits_with_turboquant {
+        right_lines.push(Line::from(""));
+        right_lines.push(Line::from(Span::styled(
+            "  TurboQuant+: Would fit with 9.8x KV compression",
+            Style::default().fg(tc.good).add_modifier(Modifier::BOLD),
+        )));
+        right_lines.push(Line::from(Span::styled(
+            "  (github.com/CG-8663/turboquant-tinygrad-bridge)",
+            Style::default().fg(tc.muted),
+        )));
     }
 
     // Track the left pane area for cursor positioning


### PR DESCRIPTION
## Summary
- Adds `fits_with_turboquant` field to `ModelFit` that flags models which are TooTight at fp16 KV but would fit with TurboQuant's 0.34 bytes/element KV compression
- Adds `TQ+ Fit` filter variant to the TUI's fit filter cycle (between TooTight and All), letting users discover models they could run with TQ+ enabled
- Shows a TurboQuant+ note in the model detail view for qualifying models, linking to the TQBridge repo

## Details
TurboQuant+ (by Tom Turney, compression algorithm by Google Research) provides ~9.8x KV cache compression. This filter helps users discover they can run larger models with TQ+ enabled via CUDA (llama.cpp) or Metal (via TQBridge). The 0.34 bytes/element rate and `KvQuant::TurboQuant` support already exist in llmfit-core -- this PR just surfaces the information in the TUI.

## Files changed
- `llmfit-core/src/fit.rs` -- `fits_with_turboquant` field + population in `analyze_inner()`
- `llmfit-tui/src/tui_app.rs` -- `TurboQuantFit` filter variant with label, cycle, and match arm
- `llmfit-tui/src/tui_ui.rs` -- Detail view note for TQ+ qualifying models
- `llmfit-tui/src/main.rs` -- Test mock updated with new field

## Test plan
- [ ] `cargo test` passes (new field has default in mock)
- [ ] TUI filter cycles through: All -> Runnable -> Perfect -> Good -> Marginal -> TooTight -> TQ+ Fit -> All
- [ ] Models that are TooTight at fp16 but fit with TQ KV show in TQ+ Fit filter
- [ ] Detail view for TQ+ models shows the compression note with repo link

🤖 Generated with [Claude Code](https://claude.com/claude-code)