### PR TITLE
fix(bench): 5 follow-up improvements to #278 (keybinding I, labels, UTF-8, dedup HTTP types, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://about.signpath.io"><img src="https://img.shields.io/badge/SignPath-signed-brightgreen?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0id2hpdGUiIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZD0iTTEwLjA2NyA0LjU2N2wtNC43MzQgNC43MzMtMS40LTEuNGExIDEgMCAwIDAtMS40MTQgMS40MTRsMi4xIDIuMWExIDEgMCAwIDAgMS40MTQgMGw1LjQ0LTUuNDRhMSAxIDAgMCAwLTEuNDE0LTEuNDE0eiIvPjwvc3ZnPg==" alt="Signed with SignPath"></a>
 </p>
 
-> **New: [Community Benchmarks](#community-benchmarks-b)** — Browse real-world performance data from actual users. Press `b` to see measured tok/s, TTFT, and VRAM for any GPU — not just yours. Pick from 27+ hardware presets (RTX 5090 to Apple M1) with `H` to compare real numbers before you buy or build.
+> **New: [Community Leaderboard](#community-leaderboard-b)** — Browse real-world performance data from actual users. Press `b` to see measured tok/s, TTFT, and VRAM for any GPU — not just yours. Pick from 27+ hardware presets (RTX 5090 to Apple M1) with `H` to compare real numbers before you buy or build.
 
 **Hundreds of models & providers. One command to find what runs on your hardware.**
 
@@ -24,7 +24,7 @@ A terminal tool that right-sizes LLM models to your system's RAM, CPU, and GPU. 
 
 Ships with an interactive TUI (default) and a classic CLI mode. Supports multi-GPU setups, MoE architectures, dynamic quantization selection, speed estimation, and local runtime providers (Ollama, llama.cpp, MLX, Docker Model Runner, LM Studio).
 
-**New: [Community Benchmarks](#community-benchmarks-b) (`b`)** — See real-world tok/s, TTFT, and VRAM usage from other users running the same hardware as you. Powered by [localmaxxing.com](https://localmaxxing.com), this bridges the gap between estimated and actual performance.
+**New: [Community Leaderboard](#community-leaderboard-b) (`b`)** — See real-world tok/s, TTFT, and VRAM usage from other users running the same hardware as you. Powered by [localmaxxing.com](https://localmaxxing.com), this bridges the gap between estimated and actual performance.
 
 Also: [Download Manager](#download-manager-d) (`D`), [Advanced Configuration](#advanced-configuration-a) (`A`), and [Hardware Simulation](#hardware-simulation-s) — Press `D` to manage downloads, view history, delete models, and configure the download directory. Press `A` to tune TPS efficiency, run mode factors, and scoring weights. Press `S` to simulate different hardware.
 
@@ -132,7 +132,8 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `R`                        | Open runtime/backend filter popup (llama.cpp, MLX, vLLM)             |
 | `S`                        | Open hardware simulation popup (override RAM/VRAM/CPU)                |
 | `A`                        | Open advanced configuration popup (tune efficiency, run mode factors) |
-| `b`                        | Open community benchmarks view (localmaxxing.com)                     |
+| `b`                        | Open community leaderboard view (localmaxxing.com)                    |
+| `I`                        | Open inference bench view (local quality scoring against your models) |
 | `h`                        | Open help popup (all key bindings)                                    |
 | `m`                        | Mark selected model for compare                                       |
 | `c`                        | Open compare view (marked vs selected)                                |
@@ -269,11 +270,11 @@ Use `Tab` / `Shift-Tab` to cycle focus between sections.
 
 For failed downloads (e.g. 404 errors), `x` removes the entry from history. For successful downloads, it deletes the model from the provider (supported for Ollama and llama.cpp).
 
-### Community Benchmarks (`b`)
+### Community Leaderboard (`b`)
 
-Press `b` to open the Community Benchmarks view. Instead of relying solely on llmfit's theoretical speed estimates, this view shows **real-world performance data** from other users with the same hardware — actual measured tok/s, time-to-first-token, and peak VRAM usage.
+Press `b` to open the Community Leaderboard view. Instead of relying solely on llmfit's theoretical speed estimates, this view shows **real-world performance data** from other users with the same hardware — actual measured tok/s, time-to-first-token, and peak VRAM usage.
 
-![Community Benchmarks](assets/benchmark.jpeg)
+![Community Leaderboard](assets/benchmark.jpeg)
 
 Data is sourced from [localmaxxing.com](https://localmaxxing.com), a community benchmark database. When you open the view, llmfit auto-detects your hardware (GPU model, VRAM tier, Apple Silicon chip family, OS) and queries for matching results.
 
@@ -314,6 +315,60 @@ llmfit --api-key "bhk_your_key_here"
 | Variable | Description |
 |---|---|
 | `LOCALMAXXING_API_KEY` | Bearer token for localmaxxing.com API |
+
+### Inference Bench (`I`)
+
+Press `I` (uppercase) to open the Inference Bench view. This runs **live inference benchmarks against your locally running providers** — Ollama, vLLM, and MLX — measuring time-to-first-token (TTFT), tokens per second (TPS), and total latency with real inference requests.
+
+Unlike the Community Leaderboard (which shows crowd-sourced data from other users), Inference Bench measures your actual hardware with your actual models.
+
+#### TUI usage
+
+| Key | Action |
+|-----|--------|
+| `I` | Open inference bench (auto-detects provider and runs benchmarks) |
+| `I` (again) | Rerun benchmarks from within the bench view |
+| `j` / `k` or arrows | Navigate model results |
+| `Enter` | Open detail view for selected model |
+| `r` | Switch to routing matrix view |
+| `q` / `Esc` | Close bench view |
+
+Results are cached to `~/.config/llmfit/bench-cache.json` and loaded instantly on subsequent opens.
+
+#### CLI usage
+
+```sh
+# Auto-detect provider and benchmark
+llmfit bench
+
+# Benchmark all discovered models across all running providers
+llmfit bench --all
+
+# Benchmark a specific model via Ollama
+llmfit bench --provider ollama llama3.2
+
+# Override endpoint URL
+llmfit bench --provider ollama --url http://my-server:11434 llama3.2
+
+# Override vLLM endpoint
+llmfit bench --provider vllm --url http://localhost:8000
+
+# Output as JSON (for scripting)
+llmfit bench --json
+
+# Run quality benchmarks (role-based scoring for routing)
+llmfit bench --quality
+
+# Output routing matrix
+llmfit bench --quality --routing
+```
+
+#### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama API base URL |
+| `VLLM_PORT` | `8000` | vLLM server port (used as `http://localhost:$VLLM_PORT`) |
 
 ### Themes
 

--- a/llmfit-core/src/bench.rs
+++ b/llmfit-core/src/bench.rs
@@ -88,21 +88,22 @@ const BENCH_PROMPTS: &[&str] = &[
 // ── Ollama benchmarking ────────────────────────────────────────────
 
 /// Ollama /api/generate response fields we care about.
+/// Shared with `quality.rs` — both modules talk to the same endpoints.
 #[derive(serde::Deserialize, Default)]
 #[allow(dead_code)]
-struct OllamaGenResponse {
+pub(crate) struct OllamaGenResponse {
     #[serde(default)]
-    response: String,
+    pub(crate) response: String,
     #[serde(default)]
-    eval_count: Option<u64>,
+    pub(crate) eval_count: Option<u64>,
     #[serde(default)]
-    eval_duration: Option<u64>, // nanoseconds
+    pub(crate) eval_duration: Option<u64>, // nanoseconds
     #[serde(default)]
-    prompt_eval_count: Option<u64>,
+    pub(crate) prompt_eval_count: Option<u64>,
     #[serde(default)]
-    prompt_eval_duration: Option<u64>, // nanoseconds
+    pub(crate) prompt_eval_duration: Option<u64>, // nanoseconds
     #[serde(default)]
-    total_duration: Option<u64>, // nanoseconds
+    pub(crate) total_duration: Option<u64>, // nanoseconds
 }
 
 /// Benchmark a model via Ollama's /api/generate endpoint.
@@ -209,36 +210,37 @@ fn ollama_generate(
 
 // ── OpenAI-compatible benchmarking (vLLM, MLX) ────────────────────
 
-/// OpenAI chat completion response fields we care about.
+/// OpenAI-compatible chat completion response fields we care about.
+/// Shared with `quality.rs` — both modules talk to the same endpoints.
 #[derive(serde::Deserialize)]
 #[allow(dead_code)]
-struct ChatCompletionResponse {
+pub(crate) struct ChatCompletionResponse {
     #[serde(default)]
-    choices: Vec<ChatChoice>,
+    pub(crate) choices: Vec<ChatChoice>,
     #[serde(default)]
-    usage: Option<ChatUsage>,
+    pub(crate) usage: Option<ChatUsage>,
 }
 
 #[derive(serde::Deserialize)]
 #[allow(dead_code)]
-struct ChatChoice {
+pub(crate) struct ChatChoice {
     #[serde(default)]
-    message: Option<ChatMessage>,
+    pub(crate) message: Option<ChatMessage>,
 }
 
 #[derive(serde::Deserialize)]
 #[allow(dead_code)]
-struct ChatMessage {
+pub(crate) struct ChatMessage {
     #[serde(default)]
-    content: Option<String>,
+    pub(crate) content: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
-struct ChatUsage {
+pub(crate) struct ChatUsage {
     #[serde(default)]
-    prompt_tokens: u32,
+    pub(crate) prompt_tokens: u32,
     #[serde(default)]
-    completion_tokens: u32,
+    pub(crate) completion_tokens: u32,
 }
 
 /// Benchmark a model via OpenAI-compatible /v1/chat/completions (vLLM, MLX).

--- a/llmfit-core/src/quality.rs
+++ b/llmfit-core/src/quality.rs
@@ -9,6 +9,10 @@ use std::time::{Duration, Instant};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+// HTTP response types are defined once in bench.rs and shared here to prevent
+// the two modules from silently diverging if fields are added or changed.
+use crate::bench::{ChatCompletionResponse, ChatUsage, OllamaGenResponse};
+
 // ── Types ──────────────────────────────────────────────────────────
 
 /// A single scoring rule applied to a model response.
@@ -112,57 +116,6 @@ pub struct RoutingRecommendation {
     pub composite: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
-}
-
-// ── Ollama response types (reuse pattern from bench.rs) ────────────
-
-#[derive(Deserialize, Default)]
-#[allow(dead_code)]
-struct OllamaGenResponse {
-    #[serde(default)]
-    response: String,
-    #[serde(default)]
-    eval_count: Option<u64>,
-    #[serde(default)]
-    eval_duration: Option<u64>,
-    #[serde(default)]
-    prompt_eval_count: Option<u64>,
-    #[serde(default)]
-    prompt_eval_duration: Option<u64>,
-    #[serde(default)]
-    total_duration: Option<u64>,
-}
-
-#[derive(Deserialize)]
-#[allow(dead_code)]
-struct ChatCompletionResponse {
-    #[serde(default)]
-    choices: Vec<ChatChoice>,
-    #[serde(default)]
-    usage: Option<ChatUsage>,
-}
-
-#[derive(Deserialize)]
-#[allow(dead_code)]
-struct ChatChoice {
-    #[serde(default)]
-    message: Option<ChatMessage>,
-}
-
-#[derive(Deserialize)]
-#[allow(dead_code)]
-struct ChatMessage {
-    #[serde(default)]
-    content: Option<String>,
-}
-
-#[derive(Deserialize)]
-#[allow(dead_code)]
-struct ChatUsage {
-    #[serde(default)]
-    prompt_tokens: u32,
-    #[serde(default)]
-    completion_tokens: u32,
 }
 
 // ── Scoring ────────────────────────────────────────────────────────

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1943,11 +1943,15 @@ fn target_info(target: &bench::BenchTarget) -> (&str, &str, &str) {
     }
 }
 
+/// Returns at most `max` characters of `s`, appending `…` if truncated.
+/// Uses char-aware slicing to avoid panics on multi-byte UTF-8 characters
+/// (e.g. CJK ideographs, emoji) that appear in HuggingFace model names.
 fn truncate_str(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    if s.chars().count() <= max {
         s.to_string()
     } else {
-        format!("{}…", &s[..max - 1])
+        let head: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{head}…")
     }
 }
 
@@ -2934,5 +2938,19 @@ mod tests {
             find_name_index_by_selector(&models, "Qwen/Qwen3-Coder-Next", |m| m.name.as_str())
                 .expect("should resolve exact model");
         assert_eq!(idx, 1);
+    }
+
+    #[test]
+    fn truncate_str_handles_multibyte_utf8() {
+        // ASCII — no truncation needed
+        assert_eq!(truncate_str("hello", 10), "hello");
+        // ASCII — truncation
+        assert_eq!(truncate_str("hello world", 5), "hell…");
+        // CJK ideographs (3-byte UTF-8 each) — must not panic
+        assert_eq!(truncate_str("こんにちは世界", 4), "こんに…");
+        // Single emoji (4-byte UTF-8) — must not panic on byte boundary
+        assert_eq!(truncate_str("🚀 hello", 4), "🚀 h…");
+        // Exact max length — no truncation
+        assert_eq!(truncate_str("abc", 3), "abc");
     }
 }

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -71,7 +71,7 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
                 } else if app.bench_running {
                     app.bench_confirm_quit = true;
                     app.bench_progress =
-                        "Benchmarks running! Press q again to exit bench, any key to cancel"
+                        "Inference bench running! Press q again to exit, any key to cancel"
                             .to_string();
                 } else {
                     app.close_bench();
@@ -213,9 +213,9 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
         // Benchmarks view (localmaxxing.com community leaderboard)
         KeyCode::Char('b') => app.open_benchmarks(),
 
-        // Live inference-bench view (llmfit bench — B=open, B again=rerun)
-        KeyCode::Char('B') if app.show_bench => app.rerun_bench(),
-        KeyCode::Char('B') => app.open_bench(),
+        // Live inference-bench view (llmfit bench — I=open, I again=rerun)
+        KeyCode::Char('I') if app.show_bench => app.rerun_bench(),
+        KeyCode::Char('I') => app.open_bench(),
 
         // Advanced Config popup
         KeyCode::Char('A') => app.open_advanced_config_popup(),

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -1567,11 +1567,15 @@ fn draw_multi_compare(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors
     frame.render_widget(table, area);
 }
 
+/// Returns at most `max_len` characters of `s`, appending `~` if truncated.
+/// Uses char-aware slicing to avoid panics on multi-byte UTF-8 characters
+/// (e.g. CJK ideographs, emoji) that appear in HuggingFace model names.
 fn truncate_str(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    if s.chars().count() <= max_len {
         s.to_string()
     } else {
-        format!("{}~", &s[..max_len.saturating_sub(1)])
+        let head: String = s.chars().take(max_len.saturating_sub(1)).collect();
+        format!("{head}~")
     }
 }
 
@@ -2764,12 +2768,12 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
                         if app.bench_show_detail {
                             " j/k:scroll  Enter/q:close detail  r:routing".to_string()
                         } else {
-                            " j/k:select  Enter:detail  r:routing  B:rerun  q:back".to_string()
+                            " j/k:select  Enter:detail  r:routing  I:rerun  q:back".to_string()
                         }
                     }
                     BenchViewMode::Routing => " r:results  q:back".to_string(),
                 };
-                return (keys, "LIVE BENCH".to_string());
+                return (keys, "INFERENCE BENCH".to_string());
             }
             if app.show_multi_compare {
                 return (
@@ -2899,7 +2903,7 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
         ),
         InputMode::Benchmarks => (
             " ↑/k:up  ↓/j:down  H:change GPU  r:refresh  b/q/Esc:close".to_string(),
-            "BENCHMARKS".to_string(),
+            "COMMUNITY LEADERBOARD".to_string(),
         ),
     }
 }
@@ -3268,8 +3272,12 @@ fn draw_help_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         ("  d", "Download/pull model"),
         ("  r", "Refresh installed models"),
         ("  p", "Plan mode"),
-        ("  b", "Benchmarks (localmaxxing.com)"),
-        ("  H", "Change GPU (in benchmarks view)"),
+        ("  b", "Community Leaderboard (localmaxxing.com)"),
+        (
+            "  I",
+            "Inference Bench (local quality scoring against your models)",
+        ),
+        ("  H", "Change GPU (in community leaderboard view)"),
         ("  y", "Copy model name"),
         ("", ""),
         ("Comparison", ""),
@@ -4006,7 +4014,7 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(tc.accent))
-        .title(" Benchmarks ")
+        .title(" Community Leaderboard ")
         .title_style(Style::default().fg(tc.accent).add_modifier(Modifier::BOLD));
 
     let inner = block.inner(area);
@@ -4501,12 +4509,12 @@ fn draw_bench(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     let title = match app.bench_view_mode {
         BenchViewMode::Results => {
             if app.bench_show_detail {
-                " BENCH: Quality Benchmarks (j/k=scroll, Enter/q=close detail) "
+                " INFERENCE BENCH: Quality Benchmarks (j/k=scroll, Enter/q=close detail) "
             } else {
-                " BENCH: Quality Benchmarks (j/k=select, Enter=detail, r=routing) "
+                " INFERENCE BENCH: Quality Benchmarks (j/k=select, Enter=detail, r=routing) "
             }
         }
-        BenchViewMode::Routing => " BENCH: Routing Matrix (r=results, q=back) ",
+        BenchViewMode::Routing => " INFERENCE BENCH: Routing Matrix (r=results, q=back) ",
     };
 
     let block = Block::default()
@@ -5156,5 +5164,24 @@ fn draw_bench(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
                 .wrap(Wrap { trim: false });
             frame.render_widget(paragraph, inner);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_str_handles_multibyte_utf8() {
+        // ASCII — no truncation needed
+        assert_eq!(truncate_str("hello", 10), "hello");
+        // ASCII — truncation with tilde marker
+        assert_eq!(truncate_str("hello world", 5), "hell~");
+        // CJK ideographs (3-byte UTF-8 each) — must not panic
+        assert_eq!(truncate_str("こんにちは世界", 4), "こんに~");
+        // Single emoji (4-byte UTF-8) — must not panic on byte boundary
+        assert_eq!(truncate_str("🚀 hello", 4), "🚀 h~");
+        // Exact max length — no truncation
+        assert_eq!(truncate_str("abc", 3), "abc");
     }
 }


### PR DESCRIPTION
Follow-up to #278. Implements the 5 improvements @AlexsJones described in [this comment on #278](https://github.com/AlexsJones/llmfit/pull/278#issuecomment-4365354134) — the `de4522b` commit referenced there wasn't actually pushed (SHA isn't reachable from any branch), so this PR re-implements the same items from the description.

### What changed

| # | Item | Where |
|---|---|---|
| 1 | Keybinding `B` → `I` for the inference bench view (deconflicts with `b` leaderboard) | `tui_events.rs`, `tui_ui.rs` |
| 2 | TUI mode label `LIVE BENCH` → `INFERENCE BENCH`; `BENCHMARKS` → `COMMUNITY LEADERBOARD`; help popup, pane titles, quit-confirm text | `tui_ui.rs`, `tui_events.rs` |
| 3 | UTF-8-safe `truncate_str` (was panicking on multi-byte chars in HF model names — real bug) + 2 new unit tests | `llmfit-tui/src/main.rs`, `llmfit-tui/src/tui_ui.rs` |
| 4 | Deduplicated 5 HTTP response types (`OllamaGenResponse`, `ChatCompletionResponse`, `ChatChoice`, `ChatMessage`, `ChatUsage`); kept canonical in `bench.rs` as `pub(crate)`, imported in `quality.rs` | `bench.rs`, `quality.rs` |
| 5 | README: renamed "Community Benchmarks" section → "Community Leaderboard (b)"; added new "Inference Bench (I)" section with keybindings, CLI usage, cache path, env vars | `README.md` |

### Diff

\`\`\`
 README.md                       |  +67 / -4
 llmfit-core/src/bench.rs        |  +38 / -19
 llmfit-core/src/quality.rs      |  +5 / -50
 llmfit-tui/src/main.rs          |  +22 / -2
 llmfit-tui/src/tui_events.rs    |  +8 / -4
 llmfit-tui/src/tui_ui.rs        |  +49 / -8
 6 files, +147 / -92
\`\`\`

### Verification

- `cargo fmt --all`: clean
- `cargo build`: clean
- `cargo test --all`: **353 passing** (was 351, +2 from new UTF-8 truncate tests), 0 failed, 1 ignored
- `cargo clippy`: zero new warnings; pre-existing baseline preserved

Single squashed commit. Ready for review.
