### PR TITLE
Sort fields at startup.

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -926,6 +926,7 @@ impl App {
         }
 
         app.apply_filters();
+        app.re_sort();
         app.enqueue_capability_probes_for_visible(24);
         app
     }


### PR DESCRIPTION
The llmserve-tui application remembers the sorting used in the last invocation but does not apply the sorting when starting. Added sorting at startup.

Tested with an existing installation and after removing the .config/llmfit directory