### PR TITLE
fix(ci): pass crates.io token via env, not argv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,14 +176,22 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # Pass the registry token via env rather than --token: argv is
+      # visible in the process listing on the runner, and GitHub secret
+      # masking only covers log output. cargo reads CARGO_REGISTRY_TOKEN
+      # automatically.
       - name: Publish llmfit-core to crates.io
-        run: cargo publish -p llmfit-core --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p llmfit-core
 
       - name: Wait for crates.io index update
         run: sleep 30
 
       - name: Publish llmfit to crates.io
-        run: cargo publish -p llmfit --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p llmfit
 
   update-homebrew:
     needs: release


### PR DESCRIPTION
Interpolating a secret into a shell command line:

  cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

leaves the token visible in /proc/<pid>/cmdline and `ps` output for the lifetime of the process. GitHub Actions secret masking redacts log output only — it cannot scrub the kernel's process table.

cargo reads the CARGO_REGISTRY_TOKEN environment variable automatically; the cargo book explicitly recommends this over --token for exactly this reason. GitHub-hosted runners are ephemeral, but defense-in-depth costs nothing here.

Co-Authored-By: gregkh_clanker_t1000