### PR TITLE
fix: add debug warning when util > 1.0 in GPU-mode VRAM pressure

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -1131,8 +1131,21 @@ fn estimate_tps(
                 // Only apply penalty when model actually fits in VRAM (util <= 1.0)
                 // AND utilization is above the threshold. Below it, the model fits
                 // easily with plenty of L2 cache room — no pressure.
-                if !(VRAM_PRESSURE_UTIL_THRESHOLD..=1.0).contains(&util) {
+                if util > 1.0 {
+                    // util > 1.0 means total model size exceeds VRAM, which should not
+                    // happen in GPU mode (the routing logic only sends models that fit).
+                    // Log a warning so this edge case is visible in debug output rather
+                    // than silently returning a no-penalty value that masks the error.
+                    debug_log!(
+                        "VRAM pressure: {} util={:.2} exceeds 1.0 in GPU mode — possible routing error (total={:.1}GB vram={:.1}GB)",
+                        model.name,
+                        util,
+                        total_model_gb,
+                        vram,
+                    );
                     1.0
+                } else if util < VRAM_PRESSURE_UTIL_THRESHOLD {
+                    1.0 // model fits easily, no cache-pressure penalty
                 } else {
                     // Expert density: ratio of inactive to total experts.
                     // More inactive experts = more cache pollution per token.


### PR DESCRIPTION
Fixes #496

## Problem

In `estimate_tps()` (fit.rs), the VRAM pressure penalty guard handled both out-of-range cases (`util > 1.0` and `util < VRAM_PRESSURE_UTIL_THRESHOLD`) in a single branch that silently returned `1.0`. When `util > 1.0` is hit in GPU mode it indicates a routing error — a model that doesn't fit in VRAM was sent to the GPU-mode path — but the silent return makes this invisible.

## Solution

Split the combined `!(VRAM_PRESSURE_UTIL_THRESHOLD..=1.0).contains(&util)` check into two explicit branches:

- **`util > 1.0`**: emits a `debug_log!()` warning with the model name, utilization value, and raw VRAM sizes before returning `1.0`. The warning is only printed when `LLMFIT_DEBUG` is set, so there is no impact on normal operation.
- **`util < VRAM_PRESSURE_UTIL_THRESHOLD`**: returns `1.0` silently as before — this is the expected low-pressure case.

No change to runtime behavior; only the observability of the unexpected branch improves.

## Testing

All 320 existing unit tests pass (`cargo test -p llmfit-core --lib`). The `util > 1.0` branch is a defensive guard that should never fire in production, so no new test case is added — the change is purely diagnostic.