### PR TITLE
fix: parse GPU name from rocm-smi output correctly

### DIFF
--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -588,10 +588,13 @@ impl SystemSpecs {
             })
             .and_then(|text| {
                 // Look for "Card Series" or "Card Model" lines
+                // rocm-smi format: "GPU[0] : Card Series:   AMD Radeon RX 6900 XT"
+                // Split into max 3 parts: ["GPU[0]", " Card Series", "   AMD Radeon RX 6900 XT"]
+                // We need the 3rd part (index 2) which contains the actual name.
                 for line in text.lines() {
                     let lower = line.to_lowercase();
                     if (lower.contains("card series") || lower.contains("card model"))
-                        && let Some(val) = line.split(':').nth(1)
+                        && let Some(val) = line.splitn(3, ':').nth(2)
                     {
                         let name = val.trim().to_string();
                         if !name.is_empty() {


### PR DESCRIPTION
## Summary
- Fixes GPU name parsing from `rocm-smi --showproductname` output on AMD GPUs
- Changes `split(':').nth(1)` → `splitn(3, ':').nth(2)` to extract the actual GPU name instead of the field label

## Problem
`rocm-smi --showproductname` outputs: `GPU[0] : Card Series:   AMD Radeon RX 6900 XT`

The old code split on `:` and took `nth(1)`, which extracted `"Card Series"` (the field label) instead of `"AMD Radeon RX 6900 XT"` (the actual name). This caused all AMD ROCm GPUs to be detected as generic "AMD GPU" with unknown VRAM.

## Fix
`splitn(3, ':').nth(2)` correctly extracts the GPU name from the third field. The `splitn(3, ...)` limit also handles GPU names that might contain colons.

## Testing
Verified on RX 6900 XT with ROCm 7.2.2 — `llmfit system` now shows `AMD Radeon RX 6900 XT` instead of `Card Series`.

Fixes #478

## Test plan
- [ ] Run `llmfit system` on an AMD GPU with ROCm installed
- [ ] Verify GPU name shows actual model (e.g., "AMD Radeon RX 6900 XT") not "Card Series"
- [ ] Verify VRAM detection still works correctly

👾 Generated with [Letta Code](https://letta.com)