### PR TITLE
chore(ci): update softprops/action-gh-release to v3.0.0 (Node.js 24)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -79,7 +79,7 @@ jobs:
           path: artifacts
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           files: artifacts/**/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
           path: artifacts
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary

- Updates `softprops/action-gh-release` from `v2.6.1` to `v3.0.0` in both `release.yml` and `release-desktop.yml`
- Fixes the Node.js 20 deprecation warning seen in [this CI run](https://github.com/AlexsJones/llmfit/actions/runs/24820307428): _"Node.js 20 actions are deprecated ... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026"_

🤖 Generated with [Claude Code](https://claude.com/claude-code)