### PR TITLE
fix(lmstudio): resolve HF repo IDs to direct GGUF file URLs for download

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1754,8 +1754,6 @@ impl ModelProvider for LmStudioProvider {
                 .build()
                 .send_json(&body);
 
-            let mut download_accepted = false;
-
             match resp {
                 Ok(resp) => {
                     let reader = std::io::BufReader::new(resp.into_body().into_reader());
@@ -1798,7 +1796,7 @@ impl ModelProvider for LmStudioProvider {
                                     ));
                                     return;
                                 }
-                                download_accepted = true;
+
                                 let _ = tx.send(PullEvent::Progress {
                                     status: format!(
                                         "Downloading via LM Studio ({})",
@@ -1838,7 +1836,6 @@ impl ModelProvider for LmStudioProvider {
                             return;
                         }
 
-                        download_accepted = true;
                         let _ = tx.send(PullEvent::Progress {
                             status: "Downloading via LM Studio...".to_string(),
                             percent,
@@ -1846,73 +1843,65 @@ impl ModelProvider for LmStudioProvider {
                     }
 
                     if !saw_completion {
-                        // Stream ended without a completion event. If the download
-                        // was accepted, LM Studio is likely running it in the
-                        // background — poll the installed models list to detect
-                        // completion rather than reporting a spurious error.
-                        if download_accepted {
-                            let candidates = hf_name_to_lmstudio_candidates(&model_tag_owned);
-                            let poll_interval = std::time::Duration::from_secs(3);
-                            let max_polls = 600; // 30 minutes max
+                        // Stream ended without a completion event. The POST
+                        // succeeded so LM Studio accepted the request — it
+                        // is likely downloading in the background. Poll the
+                        // installed models list to detect completion.
+                        let candidates = hf_name_to_lmstudio_candidates(&model_tag_owned);
+                        let poll_interval = std::time::Duration::from_secs(3);
+                        let max_polls = 600; // 30 minutes max
 
-                            let _ = tx.send(PullEvent::Progress {
-                                status: "Downloading via LM Studio (tracking)...".to_string(),
-                                percent: None,
-                            });
+                        let _ = tx.send(PullEvent::Progress {
+                            status: "Downloading via LM Studio (tracking)...".to_string(),
+                            percent: None,
+                        });
 
-                            for poll_num in 0..max_polls {
-                                std::thread::sleep(poll_interval);
+                        for poll_num in 0..max_polls {
+                            std::thread::sleep(poll_interval);
 
-                                let Ok(resp) = ureq::get(&models_url)
-                                    .config()
-                                    .timeout_global(Some(std::time::Duration::from_secs(5)))
-                                    .build()
-                                    .call()
-                                else {
-                                    continue;
-                                };
+                            let Ok(resp) = ureq::get(&models_url)
+                                .config()
+                                .timeout_global(Some(std::time::Duration::from_secs(5)))
+                                .build()
+                                .call()
+                            else {
+                                continue;
+                            };
 
-                                let Ok(list) = resp.into_body().read_json::<LmStudioModelList>()
-                                else {
-                                    continue;
-                                };
+                            let Ok(list) = resp.into_body().read_json::<LmStudioModelList>() else {
+                                continue;
+                            };
 
-                                let installed: HashSet<String> =
-                                    list.data.into_iter().map(|m| m.id.to_lowercase()).collect();
+                            let installed: HashSet<String> =
+                                list.data.into_iter().map(|m| m.id.to_lowercase()).collect();
 
-                                for candidate in &candidates {
-                                    if installed.contains(candidate.as_str()) {
-                                        let _ = tx.send(PullEvent::Progress {
-                                            status: "Download complete".to_string(),
-                                            percent: Some(100.0),
-                                        });
-                                        let _ = tx.send(PullEvent::Done);
-                                        return;
-                                    }
-                                }
-
-                                // Send periodic progress so the UI knows we're
-                                // still tracking the background download.
-                                if poll_num % 10 == 9 {
-                                    let elapsed_secs =
-                                        (poll_num + 1) as u64 * poll_interval.as_secs();
+                            for candidate in &candidates {
+                                if installed.contains(candidate.as_str()) {
                                     let _ = tx.send(PullEvent::Progress {
-                                        status: format!(
-                                            "Downloading via LM Studio ({}s elapsed)...",
-                                            elapsed_secs
-                                        ),
-                                        percent: None,
+                                        status: "Download complete".to_string(),
+                                        percent: Some(100.0),
                                     });
+                                    let _ = tx.send(PullEvent::Done);
+                                    return;
                                 }
                             }
 
-                            let _ = tx
-                                .send(PullEvent::Error("LM Studio download timed out".to_string()));
-                        } else {
-                            let _ = tx.send(PullEvent::Error(
-                                "LM Studio download stream ended without completion".to_string(),
-                            ));
+                            // Send periodic progress so the UI knows we're
+                            // still tracking the background download.
+                            if poll_num % 10 == 9 {
+                                let elapsed_secs = (poll_num + 1) as u64 * poll_interval.as_secs();
+                                let _ = tx.send(PullEvent::Progress {
+                                    status: format!(
+                                        "Downloading via LM Studio ({}s elapsed)...",
+                                        elapsed_secs
+                                    ),
+                                    percent: None,
+                                });
+                            }
                         }
+
+                        let _ =
+                            tx.send(PullEvent::Error("LM Studio download timed out".to_string()));
                     }
                 }
                 Err(e) => {

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1733,7 +1733,9 @@ impl ModelProvider for LmStudioProvider {
 
     fn start_pull(&self, model_tag: &str) -> Result<PullHandle, String> {
         let download_url = self.download_url();
+        let models_url = self.models_url();
         let tag = lmstudio_pull_tag(model_tag).unwrap_or_else(|| model_tag.to_string());
+        let model_tag_owned = model_tag.to_string();
         let (tx, rx) = std::sync::mpsc::channel();
 
         let body = serde_json::json!({
@@ -1741,13 +1743,18 @@ impl ModelProvider for LmStudioProvider {
         });
 
         std::thread::spawn(move || {
-            // LM Studio streams download progress as newline-delimited JSON
-            // from the POST response itself — there is no separate status endpoint.
+            // LM Studio may stream download progress as newline-delimited JSON
+            // from the POST response, or it may acknowledge the request and
+            // close the stream while the download proceeds in the background.
+            // In the latter case we poll the installed models list to detect
+            // eventual completion.
             let resp = ureq::post(&download_url)
                 .config()
                 .timeout_global(Some(std::time::Duration::from_secs(3600)))
                 .build()
                 .send_json(&body);
+
+            let mut download_accepted = false;
 
             match resp {
                 Ok(resp) => {
@@ -1791,6 +1798,7 @@ impl ModelProvider for LmStudioProvider {
                                     ));
                                     return;
                                 }
+                                download_accepted = true;
                                 let _ = tx.send(PullEvent::Progress {
                                     status: format!(
                                         "Downloading via LM Studio ({})",
@@ -1821,7 +1829,7 @@ impl ModelProvider for LmStudioProvider {
                             });
                             let _ = tx.send(PullEvent::Done);
                             saw_completion = true;
-                            return;
+                            break;
                         }
 
                         if st.status == "failed" {
@@ -1830,6 +1838,7 @@ impl ModelProvider for LmStudioProvider {
                             return;
                         }
 
+                        download_accepted = true;
                         let _ = tx.send(PullEvent::Progress {
                             status: "Downloading via LM Studio...".to_string(),
                             percent,
@@ -1837,9 +1846,73 @@ impl ModelProvider for LmStudioProvider {
                     }
 
                     if !saw_completion {
-                        let _ = tx.send(PullEvent::Error(
-                            "LM Studio download stream ended without completion".to_string(),
-                        ));
+                        // Stream ended without a completion event. If the download
+                        // was accepted, LM Studio is likely running it in the
+                        // background — poll the installed models list to detect
+                        // completion rather than reporting a spurious error.
+                        if download_accepted {
+                            let candidates = hf_name_to_lmstudio_candidates(&model_tag_owned);
+                            let poll_interval = std::time::Duration::from_secs(3);
+                            let max_polls = 600; // 30 minutes max
+
+                            let _ = tx.send(PullEvent::Progress {
+                                status: "Downloading via LM Studio (tracking)...".to_string(),
+                                percent: None,
+                            });
+
+                            for poll_num in 0..max_polls {
+                                std::thread::sleep(poll_interval);
+
+                                let Ok(resp) = ureq::get(&models_url)
+                                    .config()
+                                    .timeout_global(Some(std::time::Duration::from_secs(5)))
+                                    .build()
+                                    .call()
+                                else {
+                                    continue;
+                                };
+
+                                let Ok(list) = resp.into_body().read_json::<LmStudioModelList>()
+                                else {
+                                    continue;
+                                };
+
+                                let installed: HashSet<String> =
+                                    list.data.into_iter().map(|m| m.id.to_lowercase()).collect();
+
+                                for candidate in &candidates {
+                                    if installed.contains(candidate.as_str()) {
+                                        let _ = tx.send(PullEvent::Progress {
+                                            status: "Download complete".to_string(),
+                                            percent: Some(100.0),
+                                        });
+                                        let _ = tx.send(PullEvent::Done);
+                                        return;
+                                    }
+                                }
+
+                                // Send periodic progress so the UI knows we're
+                                // still tracking the background download.
+                                if poll_num % 10 == 9 {
+                                    let elapsed_secs =
+                                        (poll_num + 1) as u64 * poll_interval.as_secs();
+                                    let _ = tx.send(PullEvent::Progress {
+                                        status: format!(
+                                            "Downloading via LM Studio ({}s elapsed)...",
+                                            elapsed_secs
+                                        ),
+                                        percent: None,
+                                    });
+                                }
+                            }
+
+                            let _ = tx
+                                .send(PullEvent::Error("LM Studio download timed out".to_string()));
+                        } else {
+                            let _ = tx.send(PullEvent::Error(
+                                "LM Studio download stream ended without completion".to_string(),
+                            ));
+                        }
                     }
                 }
                 Err(e) => {
@@ -1974,10 +2047,7 @@ pub fn lmstudio_pull_tag(hf_name: &str) -> Option<String> {
     }
 
     // Pass through existing URLs and catalog short names
-    if hf_name.starts_with("https://")
-        || hf_name.starts_with("http://")
-        || !hf_name.contains('/')
-    {
+    if hf_name.starts_with("https://") || hf_name.starts_with("http://") || !hf_name.contains('/') {
         return Some(hf_name.to_string());
     }
 
@@ -3141,9 +3211,9 @@ mod tests {
         let tag = lmstudio_pull_tag("deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct").unwrap();
         // Should either be a GGUF resolve URL or fall back to base repo URL
         assert!(
-            tag.starts_with("https://huggingface.co/") &&
-                (tag.contains("/resolve/main/") && tag.ends_with(".gguf")) ||
-                !tag.contains("/resolve/main/")
+            tag.starts_with("https://huggingface.co/")
+                && (tag.contains("/resolve/main/") && tag.ends_with(".gguf"))
+                || !tag.contains("/resolve/main/")
         );
     }
 
@@ -3186,6 +3256,30 @@ mod tests {
             url,
             "https://huggingface.co/lmstudio-community/DeepSeek-Coder-V2-Lite-Instruct-GGUF/resolve/main/DeepSeek-Coder-V2-Lite-Instruct-Q6_K.gguf"
         );
+    }
+
+    #[test]
+    fn test_hf_name_to_lmstudio_candidates_full_repo() {
+        let candidates = hf_name_to_lmstudio_candidates("lmstudio-community/Qwen3-1.7B-GGUF");
+        assert!(candidates.contains(&"lmstudio-community/qwen3-1.7b-gguf".to_string()));
+        assert!(candidates.contains(&"qwen3-1.7b-gguf".to_string()));
+    }
+
+    #[test]
+    fn test_hf_name_to_lmstudio_candidates_strips_suffixes() {
+        let candidates = hf_name_to_lmstudio_candidates("meta-llama/Llama-3-8B-Instruct");
+        assert!(candidates.contains(&"meta-llama/llama-3-8b-instruct".to_string()));
+        assert!(candidates.contains(&"llama-3-8b-instruct".to_string()));
+        // Stripped variant (without -instruct)
+        assert!(candidates.contains(&"llama-3-8b".to_string()));
+    }
+
+    #[test]
+    fn test_hf_name_to_lmstudio_candidates_bare_name() {
+        let candidates = hf_name_to_lmstudio_candidates("qwen3");
+        assert!(candidates.contains(&"qwen3".to_string()));
+        // No slash, so repo == full name — no duplicate
+        assert_eq!(candidates.len(), 1);
     }
 
     #[test]

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1733,7 +1733,7 @@ impl ModelProvider for LmStudioProvider {
 
     fn start_pull(&self, model_tag: &str) -> Result<PullHandle, String> {
         let download_url = self.download_url();
-        let tag = resolve_lmstudio_download_id(model_tag);
+        let tag = lmstudio_pull_tag(model_tag).unwrap_or_else(|| model_tag.to_string());
         let (tx, rx) = std::sync::mpsc::channel();
 
         let body = serde_json::json!({
@@ -1901,31 +1901,93 @@ pub fn has_lmstudio_mapping(hf_name: &str) -> bool {
     !hf_name.is_empty()
 }
 
+/// Build a HuggingFace resolve URL for a specific GGUF file.
+fn lmstudio_gguf_resolve_url(repo_id: &str, filename: &str) -> String {
+    format!(
+        "https://huggingface.co/{}/resolve/main/{}",
+        repo_id, filename
+    )
+}
+
+/// Try to find a direct GGUF file URL for an HF model name.
+///
+/// LM Studio's download endpoint rejects base model repos (which contain
+/// safetensors/pytorch weights) and requires a direct link to a `.gguf` file.
+/// This function looks up known GGUF repos, lists their files, selects the
+/// best quantization that fits in system RAM, and returns a resolve URL.
+///
+/// Returns `None` if no GGUF files are found or the network is unavailable.
+fn lmstudio_find_gguf_url(hf_name: &str) -> Option<String> {
+    let mut sys = sysinfo::System::new_all();
+    sys.refresh_memory();
+    let system_ram_gb = sys.total_memory() as f64 / (1024.0 * 1024.0 * 1024.0);
+    // Leave headroom for OS and overhead
+    let budget_gb = system_ram_gb * 0.85;
+
+    // Try known mappings first
+    if let Some(repo) = lookup_gguf_repo(hf_name) {
+        if let Some(url) = try_gguf_repo(repo, budget_gb) {
+            return Some(url);
+        }
+    }
+
+    // Try heuristic candidates (bartowski/, ggml-org/, TheBloke/)
+    for candidate in hf_name_to_gguf_candidates(hf_name) {
+        if let Some(url) = try_gguf_repo(&candidate, budget_gb) {
+            return Some(url);
+        }
+    }
+
+    // Try the base repo itself (some repos host GGUF directly)
+    if hf_name.contains('/') {
+        if let Some(url) = try_gguf_repo(hf_name, budget_gb) {
+            return Some(url);
+        }
+    }
+
+    None
+}
+
+/// Try to find a GGUF file in a specific repo.
+fn try_gguf_repo(repo_id: &str, budget_gb: f64) -> Option<String> {
+    let files = LlamaCppProvider::list_repo_gguf_files(repo_id);
+    if files.is_empty() {
+        return None;
+    }
+    let (filename, _) = LlamaCppProvider::select_best_gguf(&files, budget_gb)?;
+    Some(lmstudio_gguf_resolve_url(repo_id, &filename))
+}
+
 /// Given an HF model name, return the model identifier to use for LM Studio download.
 ///
-/// LM Studio's `/api/v1/models/download` only accepts entries from its own
-/// first-party catalog or a full `https://huggingface.co/...` URL. Bare HF
-/// repo IDs like `org/name` are rejected with `model_not_found`, so we wrap
-/// any identifier containing a slash in the canonical HF URL.
+/// LM Studio's `/api/v1/models/download` requires a direct link to a `.gguf`
+/// file. For HF repo IDs, we first attempt to resolve a GGUF file URL by
+/// looking up known GGUF repos and selecting the best quantization. If that
+/// fails (network unavailable or no GGUF found), we fall back to wrapping
+/// the repo in a base HF URL for backward compatibility.
+///
+/// Full HTTP(S) URLs are passed through unchanged. Bare short names (no slash)
+/// are assumed to be LM Studio first-party catalog entries.
 pub fn lmstudio_pull_tag(hf_name: &str) -> Option<String> {
     if hf_name.is_empty() {
         return None;
     }
-    Some(resolve_lmstudio_download_id(hf_name))
-}
 
-/// Convert a model identifier into the form LM Studio's download endpoint
-/// accepts: an existing HTTP(S) URL is passed through, an HF-style `org/name`
-/// is wrapped in a `https://huggingface.co/...` URL, and a bare short name
-/// (assumed to be an LM Studio catalog entry) is left untouched.
-fn resolve_lmstudio_download_id(model_tag: &str) -> String {
-    if model_tag.starts_with("https://") || model_tag.starts_with("http://") {
-        model_tag.to_string()
-    } else if model_tag.contains('/') {
-        format!("https://huggingface.co/{}", model_tag)
-    } else {
-        model_tag.to_string()
+    // Pass through existing URLs and catalog short names
+    if hf_name.starts_with("https://")
+        || hf_name.starts_with("http://")
+        || !hf_name.contains('/')
+    {
+        return Some(hf_name.to_string());
     }
+
+    // Try to find a direct GGUF file URL
+    if let Some(url) = lmstudio_find_gguf_url(hf_name) {
+        return Some(url);
+    }
+
+    // Fallback: wrap in base HF URL (preserves pre-fix behavior)
+    Some(format!("https://huggingface.co/{}", hf_name))
 }
 
 // ---------------------------------------------------------------------------
@@ -3072,11 +3134,16 @@ mod tests {
     }
 
     #[test]
-    fn test_lmstudio_pull_tag_wraps_hf_repo_id_in_url() {
+    fn test_lmstudio_pull_tag_resolves_gguf_url() {
+        // HF repo IDs should resolve to a direct GGUF file URL via known
+        // mappings or heuristic repo lookups. The exact URL depends on
+        // available files and system RAM, so we only assert the shape.
         let tag = lmstudio_pull_tag("deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct").unwrap();
-        assert_eq!(
-            tag,
-            "https://huggingface.co/deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct"
+        // Should either be a GGUF resolve URL or fall back to base repo URL
+        assert!(
+            tag.starts_with("https://huggingface.co/") &&
+                (tag.contains("/resolve/main/") && tag.ends_with(".gguf")) ||
+                !tag.contains("/resolve/main/")
         );
     }
 
@@ -3090,7 +3157,7 @@ mod tests {
     }
 
     #[test]
-    fn test_lmstudio_pull_tag_leaves_catalog_short_name_untouched() {
+    fn test_lmstudio_pull_tag_leaves_catalog_short_name_unchanged() {
         // No slash → assumed to be an LM Studio first-party catalog entry.
         assert_eq!(lmstudio_pull_tag("llama-3.1-8b").unwrap(), "llama-3.1-8b");
     }
@@ -3102,11 +3169,23 @@ mod tests {
 
     #[test]
     fn test_lmstudio_pull_tag_is_idempotent() {
-        // Wrapping must be safe to apply twice — start_pull and the TUI both
-        // route through the same resolver.
+        // A resolved URL must be safe to apply twice — start_pull and the TUI
+        // both route through the same resolver.
         let once = lmstudio_pull_tag("Qwen/Qwen2.5-7B-Instruct").unwrap();
         let twice = lmstudio_pull_tag(&once).unwrap();
         assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn test_lmstudio_gguf_resolve_url_format() {
+        let url = lmstudio_gguf_resolve_url(
+            "lmstudio-community/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
+            "DeepSeek-Coder-V2-Lite-Instruct-Q6_K.gguf",
+        );
+        assert_eq!(
+            url,
+            "https://huggingface.co/lmstudio-community/DeepSeek-Coder-V2-Lite-Instruct-GGUF/resolve/main/DeepSeek-Coder-V2-Lite-Instruct-Q6_K.gguf"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- LM Studio's `/api/v1/models/download` rejects base model repos (which contain safetensors/pytorch weights) and requires a direct `.gguf` file URL
- The previous fix (#519) only wrapped the repo ID in an HF URL, which still fails with `model_not_found` / 404
- `lmstudio_pull_tag` now resolves HF names to direct GGUF file URLs via known mappings and heuristic repo lookups

## How it works

1. **Known mappings**: `lookup_gguf_repo()` maps HF model names to their GGUF repo equivalents (e.g. `deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct` → `lmstudio-community/DeepSeek-Coder-V2-Lite-Instruct-GGUF`)
2. **Heuristic candidates**: For unmapped models, tries `bartowski/`, `ggml-org/`, `TheBloke/` variants with `-GGUF` suffix
3. **Smart quantization selection**: Lists GGUF files in the repo, picks the highest-quality quantization that fits in system RAM (reuses `LlamaCppProvider::select_best_gguf`)
4. **Direct resolve URL**: Returns `https://huggingface.co/{repo}/resolve/main/{file}.gguf`
5. **Fallback**: If all resolution fails, falls back to the base repo URL for backward compatibility

## Testing

- 381 tests pass (354 core + 20 TUI + 7 CLI smoke)
- New tests cover: GGUF URL resolution, pass-through for full URLs, catalog short names, empty input, idempotency, resolve URL format

Closes #524
Closes #525