### PR TITLE
fix: synchronize Cargo.lock for releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - uses: actions/checkout@v4
+        if: steps.release.outputs.pr
+        with:
+          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Update Cargo.lock
+        if: steps.release.outputs.pr
+        run: cargo update --workspace
+
+      - name: Commit updated Cargo.lock
+        if: steps.release.outputs.pr
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git diff --cached --quiet || git commit -m "chore: update Cargo.lock"
+          git push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,7 +2319,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmfit"
-version = "0.9.9"
+version = "0.9.11"
 dependencies = [
  "arboard",
  "axum",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-core"
-version = "0.9.9"
+version = "0.9.11"
 dependencies = [
  "http",
  "serde",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "llmfit-desktop"
-version = "0.9.9"
+version = "0.9.11"
 dependencies = [
  "llmfit-core",
  "serde",


### PR DESCRIPTION
## Summary
- Updates `Cargo.lock` to match current workspace versions (v0.9.11) so `cargo build --locked` works for downstream packagers (e.g. macports)
- Adds a post-processing step to the release-please workflow that automatically runs `cargo update --workspace` on release PRs, preventing future drift

## Context
Downstream package managers like macports build with `cargo build --frozen`/`--locked` which fails when `Cargo.lock` is out of sync with `Cargo.toml`. The lock file was referencing v0.9.9 while the workspace was at v0.9.11.

Fixes #476

## Test plan
- [x] Verified `cargo build --locked` succeeds locally after the fix
- [ ] Next release-please PR should automatically include an updated `Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)