### PR TITLE
fix: correct Llama 4 metadata (expert count, context length)

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -158,8 +158,8 @@ llmfit ships with a curated database of 106 LLM models from HuggingFace. All mem
 | [meta-llama/CodeLlama-34b-Instruct-hf](https://huggingface.co/meta-llama/CodeLlama-34b-Instruct-hf) | 33.7B | Q4_K_M | 4k | Code generation and completion |
 | [meta-llama/Llama-3.1-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct) | 70.6B | Q4_K_M | 4k | Instruction following, chat |
 | [meta-llama/Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct) | 70.6B | Q4_K_M | 128k | Instruction following, chat |
-| [meta-llama/Llama-4-Scout-17B-16E-Instruct](https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct) | 109B (MoE) | Q4_K_M | 128k | Multimodal, vision and text |
-| [meta-llama/Llama-4-Maverick-17B-128E-Instruct](https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct) | 400B (MoE) | Q4_K_M | 128k | Multimodal, vision and text |
+| [meta-llama/Llama-4-Scout-17B-16E-Instruct](https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct) | 109B (MoE) | Q4_K_M | 10M | Multimodal, vision and text |
+| [meta-llama/Llama-4-Maverick-17B-128E-Instruct](https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct) | 400B (MoE) | Q4_K_M | 1M | Multimodal, vision and text |
 | [meta-llama/Llama-3.1-405B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct) | 405.9B | Q4_K_M | 4k | Instruction following, chat |
 
 ### Microsoft

--- a/data/hf_models.json
+++ b/data/hf_models.json
@@ -23759,7 +23759,7 @@
     "min_vram_gb": 205.7,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 4096,
+    "context_length": 1048576,
     "use_case": "Instruction following, chat",
     "capabilities": [
       "vision"
@@ -23770,7 +23770,7 @@
     "hf_likes": 476,
     "release_date": "2025-04-01",
     "is_moe": true,
-    "num_experts": 16,
+    "num_experts": 128,
     "active_experts": 1,
     "active_parameters": 17000000000,
     "gguf_sources": [
@@ -23794,7 +23794,7 @@
     "min_vram_gb": 205.7,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 4096,
+    "context_length": 1048576,
     "use_case": "Instruction following, chat",
     "capabilities": [],
     "pipeline_tag": "unknown",
@@ -23804,9 +23804,9 @@
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
-    "num_experts": 16,
+    "num_experts": 128,
     "active_experts": 1,
-    "active_parameters": 43930451431
+    "active_parameters": 23063487001
   },
   {
     "name": "RedHatAI/Llama-4-Maverick-17B-128E-Instruct-FP8",
@@ -23828,9 +23828,9 @@
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
-    "num_experts": 16,
+    "num_experts": 128,
     "active_experts": 1,
-    "active_parameters": 43930451431
+    "active_parameters": 23063487001
   },
   {
     "name": "Qwen/Qwen3.5-397B-A17B",

--- a/llmfit-core/data/hf_models.json
+++ b/llmfit-core/data/hf_models.json
@@ -23759,7 +23759,7 @@
     "min_vram_gb": 205.7,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 4096,
+    "context_length": 1048576,
     "use_case": "Instruction following, chat",
     "capabilities": [
       "vision"
@@ -23770,7 +23770,7 @@
     "hf_likes": 476,
     "release_date": "2025-04-01",
     "is_moe": true,
-    "num_experts": 16,
+    "num_experts": 128,
     "active_experts": 1,
     "active_parameters": 17000000000,
     "gguf_sources": [
@@ -23794,7 +23794,7 @@
     "min_vram_gb": 205.7,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 4096,
+    "context_length": 1048576,
     "use_case": "Instruction following, chat",
     "capabilities": [],
     "pipeline_tag": "unknown",
@@ -23804,9 +23804,9 @@
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
-    "num_experts": 16,
+    "num_experts": 128,
     "active_experts": 1,
-    "active_parameters": 43930451431
+    "active_parameters": 23063487001
   },
   {
     "name": "RedHatAI/Llama-4-Maverick-17B-128E-Instruct-FP8",
@@ -23828,9 +23828,9 @@
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
-    "num_experts": 16,
+    "num_experts": 128,
     "active_experts": 1,
-    "active_parameters": 43930451431
+    "active_parameters": 23063487001
   },
   {
     "name": "Qwen/Qwen3.5-397B-A17B",

--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -380,12 +380,17 @@ def detect_moe(repo_id: str, config: dict | None, architecture: str,
         "active_parameters": None,
     }
 
-    # Check config.json for MoE indicators
+    # Check config.json for MoE indicators (also check text_config for
+    # multimodal models like Llama 4 that nest MoE fields there)
     num_experts = None
     active_experts = None
     if config:
         num_experts = config.get("num_local_experts") or config.get("num_experts")
         active_experts = config.get("num_experts_per_tok") or config.get("top_k_experts")
+        if (not num_experts or not active_experts) and isinstance(config.get("text_config"), dict):
+            tc = config["text_config"]
+            num_experts = num_experts or tc.get("num_local_experts") or tc.get("num_experts")
+            active_experts = active_experts or tc.get("num_experts_per_tok") or tc.get("top_k_experts")
 
     # Check if architecture is in known MoE configs
     if architecture in MOE_CONFIGS:
@@ -454,20 +459,36 @@ def infer_context_length(config: dict | None) -> int:
         "sliding_window",
     ]
 
+    def _extract_from(cfg: dict) -> int | None:
+        for key in keys_to_check:
+            if key in cfg:
+                val = cfg[key]
+                if isinstance(val, int) and val > 0:
+                    return val
+        return None
+
+    def _apply_rope_scaling(val: int, cfg: dict) -> int:
+        """Apply RoPE scaling factor when present (e.g., Llama 4 Maverick
+        has max_position_embeddings=4096 but a rope_scaling factor of 256,
+        giving an effective context of 1M tokens)."""
+        rope = cfg.get("rope_scaling")
+        if isinstance(rope, dict) and isinstance(rope.get("factor"), (int, float)):
+            scaled = int(val * rope["factor"])
+            if scaled > val:
+                return scaled
+        return val
+
     # Check top-level config
-    for key in keys_to_check:
-        if key in config:
-            val = config[key]
-            if isinstance(val, int) and val > 0:
-                return val
+    val = _extract_from(config)
+    if val is not None:
+        return _apply_rope_scaling(val, config)
 
     # For multimodal models (e.g., Qwen3.5), check text_config
     if "text_config" in config and isinstance(config["text_config"], dict):
-        for key in keys_to_check:
-            if key in config["text_config"]:
-                val = config["text_config"][key]
-                if isinstance(val, int) and val > 0:
-                    return val
+        tc = config["text_config"]
+        val = _extract_from(tc)
+        if val is not None:
+            return _apply_rope_scaling(val, tc)
 
     return 4096
 


### PR DESCRIPTION
## Summary

Fixes #445 — Llama 4 catalog metadata was internally inconsistent.

- **Maverick `num_experts`**: was 16 (generic llama4 fallback), corrected to **128** per the model name `17B-128E`
- **Maverick `context_length`**: was 4096 (bare `max_position_embeddings`), corrected to **1,048,576** (1M) by applying the RoPE scaling factor from config
- **MODELS.md**: listed both Scout and Maverick as `128k`; corrected to **10M** (Scout) and **1M** (Maverick) per Meta's specs
- **Scraper `detect_moe()`**: now checks `text_config` for nested MoE fields — Llama 4 multimodal models store `num_local_experts` there, not at the top level
- **Scraper `infer_context_length()`**: now applies `rope_scaling.factor` when present, so models using RoPE extension get correct context values instead of the base position embedding count

## Test plan

- [x] `cargo build` compiles successfully
- [ ] Verify Maverick entries in `hf_models.json` show `num_experts: 128`, `context_length: 1048576`
- [ ] Verify Scout entries unchanged (`num_experts: 16`, `context_length: 10485760`)
- [ ] Run scraper with `--discover` to confirm no regression on other MoE models

🤖 Generated with [Claude Code](https://claude.com/claude-code)