### PR TITLE
feat(recommend): add --output-llamacpp flag 

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -210,12 +210,13 @@ pub struct ModelFit {
     pub moe_offloaded_gb: Option<f64>, // GB of inactive experts offloaded to RAM
     pub score: f64,                    // weighted composite score 0-100
     pub score_components: ScoreComponents,
-    pub estimated_tps: f64,         // baseline estimated tokens per second
-    pub best_quant: String,         // best quantization for this hardware
-    pub use_case: UseCase,          // inferred use case category
-    pub runtime: InferenceRuntime,  // inference runtime (MLX or llama.cpp)
-    pub installed: bool,            // model found in a local runtime provider
-    pub fits_with_turboquant: bool, // TooTight at fp16 KV but fits with TurboQuant KV
+    pub estimated_tps: f64,            // baseline estimated tokens per second
+    pub best_quant: String,            // best quantization for this hardware
+    pub effective_context_length: u32, // context length used for memory estimation
+    pub use_case: UseCase,             // inferred use case category
+    pub runtime: InferenceRuntime,     // inference runtime (MLX or llama.cpp)
+    pub installed: bool,               // model found in a local runtime provider
+    pub fits_with_turboquant: bool,    // TooTight at fp16 KV but fits with TurboQuant KV
 }
 
 impl ModelFit {
@@ -546,6 +547,7 @@ impl ModelFit {
             score_components,
             estimated_tps,
             best_quant: best_quant_str,
+            effective_context_length: estimation_ctx,
             use_case,
             runtime,
             installed: false, // set later by App after provider detection
@@ -1973,6 +1975,8 @@ mod tests {
         let baseline = ModelFit::analyze(&model, &system);
         let capped = ModelFit::analyze_with_context_limit(&model, &system, Some(4096));
 
+        assert_eq!(baseline.effective_context_length, DEFAULT_ESTIMATION_CTX);
+        assert_eq!(capped.effective_context_length, 4096);
         assert!(capped.memory_required_gb < baseline.memory_required_gb);
         assert!(capped.notes.iter().any(|n| n.contains("Context capped at")));
     }

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -212,11 +212,11 @@ pub struct ModelFit {
     pub score_components: ScoreComponents,
     pub estimated_tps: f64,            // baseline estimated tokens per second
     pub best_quant: String,            // best quantization for this hardware
-    pub effective_context_length: u32, // context length used for memory estimation
     pub use_case: UseCase,             // inferred use case category
     pub runtime: InferenceRuntime,     // inference runtime (MLX or llama.cpp)
     pub installed: bool,               // model found in a local runtime provider
     pub fits_with_turboquant: bool,    // TooTight at fp16 KV but fits with TurboQuant KV
+    pub effective_context_length: u32, // context length used for memory estimation
 }
 
 impl ModelFit {
@@ -547,11 +547,11 @@ impl ModelFit {
             score_components,
             estimated_tps,
             best_quant: best_quant_str,
-            effective_context_length: estimation_ctx,
             use_case,
             runtime,
             installed: false, // set later by App after provider detection
             fits_with_turboquant,
+            effective_context_length: estimation_ctx,
         }
     }
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -601,7 +601,10 @@ fn llamacpp_supports_fit_arg() -> bool {
 
     *SUPPORTS_FIT_ARG.get_or_init(|| {
         let candidate = llamacpp_binary_arg();
-        let Ok(output) = std::process::Command::new(&candidate).arg("--help").output() else {
+        let Ok(output) = std::process::Command::new(&candidate)
+            .arg("--help")
+            .output()
+        else {
             return false;
         };
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -1,3 +1,6 @@
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
 use colored::*;
 use llmfit_core::fit::{FitLevel, ModelFit, RunMode, SortColumn};
 use llmfit_core::hardware::SystemSpecs;
@@ -508,13 +511,13 @@ pub fn display_json_fits_with_llamacpp(specs: &SystemSpecs, fits: &[ModelFit]) {
             let mut json = fit_to_json(fit);
 
             // Add suggested llama.cpp command for llama.cpp-compatible models
-            if fit.runtime == InferenceRuntime::LlamaCpp {
-                if let Some(cmd) = generate_llamacpp_command(fit) {
-                    json.as_object_mut().unwrap().insert(
-                        "llamacpp_command".to_string(),
-                        serde_json::Value::String(cmd),
-                    );
-                }
+            if fit.runtime == InferenceRuntime::LlamaCpp
+                && let Some(cmd) = generate_llamacpp_command(fit)
+            {
+                json.as_object_mut().unwrap().insert(
+                    "llamacpp_command".to_string(),
+                    serde_json::Value::String(cmd),
+                );
             }
 
             json
@@ -553,30 +556,74 @@ fn generate_llamacpp_command(fit: &ModelFit) -> Option<String> {
     // downloading/caching. This avoids path guessing issues and works for both
     // installed and non-installed models. llama-cli automatically downloads
     // to its own cache if the model isn't present locally.
-    if let Some(repo) = repo {
-        // Format: llama-cli -hf repo/name:QuantLevel <offload args> -c context [-cnv]
-        // The :QuantLevel suffix tells llama-cli which quantization file to use
-        Some(format!(
+    repo.map(|repo| {
+        format!(
             "llama-cli -hf {}:{} {} -c {}{}",
             repo, quant, ngl_args, context, conversation_arg
-        ))
-    } else {
-        None
-    }
+        )
+    })
 }
 
 fn llamacpp_ngl_args(run_mode: RunMode) -> Option<&'static str> {
     match run_mode {
+        RunMode::CpuOffload | RunMode::MoeOffload => {
+            llamacpp_ngl_args_for_support(run_mode, llamacpp_supports_fit_arg())
+        }
+        _ => llamacpp_ngl_args_for_support(run_mode, false),
+    }
+}
+
+fn llamacpp_ngl_args_for_support(
+    run_mode: RunMode,
+    supports_fit_arg: bool,
+) -> Option<&'static str> {
+    match run_mode {
         RunMode::Gpu => Some("-ngl all"),
         RunMode::CpuOnly => Some("-ngl 0"),
-        RunMode::CpuOffload => Some("-ngl auto --fit on"),
+        RunMode::CpuOffload => Some(if supports_fit_arg {
+            "-ngl auto --fit on"
+        } else {
+            "-ngl auto"
+        }),
         // llmfit's MoE estimate is not an exact llama.cpp layer/MoE split, so
         // prefer llama.cpp's fit-aware auto offload rather than forcing --cpu-moe.
-        RunMode::MoeOffload => Some("-ngl auto --fit on"),
+        RunMode::MoeOffload => Some(if supports_fit_arg {
+            "-ngl auto --fit on"
+        } else {
+            "-ngl auto"
+        }),
         RunMode::TensorParallel => None,
     }
 }
 
+fn llamacpp_supports_fit_arg() -> bool {
+    static SUPPORTS_FIT_ARG: OnceLock<bool> = OnceLock::new();
+
+    *SUPPORTS_FIT_ARG.get_or_init(|| {
+        let candidate = llamacpp_binary_arg();
+        let Ok(output) = std::process::Command::new(&candidate).arg("--help").output() else {
+            return false;
+        };
+
+        String::from_utf8_lossy(&output.stdout).contains("--fit")
+            || String::from_utf8_lossy(&output.stderr).contains("--fit")
+    })
+}
+
+fn llamacpp_binary_arg() -> PathBuf {
+    let name = format!("llama-cli{}", std::env::consts::EXE_SUFFIX);
+    if let Ok(dir) = std::env::var("LLAMA_CPP_PATH") {
+        let candidate = PathBuf::from(dir).join(&name);
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    PathBuf::from(name)
+}
+
+/// Best-effort heuristic: checks use_case and name substrings to guess whether
+/// a model is conversational. May misfire on edge cases (e.g. an embedding model
+/// named "multichat", or a general-purpose model named "functionary").
 fn should_use_llamacpp_conversation_mode(fit: &ModelFit) -> bool {
     use llmfit_core::models::{Capability, UseCase};
 
@@ -931,11 +978,11 @@ mod tests {
             },
             estimated_tps: 30.0,
             best_quant: "Q4_K_M".to_string(),
-            effective_context_length: 8_192,
             use_case,
             runtime: InferenceRuntime::LlamaCpp,
             installed: false,
             fits_with_turboquant: false,
+            effective_context_length: 8_192,
         }
     }
 
@@ -960,13 +1007,23 @@ mod tests {
     }
 
     #[test]
-    fn llamacpp_command_uses_auto_fit_for_cpu_offload() {
-        let fit = mock_fit(RunMode::CpuOffload, UseCase::General, "general");
-
-        let command = generate_llamacpp_command(&fit).expect("expected command");
-
-        assert!(command.contains("-ngl auto --fit on"));
-        assert!(!command.contains("-ngl all"));
+    fn llamacpp_offload_ngl_args_use_fit_only_when_supported() {
+        assert_eq!(
+            llamacpp_ngl_args_for_support(RunMode::CpuOffload, true),
+            Some("-ngl auto --fit on")
+        );
+        assert_eq!(
+            llamacpp_ngl_args_for_support(RunMode::CpuOffload, false),
+            Some("-ngl auto")
+        );
+        assert_eq!(
+            llamacpp_ngl_args_for_support(RunMode::MoeOffload, true),
+            Some("-ngl auto --fit on")
+        );
+        assert_eq!(
+            llamacpp_ngl_args_for_support(RunMode::MoeOffload, false),
+            Some("-ngl auto")
+        );
     }
 
     #[test]

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -1,5 +1,5 @@
 use colored::*;
-use llmfit_core::fit::{FitLevel, ModelFit, SortColumn};
+use llmfit_core::fit::{FitLevel, ModelFit, RunMode, SortColumn};
 use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::LlmModel;
 use llmfit_core::plan::PlanEstimate;
@@ -498,6 +498,111 @@ pub fn display_json_fits(specs: &SystemSpecs, fits: &[ModelFit]) {
     );
 }
 
+/// Serialize system specs + model fits to JSON with llama.cpp commands and print to stdout.
+pub fn display_json_fits_with_llamacpp(specs: &SystemSpecs, fits: &[ModelFit]) {
+    use llmfit_core::fit::InferenceRuntime;
+
+    let models: Vec<serde_json::Value> = fits
+        .iter()
+        .map(|fit| {
+            let mut json = fit_to_json(fit);
+
+            // Add suggested llama.cpp command for llama.cpp-compatible models
+            if fit.runtime == InferenceRuntime::LlamaCpp {
+                if let Some(cmd) = generate_llamacpp_command(fit) {
+                    json.as_object_mut().unwrap().insert(
+                        "llamacpp_command".to_string(),
+                        serde_json::Value::String(cmd),
+                    );
+                }
+            }
+
+            json
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "system": system_json(specs),
+        "models": models,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("JSON serialization failed")
+    );
+}
+
+/// Generate a llama.cpp command string for a model fit.
+fn generate_llamacpp_command(fit: &ModelFit) -> Option<String> {
+    if fit.run_mode == RunMode::TensorParallel {
+        return None;
+    }
+
+    // Get the GGUF source repo if available
+    let repo = fit.model.gguf_sources.first().map(|s| &s.repo);
+
+    let quant = &fit.best_quant;
+    let context = fit.effective_context_length;
+    let ngl_args = llamacpp_ngl_args(fit.run_mode)?;
+    let conversation_arg = if should_use_llamacpp_conversation_mode(fit) {
+        " -cnv"
+    } else {
+        ""
+    };
+
+    // Use the -hf option with HuggingFace repo to let llama-cli handle model
+    // downloading/caching. This avoids path guessing issues and works for both
+    // installed and non-installed models. llama-cli automatically downloads
+    // to its own cache if the model isn't present locally.
+    if let Some(repo) = repo {
+        // Format: llama-cli -hf repo/name:QuantLevel <offload args> -c context [-cnv]
+        // The :QuantLevel suffix tells llama-cli which quantization file to use
+        Some(format!(
+            "llama-cli -hf {}:{} {} -c {}{}",
+            repo, quant, ngl_args, context, conversation_arg
+        ))
+    } else {
+        None
+    }
+}
+
+fn llamacpp_ngl_args(run_mode: RunMode) -> Option<&'static str> {
+    match run_mode {
+        RunMode::Gpu => Some("-ngl all"),
+        RunMode::CpuOnly => Some("-ngl 0"),
+        RunMode::CpuOffload => Some("-ngl auto --fit on"),
+        // llmfit's MoE estimate is not an exact llama.cpp layer/MoE split, so
+        // prefer llama.cpp's fit-aware auto offload rather than forcing --cpu-moe.
+        RunMode::MoeOffload => Some("-ngl auto --fit on"),
+        RunMode::TensorParallel => None,
+    }
+}
+
+fn should_use_llamacpp_conversation_mode(fit: &ModelFit) -> bool {
+    use llmfit_core::models::{Capability, UseCase};
+
+    let name = fit.model.name.to_lowercase();
+    let use_case = fit.model.use_case.to_lowercase();
+
+    if fit.use_case == UseCase::Embedding
+        || use_case.contains("embedding")
+        || name.contains("embed")
+        || name.contains("bge")
+    {
+        return false;
+    }
+
+    fit.use_case == UseCase::Chat
+        || fit.model.capabilities.contains(&Capability::ToolUse)
+        || use_case.contains("chat")
+        || use_case.contains("instruct")
+        || use_case.contains("instruction")
+        || use_case.contains("tool")
+        || use_case.contains("function")
+        || name.contains("chat")
+        || name.contains("instruct")
+        || name.contains("-it")
+}
+
 /// Serialize diff output via serde derives (new diff-only path).
 pub fn display_json_diff_fits(specs: &SystemSpecs, fits: &[ModelFit]) {
     #[derive(serde::Serialize)]
@@ -552,6 +657,7 @@ fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "parameter_count": fit.model.parameter_count,
         "params_b": round2(fit.model.params_b()),
         "context_length": fit.model.context_length,
+        "effective_context_length": fit.effective_context_length,
         "use_case": fit.model.use_case,
         "category": fit.use_case.label(),
         "release_date": fit.model.release_date,
@@ -766,4 +872,148 @@ pub fn display_csv_fits(fits: &[ModelFit]) {
     }
 
     writer.flush().expect("CSV flush failed");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llmfit_core::fit::{FitLevel, InferenceRuntime, ScoreComponents};
+    use llmfit_core::models::{Capability, GgufSource, ModelFormat, UseCase};
+
+    fn mock_fit(run_mode: RunMode, use_case: UseCase, model_use_case: &str) -> ModelFit {
+        ModelFit {
+            model: LlmModel {
+                name: "test/model-7b".to_string(),
+                provider: "test".to_string(),
+                parameter_count: "7B".to_string(),
+                parameters_raw: None,
+                min_ram_gb: 4.0,
+                recommended_ram_gb: 8.0,
+                min_vram_gb: Some(4.0),
+                quantization: "Q4_K_M".to_string(),
+                context_length: 131_072,
+                use_case: model_use_case.to_string(),
+                is_moe: false,
+                num_experts: None,
+                active_experts: None,
+                active_parameters: None,
+                release_date: None,
+                gguf_sources: vec![GgufSource {
+                    repo: "test/model-7b-GGUF".to_string(),
+                    provider: "test".to_string(),
+                }],
+                capabilities: vec![],
+                format: ModelFormat::Gguf,
+                num_attention_heads: None,
+                num_key_value_heads: None,
+                num_hidden_layers: None,
+                head_dim: None,
+                attention_layout: None,
+                license: None,
+                hidden_size: None,
+                moe_intermediate_size: None,
+                vocab_size: None,
+                shared_expert_intermediate_size: None,
+            },
+            fit_level: FitLevel::Good,
+            run_mode,
+            memory_required_gb: 4.0,
+            memory_available_gb: 8.0,
+            utilization_pct: 50.0,
+            notes: vec![],
+            moe_offloaded_gb: None,
+            score: 80.0,
+            score_components: ScoreComponents {
+                quality: 80.0,
+                speed: 80.0,
+                fit: 80.0,
+                context: 80.0,
+            },
+            estimated_tps: 30.0,
+            best_quant: "Q4_K_M".to_string(),
+            effective_context_length: 8_192,
+            use_case,
+            runtime: InferenceRuntime::LlamaCpp,
+            installed: false,
+            fits_with_turboquant: false,
+        }
+    }
+
+    #[test]
+    fn llamacpp_command_uses_effective_context() {
+        let fit = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
+
+        let command = generate_llamacpp_command(&fit).expect("expected command");
+
+        assert!(command.contains("-c 8192"));
+        assert!(!command.contains("-c 131072"));
+    }
+
+    #[test]
+    fn llamacpp_command_uses_cpu_only_ngl_zero() {
+        let fit = mock_fit(RunMode::CpuOnly, UseCase::General, "general");
+
+        let command = generate_llamacpp_command(&fit).expect("expected command");
+
+        assert!(command.contains("-ngl 0"));
+        assert!(!command.contains("-ngl all"));
+    }
+
+    #[test]
+    fn llamacpp_command_uses_auto_fit_for_cpu_offload() {
+        let fit = mock_fit(RunMode::CpuOffload, UseCase::General, "general");
+
+        let command = generate_llamacpp_command(&fit).expect("expected command");
+
+        assert!(command.contains("-ngl auto --fit on"));
+        assert!(!command.contains("-ngl all"));
+    }
+
+    #[test]
+    fn llamacpp_command_omits_conversation_for_embeddings() {
+        let fit = mock_fit(RunMode::Gpu, UseCase::Embedding, "embedding");
+
+        let command = generate_llamacpp_command(&fit).expect("expected command");
+
+        assert!(!command.contains("-cnv"));
+    }
+
+    #[test]
+    fn llamacpp_command_includes_conversation_for_chat_and_instruct() {
+        let chat = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
+        let instruct = mock_fit(RunMode::Gpu, UseCase::General, "instruction tuned");
+
+        let chat_command = generate_llamacpp_command(&chat).expect("expected command");
+        let instruct_command = generate_llamacpp_command(&instruct).expect("expected command");
+
+        assert!(chat_command.contains("-cnv"));
+        assert!(instruct_command.contains("-cnv"));
+    }
+
+    #[test]
+    fn llamacpp_command_includes_conversation_for_tool_use() {
+        let mut fit = mock_fit(RunMode::Gpu, UseCase::General, "general");
+        fit.model.capabilities.push(Capability::ToolUse);
+
+        let command = generate_llamacpp_command(&fit).expect("expected command");
+
+        assert!(command.contains("-cnv"));
+    }
+
+    #[test]
+    fn llamacpp_command_omits_tensor_parallel_suggestion() {
+        let fit = mock_fit(RunMode::TensorParallel, UseCase::Chat, "chat");
+
+        assert!(generate_llamacpp_command(&fit).is_none());
+    }
+
+    #[test]
+    fn fit_json_includes_effective_context_length() {
+        let fit = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
+
+        let json = fit_to_json(&fit);
+
+        assert_eq!(json["context_length"], 131_072);
+        assert_eq!(json["effective_context_length"], 8_192);
+    }
 }

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -438,12 +438,14 @@ AGENT USAGE:
   llmfit recommend --runtime mlx --capability vision
   llmfit recommend --force-runtime llamacpp  # get llama.cpp results on Apple Silicon
   llmfit recommend --license apache-2.0,mit
+  llmfit recommend --output-llamacpp  # include llama.cpp commands in output
 
   JSON output is the default. Fields: { system: {...}, models: [{ name,
   provider, parameter_count, fit_level, run_mode, score, score_components
   { quality, speed, fit, context }, estimated_tps, disk_size_gb,
   memory_required_gb, memory_available_gb, utilization_pct, best_quant,
-  use_case, license, runtime, capabilities }] }")]
+  effective_context_length, use_case, license, runtime, capabilities,
+  llamacpp_command (when --output-llamacpp) }] }")]
     Recommend {
         /// Limit number of recommendations
         #[arg(short = 'n', long, default_value = "5")]
@@ -477,6 +479,10 @@ AGENT USAGE:
         /// Output as JSON (default for recommend)
         #[arg(long, default_value = "true")]
         json: bool,
+
+        /// Include suggested llama.cpp commands in output for llama.cpp-compatible models
+        #[arg(long)]
+        output_llamacpp: bool,
     },
 
     /// Download a GGUF model from HuggingFace for use with llama.cpp
@@ -1181,6 +1187,7 @@ fn run_recommend(
     license: Option<String>,
     json: bool,
     csv: bool,
+    output_llamacpp: bool,
     overrides: &HardwareOverrides,
     context_limit: Option<u32>,
 ) {
@@ -1315,7 +1322,11 @@ fn run_recommend(
     if csv {
         display::display_csv_fits(&fits);
     } else if json {
-        display::display_json_fits(&specs, &fits);
+        if output_llamacpp {
+            display::display_json_fits_with_llamacpp(&specs, &fits);
+        } else {
+            display::display_json_fits(&specs, &fits);
+        }
     } else {
         if !fits.is_empty() {
             specs.display();
@@ -1743,8 +1754,8 @@ fn run_model(model: &str, server: bool, port: u16, ngl: i32, ctx_size: u32) {
                 &ngl.to_string(),
                 "-c",
                 &ctx_size.to_string(),
-            ])
-            .status();
+        ])
+        .status();
 
         match status {
             Ok(s) if !s.success() => {
@@ -1971,6 +1982,7 @@ fn main() {
                 capability,
                 license,
                 json,
+                output_llamacpp,
             } => {
                 run_recommend(
                     limit,
@@ -1982,6 +1994,7 @@ fn main() {
                     license,
                     json,
                     cli.csv,
+                    output_llamacpp,
                     &overrides,
                     context_limit,
                 );
@@ -2114,6 +2127,7 @@ mod tests {
             },
             estimated_tps: 30.0,
             best_quant: "Q4_K_M".to_string(),
+            effective_context_length: 8192,
             use_case: llmfit_core::models::UseCase::General,
             runtime: InferenceRuntime::LlamaCpp,
             installed: false,

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -2127,11 +2127,11 @@ mod tests {
             },
             estimated_tps: 30.0,
             best_quant: "Q4_K_M".to_string(),
-            effective_context_length: 8192,
             use_case: llmfit_core::models::UseCase::General,
             runtime: InferenceRuntime::LlamaCpp,
             installed: false,
             fits_with_turboquant: false,
+            effective_context_length: 8192,
         }
     }
 

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1754,8 +1754,8 @@ fn run_model(model: &str, server: bool, port: u16, ngl: i32, ctx_size: u32) {
                 &ngl.to_string(),
                 "-c",
                 &ctx_size.to_string(),
-        ])
-        .status();
+            ])
+            .status();
 
         match status {
             Ok(s) if !s.success() => {

--- a/llmfit-web/package-lock.json
+++ b/llmfit-web/package-lock.json
@@ -79,7 +79,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -429,7 +428,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -453,7 +451,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1256,27 +1253,6 @@
         "win32"
       ]
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -1331,13 +1307,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1535,29 +1504,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1611,7 +1557,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1770,13 +1715,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
@@ -1982,7 +1920,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -2070,16 +2007,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -2208,21 +2135,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2238,7 +2150,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2251,7 +2162,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2259,13 +2169,6 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2560,7 +2463,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/llmfit-web/package-lock.json
+++ b/llmfit-web/package-lock.json
@@ -79,6 +79,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -428,6 +429,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -451,6 +453,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1253,6 +1256,27 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -1307,6 +1331,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1504,6 +1535,29 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1557,6 +1611,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1715,6 +1770,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
@@ -1920,6 +1982,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -2007,6 +2070,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -2135,6 +2208,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2150,6 +2238,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2162,6 +2251,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2169,6 +2259,13 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2463,6 +2560,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
## Summary

  This PR makes `llmfit recommend` more useful for automation by adding an opt-in
  `--output-llamacpp` flag that includes ready-to-run `llama-cli` commands in the
  JSON response for llama.cpp-compatible recommendations.

  ## What changed

  - Added `--output-llamacpp` to the `recommend` command.
  - Included a `llamacpp_command` field in JSON output for compatible llama.cpp models.
  - Generated commands using the fit's `effective_context_length` instead of the
    model's maximum advertised context.
  - Mapped run modes to more accurate llama.cpp launch flags such as `-ngl all`,
    `-ngl 0`, and `-ngl auto --fit on`.
  - Added conversation mode only for chat/instruct/tool-use models, and omitted it
    for embeddings.
  - Exposed `effective_context_length` in the JSON payload so downstream consumers
    can see the context size used for fit calculations.
  - Added test coverage for command generation and context serialization.

  ## Why

  This gives CLI and agent workflows a direct path from recommendation to execution
  without forcing consumers to reconstruct llama.cpp arguments themselves. It also
  fixes argument selection so the suggested commands better match the actual fit
  calculation and model type.