### PR TITLE
Add zh-CN localization plus web planning and hardware simulation

### DIFF
--- a/llmfit-desktop/ui/app.js
+++ b/llmfit-desktop/ui/app.js
@@ -2,9 +2,22 @@ const invoke = window.__TAURI_INTERNALS__
   ? window.__TAURI_INTERNALS__.invoke
   : async (cmd) => { console.warn('Tauri not available, cmd:', cmd); return null; };
 
+const {
+  t,
+  getLocale,
+  setLocale,
+  subscribe,
+  applyStaticTranslations,
+  translateFitLevel,
+  translateRunMode,
+  translateUseCase,
+} = window.llmfitI18n;
+
 let allFits = [];
 let ollamaAvailable = false;
 let pullInterval = null;
+let lastSpecs = null;
+let currentModalFit = null;
 
 function esc(s) {
   const d = document.createElement('div');
@@ -12,49 +25,55 @@ function esc(s) {
   return d.innerHTML;
 }
 
+function renderSpecs(specs) {
+  if (!specs) return;
+
+  document.getElementById('cpu-name').textContent = specs.cpu_name;
+  document.getElementById('cpu-cores').textContent = t('system.cores', { count: specs.cpu_cores });
+  document.getElementById('ram-total').textContent = specs.total_ram_gb.toFixed(1) + ' GB';
+  document.getElementById('ram-available').textContent = specs.available_ram_gb.toFixed(1) + ' GB';
+
+  const container = document.getElementById('gpus-container');
+  container.innerHTML = '';
+
+  if (specs.gpus.length === 0) {
+    const card = document.createElement('div');
+    card.className = 'spec-card';
+    card.innerHTML = '<span class="spec-label">' + esc(t('system.gpu')) + '</span>' +
+      '<span class="spec-value">' + esc(t('system.noGpu')) + '</span>';
+    container.appendChild(card);
+  } else {
+    specs.gpus.forEach((gpu, i) => {
+      const card = document.createElement('div');
+      card.className = 'spec-card';
+      const label = specs.gpus.length > 1 ? t('system.gpuIndexed', { index: i + 1 }) : t('system.gpu');
+      const countStr = gpu.count > 1 ? ' ×' + gpu.count : '';
+      const vramStr = gpu.vram_gb != null ? gpu.vram_gb.toFixed(1) + ' GB VRAM' : t('system.sharedMemory');
+      const backendStr = gpu.backend !== 'None' ? gpu.backend : '';
+      const details = [vramStr, backendStr].filter(Boolean).join(' · ');
+      card.innerHTML = '<span class="spec-label">' + esc(label) + '</span>' +
+        '<span class="spec-value">' + esc(gpu.name + countStr) + '</span>' +
+        '<span class="spec-detail">' + esc(details) + '</span>';
+      container.appendChild(card);
+    });
+  }
+
+  if (specs.unified_memory) {
+    const archCard = document.getElementById('memory-arch-card');
+    archCard.style.display = '';
+    document.getElementById('memory-arch').textContent = t('system.unifiedMemory');
+  }
+}
+
 async function loadSpecs() {
   try {
     const specs = await invoke('get_system_specs');
     if (!specs) return;
-
-    document.getElementById('cpu-name').textContent = specs.cpu_name;
-    document.getElementById('cpu-cores').textContent = specs.cpu_cores + ' cores';
-    document.getElementById('ram-total').textContent = specs.total_ram_gb.toFixed(1) + ' GB';
-    document.getElementById('ram-available').textContent = specs.available_ram_gb.toFixed(1) + ' GB';
-
-    const container = document.getElementById('gpus-container');
-    container.innerHTML = '';
-
-    if (specs.gpus.length === 0) {
-      const card = document.createElement('div');
-      card.className = 'spec-card';
-      card.innerHTML = '<span class="spec-label">GPU</span>' +
-        '<span class="spec-value">No GPU detected</span>';
-      container.appendChild(card);
-    } else {
-      specs.gpus.forEach((gpu, i) => {
-        const card = document.createElement('div');
-        card.className = 'spec-card';
-        const label = specs.gpus.length > 1 ? 'GPU ' + (i + 1) : 'GPU';
-        const countStr = gpu.count > 1 ? ' ×' + gpu.count : '';
-        const vramStr = gpu.vram_gb != null ? gpu.vram_gb.toFixed(1) + ' GB VRAM' : 'Shared memory';
-        const backendStr = gpu.backend !== 'None' ? gpu.backend : '';
-        const details = [vramStr, backendStr].filter(Boolean).join(' · ');
-        card.innerHTML = '<span class="spec-label">' + esc(label) + '</span>' +
-          '<span class="spec-value">' + esc(gpu.name + countStr) + '</span>' +
-          '<span class="spec-detail">' + esc(details) + '</span>';
-        container.appendChild(card);
-      });
-    }
-
-    if (specs.unified_memory) {
-      const archCard = document.getElementById('memory-arch-card');
-      archCard.style.display = '';
-      document.getElementById('memory-arch').textContent = 'Unified (CPU + GPU shared)';
-    }
+    lastSpecs = specs;
+    renderSpecs(specs);
   } catch (e) {
     console.error('Failed to load specs:', e);
-    document.getElementById('cpu-name').textContent = 'Error loading specs';
+    document.getElementById('cpu-name').textContent = t('system.errorLoading');
   }
 }
 
@@ -77,6 +96,7 @@ function modeClass(mode) {
 }
 
 function showModal(fit) {
+  currentModalFit = fit;
   const modal = document.getElementById('model-modal');
   const body = document.getElementById('modal-body');
 
@@ -85,17 +105,17 @@ function showModal(fit) {
 
   let notesHtml = '';
   if (fit.notes && fit.notes.length > 0) {
-    notesHtml = '<div class="modal-section"><h4>Notes</h4><ul>' +
+    notesHtml = '<div class="modal-section"><h4>' + esc(t('desktop.notes')) + '</h4><ul>' +
       fit.notes.map(n => '<li>' + esc(n) + '</li>').join('') +
       '</ul></div>';
   }
 
   const installedBadge = fit.installed
-    ? '<span class="badge badge-installed">Installed</span>'
-    : '<span class="badge badge-not-installed">Not Installed</span>';
+    ? '<span class="badge badge-installed">' + esc(t('desktop.installed')) + '</span>'
+    : '<span class="badge badge-not-installed">' + esc(t('desktop.notInstalled')) + '</span>';
 
   const downloadBtn = (!fit.installed && ollamaAvailable)
-    ? '<button class="btn-download">⬇ Download via Ollama</button>'
+    ? '<button class="btn-download">' + esc(t('desktop.downloadViaOllama')) + '</button>'
     : '';
 
   body.innerHTML = `
@@ -106,40 +126,40 @@ function showModal(fit) {
 
     <div class="modal-grid">
       <div class="modal-stat">
-        <span class="stat-label">Parameters</span>
+        <span class="stat-label">${esc(t('desktop.parameters'))}</span>
         <span class="stat-value">${esc(fit.params_b.toFixed(1))}B</span>
       </div>
       <div class="modal-stat">
-        <span class="stat-label">Quantization</span>
+        <span class="stat-label">${esc(t('desktop.quantization'))}</span>
         <span class="stat-value">${esc(fit.quant)}</span>
       </div>
       <div class="modal-stat">
-        <span class="stat-label">Runtime</span>
+        <span class="stat-label">${esc(t('desktop.runtime'))}</span>
         <span class="stat-value">${esc(fit.runtime)}</span>
       </div>
       <div class="modal-stat">
-        <span class="stat-label">Score</span>
+        <span class="stat-label">${esc(t('desktop.score'))}</span>
         <span class="stat-value">${esc(fit.score.toFixed(0))}/100</span>
       </div>
       <div class="modal-stat">
-        <span class="stat-label">Est. Speed</span>
+        <span class="stat-label">${esc(t('desktop.estSpeed'))}</span>
         <span class="stat-value">${esc(fit.estimated_tps.toFixed(1))} tok/s</span>
       </div>
       <div class="modal-stat">
-        <span class="stat-label">Use Case</span>
-        <span class="stat-value">${esc(fit.use_case)}</span>
+        <span class="stat-label">${esc(t('desktop.useCase'))}</span>
+        <span class="stat-value">${esc(translateUseCase(fit.use_case))}</span>
       </div>
     </div>
 
     <div class="modal-section">
-      <h4>Fit Analysis</h4>
+      <h4>${esc(t('desktop.fitAnalysis'))}</h4>
       <div class="fit-row">
-        <span class="${fitClass(fit.fit_level)}">${esc(fit.fit_level)}</span>
-        <span class="fit-detail">${esc(fit.run_mode)}</span>
+        <span class="${fitClass(fit.fit_level)}">${esc(translateFitLevel(fit.fit_level))}</span>
+        <span class="fit-detail">${esc(translateRunMode(fit.run_mode))}</span>
       </div>
       <div class="mem-bar-container">
         <div class="mem-bar-label">
-          <span>Memory: ${esc(fit.memory_required_gb.toFixed(1))} / ${esc(fit.memory_available_gb.toFixed(1))} GB</span>
+          <span>${esc(t('desktop.memorySummary', { required: fit.memory_required_gb.toFixed(1), available: fit.memory_available_gb.toFixed(1) }))}</span>
           <span>${esc(fit.utilization_pct.toFixed(0))}%</span>
         </div>
         <div class="mem-bar-track">
@@ -159,7 +179,7 @@ function showModal(fit) {
 
     <div class="modal-actions">
       ${downloadBtn}
-      <button class="btn-close" onclick="closeModal()">Close</button>
+      <button class="btn-close" onclick="closeModal()">${esc(t('desktop.close'))}</button>
     </div>
   `;
 
@@ -170,12 +190,14 @@ function showModal(fit) {
 }
 
 function closeModal() {
+  currentModalFit = null;
   document.getElementById('model-modal').classList.remove('visible');
   if (pullInterval) {
     clearInterval(pullInterval);
     pullInterval = null;
   }
 }
+window.closeModal = closeModal;
 
 async function pullModel(name) {
   const statusEl = document.getElementById('pull-status');
@@ -185,7 +207,7 @@ async function pullModel(name) {
 
   statusEl.style.display = '';
   if (btn) btn.disabled = true;
-  textEl.textContent = 'Starting download...';
+  textEl.textContent = t('desktop.startingDownload');
 
   try {
     await invoke('start_pull', { modelTag: name });
@@ -200,12 +222,11 @@ async function pullModel(name) {
           clearInterval(pullInterval);
           pullInterval = null;
           if (s.error) {
-            textEl.textContent = 'Error: ' + s.error;
+            textEl.textContent = t('desktop.errorPrefix') + s.error;
             if (btn) btn.disabled = false;
           } else {
-            textEl.textContent = 'Download complete!';
+            textEl.textContent = t('desktop.downloadComplete');
             barEl.style.width = '100%';
-            // Refresh model list
             await loadModels();
           }
         }
@@ -214,7 +235,7 @@ async function pullModel(name) {
       }
     }, 500);
   } catch (e) {
-    textEl.textContent = 'Error: ' + e;
+    textEl.textContent = t('desktop.errorPrefix') + e;
     if (btn) btn.disabled = false;
   }
 }
@@ -222,24 +243,23 @@ async function pullModel(name) {
 function renderModels(fits) {
   const tbody = document.getElementById('models-body');
   if (!fits || fits.length === 0) {
-    tbody.innerHTML = '<tr><td colspan="9" class="loading">No models found</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="9" class="loading">' + esc(t('desktop.noModels')) + '</td></tr>';
     return;
   }
   tbody.innerHTML = fits.map((f, i) => `
     <tr class="model-row" data-index="${i}">
-      <td><strong>${esc(f.name)}</strong>${f.installed ? ' <span class="installed-dot" title="Installed">●</span>' : ''}</td>
+      <td><strong>${esc(f.name)}</strong>${f.installed ? ' <span class="installed-dot" title="' + esc(t('desktop.installed')) + '">●</span>' : ''}</td>
       <td>${esc(f.params_b.toFixed(1))}B</td>
       <td>${esc(f.quant)}</td>
-      <td class="${fitClass(f.fit_level)}">${esc(f.fit_level)}</td>
-      <td class="${modeClass(f.run_mode)}">${esc(f.run_mode)}</td>
+      <td class="${fitClass(f.fit_level)}">${esc(translateFitLevel(f.fit_level))}</td>
+      <td class="${modeClass(f.run_mode)}">${esc(translateRunMode(f.run_mode))}</td>
       <td>${esc(f.score.toFixed(0))}</td>
       <td>${esc(f.memory_required_gb.toFixed(1))} GB</td>
       <td>${esc(f.estimated_tps.toFixed(1))}</td>
-      <td>${esc(f.use_case)}</td>
+      <td>${esc(translateUseCase(f.use_case))}</td>
     </tr>
   `).join('');
 
-  // Attach click handlers
   const currentFits = fits;
   tbody.querySelectorAll('.model-row').forEach(row => {
     row.addEventListener('click', () => {
@@ -270,24 +290,41 @@ async function loadModels() {
   } catch (e) {
     console.error('Failed to load models:', e);
     document.getElementById('models-body').innerHTML =
-      '<tr><td colspan="9" class="loading">Error loading models</td></tr>';
+      '<tr><td colspan="9" class="loading">' + esc(t('desktop.errorLoadingModels')) + '</td></tr>';
   }
 }
 
-// Close modal on backdrop click
+function rerenderForLocale() {
+  applyStaticTranslations();
+  document.getElementById('locale-select').value = getLocale();
+  if (lastSpecs) {
+    renderSpecs(lastSpecs);
+  }
+  applyFilters();
+  if (currentModalFit) {
+    showModal(currentModalFit);
+  }
+}
+
 document.getElementById('model-modal').addEventListener('click', (e) => {
   if (e.target === e.currentTarget) closeModal();
 });
 
-// Close modal on Escape
 document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') closeModal();
 });
 
 document.getElementById('search').addEventListener('input', applyFilters);
 document.getElementById('fit-filter').addEventListener('change', applyFilters);
+document.getElementById('locale-select').addEventListener('change', (e) => {
+  setLocale(e.target.value);
+});
+
+subscribe(rerenderForLocale);
 
 async function init() {
+  applyStaticTranslations();
+  document.getElementById('locale-select').value = getLocale();
   ollamaAvailable = await invoke('is_ollama_available') || false;
   loadSpecs();
   loadModels();

--- a/llmfit-desktop/ui/i18n.js
+++ b/llmfit-desktop/ui/i18n.js
@@ -1,0 +1,322 @@
+(function initI18n(global) {
+  const LOCALE_KEY = 'llmfit.locale';
+  const FALLBACK_LOCALE = 'en';
+
+  const MESSAGES = {
+    en: {
+      language: {
+        label: 'Language',
+        english: 'English',
+        chinese: '中文'
+      },
+      system: {
+        title: 'System',
+        cpu: 'CPU',
+        totalRam: 'Total RAM',
+        availableRam: 'Available RAM',
+        memory: 'Memory',
+        gpu: 'GPU',
+        detecting: 'Detecting…',
+        noGpu: 'No GPU detected',
+        sharedMemory: 'Shared memory',
+        unifiedMemory: 'Unified (CPU + GPU shared)',
+        errorLoading: 'Error loading specs',
+        cores: ({ count }) => `${count} cores`,
+        gpuIndexed: ({ index }) => `GPU ${index}`
+      },
+      desktop: {
+        pageTitle: 'llmfit',
+        modelsTitle: 'Model Compatibility',
+        searchPlaceholder: 'Filter models...',
+        allFitLevels: 'All Fit Levels',
+        loadingModels: 'Loading models...',
+        noModels: 'No models found',
+        errorLoadingModels: 'Error loading models',
+        notes: 'Notes',
+        fitAnalysis: 'Fit Analysis',
+        installed: 'Installed',
+        notInstalled: 'Not Installed',
+        downloadViaOllama: '⬇ Download via Ollama',
+        close: 'Close',
+        parameters: 'Parameters',
+        quantization: 'Quantization',
+        runtime: 'Runtime',
+        score: 'Score',
+        estSpeed: 'Est. Speed',
+        useCase: 'Use Case',
+        memorySummary: ({ required, available }) => `Memory: ${required} / ${available} GB`,
+        startingDownload: 'Starting download...',
+        downloadComplete: 'Download complete!',
+        errorPrefix: 'Error: '
+      },
+      table: {
+        model: 'Model',
+        params: 'Params',
+        quant: 'Quant',
+        fit: 'Fit',
+        mode: 'Mode',
+        score: 'Score',
+        ramReq: 'RAM Req',
+        estTps: 'Est. TPS',
+        useCase: 'Use Case'
+      },
+      labels: {
+        fit: {
+          perfect: 'Perfect',
+          good: 'Good',
+          marginal: 'Marginal',
+          too_tight: 'Too Tight'
+        },
+        runMode: {
+          gpu: 'GPU',
+          moe_offload: 'MoE Offload',
+          cpu_offload: 'CPU Offload',
+          cpu_only: 'CPU Only'
+        },
+        useCase: {
+          general: 'General',
+          coding: 'Coding',
+          reasoning: 'Reasoning',
+          chat: 'Chat',
+          multimodal: 'Multimodal',
+          embedding: 'Embedding'
+        }
+      }
+    },
+    'zh-CN': {
+      language: {
+        label: '语言',
+        english: 'English',
+        chinese: '中文'
+      },
+      system: {
+        title: '系统信息',
+        cpu: 'CPU',
+        totalRam: '总内存',
+        availableRam: '可用内存',
+        memory: '内存',
+        gpu: 'GPU',
+        detecting: '检测中…',
+        noGpu: '未检测到 GPU',
+        sharedMemory: '共享内存',
+        unifiedMemory: '统一内存（CPU 与 GPU 共享）',
+        errorLoading: '加载硬件信息失败',
+        cores: ({ count }) => `${count} 核`,
+        gpuIndexed: ({ index }) => `GPU ${index}`
+      },
+      desktop: {
+        pageTitle: 'llmfit',
+        modelsTitle: '模型适配分析',
+        searchPlaceholder: '筛选模型...',
+        allFitLevels: '全部适配等级',
+        loadingModels: '正在加载模型...',
+        noModels: '未找到匹配模型',
+        errorLoadingModels: '加载模型失败',
+        notes: '说明',
+        fitAnalysis: '适配分析',
+        installed: '已安装',
+        notInstalled: '未安装',
+        downloadViaOllama: '⬇ 通过 Ollama 下载',
+        close: '关闭',
+        parameters: '参数量',
+        quantization: '量化',
+        runtime: '运行时',
+        score: '得分',
+        estSpeed: '预估速度',
+        useCase: '用途',
+        memorySummary: ({ required, available }) => `内存：${required} / ${available} GB`,
+        startingDownload: '开始下载...',
+        downloadComplete: '下载完成！',
+        errorPrefix: '错误：'
+      },
+      table: {
+        model: '模型',
+        params: '参数量',
+        quant: '量化',
+        fit: '适配度',
+        mode: '模式',
+        score: '得分',
+        ramReq: '内存需求',
+        estTps: '预估 TPS',
+        useCase: '用途'
+      },
+      labels: {
+        fit: {
+          perfect: '完美适配',
+          good: '良好适配',
+          marginal: '勉强可用',
+          too_tight: '过紧无法稳定运行'
+        },
+        runMode: {
+          gpu: 'GPU',
+          moe_offload: 'MoE 卸载',
+          cpu_offload: 'CPU 卸载',
+          cpu_only: '仅 CPU'
+        },
+        useCase: {
+          general: '通用',
+          coding: '编程',
+          reasoning: '推理',
+          chat: '对话',
+          multimodal: '多模态',
+          embedding: '向量嵌入'
+        }
+      }
+    }
+  };
+
+  function getNestedValue(obj, key) {
+    return key.split('.').reduce((acc, part) => (acc ? acc[part] : undefined), obj);
+  }
+
+  function formatMessage(message, params) {
+    if (typeof message === 'function') {
+      return message(params || {});
+    }
+    if (typeof message !== 'string') {
+      return message;
+    }
+    return message.replace(/\{(\w+)\}/g, function replaceToken(_, token) {
+      return params && params[token] != null ? String(params[token]) : `{${token}}`;
+    });
+  }
+
+  function normalizeLocale(locale) {
+    if (!locale || typeof locale !== 'string') {
+      return FALLBACK_LOCALE;
+    }
+    return locale.toLowerCase().startsWith('zh') ? 'zh-CN' : FALLBACK_LOCALE;
+  }
+
+  function getStoredLocale() {
+    try {
+      const stored = global.localStorage.getItem(LOCALE_KEY);
+      return stored ? normalizeLocale(stored) : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function detectLocale() {
+    return getStoredLocale() || normalizeLocale(global.navigator && global.navigator.language);
+  }
+
+  let currentLocale = detectLocale();
+  const listeners = new Set();
+
+  function t(key, params) {
+    const value =
+      getNestedValue(MESSAGES[currentLocale], key) ??
+      getNestedValue(MESSAGES[FALLBACK_LOCALE], key) ??
+      key;
+    return formatMessage(value, params);
+  }
+
+  function setLocale(locale) {
+    const nextLocale = normalizeLocale(locale);
+    if (nextLocale === currentLocale) {
+      return;
+    }
+    currentLocale = nextLocale;
+    try {
+      global.localStorage.setItem(LOCALE_KEY, currentLocale);
+    } catch (_) {
+      // ignore storage failures
+    }
+    document.documentElement.lang = currentLocale;
+    listeners.forEach(function notify(listener) {
+      listener(currentLocale);
+    });
+  }
+
+  function getLocale() {
+    return currentLocale;
+  }
+
+  function subscribe(listener) {
+    listeners.add(listener);
+    return function unsubscribe() {
+      listeners.delete(listener);
+    };
+  }
+
+  function applyStaticTranslations() {
+    document.title = t('desktop.pageTitle');
+    document.documentElement.lang = currentLocale;
+
+    document.querySelectorAll('[data-i18n]').forEach(function updateText(node) {
+      node.textContent = t(node.getAttribute('data-i18n'));
+    });
+
+    document.querySelectorAll('[data-i18n-placeholder]').forEach(function updatePlaceholder(node) {
+      node.setAttribute('placeholder', t(node.getAttribute('data-i18n-placeholder')));
+    });
+
+    document.querySelectorAll('[data-i18n-aria-label]').forEach(function updateAria(node) {
+      node.setAttribute('aria-label', t(node.getAttribute('data-i18n-aria-label')));
+    });
+  }
+
+  function normalizeFitCode(value) {
+    if (!value) return null;
+    const normalized = String(value).trim().toLowerCase().replace(/[\s-]+/g, '_');
+    const aliases = {
+      perfect: 'perfect',
+      good: 'good',
+      marginal: 'marginal',
+      too_tight: 'too_tight',
+      tootight: 'too_tight'
+    };
+    return aliases[normalized] || null;
+  }
+
+  function normalizeRunModeCode(value) {
+    if (!value) return null;
+    const normalized = String(value).trim().toLowerCase().replace(/[\s-]+/g, '_');
+    const aliases = {
+      gpu: 'gpu',
+      moe_offload: 'moe_offload',
+      cpu_offload: 'cpu_offload',
+      cpu_only: 'cpu_only'
+    };
+    return aliases[normalized] || null;
+  }
+
+  function normalizeUseCaseCode(value) {
+    if (!value) return null;
+    const normalized = String(value).trim().toLowerCase();
+    return ['general', 'coding', 'reasoning', 'chat', 'multimodal', 'embedding'].includes(normalized)
+      ? normalized
+      : null;
+  }
+
+  function translateFitLevel(value) {
+    const code = normalizeFitCode(value);
+    return code ? t(`labels.fit.${code}`) : (value || '—');
+  }
+
+  function translateRunMode(value) {
+    const code = normalizeRunModeCode(value);
+    return code ? t(`labels.runMode.${code}`) : (value || '—');
+  }
+
+  function translateUseCase(value) {
+    const code = normalizeUseCaseCode(value);
+    return code ? t(`labels.useCase.${code}`) : (value || '—');
+  }
+
+  global.llmfitI18n = {
+    LOCALE_KEY,
+    getLocale,
+    setLocale,
+    subscribe,
+    t,
+    applyStaticTranslations,
+    normalizeFitCode,
+    normalizeRunModeCode,
+    normalizeUseCaseCode,
+    translateFitLevel,
+    translateRunMode,
+    translateUseCase
+  };
+})(window);

--- a/llmfit-desktop/ui/index.html
+++ b/llmfit-desktop/ui/index.html
@@ -8,60 +8,64 @@
 </head>
 <body>
   <section id="system-panel">
-    <h2>System</h2>
+    <h2 data-i18n="system.title">System</h2>
     <div id="specs-grid" class="specs-grid">
       <div class="spec-card">
-        <span class="spec-label">CPU</span>
-        <span id="cpu-name" class="spec-value">Detecting...</span>
+        <span class="spec-label" data-i18n="system.cpu">CPU</span>
+        <span id="cpu-name" class="spec-value" data-i18n="system.detecting">Detecting...</span>
         <span id="cpu-cores" class="spec-detail"></span>
       </div>
       <div class="spec-card">
-        <span class="spec-label">Total RAM</span>
+        <span class="spec-label" data-i18n="system.totalRam">Total RAM</span>
         <span id="ram-total" class="spec-value">—</span>
       </div>
       <div class="spec-card">
-        <span class="spec-label">Available RAM</span>
+        <span class="spec-label" data-i18n="system.availableRam">Available RAM</span>
         <span id="ram-available" class="spec-value">—</span>
       </div>
       <div id="gpus-container">
         <!-- GPU cards injected by JS -->
       </div>
       <div class="spec-card" id="memory-arch-card" style="display:none">
-        <span class="spec-label">Memory</span>
+        <span class="spec-label" data-i18n="system.memory">Memory</span>
         <span id="memory-arch" class="spec-value">—</span>
       </div>
     </div>
   </section>
 
   <section id="models-panel">
-    <h2>Model Compatibility</h2>
+    <h2 data-i18n="desktop.modelsTitle">Model Compatibility</h2>
     <div class="controls">
-      <input type="text" id="search" placeholder="Filter models..." />
+      <input type="text" id="search" data-i18n-placeholder="desktop.searchPlaceholder" placeholder="Filter models..." />
       <select id="fit-filter">
-        <option value="all">All Fit Levels</option>
-        <option value="Perfect">Perfect</option>
-        <option value="Good">Good</option>
-        <option value="Marginal">Marginal</option>
-        <option value="Too Tight">Too Tight</option>
+        <option value="all" data-i18n="desktop.allFitLevels">All Fit Levels</option>
+        <option value="Perfect" data-i18n="labels.fit.perfect">Perfect</option>
+        <option value="Good" data-i18n="labels.fit.good">Good</option>
+        <option value="Marginal" data-i18n="labels.fit.marginal">Marginal</option>
+        <option value="Too Tight" data-i18n="labels.fit.too_tight">Too Tight</option>
+      </select>
+      <select id="locale-select" data-i18n-aria-label="language.label" aria-label="Language">
+        <option value="en" data-i18n="language.english">English</option>
+        <option value="zh-CN" data-i18n="language.chinese">中文</option>
       </select>
     </div>
     <div id="models-table-container">
       <table id="models-table">
         <thead>
           <tr>
-            <th>Model</th>
-            <th>Params</th>
-            <th>Quant</th>
-            <th>Fit</th>
-            <th>Mode</th>
-            <th>Score</th>
-            <th>RAM Req</th>
-            <th>Est. TPS</th>
-            <th>Use Case</th>
+            <th data-i18n="table.model">Model</th>
+            <th data-i18n="table.params">Params</th>
+            <th data-i18n="table.quant">Quant</th>
+            <th data-i18n="table.fit">Fit</th>
+            <th data-i18n="table.mode">Mode</th>
+            <th data-i18n="table.score">Score</th>
+            <th data-i18n="table.ramReq">RAM Req</th>
+            <th data-i18n="table.estTps">Est. TPS</th>
+            <th data-i18n="table.useCase">Use Case</th>
           </tr>
         </thead>
         <tbody id="models-body">
-          <tr><td colspan="9" class="loading">Loading models...</td></tr>
+          <tr><td colspan="9" class="loading" data-i18n="desktop.loadingModels">Loading models...</td></tr>
         </tbody>
       </table>
     </div>
@@ -71,6 +75,7 @@
     <div class="modal-content" id="modal-body"></div>
   </div>
 
+  <script src="i18n.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/llmfit-desktop/ui/styles.css
+++ b/llmfit-desktop/ui/styles.css
@@ -51,6 +51,8 @@ h2 { font-size: 18px; font-weight: 600; margin-bottom: 12px; color: var(--text-d
   display: flex;
   gap: 12px;
   margin-bottom: 12px;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 #search {
@@ -63,7 +65,8 @@ h2 { font-size: 18px; font-weight: 600; margin-bottom: 12px; color: var(--text-d
   font-size: 14px;
 }
 
-#fit-filter {
+#fit-filter,
+#locale-select {
   padding: 8px 12px;
   background: var(--surface);
   border: 1px solid var(--border);

--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -52,6 +52,15 @@ struct InstalledModel {
 }
 
 #[derive(Debug, Deserialize)]
+struct HardwareOverrideQuery {
+    #[serde(alias = "ram")]
+    ram_gb: Option<f64>,
+    #[serde(alias = "memory")]
+    vram_gb: Option<f64>,
+    cpu_cores: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
 struct ModelsQuery {
     limit: Option<usize>,
     #[serde(alias = "n")]
@@ -67,6 +76,11 @@ struct ModelsQuery {
     max_context: Option<u32>,
     force_runtime: Option<String>,
     license: Option<String>,
+    #[serde(alias = "ram")]
+    ram_gb: Option<f64>,
+    #[serde(alias = "memory")]
+    vram_gb: Option<f64>,
+    cpu_cores: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -214,14 +228,19 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     }))
 }
 
-async fn system(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
-    Json(serde_json::json!({
+async fn system(
+    State(state): State<Arc<AppState>>,
+    Query(overrides): Query<HardwareOverrideQuery>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let specs = effective_specs(&state.specs, &overrides)?;
+
+    Ok(Json(serde_json::json!({
         "node": {
             "name": state.node_name,
             "os": state.os,
         },
-        "system": system_json(&state.specs),
-    }))
+        "system": system_json(&specs),
+    })))
 }
 
 async fn web_index() -> Response {
@@ -268,7 +287,8 @@ async fn models(
     State(state): State<Arc<AppState>>,
     Query(query): Query<ModelsQuery>,
 ) -> ApiResult<Json<ApiEnvelope>> {
-    let mut fits = filtered_fits(&state, &query, false)?;
+    let specs = effective_specs(&state.specs, &query.hardware_overrides())?;
+    let mut fits = filtered_fits(&state, &specs, &query, false)?;
     let total_models = fits.len();
 
     let limit = query.limit.or(query.top).unwrap_or(usize::MAX);
@@ -281,7 +301,7 @@ async fn models(
             name: state.node_name.clone(),
             os: state.os.clone(),
         },
-        system: system_json(&state.specs),
+        system: system_json(&specs),
         total_models,
         returned_models: fits.len(),
         filters: active_filters_json(&query, false),
@@ -295,7 +315,8 @@ async fn top_models(
     State(state): State<Arc<AppState>>,
     Query(query): Query<ModelsQuery>,
 ) -> ApiResult<Json<ApiEnvelope>> {
-    let mut fits = filtered_fits(&state, &query, true)?;
+    let specs = effective_specs(&state.specs, &query.hardware_overrides())?;
+    let mut fits = filtered_fits(&state, &specs, &query, true)?;
     let total_models = fits.len();
 
     let limit = query.limit.or(query.top).unwrap_or(5);
@@ -308,7 +329,7 @@ async fn top_models(
             name: state.node_name.clone(),
             os: state.os.clone(),
         },
-        system: system_json(&state.specs),
+        system: system_json(&specs),
         total_models,
         returned_models: fits.len(),
         filters: active_filters_json(&query, true),
@@ -326,7 +347,8 @@ async fn model_by_name(
     let mut scoped = query;
     scoped.search = Some(name);
 
-    let mut fits = filtered_fits(&state, &scoped, false)?;
+    let specs = effective_specs(&state.specs, &scoped.hardware_overrides())?;
+    let mut fits = filtered_fits(&state, &specs, &scoped, false)?;
     let total_models = fits.len();
 
     let limit = scoped.limit.or(scoped.top).unwrap_or(20);
@@ -339,7 +361,7 @@ async fn model_by_name(
             name: state.node_name.clone(),
             os: state.os.clone(),
         },
-        system: system_json(&state.specs),
+        system: system_json(&specs),
         total_models,
         returned_models: fits.len(),
         filters: active_filters_json(&scoped, false),
@@ -363,6 +385,31 @@ struct PlanBody {
     target_tps: Option<f64>,
     #[serde(default)]
     kv_quant: Option<String>,
+    #[serde(alias = "ram")]
+    ram_gb: Option<f64>,
+    #[serde(alias = "memory")]
+    vram_gb: Option<f64>,
+    cpu_cores: Option<usize>,
+}
+
+impl ModelsQuery {
+    fn hardware_overrides(&self) -> HardwareOverrideQuery {
+        HardwareOverrideQuery {
+            ram_gb: self.ram_gb,
+            vram_gb: self.vram_gb,
+            cpu_cores: self.cpu_cores,
+        }
+    }
+}
+
+impl PlanBody {
+    fn hardware_overrides(&self) -> HardwareOverrideQuery {
+        HardwareOverrideQuery {
+            ram_gb: self.ram_gb,
+            vram_gb: self.vram_gb,
+            cpu_cores: self.cpu_cores,
+        }
+    }
 }
 
 async fn runtimes(State(_state): State<Arc<AppState>>) -> Json<serde_json::Value> {
@@ -395,7 +442,7 @@ async fn runtimes(State(_state): State<Arc<AppState>>) -> Json<serde_json::Value
     Json(serde_json::json!({ "runtimes": runtimes, "warnings": warnings }))
 }
 
-async fn installed(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
+async fn installed(State(_state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     let mut set = tokio::task::JoinSet::new();
 
     set.spawn_blocking(|| {
@@ -640,14 +687,16 @@ async fn plan_estimate(
         None => None,
     };
 
+    let overrides = body.hardware_overrides();
     let request = PlanRequest {
         context: body.context,
         quant: body.quant,
         target_tps: body.target_tps,
         kv_quant,
     };
+    let specs = effective_specs(&state.specs, &overrides)?;
 
-    match estimate_model_plan(model, &request, &state.specs) {
+    match estimate_model_plan(model, &request, &specs) {
         Ok(estimate) => Ok(Json(serde_json::json!(estimate))),
         Err(e) => Err(ApiError::bad_request(e)),
     }
@@ -655,6 +704,7 @@ async fn plan_estimate(
 
 fn filtered_fits(
     state: &AppState,
+    specs: &SystemSpecs,
     query: &ModelsQuery,
     top_only: bool,
 ) -> Result<Vec<ModelFit>, ApiError> {
@@ -668,11 +718,11 @@ fn filtered_fits(
     let mut fits: Vec<ModelFit> = state
         .models
         .iter()
-        .filter(|m| backend_compatible(m, &state.specs))
-        .map(|m| ModelFit::analyze_with_forced_runtime(m, &state.specs, context_limit, forced_rt))
+        .filter(|m| backend_compatible(m, specs))
+        .map(|m| ModelFit::analyze_with_forced_runtime(m, specs, context_limit, forced_rt))
         .collect();
 
-    let is_apple_silicon = state.specs.backend == GpuBackend::Metal && state.specs.unified_memory;
+    let is_apple_silicon = specs.backend == GpuBackend::Metal && specs.unified_memory;
     if !is_apple_silicon {
         fits.retain(|f| !f.model.is_mlx_only());
     }
@@ -725,6 +775,42 @@ fn filtered_fits(
     }
 
     Ok(rank_models_by_fit_opts_col(fits, false, sort_column))
+}
+
+fn effective_specs(
+    base_specs: &SystemSpecs,
+    overrides: &HardwareOverrideQuery,
+) -> Result<SystemSpecs, ApiError> {
+    let mut specs = base_specs.clone();
+
+    if let Some(ram_gb) = overrides.ram_gb {
+        if !ram_gb.is_finite() || ram_gb <= 0.0 {
+            return Err(ApiError::bad_request(
+                "invalid ram_gb value: expected a positive number",
+            ));
+        }
+        specs = specs.with_ram_override(ram_gb);
+    }
+
+    if let Some(vram_gb) = overrides.vram_gb {
+        if !vram_gb.is_finite() || vram_gb < 0.0 {
+            return Err(ApiError::bad_request(
+                "invalid vram_gb value: expected a non-negative number",
+            ));
+        }
+        specs = specs.with_gpu_memory_override(vram_gb);
+    }
+
+    if let Some(cpu_cores) = overrides.cpu_cores {
+        if cpu_cores == 0 {
+            return Err(ApiError::bad_request(
+                "invalid cpu_cores value: expected a positive integer",
+            ));
+        }
+        specs = specs.with_cpu_core_override(cpu_cores);
+    }
+
+    Ok(specs)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -850,6 +936,9 @@ fn active_filters_json(query: &ModelsQuery, top_only: bool) -> serde_json::Value
         "sort": query.sort,
         "max_context": query.max_context,
         "include_too_tight": query.include_too_tight,
+        "ram_gb": query.ram_gb,
+        "vram_gb": query.vram_gb,
+        "cpu_cores": query.cpu_cores,
         "top_only": top_only,
     })
 }
@@ -1081,6 +1170,70 @@ mod tests {
             let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
             assert!(value.get("node").is_some());
             assert!(value.get("system").is_some());
+        });
+    }
+
+    #[test]
+    fn system_endpoint_applies_hardware_overrides() {
+        run_async(async {
+            let response = test_router()
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/v1/system?ram_gb=64&vram_gb=24&cpu_cores=16")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = response.into_body().collect().await.unwrap().to_bytes();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(value["system"]["total_ram_gb"], 64.0);
+            assert_eq!(value["system"]["gpu_vram_gb"], 24.0);
+            assert_eq!(value["system"]["cpu_cores"], 16);
+        });
+    }
+
+    #[test]
+    fn models_endpoint_returns_effective_simulated_system() {
+        run_async(async {
+            let response = test_router()
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/v1/models?limit=1&ram_gb=48&vram_gb=12&cpu_cores=8")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = response.into_body().collect().await.unwrap().to_bytes();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(value["filters"]["ram_gb"], 48.0);
+            assert_eq!(value["filters"]["vram_gb"], 12.0);
+            assert_eq!(value["filters"]["cpu_cores"], 8);
+            assert_eq!(value["system"]["total_ram_gb"], 48.0);
+            assert_eq!(value["system"]["gpu_vram_gb"], 12.0);
+            assert_eq!(value["system"]["cpu_cores"], 8);
+        });
+    }
+
+    #[test]
+    fn invalid_cpu_override_returns_bad_request() {
+        run_async(async {
+            let response = test_router()
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/v1/system?cpu_cores=0")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         });
     }
 

--- a/llmfit-web/src/App.jsx
+++ b/llmfit-web/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { FilterProvider } from './contexts/FilterContext';
+import { I18nProvider, useI18n } from './contexts/I18nContext';
 import { ModelProvider, useModelContext } from './contexts/ModelContext';
 import { useModels } from './hooks/useModels';
 import { useSystem } from './hooks/useSystem';
@@ -17,6 +18,7 @@ function DataLoader() {
 }
 
 function ModelsSection() {
+  const { t } = useI18n();
   const { compareList, clearCompare, returned, total } = useModelContext();
   const [showCompare, setShowCompare] = useState(false);
 
@@ -34,7 +36,7 @@ function ModelsSection() {
   return (
     <section className="panel models-panel">
       <div className="panel-heading">
-        <h2>Model Fit Explorer</h2>
+        <h2>{t('models.title')}</h2>
         <div className="panel-heading-actions">
           {compareCount > 0 && (
             <button
@@ -42,13 +44,13 @@ function ModelsSection() {
               className="btn btn-ghost btn-sm"
               onClick={openCompare}
               disabled={compareCount < 2}
-              title={compareCount < 2 ? 'Select at least 2 models to compare' : ''}
+              title={compareCount < 2 ? t('models.compareDisabledTooltip') : ''}
             >
-              Compare ({compareCount})
+              {t('models.compareAction', { count: compareCount })}
             </button>
           )}
           <span className="chip">
-            {returned} shown / {total} matched
+            {t('models.summary', { returned, total })}
           </span>
         </div>
       </div>
@@ -69,18 +71,20 @@ function ModelsSection() {
 
 export default function App() {
   return (
-    <FilterProvider>
-      <ModelProvider>
-        <DataLoader />
-        <div className="page-shell">
-          <div className="orb orb-one" aria-hidden="true" />
-          <div className="orb orb-two" aria-hidden="true" />
+    <I18nProvider>
+      <FilterProvider>
+        <ModelProvider>
+          <DataLoader />
+          <div className="page-shell">
+            <div className="orb orb-one" aria-hidden="true" />
+            <div className="orb orb-two" aria-hidden="true" />
 
-          <Header />
-          <SystemPanel />
-          <ModelsSection />
-        </div>
-      </ModelProvider>
-    </FilterProvider>
+            <Header />
+            <SystemPanel />
+            <ModelsSection />
+          </div>
+        </ModelProvider>
+      </FilterProvider>
+    </I18nProvider>
   );
 }

--- a/llmfit-web/src/App.test.jsx
+++ b/llmfit-web/src/App.test.jsx
@@ -106,25 +106,46 @@ const modelsPayload = {
   ]
 };
 
+function installFetchMock() {
+  const fetchMock = vi.fn((url) => {
+    const target = String(url);
+    if (target.includes('/api/v1/system')) {
+      return Promise.resolve(jsonResponse(systemPayload));
+    }
+    if (target.includes('/api/v1/models')) {
+      return Promise.resolve(jsonResponse(modelsPayload));
+    }
+    return Promise.reject(new Error(`Unexpected URL: ${target}`));
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+const originalNavigatorLanguage = Object.getOwnPropertyDescriptor(window.navigator, 'language');
+
+function setNavigatorLanguage(language) {
+  Object.defineProperty(window.navigator, 'language', {
+    configurable: true,
+    value: language
+  });
+}
+
 describe('App', () => {
+  beforeEach(() => {
+    setNavigatorLanguage('en-US');
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
     window.localStorage.clear();
+    if (originalNavigatorLanguage) {
+      Object.defineProperty(window.navigator, 'language', originalNavigatorLanguage);
+    }
   });
 
   it('renders models and refetches when sort changes', async () => {
-    const fetchMock = vi.fn((url) => {
-      const target = String(url);
-      if (target.includes('/api/v1/system')) {
-        return Promise.resolve(jsonResponse(systemPayload));
-      }
-      if (target.includes('/api/v1/models')) {
-        return Promise.resolve(jsonResponse(modelsPayload));
-      }
-      return Promise.reject(new Error(`Unexpected URL: ${target}`));
-    });
-
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = installFetchMock();
 
     render(<App />);
 
@@ -140,13 +161,7 @@ describe('App', () => {
   });
 
   it('opens detail diagnostics when a model row is selected', async () => {
-    vi.stubGlobal('fetch', vi.fn((url) => {
-      const target = String(url);
-      if (target.includes('/api/v1/system')) {
-        return Promise.resolve(jsonResponse(systemPayload));
-      }
-      return Promise.resolve(jsonResponse(modelsPayload));
-    }));
+    installFetchMock();
 
     render(<App />);
 
@@ -177,13 +192,7 @@ describe('App', () => {
   });
 
   it('switches theme via theme picker', async () => {
-    vi.stubGlobal('fetch', vi.fn((url) => {
-      const target = String(url);
-      if (target.includes('/api/v1/system')) {
-        return Promise.resolve(jsonResponse(systemPayload));
-      }
-      return Promise.resolve(jsonResponse(modelsPayload));
-    }));
+    installFetchMock();
 
     render(<App />);
 
@@ -194,13 +203,7 @@ describe('App', () => {
   });
 
   it('can filter to too-tight only', async () => {
-    vi.stubGlobal('fetch', vi.fn((url) => {
-      const target = String(url);
-      if (target.includes('/api/v1/system')) {
-        return Promise.resolve(jsonResponse(systemPayload));
-      }
-      return Promise.resolve(jsonResponse(modelsPayload));
-    }));
+    installFetchMock();
 
     render(<App />);
 
@@ -209,5 +212,35 @@ describe('App', () => {
 
     expect(await screen.findAllByText('LargeModel/220B-Preview')).not.toHaveLength(0);
     expect(screen.queryAllByText('Qwen/Qwen2.5-7B-Instruct')).toHaveLength(0);
+  });
+
+  it('defaults to Chinese when navigator language is Chinese', async () => {
+    setNavigatorLanguage('zh-CN');
+    installFetchMock();
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: 'llmfit 控制台' })).toBeInTheDocument();
+    expect(screen.getByText('模型适配分析')).toBeInTheDocument();
+    expect(window.localStorage.getItem('llmfit.locale')).toBe('zh-CN');
+  });
+
+  it('persists manual locale switching across remounts', async () => {
+    installFetchMock();
+
+    const { unmount } = render(<App />);
+
+    const localePicker = await screen.findByLabelText('Language');
+    fireEvent.change(localePicker, { target: { value: 'zh-CN' } });
+
+    expect(await screen.findByRole('heading', { name: 'llmfit 控制台' })).toBeInTheDocument();
+    expect(window.localStorage.getItem('llmfit.locale')).toBe('zh-CN');
+
+    unmount();
+    installFetchMock();
+    render(<App />);
+
+    expect(await screen.findByLabelText('语言')).toHaveValue('zh-CN');
+    expect(screen.getByText('系统信息')).toBeInTheDocument();
   });
 });

--- a/llmfit-web/src/api.js
+++ b/llmfit-web/src/api.js
@@ -12,7 +12,40 @@ function trimOrEmpty(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
 
-export function buildModelsQuery(filters) {
+function parseOptionalNumber(value) {
+  const raw = trimOrEmpty(String(value ?? ''));
+  if (!raw) {
+    return null;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function appendSimulationParams(params, simulation = {}) {
+  const ramGb = parseOptionalNumber(simulation.ramGb);
+  if (ramGb !== null && ramGb > 0) {
+    params.set('ram_gb', String(ramGb));
+  }
+
+  const vramGb = parseOptionalNumber(simulation.vramGb);
+  if (vramGb !== null && vramGb >= 0) {
+    params.set('vram_gb', String(vramGb));
+  }
+
+  const cpuCores = parseOptionalNumber(simulation.cpuCores);
+  if (cpuCores !== null && cpuCores > 0) {
+    params.set('cpu_cores', String(Math.trunc(cpuCores)));
+  }
+
+  return params;
+}
+
+export function buildModelsQuery(filters, simulation = {}) {
   const params = new URLSearchParams();
 
   const search = trimOrEmpty(filters.search);
@@ -65,6 +98,7 @@ export function buildModelsQuery(filters) {
     }
   }
 
+  appendSimulationParams(params, simulation);
   return params.toString();
 }
 
@@ -84,13 +118,15 @@ async function parseJsonOrThrow(response) {
   return payload;
 }
 
-export async function fetchSystemInfo(signal) {
-  const response = await fetch('/api/v1/system', { signal });
+export async function fetchSystemInfo(simulation = {}, signal) {
+  const query = appendSimulationParams(new URLSearchParams(), simulation).toString();
+  const path = query ? `/api/v1/system?${query}` : '/api/v1/system';
+  const response = await fetch(path, { signal });
   return parseJsonOrThrow(response);
 }
 
-export async function fetchModels(filters, signal) {
-  const query = buildModelsQuery(filters);
+export async function fetchModels(filters, simulation = {}, signal) {
+  const query = buildModelsQuery(filters, simulation);
   const path = query ? `/api/v1/models?${query}` : '/api/v1/models';
   const response = await fetch(path, { signal });
   return parseJsonOrThrow(response);
@@ -121,11 +157,30 @@ export async function fetchDownloadStatus(id, signal) {
   return parseJsonOrThrow(response);
 }
 
-export async function fetchPlanEstimate({ model, context, quant, target_tps }, signal) {
+export async function fetchPlanEstimate(
+  { model, context, quant, kv_quant, target_tps },
+  simulation = {},
+  signal
+) {
+  const body = { model, context, quant, kv_quant, target_tps };
+  const ramGb = parseOptionalNumber(simulation.ramGb);
+  const vramGb = parseOptionalNumber(simulation.vramGb);
+  const cpuCores = parseOptionalNumber(simulation.cpuCores);
+
+  if (ramGb !== null && ramGb > 0) {
+    body.ram_gb = ramGb;
+  }
+  if (vramGb !== null && vramGb >= 0) {
+    body.vram_gb = vramGb;
+  }
+  if (cpuCores !== null && cpuCores > 0) {
+    body.cpu_cores = Math.trunc(cpuCores);
+  }
+
   const response = await fetch('/api/v1/plan', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ model, context, quant, target_tps }),
+    body: JSON.stringify(body),
     signal
   });
   return parseJsonOrThrow(response);

--- a/llmfit-web/src/api.test.js
+++ b/llmfit-web/src/api.test.js
@@ -1,4 +1,4 @@
-import { buildModelsQuery } from './api';
+import { appendSimulationParams, buildModelsQuery } from './api';
 
 describe('buildModelsQuery', () => {
   it('maps filter state to API query parameters', () => {
@@ -60,5 +60,43 @@ describe('buildModelsQuery', () => {
     expect(params.get('sort')).toBe('score');
     expect(params.get('limit')).toBeNull();
     expect(params.get('include_too_tight')).toBe('true');
+  });
+
+  it('includes hardware simulation params when present', () => {
+    const query = buildModelsQuery(
+      {
+        search: 'qwen',
+        minFit: 'good',
+        runtime: 'llamacpp',
+        useCase: 'coding',
+        provider: 'Qwen',
+        sort: 'tps',
+        limit: 25
+      },
+      {
+        ramGb: '64',
+        vramGb: '24',
+        cpuCores: '16'
+      }
+    );
+
+    const params = new URLSearchParams(query);
+    expect(params.get('ram_gb')).toBe('64');
+    expect(params.get('vram_gb')).toBe('24');
+    expect(params.get('cpu_cores')).toBe('16');
+  });
+});
+
+describe('appendSimulationParams', () => {
+  it('ignores invalid values and preserves zero vram', () => {
+    const params = appendSimulationParams(new URLSearchParams(), {
+      ramGb: 'abc',
+      vramGb: '0',
+      cpuCores: '-2'
+    });
+
+    expect(params.get('ram_gb')).toBeNull();
+    expect(params.get('vram_gb')).toBe('0');
+    expect(params.get('cpu_cores')).toBeNull();
   });
 });

--- a/llmfit-web/src/components/ComparePanel.jsx
+++ b/llmfit-web/src/components/ComparePanel.jsx
@@ -1,42 +1,45 @@
 import { useMemo } from 'react';
+import { useI18n } from '../contexts/I18nContext';
 import { useModelContext } from '../contexts/ModelContext';
-import { round } from '../utils';
+import { round, translateFitLevel, translateRunMode } from '../utils';
 
-const COMPARE_FIELDS = [
-  { key: 'fit_label', label: 'Fit level', type: 'text' },
-  { key: 'score', label: 'Score', type: 'number', digits: 1, best: 'max' },
-  {
-    key: 'estimated_tps',
-    label: 'TPS',
-    type: 'number',
-    digits: 1,
-    best: 'max'
-  },
-  {
-    key: 'memory_required_gb',
-    label: 'Memory required (GB)',
-    type: 'number',
-    digits: 2,
-    best: 'min'
-  },
-  {
-    key: 'memory_available_gb',
-    label: 'Memory available (GB)',
-    type: 'number',
-    digits: 2,
-    best: 'max'
-  },
-  { key: 'best_quant', label: 'Best quant', type: 'text' },
-  {
-    key: 'context_length',
-    label: 'Context',
-    type: 'number',
-    digits: 0,
-    best: 'max'
-  },
-  { key: 'runtime_label', label: 'Runtime', type: 'text' },
-  { key: 'run_mode_label', label: 'Run mode', type: 'text' }
-];
+function buildCompareFields(t) {
+  return [
+    { key: 'fit_level', label: t('compare.fields.fitLevel'), type: 'fit' },
+    { key: 'score', label: t('compare.fields.score'), type: 'number', digits: 1, best: 'max' },
+    {
+      key: 'estimated_tps',
+      label: t('compare.fields.tps'),
+      type: 'number',
+      digits: 1,
+      best: 'max'
+    },
+    {
+      key: 'memory_required_gb',
+      label: t('compare.fields.memoryRequired'),
+      type: 'number',
+      digits: 2,
+      best: 'min'
+    },
+    {
+      key: 'memory_available_gb',
+      label: t('compare.fields.memoryAvailable'),
+      type: 'number',
+      digits: 2,
+      best: 'max'
+    },
+    { key: 'best_quant', label: t('compare.fields.bestQuant'), type: 'text' },
+    {
+      key: 'context_length',
+      label: t('compare.fields.context'),
+      type: 'number',
+      digits: 0,
+      best: 'max'
+    },
+    { key: 'runtime_label', label: t('compare.fields.runtime'), type: 'text' },
+    { key: 'run_mode', label: t('compare.fields.runMode'), type: 'run_mode' }
+  ];
+}
 
 function bestValue(compareModels, field) {
   if (field.type !== 'number' || !field.best) return null;
@@ -47,20 +50,28 @@ function bestValue(compareModels, field) {
   return field.best === 'max' ? Math.max(...values) : Math.min(...values);
 }
 
-function formatField(model, field) {
+function formatField(t, locale, model, field) {
   const val = model[field.key];
   if (field.type === 'number') {
     if (field.key === 'context_length') {
-      return val?.toLocaleString?.() ?? val ?? '\u2014';
+      return typeof val === 'number' ? val.toLocaleString(locale) : (val ?? '\u2014');
     }
     return round(val, field.digits ?? 1);
+  }
+  if (field.type === 'fit') {
+    return translateFitLevel(t, model.fit_level, model.fit_label);
+  }
+  if (field.type === 'run_mode') {
+    return translateRunMode(t, model.run_mode, model.run_mode_label);
   }
   return val ?? '\u2014';
 }
 
 export default function ComparePanel({ onClose }) {
+  const { locale, t } = useI18n();
   const { models, compareList } = useModelContext();
   const close = onClose || (() => {});
+  const compareFields = useMemo(() => buildCompareFields(t), [t]);
 
   const compareModels = useMemo(() => {
     return compareList
@@ -72,18 +83,17 @@ export default function ComparePanel({ onClose }) {
     return (
       <div className="compare-panel">
         <div className="compare-header">
-          <h3>Model Comparison</h3>
+          <h3>{t('compare.titleEmpty')}</h3>
           <button
             type="button"
             className="btn btn-ghost btn-sm"
             onClick={close}
           >
-            Close
+            {t('compare.close')}
           </button>
         </div>
         <p className="muted-copy">
-          Select models using the checkboxes in the table to compare them side by
-          side.
+          {t('compare.instructions')}
         </p>
       </div>
     );
@@ -92,16 +102,13 @@ export default function ComparePanel({ onClose }) {
   return (
     <div className="compare-panel">
       <div className="compare-header">
-        <h3>
-          Comparing {compareModels.length} model
-          {compareModels.length !== 1 ? 's' : ''}
-        </h3>
+        <h3>{t('compare.headerCount', { count: compareModels.length })}</h3>
         <button
           type="button"
           className="btn btn-ghost btn-sm"
           onClick={close}
         >
-          Close
+          {t('compare.close')}
         </button>
       </div>
 
@@ -118,7 +125,7 @@ export default function ComparePanel({ onClose }) {
             </tr>
           </thead>
           <tbody>
-            {COMPARE_FIELDS.map((field) => {
+            {compareFields.map((field) => {
               const best = bestValue(compareModels, field);
               return (
                 <tr key={field.key}>
@@ -135,7 +142,7 @@ export default function ComparePanel({ onClose }) {
                         key={m.name}
                         className={isBest ? 'compare-best' : ''}
                       >
-                        {formatField(m, field)}
+                        {formatField(t, locale, m, field)}
                       </td>
                     );
                   })}

--- a/llmfit-web/src/components/DetailPanel.jsx
+++ b/llmfit-web/src/components/DetailPanel.jsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
+import { useI18n } from '../contexts/I18nContext';
 import { useModelContext } from '../contexts/ModelContext';
-import { round, fitClass } from '../utils';
+import { round, fitClass, translateFitLevel, translateRunMode } from '../utils';
 
 function MetricBar({ label, value }) {
   const safe = Number.isFinite(value) ? Math.max(0, Math.min(value, 100)) : 0;
@@ -18,6 +19,7 @@ function MetricBar({ label, value }) {
 }
 
 export default function DetailPanel() {
+  const { t } = useI18n();
   const { models, selectedModelName } = useModelContext();
 
   const selectedModel = useMemo(
@@ -29,7 +31,7 @@ export default function DetailPanel() {
     return (
       <aside className="details-panel">
         <p className="muted-copy">
-          Select a model row to inspect detailed fit diagnostics.
+          {t('detail.selectPrompt')}
         </p>
       </aside>
     );
@@ -50,48 +52,48 @@ export default function DetailPanel() {
       <div className="details-header">
         <h3>{selectedModel.name}</h3>
         <span className={fitClass(selectedModel.fit_level)}>
-          {selectedModel.fit_label}
+          {translateFitLevel(t, selectedModel.fit_level, selectedModel.fit_label)}
         </span>
       </div>
 
       <dl className="details-grid">
         <div>
-          <dt>Provider</dt>
+          <dt>{t('detail.fields.provider')}</dt>
           <dd>{selectedModel.provider}</dd>
         </div>
         <div>
-          <dt>Run mode</dt>
-          <dd>{selectedModel.run_mode_label}</dd>
+          <dt>{t('detail.fields.runMode')}</dt>
+          <dd>{translateRunMode(t, selectedModel.run_mode, selectedModel.run_mode_label)}</dd>
         </div>
         <div>
-          <dt>Runtime</dt>
+          <dt>{t('detail.fields.runtime')}</dt>
           <dd>{selectedModel.runtime_label}</dd>
         </div>
         <div>
-          <dt>Best quant</dt>
+          <dt>{t('detail.fields.bestQuant')}</dt>
           <dd>{selectedModel.best_quant}</dd>
         </div>
         <div>
-          <dt>Memory required</dt>
+          <dt>{t('detail.fields.memoryRequired')}</dt>
           <dd>{round(selectedModel.memory_required_gb, 2)} GB</dd>
         </div>
         <div>
-          <dt>Memory available</dt>
+          <dt>{t('detail.fields.memoryAvailable')}</dt>
           <dd>{round(selectedModel.memory_available_gb, 2)} GB</dd>
         </div>
         {license && (
           <div>
-            <dt>License</dt>
+            <dt>{t('detail.fields.license')}</dt>
             <dd>{license}</dd>
           </div>
         )}
         {isMoe && (
           <div>
-            <dt>MoE offloaded</dt>
+            <dt>{t('detail.fields.moeOffloaded')}</dt>
             <dd>
               {typeof moeOffloadedGb === 'number'
                 ? `${round(moeOffloadedGb, 2)} GB`
-                : 'Yes (MoE)'}
+                : t('detail.noMoeValue')}
             </dd>
           </div>
         )}
@@ -99,7 +101,7 @@ export default function DetailPanel() {
 
       {capabilities.length > 0 && (
         <div className="metrics-card">
-          <h4>Capabilities</h4>
+          <h4>{t('detail.sections.capabilities')}</h4>
           <div className="capability-badges">
             {capabilities.map((cap) => (
               <span key={cap} className="capability-badge">
@@ -112,7 +114,7 @@ export default function DetailPanel() {
 
       {ggufSources.length > 0 && (
         <div className="metrics-card">
-          <h4>GGUF Sources</h4>
+          <h4>{t('detail.sections.ggufSources')}</h4>
           <ul className="gguf-list">
             {ggufSources.map((source, idx) => {
               const repo = typeof source === 'string' ? source : source.repo;
@@ -134,35 +136,38 @@ export default function DetailPanel() {
       )}
 
       <div className="metrics-card">
-        <h4>Score Breakdown</h4>
+        <h4>{t('detail.sections.scoreBreakdown')}</h4>
         <MetricBar
-          label="Quality"
+          label={t('detail.metrics.quality')}
           value={selectedModel.score_components?.quality}
         />
         <MetricBar
-          label="Speed"
+          label={t('detail.metrics.speed')}
           value={selectedModel.score_components?.speed}
         />
-        <MetricBar label="Fit" value={selectedModel.score_components?.fit} />
         <MetricBar
-          label="Context"
+          label={t('detail.metrics.fit')}
+          value={selectedModel.score_components?.fit}
+        />
+        <MetricBar
+          label={t('detail.metrics.context')}
           value={selectedModel.score_components?.context}
         />
       </div>
 
       <div className="metrics-card">
-        <h4>Performance</h4>
+        <h4>{t('detail.sections.performance')}</h4>
         <MetricBar
-          label="Memory Utilization %"
+          label={t('detail.metrics.memoryUtilization')}
           value={selectedModel.utilization_pct}
         />
         <div className="kpi-grid">
           <div>
-            <span>Composite score</span>
+            <span>{t('detail.metrics.compositeScore')}</span>
             <strong>{round(selectedModel.score, 1)}</strong>
           </div>
           <div>
-            <span>Estimated TPS</span>
+            <span>{t('detail.metrics.estimatedTps')}</span>
             <strong>{round(selectedModel.estimated_tps, 1)}</strong>
           </div>
         </div>
@@ -170,7 +175,7 @@ export default function DetailPanel() {
 
       {Array.isArray(selectedModel.notes) && selectedModel.notes.length > 0 ? (
         <div className="metrics-card">
-          <h4>Notes</h4>
+          <h4>{t('detail.sections.notes')}</h4>
           <ul>
             {selectedModel.notes.map((note, i) => (
               <li key={i}>{note}</li>
@@ -179,7 +184,7 @@ export default function DetailPanel() {
         </div>
       ) : (
         <p className="muted-copy">
-          No additional notes for this model fit.
+          {t('detail.noNotes')}
         </p>
       )}
     </aside>

--- a/llmfit-web/src/components/DetailPanel.jsx
+++ b/llmfit-web/src/components/DetailPanel.jsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { fetchPlanEstimate } from '../api';
 import { useI18n } from '../contexts/I18nContext';
 import { useModelContext } from '../contexts/ModelContext';
 import { round, fitClass, translateFitLevel, translateRunMode } from '../utils';
@@ -18,14 +19,88 @@ function MetricBar({ label, value }) {
   );
 }
 
+function HardwareEstimateCard({ title, estimate, t }) {
+  return (
+    <div className="plan-summary-card">
+      <h5>{title}</h5>
+      <dl className="plan-summary-list">
+        <div>
+          <dt>{t('plan.summary.vram')}</dt>
+          <dd>
+            {typeof estimate?.vram_gb === 'number'
+              ? `${round(estimate.vram_gb, 1)} GB`
+              : t('plan.summary.notRequired')}
+          </dd>
+        </div>
+        <div>
+          <dt>{t('plan.summary.ram')}</dt>
+          <dd>{typeof estimate?.ram_gb === 'number' ? `${round(estimate.ram_gb, 1)} GB` : '\u2014'}</dd>
+        </div>
+        <div>
+          <dt>{t('plan.summary.cpuCores')}</dt>
+          <dd>{typeof estimate?.cpu_cores === 'number' ? estimate.cpu_cores : '\u2014'}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function translatePlanPath(t, path) {
+  return t(`plan.paths.${path}`);
+}
+
 export default function DetailPanel() {
   const { t } = useI18n();
-  const { models, selectedModelName } = useModelContext();
+  const { models, selectedModelName, appliedSimulation, simulationActive } = useModelContext();
+  const [planForm, setPlanForm] = useState({
+    context: '',
+    quant: '',
+    kvQuant: '',
+    targetTps: ''
+  });
+  const [planLoading, setPlanLoading] = useState(false);
+  const [planError, setPlanError] = useState('');
+  const [planResult, setPlanResult] = useState(null);
 
   const selectedModel = useMemo(
     () => models.find((m) => m.name === selectedModelName) ?? null,
     [models, selectedModelName]
   );
+
+  useEffect(() => {
+    if (!selectedModel) {
+      setPlanForm({
+        context: '',
+        quant: '',
+        kvQuant: '',
+        targetTps: ''
+      });
+      setPlanResult(null);
+      setPlanError('');
+      setPlanLoading(false);
+      return;
+    }
+
+    setPlanForm({
+      context: String(
+        Math.max(
+          1,
+          Math.min(
+            Number.isFinite(selectedModel.context_length)
+              ? selectedModel.context_length
+              : 4096,
+            8192
+          )
+        )
+      ),
+      quant: selectedModel.best_quant ?? '',
+      kvQuant: '',
+      targetTps: ''
+    });
+    setPlanResult(null);
+    setPlanError('');
+    setPlanLoading(false);
+  }, [selectedModel]);
 
   if (!selectedModel) {
     return (
@@ -46,6 +121,57 @@ export default function DetailPanel() {
   const license = selectedModel.license || null;
   const isMoe = selectedModel.is_moe === true;
   const moeOffloadedGb = selectedModel.moe_offloaded_gb;
+
+  function updatePlanField(field, value) {
+    setPlanForm((current) => ({
+      ...current,
+      [field]: value
+    }));
+  }
+
+  async function handlePlanSubmit(event) {
+    event.preventDefault();
+
+    const context = Number.parseInt(planForm.context, 10);
+    if (!Number.isFinite(context) || context <= 0) {
+      setPlanError(t('plan.validation.context'));
+      setPlanResult(null);
+      return;
+    }
+
+    let targetTps;
+    if (planForm.targetTps.trim()) {
+      targetTps = Number.parseFloat(planForm.targetTps);
+      if (!Number.isFinite(targetTps) || targetTps <= 0) {
+        setPlanError(t('plan.validation.targetTps'));
+        setPlanResult(null);
+        return;
+      }
+    }
+
+    setPlanLoading(true);
+    setPlanError('');
+    try {
+      const payload = await fetchPlanEstimate(
+        {
+          model: selectedModel.name,
+          context,
+          quant: planForm.quant.trim() || undefined,
+          kv_quant: planForm.kvQuant.trim() || undefined,
+          target_tps: targetTps
+        },
+        appliedSimulation
+      );
+      setPlanResult(payload);
+    } catch (error) {
+      setPlanResult(null);
+      setPlanError(
+        error instanceof Error ? error.message : t('plan.errorFallback')
+      );
+    } finally {
+      setPlanLoading(false);
+    }
+  }
 
   return (
     <aside className="details-panel">
@@ -98,6 +224,229 @@ export default function DetailPanel() {
           </div>
         )}
       </dl>
+
+      <div className="metrics-card planning-card">
+        <div className="planning-header">
+          <div>
+            <h4>{t('plan.title')}</h4>
+            <p className="muted-copy">
+              {simulationActive ? t('plan.simulatedHint') : t('plan.defaultHint')}
+            </p>
+          </div>
+          {simulationActive ? (
+            <span className="chip chip-accent">{t('plan.simulatedBadge')}</span>
+          ) : null}
+        </div>
+
+        <form className="plan-form" onSubmit={handlePlanSubmit}>
+          <div className="plan-grid">
+            <label>
+              <span>{t('plan.fields.context')}</span>
+              <input
+                type="number"
+                min="1"
+                step="1"
+                value={planForm.context}
+                onChange={(event) => updatePlanField('context', event.target.value)}
+                placeholder={t('plan.placeholders.context')}
+              />
+            </label>
+
+            <label>
+              <span>{t('plan.fields.quant')}</span>
+              <input
+                type="text"
+                value={planForm.quant}
+                onChange={(event) => updatePlanField('quant', event.target.value)}
+                placeholder={t('plan.placeholders.quant')}
+              />
+            </label>
+
+            <label>
+              <span>{t('plan.fields.kvQuant')}</span>
+              <input
+                type="text"
+                value={planForm.kvQuant}
+                onChange={(event) => updatePlanField('kvQuant', event.target.value)}
+                placeholder={t('plan.placeholders.kvQuant')}
+              />
+            </label>
+
+            <label>
+              <span>{t('plan.fields.targetTps')}</span>
+              <input
+                type="number"
+                min="0"
+                step="0.1"
+                value={planForm.targetTps}
+                onChange={(event) => updatePlanField('targetTps', event.target.value)}
+                placeholder={t('plan.placeholders.targetTps')}
+              />
+            </label>
+          </div>
+
+          <div className="plan-actions">
+            <button type="submit" className="btn btn-accent btn-sm" disabled={planLoading}>
+              {planLoading ? t('plan.actions.loading') : t('plan.actions.estimate')}
+            </button>
+          </div>
+        </form>
+
+        {planError ? (
+          <div role="alert" className="alert error">
+            {t('plan.error', { error: planError })}
+          </div>
+        ) : null}
+
+        {planResult ? (
+          <div className="plan-results">
+            <p className="plan-notice">{planResult.estimate_notice}</p>
+
+            <div className="plan-summary-grid">
+              <div className="plan-summary-card">
+                <h5>{t('plan.summary.current')}</h5>
+                <dl className="plan-summary-list">
+                  <div>
+                    <dt>{t('plan.summary.fitLevel')}</dt>
+                    <dd>
+                      {translateFitLevel(
+                        t,
+                        planResult.current?.fit_level,
+                        planResult.current?.fit_level
+                      )}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>{t('plan.summary.runMode')}</dt>
+                    <dd>
+                      {translateRunMode(
+                        t,
+                        planResult.current?.run_mode,
+                        planResult.current?.run_mode
+                      )}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>{t('plan.summary.estimatedTps')}</dt>
+                    <dd>{round(planResult.current?.estimated_tps, 1)}</dd>
+                  </div>
+                  <div>
+                    <dt>{t('plan.summary.kvQuant')}</dt>
+                    <dd>{planResult.kv_quant?.label ?? planResult.kv_quant ?? '\u2014'}</dd>
+                  </div>
+                </dl>
+              </div>
+
+              <HardwareEstimateCard
+                title={t('plan.summary.minimum')}
+                estimate={planResult.minimum}
+                t={t}
+              />
+              <HardwareEstimateCard
+                title={t('plan.summary.recommended')}
+                estimate={planResult.recommended}
+                t={t}
+              />
+            </div>
+
+            <div className="plan-section">
+              <h5>{t('plan.sections.paths')}</h5>
+              <div className="plan-runpaths">
+                {(planResult.run_paths ?? []).map((path) => (
+                  <article key={path.path} className="plan-path-card">
+                    <div className="plan-path-header">
+                      <strong>{translatePlanPath(t, path.path)}</strong>
+                      <span className={`fit ${path.feasible ? 'fit-good' : 'fit-too_tight'}`}>
+                        {path.feasible ? t('plan.pathsFeasible.yes') : t('plan.pathsFeasible.no')}
+                      </span>
+                    </div>
+                    <dl className="plan-summary-list">
+                      <div>
+                        <dt>{t('plan.summary.fitLevel')}</dt>
+                        <dd>
+                          {path.fit_level
+                            ? translateFitLevel(t, path.fit_level, path.fit_level)
+                            : '\u2014'}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>{t('plan.summary.estimatedTps')}</dt>
+                        <dd>
+                          {typeof path.estimated_tps === 'number'
+                            ? round(path.estimated_tps, 1)
+                            : '\u2014'}
+                        </dd>
+                      </div>
+                    </dl>
+                    <div className="plan-path-estimates">
+                      <HardwareEstimateCard
+                        title={t('plan.summary.minimum')}
+                        estimate={path.minimum}
+                        t={t}
+                      />
+                      <HardwareEstimateCard
+                        title={t('plan.summary.recommended')}
+                        estimate={path.recommended}
+                        t={t}
+                      />
+                    </div>
+                    {Array.isArray(path.notes) && path.notes.length > 0 ? (
+                      <ul className="plan-list">
+                        {path.notes.map((note, index) => (
+                          <li key={`${path.path}-${index}`}>{note}</li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <div className="plan-section">
+              <h5>{t('plan.sections.upgrades')}</h5>
+              {Array.isArray(planResult.upgrade_deltas) && planResult.upgrade_deltas.length > 0 ? (
+                <ul className="plan-list">
+                  {planResult.upgrade_deltas.map((item, index) => (
+                    <li key={`${item.resource}-${index}`}>{item.description}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="muted-copy">{t('plan.noUpgrades')}</p>
+              )}
+            </div>
+
+            {Array.isArray(planResult.kv_alternatives) && planResult.kv_alternatives.length > 0 ? (
+              <div className="plan-section">
+                <h5>{t('plan.sections.kvAlternatives')}</h5>
+                <div className="table-wrap plan-table-wrap">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>{t('plan.kvTable.quant')}</th>
+                        <th>{t('plan.kvTable.memory')}</th>
+                        <th>{t('plan.kvTable.kvCache')}</th>
+                        <th>{t('plan.kvTable.savings')}</th>
+                        <th>{t('plan.kvTable.supported')}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {planResult.kv_alternatives.map((alt) => (
+                        <tr key={alt.kv_quant?.label ?? alt.kv_quant}>
+                          <td>{alt.kv_quant?.label ?? alt.kv_quant}</td>
+                          <td>{round(alt.memory_required_gb, 1)} GB</td>
+                          <td>{round(alt.kv_cache_gb, 1)} GB</td>
+                          <td>{round((alt.savings_fraction ?? 0) * 100, 1)}%</td>
+                          <td>{alt.supported ? t('plan.pathsFeasible.yes') : t('plan.pathsFeasible.no')}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
 
       {capabilities.length > 0 && (
         <div className="metrics-card">

--- a/llmfit-web/src/components/FilterBar.jsx
+++ b/llmfit-web/src/components/FilterBar.jsx
@@ -1,70 +1,11 @@
 import { useMemo, useRef, useState, useEffect } from 'react';
 import { useFilters, useFilterDispatch } from '../contexts/FilterContext';
+import { useI18n } from '../contexts/I18nContext';
 import { useModelContext } from '../contexts/ModelContext';
 import { collectUniqueValues } from '../utils';
 
-const FIT_OPTIONS = [
-  { value: 'marginal', label: 'Runnable (Marginal+)' },
-  { value: 'good', label: 'Good or better' },
-  { value: 'perfect', label: 'Perfect only' },
-  { value: 'too_tight', label: 'Too-tight only' },
-  { value: 'all', label: 'All levels' }
-];
-
-const RUNTIME_OPTIONS = [
-  { value: 'any', label: 'Any runtime' },
-  { value: 'mlx', label: 'MLX' },
-  { value: 'llamacpp', label: 'llama.cpp' },
-  { value: 'vllm', label: 'vLLM' }
-];
-
-const USE_CASE_OPTIONS = [
-  { value: 'all', label: 'All use cases' },
-  { value: 'general', label: 'General' },
-  { value: 'coding', label: 'Coding' },
-  { value: 'reasoning', label: 'Reasoning' },
-  { value: 'chat', label: 'Chat' },
-  { value: 'multimodal', label: 'Multimodal' },
-  { value: 'embedding', label: 'Embedding' }
-];
-
-const LIMIT_OPTIONS = [
-  { value: '10', label: '10' },
-  { value: '20', label: '20' },
-  { value: '50', label: '50' },
-  { value: '100', label: '100' },
-  { value: '200', label: '200' },
-  { value: '', label: 'All' }
-];
-
-const SORT_OPTIONS = [
-  { value: 'score', label: 'Sort: Score' },
-  { value: 'tps', label: 'Sort: TPS' },
-  { value: 'params', label: 'Sort: Params' },
-  { value: 'mem', label: 'Sort: Memory' },
-  { value: 'ctx', label: 'Sort: Context' },
-  { value: 'date', label: 'Sort: Release date' },
-  { value: 'use_case', label: 'Sort: Use case' }
-];
-
-const PARAMS_BUCKET_OPTIONS = [
-  { value: 'all', label: 'All sizes' },
-  { value: 'tiny', label: 'Tiny (<3B)' },
-  { value: 'small', label: 'Small (3-8B)' },
-  { value: 'medium', label: 'Medium (8-30B)' },
-  { value: 'large', label: 'Large (30-70B)' },
-  { value: 'xl', label: 'XL (70B+)' }
-];
-
-const TP_OPTIONS = [
-  { value: 'all', label: 'Any TP' },
-  { value: '1', label: 'TP=1' },
-  { value: '2', label: 'TP=2' },
-  { value: '4', label: 'TP=4' },
-  { value: '8', label: 'TP=8' }
-];
-
 function MultiSelectDropdown({ label, field, options }) {
+  const { t } = useI18n();
   const filters = useFilters();
   const dispatch = useFilterDispatch();
   const [open, setOpen] = useState(false);
@@ -100,13 +41,15 @@ function MultiSelectDropdown({ label, field, options }) {
         className="multi-select-btn"
         onClick={() => setOpen((o) => !o)}
       >
-        {count > 0 ? `${count} selected` : 'Any'}
+        {count > 0
+          ? t('filters.multiSelect.selectedCount', { count })
+          : t('filters.multiSelect.any')}
         <span className="multi-select-caret">{open ? '\u25B2' : '\u25BC'}</span>
       </button>
       {open && (
         <div className="multi-select-popover">
           {options.length === 0 ? (
-            <p className="multi-select-empty">No options available</p>
+            <p className="multi-select-empty">{t('filters.multiSelect.noOptions')}</p>
           ) : (
             options.map((opt) => (
               <label key={opt} className="multi-select-option">
@@ -126,9 +69,92 @@ function MultiSelectDropdown({ label, field, options }) {
 }
 
 export default function FilterBar() {
+  const { t } = useI18n();
   const filters = useFilters();
   const dispatch = useFilterDispatch();
   const { allModels } = useModelContext();
+
+  const FIT_OPTIONS = useMemo(
+    () => [
+      { value: 'marginal', label: t('filters.fitOptions.marginal') },
+      { value: 'good', label: t('filters.fitOptions.good') },
+      { value: 'perfect', label: t('filters.fitOptions.perfect') },
+      { value: 'too_tight', label: t('filters.fitOptions.too_tight') },
+      { value: 'all', label: t('filters.fitOptions.all') },
+    ],
+    [t]
+  );
+
+  const RUNTIME_OPTIONS = useMemo(
+    () => [
+      { value: 'any', label: t('filters.runtimeOptions.any') },
+      { value: 'mlx', label: t('filters.runtimeOptions.mlx') },
+      { value: 'llamacpp', label: t('filters.runtimeOptions.llamacpp') },
+      { value: 'vllm', label: t('filters.runtimeOptions.vllm') },
+    ],
+    [t]
+  );
+
+  const USE_CASE_OPTIONS = useMemo(
+    () => [
+      { value: 'all', label: t('filters.useCaseOptions.all') },
+      { value: 'general', label: t('filters.useCaseOptions.general') },
+      { value: 'coding', label: t('filters.useCaseOptions.coding') },
+      { value: 'reasoning', label: t('filters.useCaseOptions.reasoning') },
+      { value: 'chat', label: t('filters.useCaseOptions.chat') },
+      { value: 'multimodal', label: t('filters.useCaseOptions.multimodal') },
+      { value: 'embedding', label: t('filters.useCaseOptions.embedding') },
+    ],
+    [t]
+  );
+
+  const LIMIT_OPTIONS = useMemo(
+    () => [
+      { value: '10', label: '10' },
+      { value: '20', label: '20' },
+      { value: '50', label: '50' },
+      { value: '100', label: '100' },
+      { value: '200', label: '200' },
+      { value: '', label: t('filters.limitAll') },
+    ],
+    [t]
+  );
+
+  const SORT_OPTIONS = useMemo(
+    () => [
+      { value: 'score', label: t('filters.sortOptions.score') },
+      { value: 'tps', label: t('filters.sortOptions.tps') },
+      { value: 'params', label: t('filters.sortOptions.params') },
+      { value: 'mem', label: t('filters.sortOptions.mem') },
+      { value: 'ctx', label: t('filters.sortOptions.ctx') },
+      { value: 'date', label: t('filters.sortOptions.date') },
+      { value: 'use_case', label: t('filters.sortOptions.use_case') },
+    ],
+    [t]
+  );
+
+  const PARAMS_BUCKET_OPTIONS = useMemo(
+    () => [
+      { value: 'all', label: t('filters.paramsBucketOptions.all') },
+      { value: 'tiny', label: t('filters.paramsBucketOptions.tiny') },
+      { value: 'small', label: t('filters.paramsBucketOptions.small') },
+      { value: 'medium', label: t('filters.paramsBucketOptions.medium') },
+      { value: 'large', label: t('filters.paramsBucketOptions.large') },
+      { value: 'xl', label: t('filters.paramsBucketOptions.xl') },
+    ],
+    [t]
+  );
+
+  const TP_OPTIONS = useMemo(
+    () => [
+      { value: 'all', label: t('filters.tpOptions.all') },
+      { value: '1', label: t('filters.tpOptions.1') },
+      { value: '2', label: t('filters.tpOptions.2') },
+      { value: '4', label: t('filters.tpOptions.4') },
+      { value: '8', label: t('filters.tpOptions.8') },
+    ],
+    [t]
+  );
 
   const handleChange = (field) => (e) => {
     const value =
@@ -164,17 +190,17 @@ export default function FilterBar() {
     <div className="filters-outer">
       <div className="filters-shell">
         <label>
-          <span>Search</span>
+          <span>{t('filters.searchLabel')}</span>
           <input
             type="text"
             value={filters.search}
             onChange={handleChange('search')}
-            placeholder="model, provider, use case"
+            placeholder={t('filters.searchPlaceholder')}
           />
         </label>
 
         <label>
-          <span>Fit filter</span>
+          <span>{t('filters.fitLabel')}</span>
           <select value={filters.minFit} onChange={handleChange('minFit')}>
             {FIT_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -185,7 +211,7 @@ export default function FilterBar() {
         </label>
 
         <label>
-          <span>Runtime</span>
+          <span>{t('filters.runtimeLabel')}</span>
           <select value={filters.runtime} onChange={handleChange('runtime')}>
             {RUNTIME_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -196,7 +222,7 @@ export default function FilterBar() {
         </label>
 
         <label>
-          <span>Use case</span>
+          <span>{t('filters.useCaseLabel')}</span>
           <select value={filters.useCase} onChange={handleChange('useCase')}>
             {USE_CASE_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -207,17 +233,17 @@ export default function FilterBar() {
         </label>
 
         <label>
-          <span>Provider</span>
+          <span>{t('filters.providerLabel')}</span>
           <input
             type="text"
             value={filters.provider}
             onChange={handleChange('provider')}
-            placeholder="Meta, Qwen, Mistral"
+            placeholder={t('filters.providerPlaceholder')}
           />
         </label>
 
         <label>
-          <span>Sort</span>
+          <span>{t('filters.sortLabel')}</span>
           <select value={filters.sort} onChange={handleChange('sort')}>
             {SORT_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -228,7 +254,7 @@ export default function FilterBar() {
         </label>
 
         <label>
-          <span>Limit</span>
+          <span>{t('filters.limitLabel')}</span>
           <select
             value={String(filters.limit)}
             onChange={handleChange('limit')}
@@ -254,43 +280,45 @@ export default function FilterBar() {
             })
           }
         >
-          {filters.showAdvanced ? 'Fewer filters' : 'More filters'}
-          {advancedCount > 0 ? ` (${advancedCount} active)` : ''}
+          {filters.showAdvanced
+            ? t('filters.advancedLess')
+            : t('filters.advancedMore')}
+          {advancedCount > 0 ? ` ${t('filters.advancedActive', { count: advancedCount })}` : ''}
         </button>
       </div>
 
       {filters.showAdvanced && (
         <div className="filters-shell filters-advanced">
           <MultiSelectDropdown
-            label="Capability"
+            label={t('filters.capabilityLabel')}
             field="capability"
             options={availableCapabilities}
           />
 
           <label>
-            <span>License</span>
+            <span>{t('filters.licenseLabel')}</span>
             <input
               type="text"
               value={filters.license}
               onChange={handleChange('license')}
-              placeholder="apache-2.0, mit, ..."
+              placeholder={t('filters.licensePlaceholder')}
             />
           </label>
 
           <MultiSelectDropdown
-            label="Quantization"
+            label={t('filters.quantizationLabel')}
             field="quant"
             options={availableQuants}
           />
 
           <MultiSelectDropdown
-            label="Run mode"
+            label={t('filters.runModeLabel')}
             field="runMode"
             options={availableRunModes}
           />
 
           <label>
-            <span>Params bucket</span>
+            <span>{t('filters.paramsBucketLabel')}</span>
             <select
               value={filters.paramsBucket}
               onChange={handleChange('paramsBucket')}
@@ -304,7 +332,7 @@ export default function FilterBar() {
           </label>
 
           <label>
-            <span>Tensor Parallel</span>
+            <span>{t('filters.tensorParallelLabel')}</span>
             <select value={filters.tp} onChange={handleChange('tp')}>
               {TP_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -315,12 +343,12 @@ export default function FilterBar() {
           </label>
 
           <label>
-            <span>Max context</span>
+            <span>{t('filters.maxContextLabel')}</span>
             <input
               type="number"
               value={filters.maxContext}
               onChange={handleChange('maxContext')}
-              placeholder="e.g. 32768"
+              placeholder={t('filters.maxContextPlaceholder')}
               min="0"
             />
           </label>

--- a/llmfit-web/src/components/Header.jsx
+++ b/llmfit-web/src/components/Header.jsx
@@ -1,20 +1,26 @@
 import { useState, useEffect } from 'react';
 import { useFilterDispatch } from '../contexts/FilterContext';
+import { useI18n } from '../contexts/I18nContext';
 import { useModelContext } from '../contexts/ModelContext';
 
 const THEME_KEY = 'llmfit-theme';
 
 const THEMES = [
-  { value: 'default', label: 'Default' },
-  { value: 'dracula', label: 'Dracula' },
-  { value: 'solarized', label: 'Solarized' },
-  { value: 'nord', label: 'Nord' },
-  { value: 'monokai', label: 'Monokai' },
-  { value: 'gruvbox', label: 'Gruvbox' },
-  { value: 'catppuccin-latte', label: 'Catppuccin Latte' },
-  { value: 'catppuccin-frappe', label: 'Catppuccin Frappé' },
-  { value: 'catppuccin-macchiato', label: 'Catppuccin Macchiato' },
-  { value: 'catppuccin-mocha', label: 'Catppuccin Mocha' },
+  { value: 'default', labelKey: 'themes.default' },
+  { value: 'dracula', labelKey: 'themes.dracula' },
+  { value: 'solarized', labelKey: 'themes.solarized' },
+  { value: 'nord', labelKey: 'themes.nord' },
+  { value: 'monokai', labelKey: 'themes.monokai' },
+  { value: 'gruvbox', labelKey: 'themes.gruvbox' },
+  { value: 'catppuccin-latte', labelKey: 'themes.catppuccin-latte' },
+  { value: 'catppuccin-frappe', labelKey: 'themes.catppuccin-frappe' },
+  { value: 'catppuccin-macchiato', labelKey: 'themes.catppuccin-macchiato' },
+  { value: 'catppuccin-mocha', labelKey: 'themes.catppuccin-mocha' },
+];
+
+const LANGUAGE_OPTIONS = [
+  { value: 'en', labelKey: 'language.english' },
+  { value: 'zh-CN', labelKey: 'language.chinese' },
 ];
 
 function initialTheme() {
@@ -27,7 +33,6 @@ function initialTheme() {
     return stored;
   }
 
-  // Legacy light/dark mapping
   if (stored === 'light') return 'catppuccin-latte';
   if (stored === 'dark') return 'default';
 
@@ -37,6 +42,7 @@ function initialTheme() {
 }
 
 export default function Header() {
+  const { locale, setLocale, t } = useI18n();
   const [theme, setTheme] = useState(initialTheme);
   const dispatch = useFilterDispatch();
   const { triggerRefresh } = useModelContext();
@@ -49,12 +55,9 @@ export default function Header() {
   return (
     <header className="hero-shell">
       <div>
-        <p className="hero-eyebrow">Local LLM Planning</p>
-        <h1>llmfit Dashboard</h1>
-        <p className="hero-copy">
-          Hundreds of models &amp; providers. One command to find what runs on
-          your hardware.
-        </p>
+        <p className="hero-eyebrow">{t('header.eyebrow')}</p>
+        <h1>{t('header.title')}</h1>
+        <p className="hero-copy">{t('header.copy')}</p>
       </div>
 
       <div className="hero-actions">
@@ -63,24 +66,36 @@ export default function Header() {
           onClick={() => dispatch({ type: 'RESET_FILTERS' })}
           className="btn btn-ghost"
         >
-          Reset filters
+          {t('header.resetFilters')}
         </button>
         <button
           type="button"
           onClick={triggerRefresh}
           className="btn btn-accent"
         >
-          Refresh
+          {t('header.refresh')}
         </button>
+        <select
+          value={locale}
+          onChange={(e) => setLocale(e.target.value)}
+          className="btn btn-theme theme-select"
+          aria-label={t('header.localeLabel')}
+        >
+          {LANGUAGE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {t(option.labelKey)}
+            </option>
+          ))}
+        </select>
         <select
           value={theme}
           onChange={(e) => setTheme(e.target.value)}
           className="btn btn-theme theme-select"
-          aria-label="Theme"
+          aria-label={t('header.themeLabel')}
         >
-          {THEMES.map((t) => (
-            <option key={t.value} value={t.value}>
-              {t.label}
+          {THEMES.map((themeOption) => (
+            <option key={themeOption.value} value={themeOption.value}>
+              {t(themeOption.labelKey)}
             </option>
           ))}
         </select>

--- a/llmfit-web/src/components/ModelTable.jsx
+++ b/llmfit-web/src/components/ModelTable.jsx
@@ -1,7 +1,16 @@
+import { useI18n } from '../contexts/I18nContext';
 import { useModelContext, MAX_COMPARE } from '../contexts/ModelContext';
-import { round, fitClass, modeClass, copyModelName } from '../utils';
+import {
+  round,
+  fitClass,
+  modeClass,
+  copyModelName,
+  translateFitLevel,
+  translateRunMode,
+} from '../utils';
 
 export default function ModelTable() {
+  const { locale, t } = useI18n();
   const {
     models,
     loading,
@@ -22,33 +31,32 @@ export default function ModelTable() {
     <div className="table-wrap">
       {error ? (
         <div role="alert" className="alert error" style={{ margin: '0.75rem' }}>
-          Could not load models: {error}. Confirm this page is opened from
-          `llmfit serve`.
+          {t('table.error', { error })}
         </div>
       ) : null}
 
       <table>
         <thead>
           <tr>
-            <th className="col-compare">Cmp</th>
-            <th>Model</th>
-            <th>Provider</th>
-            <th>Params</th>
-            <th>Fit</th>
-            <th>Mode</th>
-            <th>Runtime</th>
-            <th>Score</th>
-            <th>TPS</th>
-            <th>Mem%</th>
-            <th>Context</th>
-            <th>Release</th>
+            <th className="col-compare">{t('table.columns.compare')}</th>
+            <th>{t('table.columns.model')}</th>
+            <th>{t('table.columns.provider')}</th>
+            <th>{t('table.columns.params')}</th>
+            <th>{t('table.columns.fit')}</th>
+            <th>{t('table.columns.mode')}</th>
+            <th>{t('table.columns.runtime')}</th>
+            <th>{t('table.columns.score')}</th>
+            <th>{t('table.columns.tps')}</th>
+            <th>{t('table.columns.mem')}</th>
+            <th>{t('table.columns.context')}</th>
+            <th>{t('table.columns.release')}</th>
           </tr>
         </thead>
         <tbody>
           {loading ? (
             <tr>
               <td colSpan="12" className="table-status">
-                Loading model fit data&hellip;
+                {t('table.loading')}
               </td>
             </tr>
           ) : null}
@@ -56,7 +64,7 @@ export default function ModelTable() {
           {!loading && models.length === 0 && !error ? (
             <tr>
               <td colSpan="12" className="table-status">
-                No models match the current filters.
+                {t('table.empty')}
               </td>
             </tr>
           ) : null}
@@ -86,20 +94,20 @@ export default function ModelTable() {
                         onChange={() => toggleCompare(model.name)}
                         title={
                           disableCompare
-                            ? `Max ${MAX_COMPARE} models for comparison`
-                            : 'Add to comparison'
+                            ? t('table.maxCompare', { count: MAX_COMPARE })
+                            : t('table.addToComparison')
                         }
                       />
                     </td>
                     <td className="model-name">
                       <span>{model.name}</span>
                       {isInstalled && (
-                        <span className="chip chip-installed">Installed</span>
+                        <span className="chip chip-installed">{t('table.installed')}</span>
                       )}
                       <button
                         type="button"
                         className="btn-copy"
-                        title="Copy model name"
+                        title={t('table.copyModelName')}
                         onClick={(e) => {
                           e.stopPropagation();
                           copyModelName(model.name);
@@ -112,12 +120,12 @@ export default function ModelTable() {
                     <td>{round(model.params_b, 1)}B</td>
                     <td>
                       <span className={fitClass(model.fit_level)}>
-                        {model.fit_label}
+                        {translateFitLevel(t, model.fit_level, model.fit_label)}
                       </span>
                     </td>
                     <td>
                       <span className={modeClass(model.run_mode)}>
-                        {model.run_mode_label}
+                        {translateRunMode(t, model.run_mode, model.run_mode_label)}
                       </span>
                     </td>
                     <td>{model.runtime_label}</td>
@@ -125,9 +133,9 @@ export default function ModelTable() {
                     <td>{round(model.estimated_tps, 1)}</td>
                     <td>{round(model.utilization_pct, 1)}</td>
                     <td>
-                      {model.context_length?.toLocaleString?.() ??
-                        model.context_length ??
-                        '\u2014'}
+                      {typeof model.context_length === 'number'
+                        ? model.context_length.toLocaleString(locale)
+                        : model.context_length ?? '\u2014'}
                     </td>
                     <td>{model.release_date ?? '\u2014'}</td>
                   </tr>

--- a/llmfit-web/src/components/SystemPanel.jsx
+++ b/llmfit-web/src/components/SystemPanel.jsx
@@ -14,7 +14,16 @@ function SystemCard({ label, value, detail }) {
 
 export default function SystemPanel() {
   const { t } = useI18n();
-  const { systemInfo, systemLoading, systemError } = useModelContext();
+  const {
+    systemInfo,
+    systemLoading,
+    systemError,
+    simulationDraft,
+    updateSimulationDraft,
+    simulationActive,
+    applySimulation,
+    resetSimulation
+  } = useModelContext();
 
   const gpus = systemInfo?.system?.gpus ?? [];
   const gpuSummary =
@@ -27,15 +36,25 @@ export default function SystemPanel() {
           )
           .join(', ');
 
+  function handleSubmit(event) {
+    event.preventDefault();
+    applySimulation();
+  }
+
   return (
     <section className="panel system-panel">
       <div className="panel-heading">
         <h2>{t('system.title')}</h2>
-        {systemInfo?.node ? (
-          <span className="chip">
-            {systemInfo.node.name} &middot; {systemInfo.node.os}
-          </span>
-        ) : null}
+        <div className="panel-heading-actions">
+          {simulationActive ? (
+            <span className="chip chip-accent">{t('simulation.active')}</span>
+          ) : null}
+          {systemInfo?.node ? (
+            <span className="chip">
+              {systemInfo.node.name} &middot; {systemInfo.node.os}
+            </span>
+          ) : null}
+        </div>
       </div>
 
       {systemError ? (
@@ -80,6 +99,72 @@ export default function SystemPanel() {
           }
         />
       </div>
+
+      <form className="simulation-panel" onSubmit={handleSubmit}>
+        <div className="simulation-header">
+          <div>
+            <h3>{t('simulation.title')}</h3>
+            <p className="muted-copy">
+              {simulationActive
+                ? t('simulation.activeHint')
+                : t('simulation.idleHint')}
+            </p>
+          </div>
+          <div className="simulation-actions">
+            <button type="submit" className="btn btn-accent btn-sm">
+              {simulationActive
+                ? t('simulation.actions.update')
+                : t('simulation.actions.apply')}
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={resetSimulation}
+              disabled={!simulationActive && !Object.values(simulationDraft).some(Boolean)}
+            >
+              {t('simulation.actions.reset')}
+            </button>
+          </div>
+        </div>
+
+        <div className="simulation-grid">
+          <label>
+            <span>{t('simulation.fields.ram')}</span>
+            <input
+              type="number"
+              min="0"
+              step="0.1"
+              value={simulationDraft.ramGb}
+              onChange={(event) => updateSimulationDraft('ramGb', event.target.value)}
+              placeholder={t('simulation.placeholders.ram')}
+            />
+          </label>
+
+          <label>
+            <span>{t('simulation.fields.vram')}</span>
+            <input
+              type="number"
+              min="0"
+              step="0.1"
+              value={simulationDraft.vramGb}
+              onChange={(event) => updateSimulationDraft('vramGb', event.target.value)}
+              placeholder={t('simulation.placeholders.vram')}
+            />
+          </label>
+
+          <label>
+            <span>{t('simulation.fields.cpuCores')}</span>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={simulationDraft.cpuCores}
+              onChange={(event) => updateSimulationDraft('cpuCores', event.target.value)}
+              placeholder={t('simulation.placeholders.cpuCores')}
+            />
+          </label>
+        </div>
+      </form>
     </section>
   );
 }

--- a/llmfit-web/src/components/SystemPanel.jsx
+++ b/llmfit-web/src/components/SystemPanel.jsx
@@ -1,3 +1,4 @@
+import { useI18n } from '../contexts/I18nContext';
 import { useModelContext } from '../contexts/ModelContext';
 import { round } from '../utils';
 
@@ -12,12 +13,13 @@ function SystemCard({ label, value, detail }) {
 }
 
 export default function SystemPanel() {
+  const { t } = useI18n();
   const { systemInfo, systemLoading, systemError } = useModelContext();
 
   const gpus = systemInfo?.system?.gpus ?? [];
   const gpuSummary =
     gpus.length === 0
-      ? 'No GPU detected'
+      ? t('system.noGpu')
       : gpus
           .map(
             (gpu) =>
@@ -28,7 +30,7 @@ export default function SystemPanel() {
   return (
     <section className="panel system-panel">
       <div className="panel-heading">
-        <h2>System Summary</h2>
+        <h2>{t('system.title')}</h2>
         {systemInfo?.node ? (
           <span className="chip">
             {systemInfo.node.name} &middot; {systemInfo.node.os}
@@ -38,23 +40,22 @@ export default function SystemPanel() {
 
       {systemError ? (
         <div role="alert" className="alert error">
-          Could not load system information: {systemError}. Make sure `llmfit
-          serve` is running.
+          {t('system.error', { error: systemError })}
         </div>
       ) : null}
 
       <div className="system-grid" aria-busy={systemLoading}>
         <SystemCard
-          label="CPU"
-          value={systemInfo?.system?.cpu_name ?? 'Loading\u2026'}
+          label={t('system.labels.cpu')}
+          value={systemInfo?.system?.cpu_name ?? t('system.loading')}
           detail={
             systemInfo?.system?.cpu_cores
-              ? `${systemInfo.system.cpu_cores} cores`
+              ? t('system.cores', { count: systemInfo.system.cpu_cores })
               : undefined
           }
         />
         <SystemCard
-          label="Total RAM"
+          label={t('system.labels.totalRam')}
           value={
             systemInfo?.system?.total_ram_gb
               ? `${round(systemInfo.system.total_ram_gb, 1)} GB`
@@ -62,7 +63,7 @@ export default function SystemPanel() {
           }
         />
         <SystemCard
-          label="Available RAM"
+          label={t('system.labels.availableRam')}
           value={
             systemInfo?.system?.available_ram_gb
               ? `${round(systemInfo.system.available_ram_gb, 1)} GB`
@@ -70,11 +71,11 @@ export default function SystemPanel() {
           }
         />
         <SystemCard
-          label="GPU"
+          label={t('system.labels.gpu')}
           value={gpuSummary}
           detail={
             systemInfo?.system?.unified_memory
-              ? 'Unified memory (CPU + GPU shared)'
+              ? t('system.unifiedMemory')
               : undefined
           }
         />

--- a/llmfit-web/src/contexts/I18nContext.jsx
+++ b/llmfit-web/src/contexts/I18nContext.jsx
@@ -1,0 +1,106 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import en from '../i18n/locales/en';
+import zhCN from '../i18n/locales/zh-CN';
+
+export const LOCALE_STORAGE_KEY = 'llmfit.locale';
+const FALLBACK_LOCALE = 'en';
+const SUPPORTED_LOCALES = {
+  en,
+  'zh-CN': zhCN
+};
+
+const I18nContext = createContext({
+  locale: FALLBACK_LOCALE,
+  setLocale: () => {},
+  t: (key) => key
+});
+
+function getNestedValue(obj, key) {
+  return key.split('.').reduce((acc, part) => (acc ? acc[part] : undefined), obj);
+}
+
+function formatMessage(message, params = {}) {
+  if (typeof message === 'function') {
+    return message(params);
+  }
+
+  if (typeof message !== 'string') {
+    return message;
+  }
+
+  return message.replace(/\{(\w+)\}/g, (_, token) => {
+    return params[token] == null ? `{${token}}` : String(params[token]);
+  });
+}
+
+export function normalizeLocale(locale) {
+  if (!locale || typeof locale !== 'string') {
+    return FALLBACK_LOCALE;
+  }
+
+  const normalized = locale.toLowerCase();
+  if (normalized.startsWith('zh')) {
+    return 'zh-CN';
+  }
+
+  return FALLBACK_LOCALE;
+}
+
+export function resolveLocale() {
+  if (typeof window === 'undefined') {
+    return FALLBACK_LOCALE;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(LOCALE_STORAGE_KEY);
+    if (stored) {
+      return normalizeLocale(stored);
+    }
+  } catch (_) {
+    // ignore storage failures
+  }
+
+  return normalizeLocale(window.navigator?.language);
+}
+
+export function resolveMessage(locale, key, params = {}) {
+  const normalizedLocale = normalizeLocale(locale);
+  const message =
+    getNestedValue(SUPPORTED_LOCALES[normalizedLocale], key) ??
+    getNestedValue(SUPPORTED_LOCALES[FALLBACK_LOCALE], key) ??
+    key;
+
+  return formatMessage(message, params);
+}
+
+export function I18nProvider({ children }) {
+  const [locale, setLocaleState] = useState(resolveLocale);
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = locale;
+    }
+
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+      } catch (_) {
+        // ignore storage failures
+      }
+    }
+  }, [locale]);
+
+  const value = useMemo(() => {
+    return {
+      locale,
+      setLocale: (nextLocale) => setLocaleState(normalizeLocale(nextLocale)),
+      t: (key, params) => resolveMessage(locale, key, params)
+    };
+  }, [locale]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/llmfit-web/src/contexts/ModelContext.jsx
+++ b/llmfit-web/src/contexts/ModelContext.jsx
@@ -3,6 +3,19 @@ import { createContext, useCallback, useContext, useState } from 'react';
 const ModelContext = createContext(null);
 
 const MAX_COMPARE = 5;
+const EMPTY_SIMULATION = {
+  ramGb: '',
+  vramGb: '',
+  cpuCores: ''
+};
+
+function sanitizeSimulation(simulation) {
+  return {
+    ramGb: String(simulation?.ramGb ?? '').trim(),
+    vramGb: String(simulation?.vramGb ?? '').trim(),
+    cpuCores: String(simulation?.cpuCores ?? '').trim()
+  };
+}
 
 export function ModelProvider({ children }) {
   const [models, setModels] = useState([]);
@@ -18,10 +31,30 @@ export function ModelProvider({ children }) {
   const [compareList, setCompareList] = useState([]);
   const [installedModels, setInstalledModels] = useState([]);
   const [refreshTick, setRefreshTick] = useState(0);
+  const [simulationDraft, setSimulationDraft] = useState(EMPTY_SIMULATION);
+  const [appliedSimulation, setAppliedSimulation] = useState(EMPTY_SIMULATION);
 
   const triggerRefresh = useCallback(() => {
     setRefreshTick((t) => t + 1);
   }, []);
+
+  const updateSimulationDraft = useCallback((field, value) => {
+    setSimulationDraft((current) => ({
+      ...current,
+      [field]: value
+    }));
+  }, []);
+
+  const applySimulation = useCallback(() => {
+    setAppliedSimulation(sanitizeSimulation(simulationDraft));
+  }, [simulationDraft]);
+
+  const resetSimulation = useCallback(() => {
+    setSimulationDraft(EMPTY_SIMULATION);
+    setAppliedSimulation(EMPTY_SIMULATION);
+  }, []);
+
+  const simulationActive = Object.values(appliedSimulation).some((value) => value !== '');
 
   const toggleCompare = useCallback((modelName) => {
     setCompareList((prev) => {
@@ -66,7 +99,13 @@ export function ModelProvider({ children }) {
     installedModels,
     setInstalledModels,
     refreshTick,
-    triggerRefresh
+    triggerRefresh,
+    simulationDraft,
+    updateSimulationDraft,
+    appliedSimulation,
+    simulationActive,
+    applySimulation,
+    resetSimulation
   };
 
   return (

--- a/llmfit-web/src/hooks/useModels.js
+++ b/llmfit-web/src/hooks/useModels.js
@@ -14,7 +14,8 @@ export function useModels() {
     setLoading,
     setError,
     setSelectedModelName,
-    refreshTick
+    refreshTick,
+    appliedSimulation
   } = useModelContext();
 
   useEffect(() => {
@@ -24,7 +25,7 @@ export function useModels() {
       setLoading(true);
       setError('');
       try {
-        const payload = await fetchModels(filters, controller.signal);
+        const payload = await fetchModels(filters, appliedSimulation, controller.signal);
         const fetchedModels = Array.isArray(payload.models)
           ? payload.models
           : [];
@@ -72,6 +73,7 @@ export function useModels() {
     return () => controller.abort();
   }, [
     filters,
+    appliedSimulation,
     refreshTick,
     setModels,
     setAllModels,

--- a/llmfit-web/src/hooks/useSystem.js
+++ b/llmfit-web/src/hooks/useSystem.js
@@ -7,7 +7,8 @@ export function useSystem() {
     setSystemInfo,
     setSystemLoading,
     setSystemError,
-    refreshTick
+    refreshTick,
+    appliedSimulation
   } = useModelContext();
 
   useEffect(() => {
@@ -17,7 +18,7 @@ export function useSystem() {
       setSystemLoading(true);
       setSystemError('');
       try {
-        const payload = await fetchSystemInfo(controller.signal);
+        const payload = await fetchSystemInfo(appliedSimulation, controller.signal);
         setSystemInfo(payload);
         setSystemLoading(false);
       } catch (error) {
@@ -36,5 +37,11 @@ export function useSystem() {
 
     loadSystem();
     return () => controller.abort();
-  }, [refreshTick, setSystemInfo, setSystemLoading, setSystemError]);
+  }, [
+    refreshTick,
+    appliedSimulation,
+    setSystemInfo,
+    setSystemLoading,
+    setSystemError
+  ]);
 }

--- a/llmfit-web/src/i18n.test.js
+++ b/llmfit-web/src/i18n.test.js
@@ -1,0 +1,12 @@
+import { normalizeLocale, resolveMessage } from './contexts/I18nContext';
+
+describe('i18n helpers', () => {
+  it('normalizes Chinese locales to zh-CN', () => {
+    expect(normalizeLocale('zh')).toBe('zh-CN');
+    expect(normalizeLocale('zh-TW')).toBe('zh-CN');
+  });
+
+  it('falls back to English when a key is missing in the active locale', () => {
+    expect(resolveMessage('zh-CN', 'test.fallbackOnly')).toBe('Fallback only');
+  });
+});

--- a/llmfit-web/src/i18n/locales/en.js
+++ b/llmfit-web/src/i18n/locales/en.js
@@ -1,0 +1,221 @@
+const en = {
+  language: {
+    label: 'Language',
+    english: 'English',
+    chinese: '中文'
+  },
+  header: {
+    eyebrow: 'Local LLM Planning',
+    title: 'llmfit Dashboard',
+    copy: 'Hundreds of models & providers. One command to find what runs on your hardware.',
+    resetFilters: 'Reset filters',
+    refresh: 'Refresh',
+    themeLabel: 'Theme',
+    localeLabel: 'Language'
+  },
+  themes: {
+    default: 'Default',
+    dracula: 'Dracula',
+    solarized: 'Solarized',
+    nord: 'Nord',
+    monokai: 'Monokai',
+    gruvbox: 'Gruvbox',
+    'catppuccin-latte': 'Catppuccin Latte',
+    'catppuccin-frappe': 'Catppuccin Frappé',
+    'catppuccin-macchiato': 'Catppuccin Macchiato',
+    'catppuccin-mocha': 'Catppuccin Mocha'
+  },
+  system: {
+    title: 'System Summary',
+    noGpu: 'No GPU detected',
+    loading: 'Loading…',
+    error: ({ error }) => `Could not load system information: ${error}. Make sure \`llmfit serve\` is running.`,
+    unifiedMemory: 'Unified memory (CPU + GPU shared)',
+    cores: ({ count }) => `${count} cores`,
+    labels: {
+      cpu: 'CPU',
+      totalRam: 'Total RAM',
+      availableRam: 'Available RAM',
+      gpu: 'GPU'
+    }
+  },
+  models: {
+    title: 'Model Fit Explorer',
+    compareAction: ({ count }) => `Compare (${count})`,
+    compareDisabledTooltip: 'Select at least 2 models to compare',
+    summary: ({ returned, total }) => `${returned} shown / ${total} matched`
+  },
+  filters: {
+    searchLabel: 'Search',
+    searchPlaceholder: 'model, provider, use case',
+    fitLabel: 'Fit filter',
+    runtimeLabel: 'Runtime',
+    useCaseLabel: 'Use case',
+    providerLabel: 'Provider',
+    providerPlaceholder: 'Meta, Qwen, Mistral',
+    sortLabel: 'Sort',
+    limitLabel: 'Limit',
+    limitAll: 'All',
+    capabilityLabel: 'Capability',
+    licenseLabel: 'License',
+    licensePlaceholder: 'apache-2.0, mit, ...',
+    quantizationLabel: 'Quantization',
+    runModeLabel: 'Run mode',
+    paramsBucketLabel: 'Params bucket',
+    tensorParallelLabel: 'Tensor Parallel',
+    maxContextLabel: 'Max context',
+    maxContextPlaceholder: 'e.g. 32768',
+    advancedMore: 'More filters',
+    advancedLess: 'Fewer filters',
+    advancedActive: ({ count }) => `(${count} active)`,
+    multiSelect: {
+      any: 'Any',
+      selectedCount: ({ count }) => `${count} selected`,
+      noOptions: 'No options available'
+    },
+    fitOptions: {
+      marginal: 'Runnable (Marginal+)',
+      good: 'Good or better',
+      perfect: 'Perfect only',
+      too_tight: 'Too-tight only',
+      all: 'All levels'
+    },
+    runtimeOptions: {
+      any: 'Any runtime',
+      mlx: 'MLX',
+      llamacpp: 'llama.cpp',
+      vllm: 'vLLM'
+    },
+    useCaseOptions: {
+      all: 'All use cases',
+      general: 'General',
+      coding: 'Coding',
+      reasoning: 'Reasoning',
+      chat: 'Chat',
+      multimodal: 'Multimodal',
+      embedding: 'Embedding'
+    },
+    sortOptions: {
+      score: 'Sort: Score',
+      tps: 'Sort: TPS',
+      params: 'Sort: Params',
+      mem: 'Sort: Memory',
+      ctx: 'Sort: Context',
+      date: 'Sort: Release date',
+      use_case: 'Sort: Use case'
+    },
+    paramsBucketOptions: {
+      all: 'All sizes',
+      tiny: 'Tiny (<3B)',
+      small: 'Small (3-8B)',
+      medium: 'Medium (8-30B)',
+      large: 'Large (30-70B)',
+      xl: 'XL (70B+)'
+    },
+    tpOptions: {
+      all: 'Any TP',
+      1: 'TP=1',
+      2: 'TP=2',
+      4: 'TP=4',
+      8: 'TP=8'
+    }
+  },
+  table: {
+    error: ({ error }) => `Could not load models: ${error}. Confirm this page is opened from \`llmfit serve\`.`,
+    loading: 'Loading model fit data…',
+    empty: 'No models match the current filters.',
+    copyModelName: 'Copy model name',
+    addToComparison: 'Add to comparison',
+    maxCompare: ({ count }) => `Max ${count} models for comparison`,
+    installed: 'Installed',
+    columns: {
+      compare: 'Cmp',
+      model: 'Model',
+      provider: 'Provider',
+      params: 'Params',
+      fit: 'Fit',
+      mode: 'Mode',
+      runtime: 'Runtime',
+      score: 'Score',
+      tps: 'TPS',
+      mem: 'Mem%',
+      context: 'Context',
+      release: 'Release'
+    }
+  },
+  detail: {
+    selectPrompt: 'Select a model row to inspect detailed fit diagnostics.',
+    sections: {
+      capabilities: 'Capabilities',
+      ggufSources: 'GGUF Sources',
+      scoreBreakdown: 'Score Breakdown',
+      performance: 'Performance',
+      notes: 'Notes'
+    },
+    fields: {
+      provider: 'Provider',
+      runMode: 'Run mode',
+      runtime: 'Runtime',
+      bestQuant: 'Best quant',
+      memoryRequired: 'Memory required',
+      memoryAvailable: 'Memory available',
+      license: 'License',
+      moeOffloaded: 'MoE offloaded'
+    },
+    metrics: {
+      quality: 'Quality',
+      speed: 'Speed',
+      fit: 'Fit',
+      context: 'Context',
+      memoryUtilization: 'Memory Utilization %',
+      compositeScore: 'Composite score',
+      estimatedTps: 'Estimated TPS'
+    },
+    noMoeValue: 'Yes (MoE)',
+    noNotes: 'No additional notes for this model fit.'
+  },
+  compare: {
+    titleEmpty: 'Model Comparison',
+    instructions: 'Select models using the checkboxes in the table to compare them side by side.',
+    close: 'Close',
+    headerCount: ({ count }) => `Comparing ${count} model${count !== 1 ? 's' : ''}`,
+    fields: {
+      fitLevel: 'Fit level',
+      score: 'Score',
+      tps: 'TPS',
+      memoryRequired: 'Memory required (GB)',
+      memoryAvailable: 'Memory available (GB)',
+      bestQuant: 'Best quant',
+      context: 'Context',
+      runtime: 'Runtime',
+      runMode: 'Run mode'
+    }
+  },
+  labels: {
+    fit: {
+      perfect: 'Perfect',
+      good: 'Good',
+      marginal: 'Marginal',
+      too_tight: 'Too Tight'
+    },
+    runMode: {
+      gpu: 'GPU',
+      moe_offload: 'MoE Offload',
+      cpu_offload: 'CPU Offload',
+      cpu_only: 'CPU Only'
+    },
+    useCase: {
+      general: 'General',
+      coding: 'Coding',
+      reasoning: 'Reasoning',
+      chat: 'Chat',
+      multimodal: 'Multimodal',
+      embedding: 'Embedding'
+    }
+  },
+  test: {
+    fallbackOnly: 'Fallback only'
+  }
+};
+
+export default en;

--- a/llmfit-web/src/i18n/locales/en.js
+++ b/llmfit-web/src/i18n/locales/en.js
@@ -39,6 +39,27 @@ const en = {
       gpu: 'GPU'
     }
   },
+  simulation: {
+    title: 'Hardware Simulation',
+    active: 'Simulation Active',
+    idleHint: 'Override RAM, VRAM, or CPU cores to rescore all models against a target machine.',
+    activeHint: 'Current model fits and plan estimates are based on your simulated hardware.',
+    fields: {
+      ram: 'RAM (GB)',
+      vram: 'VRAM (GB)',
+      cpuCores: 'CPU Cores'
+    },
+    placeholders: {
+      ram: 'e.g. 64',
+      vram: 'e.g. 24',
+      cpuCores: 'e.g. 16'
+    },
+    actions: {
+      apply: 'Apply simulation',
+      update: 'Update simulation',
+      reset: 'Reset'
+    }
+  },
   models: {
     title: 'Model Fit Explorer',
     compareAction: ({ count }) => `Compare (${count})`,
@@ -173,6 +194,69 @@ const en = {
     },
     noMoeValue: 'Yes (MoE)',
     noNotes: 'No additional notes for this model fit.'
+  },
+  plan: {
+    title: 'Planning',
+    defaultHint: 'Estimate the minimum and recommended hardware for this model.',
+    simulatedHint: 'This estimate is using your simulated hardware profile.',
+    simulatedBadge: 'Simulated',
+    error: ({ error }) => `Plan request failed: ${error}`,
+    errorFallback: 'Unable to estimate hardware plan.',
+    validation: {
+      context: 'Context must be a positive integer.',
+      targetTps: 'Target TPS must be a positive number.'
+    },
+    fields: {
+      context: 'Context',
+      quant: 'Quant',
+      kvQuant: 'KV quant',
+      targetTps: 'Target TPS'
+    },
+    placeholders: {
+      context: 'e.g. 8192',
+      quant: 'e.g. Q4_K_M',
+      kvQuant: 'fp16, fp8, q8_0, q4_0, tq',
+      targetTps: 'optional'
+    },
+    actions: {
+      estimate: 'Estimate plan',
+      loading: 'Estimating…'
+    },
+    sections: {
+      paths: 'Run paths',
+      upgrades: 'Upgrade guidance',
+      kvAlternatives: 'KV cache alternatives'
+    },
+    summary: {
+      current: 'Current status',
+      minimum: 'Minimum hardware',
+      recommended: 'Recommended hardware',
+      fitLevel: 'Fit level',
+      runMode: 'Run mode',
+      estimatedTps: 'Estimated TPS',
+      kvQuant: 'KV quant',
+      vram: 'VRAM',
+      ram: 'RAM',
+      cpuCores: 'CPU cores',
+      notRequired: 'Not required'
+    },
+    paths: {
+      gpu: 'GPU',
+      cpu_offload: 'CPU offload',
+      cpu_only: 'CPU-only'
+    },
+    pathsFeasible: {
+      yes: 'Feasible',
+      no: 'Not feasible'
+    },
+    noUpgrades: 'The current target already satisfies this estimate.',
+    kvTable: {
+      quant: 'KV quant',
+      memory: 'Total memory',
+      kvCache: 'KV cache',
+      savings: 'Savings',
+      supported: 'Supported'
+    }
   },
   compare: {
     titleEmpty: 'Model Comparison',

--- a/llmfit-web/src/i18n/locales/zh-CN.js
+++ b/llmfit-web/src/i18n/locales/zh-CN.js
@@ -1,0 +1,218 @@
+const zhCN = {
+  language: {
+    label: '语言',
+    english: 'English',
+    chinese: '中文'
+  },
+  header: {
+    eyebrow: '本地 LLM 规划',
+    title: 'llmfit 控制台',
+    copy: '聚合海量模型与提供方，用一条命令找出哪些模型能在你的硬件上真正跑起来。',
+    resetFilters: '重置筛选',
+    refresh: '刷新',
+    themeLabel: '主题',
+    localeLabel: '语言'
+  },
+  themes: {
+    default: '默认',
+    dracula: 'Dracula',
+    solarized: 'Solarized',
+    nord: 'Nord',
+    monokai: 'Monokai',
+    gruvbox: 'Gruvbox',
+    'catppuccin-latte': 'Catppuccin Latte',
+    'catppuccin-frappe': 'Catppuccin Frappé',
+    'catppuccin-macchiato': 'Catppuccin Macchiato',
+    'catppuccin-mocha': 'Catppuccin Mocha'
+  },
+  system: {
+    title: '系统信息',
+    noGpu: '未检测到 GPU',
+    loading: '加载中…',
+    error: ({ error }) => `无法加载系统信息：${error}。请确认 \`llmfit serve\` 正在运行。`,
+    unifiedMemory: '统一内存（CPU 与 GPU 共享）',
+    cores: ({ count }) => `${count} 核`,
+    labels: {
+      cpu: 'CPU',
+      totalRam: '总内存',
+      availableRam: '可用内存',
+      gpu: 'GPU'
+    }
+  },
+  models: {
+    title: '模型适配分析',
+    compareAction: ({ count }) => `对比（${count}）`,
+    compareDisabledTooltip: '至少选择 2 个模型后才能对比',
+    summary: ({ returned, total }) => `当前显示 ${returned} / 匹配 ${total}`
+  },
+  filters: {
+    searchLabel: '搜索',
+    searchPlaceholder: '模型、提供方、用途',
+    fitLabel: '适配筛选',
+    runtimeLabel: '运行时',
+    useCaseLabel: '用途',
+    providerLabel: '提供方',
+    providerPlaceholder: '如 Meta、Qwen、Mistral',
+    sortLabel: '排序',
+    limitLabel: '数量限制',
+    limitAll: '全部',
+    capabilityLabel: '能力',
+    licenseLabel: '许可证',
+    licensePlaceholder: '如 apache-2.0、mit',
+    quantizationLabel: '量化',
+    runModeLabel: '运行模式',
+    paramsBucketLabel: '参数区间',
+    tensorParallelLabel: '张量并行',
+    maxContextLabel: '最大上下文',
+    maxContextPlaceholder: '例如 32768',
+    advancedMore: '更多筛选',
+    advancedLess: '收起筛选',
+    advancedActive: ({ count }) => `（已启用 ${count} 项）`,
+    multiSelect: {
+      any: '不限',
+      selectedCount: ({ count }) => `已选 ${count} 项`,
+      noOptions: '暂无可选项'
+    },
+    fitOptions: {
+      marginal: '可运行（勉强可用及以上）',
+      good: '良好适配及以上',
+      perfect: '仅完美适配',
+      too_tight: '仅显示过紧模型',
+      all: '全部等级'
+    },
+    runtimeOptions: {
+      any: '任意运行时',
+      mlx: 'MLX',
+      llamacpp: 'llama.cpp',
+      vllm: 'vLLM'
+    },
+    useCaseOptions: {
+      all: '全部用途',
+      general: '通用',
+      coding: '编程',
+      reasoning: '推理',
+      chat: '对话',
+      multimodal: '多模态',
+      embedding: '向量嵌入'
+    },
+    sortOptions: {
+      score: '排序：得分',
+      tps: '排序：TPS',
+      params: '排序：参数量',
+      mem: '排序：内存',
+      ctx: '排序：上下文',
+      date: '排序：发布日期',
+      use_case: '排序：用途'
+    },
+    paramsBucketOptions: {
+      all: '全部尺寸',
+      tiny: '超小（<3B）',
+      small: '小型（3-8B）',
+      medium: '中型（8-30B）',
+      large: '大型（30-70B）',
+      xl: '超大（70B+）'
+    },
+    tpOptions: {
+      all: '任意 TP',
+      1: 'TP=1',
+      2: 'TP=2',
+      4: 'TP=4',
+      8: 'TP=8'
+    }
+  },
+  table: {
+    error: ({ error }) => `无法加载模型数据：${error}。请确认当前页面来自 \`llmfit serve\`。`,
+    loading: '正在加载模型适配数据…',
+    empty: '当前筛选条件下没有匹配的模型。',
+    copyModelName: '复制模型名称',
+    addToComparison: '加入对比',
+    maxCompare: ({ count }) => `最多只能对比 ${count} 个模型`,
+    installed: '已安装',
+    columns: {
+      compare: '对比',
+      model: '模型',
+      provider: '提供方',
+      params: '参数量',
+      fit: '适配度',
+      mode: '模式',
+      runtime: '运行时',
+      score: '得分',
+      tps: 'TPS',
+      mem: '内存%',
+      context: '上下文',
+      release: '发布'
+    }
+  },
+  detail: {
+    selectPrompt: '点击模型行以查看更详细的适配诊断。',
+    sections: {
+      capabilities: '能力',
+      ggufSources: 'GGUF 来源',
+      scoreBreakdown: '评分拆解',
+      performance: '性能',
+      notes: '说明'
+    },
+    fields: {
+      provider: '提供方',
+      runMode: '运行模式',
+      runtime: '运行时',
+      bestQuant: '最佳量化',
+      memoryRequired: '所需内存',
+      memoryAvailable: '可用内存',
+      license: '许可证',
+      moeOffloaded: 'MoE 卸载'
+    },
+    metrics: {
+      quality: '质量',
+      speed: '速度',
+      fit: '适配度',
+      context: '上下文',
+      memoryUtilization: '内存利用率 %',
+      compositeScore: '综合得分',
+      estimatedTps: '预估 TPS'
+    },
+    noMoeValue: '是（MoE）',
+    noNotes: '该模型适配结果暂无额外说明。'
+  },
+  compare: {
+    titleEmpty: '模型对比',
+    instructions: '勾选表格中的模型后，可以在这里并排对比。',
+    close: '关闭',
+    headerCount: ({ count }) => `正在对比 ${count} 个模型`,
+    fields: {
+      fitLevel: '适配等级',
+      score: '得分',
+      tps: 'TPS',
+      memoryRequired: '所需内存（GB）',
+      memoryAvailable: '可用内存（GB）',
+      bestQuant: '最佳量化',
+      context: '上下文',
+      runtime: '运行时',
+      runMode: '运行模式'
+    }
+  },
+  labels: {
+    fit: {
+      perfect: '完美适配',
+      good: '良好适配',
+      marginal: '勉强可用',
+      too_tight: '过紧无法稳定运行'
+    },
+    runMode: {
+      gpu: 'GPU',
+      moe_offload: 'MoE 卸载',
+      cpu_offload: 'CPU 卸载',
+      cpu_only: '仅 CPU'
+    },
+    useCase: {
+      general: '通用',
+      coding: '编程',
+      reasoning: '推理',
+      chat: '对话',
+      multimodal: '多模态',
+      embedding: '向量嵌入'
+    }
+  }
+};
+
+export default zhCN;

--- a/llmfit-web/src/i18n/locales/zh-CN.js
+++ b/llmfit-web/src/i18n/locales/zh-CN.js
@@ -39,6 +39,27 @@ const zhCN = {
       gpu: 'GPU'
     }
   },
+  simulation: {
+    title: '硬件模拟',
+    active: '模拟已启用',
+    idleHint: '填写目标机器的 RAM、VRAM 或 CPU 核心数后，可按该硬件重新计算全部模型适配度。',
+    activeHint: '当前模型适配结果和规划结果都基于你设置的模拟硬件。',
+    fields: {
+      ram: '内存（GB）',
+      vram: '显存（GB）',
+      cpuCores: 'CPU 核心数'
+    },
+    placeholders: {
+      ram: '例如 64',
+      vram: '例如 24',
+      cpuCores: '例如 16'
+    },
+    actions: {
+      apply: '应用模拟',
+      update: '更新模拟',
+      reset: '重置'
+    }
+  },
   models: {
     title: '模型适配分析',
     compareAction: ({ count }) => `对比（${count}）`,
@@ -173,6 +194,69 @@ const zhCN = {
     },
     noMoeValue: '是（MoE）',
     noNotes: '该模型适配结果暂无额外说明。'
+  },
+  plan: {
+    title: '硬件规划',
+    defaultHint: '估算当前模型的最低硬件要求和推荐硬件要求。',
+    simulatedHint: '当前估算结果基于你设置的模拟硬件环境。',
+    simulatedBadge: '模拟中',
+    error: ({ error }) => `规划请求失败：${error}`,
+    errorFallback: '无法估算硬件规划。',
+    validation: {
+      context: '上下文长度必须是正整数。',
+      targetTps: '目标 TPS 必须是正数。'
+    },
+    fields: {
+      context: '上下文',
+      quant: '量化',
+      kvQuant: 'KV 量化',
+      targetTps: '目标 TPS'
+    },
+    placeholders: {
+      context: '例如 8192',
+      quant: '例如 Q4_K_M',
+      kvQuant: 'fp16、fp8、q8_0、q4_0、tq',
+      targetTps: '可选'
+    },
+    actions: {
+      estimate: '生成规划',
+      loading: '估算中…'
+    },
+    sections: {
+      paths: '运行路径',
+      upgrades: '升级建议',
+      kvAlternatives: 'KV Cache 备选方案'
+    },
+    summary: {
+      current: '当前状态',
+      minimum: '最低硬件',
+      recommended: '推荐硬件',
+      fitLevel: '适配等级',
+      runMode: '运行模式',
+      estimatedTps: '预估 TPS',
+      kvQuant: 'KV 量化',
+      vram: '显存',
+      ram: '内存',
+      cpuCores: 'CPU 核心',
+      notRequired: '不要求'
+    },
+    paths: {
+      gpu: 'GPU',
+      cpu_offload: 'CPU 卸载',
+      cpu_only: '纯 CPU'
+    },
+    pathsFeasible: {
+      yes: '可行',
+      no: '不可行'
+    },
+    noUpgrades: '当前目标已经满足该规划要求。',
+    kvTable: {
+      quant: 'KV 量化',
+      memory: '总内存',
+      kvCache: 'KV Cache',
+      savings: '节省',
+      supported: '支持'
+    }
   },
   compare: {
     titleEmpty: '模型对比',

--- a/llmfit-web/src/styles.css
+++ b/llmfit-web/src/styles.css
@@ -525,6 +525,177 @@ tbody tr.selected {
   font-size: 0.88rem;
 }
 
+.chip-accent {
+  border-color: color-mix(in oklab, var(--accent) 45%, var(--line));
+  background: color-mix(in oklab, var(--accent) 16%, var(--panel));
+  color: var(--accent);
+}
+
+.simulation-panel,
+.planning-card {
+  display: grid;
+  gap: 0.72rem;
+}
+
+.simulation-panel {
+  margin-top: 0.8rem;
+  border-top: 1px solid var(--line);
+  padding-top: 0.8rem;
+}
+
+.simulation-header,
+.planning-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.simulation-header h3,
+.plan-section h5,
+.plan-summary-card h5 {
+  margin: 0;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.simulation-grid,
+.plan-grid,
+.plan-summary-grid,
+.plan-path-estimates {
+  display: grid;
+  gap: 0.58rem;
+}
+
+.simulation-grid,
+.plan-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.plan-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.simulation-grid label,
+.plan-grid label {
+  display: grid;
+  gap: 0.24rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.simulation-grid input,
+.plan-grid input {
+  width: 100%;
+  border-radius: 9px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--ink);
+  padding: 0.5rem 0.57rem;
+  font-family: inherit;
+  font-size: 0.88rem;
+}
+
+.simulation-grid input:focus,
+.plan-grid input:focus {
+  outline: 2px solid color-mix(in oklab, var(--accent) 48%, transparent);
+  outline-offset: 1px;
+}
+
+.simulation-actions,
+.plan-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.plan-form,
+.plan-results,
+.plan-section {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.plan-notice {
+  margin: 0;
+  padding: 0.65rem 0.72rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: color-mix(in oklab, var(--panel) 84%, transparent);
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.plan-summary-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.plan-summary-card,
+.plan-path-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 0.62rem;
+  background: color-mix(in oklab, var(--panel) 88%, transparent);
+}
+
+.plan-summary-list {
+  margin: 0.45rem 0 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.plan-summary-list div {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.84rem;
+}
+
+.plan-summary-list dt {
+  color: var(--muted);
+}
+
+.plan-summary-list dd {
+  margin: 0;
+  font-weight: 620;
+  text-align: right;
+}
+
+.plan-runpaths {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.plan-path-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin-bottom: 0.55rem;
+}
+
+.plan-path-estimates {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 0.65rem;
+}
+
+.plan-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.plan-list li + li {
+  margin-top: 0.35rem;
+}
+
+.plan-table-wrap {
+  max-height: 300px;
+}
+
 /* Theme selector */
 .theme-select {
   appearance: auto;
@@ -940,6 +1111,10 @@ tbody tr.selected {
 
   .system-grid,
   .filters-shell,
+  .simulation-grid,
+  .plan-grid,
+  .plan-summary-grid,
+  .plan-path-estimates,
   .details-grid,
   .kpi-grid {
     grid-template-columns: 1fr;

--- a/llmfit-web/src/utils.js
+++ b/llmfit-web/src/utils.js
@@ -28,6 +28,53 @@ export function fitRank(level) {
   }
 }
 
+export function normalizeFitCode(value) {
+  if (!value) return null;
+  const normalized = String(value).trim().toLowerCase().replace(/[\s-]+/g, '_');
+  const aliases = {
+    perfect: 'perfect',
+    good: 'good',
+    marginal: 'marginal',
+    too_tight: 'too_tight',
+    tootight: 'too_tight'
+  };
+  return aliases[normalized] ?? null;
+}
+
+export function normalizeRunModeCode(value) {
+  if (!value) return null;
+  const normalized = String(value).trim().toLowerCase().replace(/[\s-]+/g, '_');
+  const aliases = {
+    gpu: 'gpu',
+    moe_offload: 'moe_offload',
+    cpu_offload: 'cpu_offload',
+    cpu_only: 'cpu_only'
+  };
+  return aliases[normalized] ?? null;
+}
+
+export function normalizeUseCaseCode(value) {
+  if (!value) return null;
+  const normalized = String(value).trim().toLowerCase();
+  const allowed = ['general', 'coding', 'reasoning', 'chat', 'multimodal', 'embedding'];
+  return allowed.includes(normalized) ? normalized : null;
+}
+
+export function translateFitLevel(t, fitLevel, fitLabel) {
+  const code = normalizeFitCode(fitLevel) ?? normalizeFitCode(fitLabel);
+  return code ? t(`labels.fit.${code}`) : (fitLabel ?? '\u2014');
+}
+
+export function translateRunMode(t, runMode, runModeLabel) {
+  const code = normalizeRunModeCode(runMode) ?? normalizeRunModeCode(runModeLabel);
+  return code ? t(`labels.runMode.${code}`) : (runModeLabel ?? runMode ?? '\u2014');
+}
+
+export function translateUseCase(t, useCase) {
+  const code = normalizeUseCaseCode(useCase);
+  return code ? t(`labels.useCase.${code}`) : (useCase ?? '\u2014');
+}
+
 export function applyClientFitFilter(models, minFit) {
   const list = Array.isArray(models) ? models : [];
   if (minFit === 'all') {
@@ -88,21 +135,18 @@ export function collectUniqueValues(models, field) {
 export function applyClientFilters(models, filters) {
   let result = models;
 
-  // quant filter
   if (filters.quant && filters.quant.length > 0) {
     result = result.filter(
       (m) => m.best_quant && filters.quant.includes(m.best_quant)
     );
   }
 
-  // runMode filter
   if (filters.runMode && filters.runMode.length > 0) {
     result = result.filter(
       (m) => m.run_mode && filters.runMode.includes(m.run_mode)
     );
   }
 
-  // capability filter
   if (filters.capability && filters.capability.length > 0) {
     result = result.filter((m) => {
       const caps = Array.isArray(m.capabilities) ? m.capabilities : [];
@@ -110,7 +154,6 @@ export function applyClientFilters(models, filters) {
     });
   }
 
-  // paramsBucket filter
   if (filters.paramsBucket && filters.paramsBucket !== 'all') {
     const bucket = filters.paramsBucket;
     result = result.filter((m) => {
@@ -133,7 +176,6 @@ export function applyClientFilters(models, filters) {
     });
   }
 
-  // tp filter
   if (filters.tp && filters.tp !== 'all') {
     const tpVal = Number(filters.tp);
     if (Number.isFinite(tpVal)) {


### PR DESCRIPTION
## Summary

This PR now includes two layers of improvements for browser-first users:

- built-in `en` / `zh-CN` localization for Web/Desktop UI
- Web planning + hardware simulation, reusing llmfit's existing core logic

## What changed

### Localization
- add a lightweight i18n layer for `llmfit-web`
- add `en` and `zh-CN` dictionaries with English fallback
- detect locale via `localStorage("llmfit.locale") -> navigator.language -> en`
- add a manual language switcher in the header
- localize the main Web/Desktop UI surfaces, loading states, empty states, errors, and actions

### Web planning + simulation
- add optional hardware override handling to Web-facing API routes:
  - `GET /api/v1/system`
  - `GET /api/v1/models`
  - `GET /api/v1/models/top`
  - `GET /api/v1/models/{name}`
  - `POST /api/v1/plan`
- reuse llmfit core scoring / planning logic for simulated hardware rather than client-side heuristics
- add a Web **Hardware Simulation** panel with RAM / VRAM / CPU cores inputs, apply, and reset
- add a Web **Plan** panel in model details with:
  - context
  - quant
  - KV quant
  - target TPS
  - current status
  - minimum / recommended hardware
  - run paths
  - upgrade guidance
  - KV cache alternatives
- localize all newly added Web strings in both `en` and `zh-CN`

## Why

`llmfit` already had strong TUI support for planning and simulated hardware evaluation, but these capabilities were missing from the Web UI.
This update closes that gap while also making the UI much more usable for Chinese-speaking users.

## Behavior

- saved user locale wins first
- otherwise Chinese browser/system language defaults to `zh-CN`
- otherwise fallback is `en`
- Web users can simulate hardware and re-score models without changing backend scoring logic
- Web users can run plan estimates directly from the model detail panel
- the new simulation parameters are optional and do not change existing API behavior when omitted
- no TUI / CLI localization in this PR

## Testing

- `cd llmfit-web && npm test`
- `cd llmfit-web && npm run build`
- `cargo test -p llmfit serve_api`
- `cargo build --release -p llmfit`
- manual verification on:
  - `http://127.0.0.1:5173/`
  - `http://127.0.0.1:8787/`

### Manual checks completed
- confirmed the localized `硬件模拟` panel renders on the formal Web entry
- confirmed the localized `硬件规划` panel renders on the formal Web entry
- confirmed clicking `生成规划` returns plan results in the UI
- confirmed simulation overrides work through the API and are reflected by `/api/v1/system`

## Notes

- translation is applied at the presentation layer only
- model names / providers / raw backend values are not changed at the API layer
- hardware simulation is computed server-side using the existing fit logic
- this PR intentionally limits locale scope to `en` and `zh-CN`
