### PR TITLE
fix: replace unreachable!() with graceful fallback in estimate_tps_with_gpu

### DIFF
--- a/llmfit-core/src/plan.rs
+++ b/llmfit-core/src/plan.rs
@@ -198,10 +198,13 @@ fn estimate_tps_with_gpu(
         let efficiency = 0.55;
         let raw_tps = (bw / model_gb) * efficiency;
 
+        // CpuOnly is unreachable here (guarded by the `path != CpuOnly` check above),
+        // but use a fallback value instead of unreachable!() so adding new PlanRunPath
+        // variants won't cause a panic at runtime.
         let mode_factor = match path {
             PlanRunPath::Gpu => 1.0,
             PlanRunPath::CpuOffload => 0.5,
-            PlanRunPath::CpuOnly => unreachable!(),
+            _ => 1.0,
         };
 
         return (raw_tps * mode_factor).max(0.1);

--- a/llmfit-core/src/plan.rs
+++ b/llmfit-core/src/plan.rs
@@ -198,9 +198,8 @@ fn estimate_tps_with_gpu(
         let efficiency = 0.55;
         let raw_tps = (bw / model_gb) * efficiency;
 
-        // CpuOnly is unreachable here (guarded by the `path != CpuOnly` check above),
-        // but use a fallback value instead of unreachable!() so adding new PlanRunPath
-        // variants won't cause a panic at runtime.
+        // CpuOnly is unreachable here (guarded above). The default fallback handles
+        // any future PlanRunPath variants gracefully.
         let mode_factor = match path {
             PlanRunPath::Gpu => 1.0,
             PlanRunPath::CpuOffload => 0.5,


### PR DESCRIPTION
## Summary
- Replaces `unreachable!()` on `PlanRunPath::CpuOnly` in the bandwidth-aware TPS estimation match with a catch-all `_ => 1.0` fallback
- The `CpuOnly` branch is already guarded by a `path != PlanRunPath::CpuOnly` check above, so the fallback is safe
- Makes the match arm future-proof: if new `PlanRunPath` variants are added later, they degrade gracefully instead of panicking at runtime

This addresses one of the nitpicks from Alex's review on PR #450.

## Test plan
- [x] All 293 existing tests pass
- [x] Verify no behavioral change for existing Gpu/CpuOffload paths (self-evident: replacing unreachable!() with 1.0 in dead code path)

👾 Generated with [Letta Code](https://letta.com)
Co-Authored-By: Letta Code <noreply@letta.com>