### PR TITLE
feat(download): add --output-dir flag to override cache path

### DIFF
--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -494,6 +494,7 @@ PRECONDITIONS:
 SIDE EFFECTS:
   Downloads a GGUF file to the local model cache directory
   (~/.cache/llmfit/models/ or platform equivalent).
+  Pass --output-dir to write to a different location (e.g. a shared NFS volume).
 
 EXIT CODES:
   0  Success
@@ -522,6 +523,12 @@ AGENT USAGE:
         /// List available GGUF files in the repo without downloading
         #[arg(long)]
         list: bool,
+
+        /// Override the destination directory for the downloaded GGUF file.
+        /// Defaults to the platform-specific models cache
+        /// (~/.cache/llmfit/models/ or equivalent).
+        #[arg(long, value_name = "PATH")]
+        output_dir: Option<std::path::PathBuf>,
     },
 
     /// Search HuggingFace for GGUF models compatible with llama.cpp
@@ -1322,11 +1329,15 @@ fn run_download(
     quant: Option<&str>,
     budget: Option<f64>,
     list_only: bool,
+    output_dir: Option<&std::path::Path>,
     overrides: &HardwareOverrides,
 ) {
     use llmfit_core::providers::LlamaCppProvider;
 
-    let provider = LlamaCppProvider::new();
+    let mut provider = LlamaCppProvider::new();
+    if let Some(dir) = output_dir {
+        provider.set_models_dir(dir.to_path_buf());
+    }
 
     // Resolve repo ID: try known mapping, then treat as repo, then search
     let repo_id = if model.contains('/') {
@@ -1967,8 +1978,16 @@ fn main() {
                 quant,
                 budget,
                 list,
+                output_dir,
             } => {
-                run_download(&model, quant.as_deref(), budget, list, &overrides);
+                run_download(
+                    &model,
+                    quant.as_deref(),
+                    budget,
+                    list,
+                    output_dir.as_deref(),
+                    &overrides,
+                );
             }
 
             Commands::HfSearch { query, limit } => {

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1336,6 +1336,20 @@ fn run_download(
 
     let mut provider = LlamaCppProvider::new();
     if let Some(dir) = output_dir {
+        if !dir.exists() {
+            eprintln!(
+                "Error: --output-dir '{}' does not exist. Create it first or pass an existing directory.",
+                dir.display()
+            );
+            std::process::exit(1);
+        }
+        if !dir.is_dir() {
+            eprintln!(
+                "Error: --output-dir '{}' is not a directory.",
+                dir.display()
+            );
+            std::process::exit(1);
+        }
         provider.set_models_dir(dir.to_path_buf());
     }
 


### PR DESCRIPTION
## Summary

Add `--output-dir <PATH>` flag to `llmfit download` so cluster operators can write model files to shared storage (NFS / SMB / mirrored RAID) instead of the default `~/.cache/llmfit/models/` cache.

Fixes #443.

## Why this matters

The issue describes a 5-node cluster (2x GB10 + 2x Apple Silicon + RTX eGPU) backed by 18TB mirrored RAID where every node currently pulls a separate copy of the same GGUF into its per-user cache. The reporter is working around this today with a wrapper script that downloads into the cache, then `cp`s to the shared volume. Giving `download` a destination flag removes the wrapper and avoids the duplicate bandwidth + disk footprint for multi-GB models.

The CLI already knew how to write to an arbitrary directory - the TUI Download Manager at `llmfit-tui/src/tui_app.rs:587` and `:1447` already calls `self.llamacpp.set_models_dir(path)` from `dm_dir_input`. `LlamaCppProvider::set_models_dir` is public at `llmfit-core/src/providers.rs:657`. This PR just wires the same setter into the non-TUI `run_download` code path.

## Changes

`llmfit-tui/src/main.rs` (21 lines, one file):

- Add `output_dir: Option<PathBuf>` field to the `Commands::Download` clap variant, with `#[arg(long, value_name = "PATH")]` and a doc comment pointing to the default cache.
- Append one line to the `SIDE EFFECTS:` section of the `long_about` text so `llmfit download --help` documents the flag.
- Pass `output_dir` from the match arm at line 1978 into `run_download`.
- Extend `run_download` signature to take `output_dir: Option<&Path>`. When set, call `provider.set_models_dir(dir.to_path_buf())` before the download path runs (`provider` is now `let mut`).

`llmfit-core` is unchanged - the setter already exists and is the same one the TUI uses.

## Testing

Ran locally against the workspace cloned from `upstream/main`:

```
cargo fmt --all                # passed
cargo check --all-features     # passed
cargo build --release -p llmfit # passed
```

`cargo test --package llmfit-tui --no-run` could not fetch `assert_cmd` from `static.crates.io` in this environment; the rest of CI will cover that.

Manual verification is `llmfit download <model> --help` shows the new flag and `llmfit download <model> --output-dir /tmp/test` resolves the path before downloading. Default behavior (no flag) is unchanged and still uses `llamacpp_models_dir()`.

## AI disclosure

This contribution was developed with AI assistance (Codex).
