### PR TITLE
feat(ci): add SignPath code-signing for Windows binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ on:
 
 permissions:
   contents: write
+  actions: read
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -100,6 +102,37 @@ jobs:
           else
             cargo build --release --target ${{ matrix.target }}
           fi
+
+      # ── SignPath code-signing for Windows binaries ──────────────
+      - name: Upload unsigned binary for signing
+        if: contains(matrix.target, 'windows')
+        id: upload-unsigned
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unsigned-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/${{ env.BINARY }}.exe
+
+      - name: Submit SignPath signing request
+        if: contains(matrix.target, 'windows')
+        id: sign
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ secrets.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'llmfit'
+          signing-policy-slug: 'release-signing'
+          github-artifact-id: '${{ steps.upload-unsigned.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: '${{ runner.temp }}/signed'
+          wait-for-completion-timeout-in-seconds: 900
+
+      - name: Replace binary with signed version
+        if: contains(matrix.target, 'windows')
+        shell: bash
+        run: |
+          cp "${{ runner.temp }}/signed/${{ env.BINARY }}.exe" \
+             "target/${{ matrix.target }}/release/${{ env.BINARY }}.exe"
+      # ──────────────────────────────────────────────────────────────
 
       - name: Package
         shell: bash


### PR DESCRIPTION
## Summary
- Integrates SignPath code-signing into the release workflow for Windows binaries (x86_64 and ARM64)
- Signs the `.exe` before packaging, so the release `.zip` contains a properly signed binary
- Adds `actions:read` and `id-token:write` permissions for SignPath origin verification

## Setup required
1. Add repo secrets: `SIGNPATH_API_TOKEN` and `SIGNPATH_ORGANIZATION_ID`
2. Install the [SignPath GitHub App](https://github.com/apps/signpath) on this repo
3. In SignPath: link the GitHub.com Trusted Build System to the project, create project slug `llmfit` and signing policy slug `release-signing`
4. Configure artifact configuration with `<zip-file>` root containing `<pe-file path="llmfit.exe" />`

## Test plan
- [ ] Secrets configured in repo settings
- [ ] SignPath GitHub App installed
- [ ] Trigger a test release or workflow_dispatch to verify signing completes
- [ ] Verify the released Windows binary is Authenticode-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)