### PR TITLE
feat: overhaul model discovery with cursor pagination and trending

### DIFF
--- a/data/hf_models.json
+++ b/data/hf_models.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "echarlaix/tiny-random-PhiForCausalLM",
+    "provider": "echarlaix",
+    "parameter_count": "80K",
+    "parameters_raw": 80074,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 512,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phi",
+    "hf_downloads": 27280,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "peft-internal-testing/tiny-random-GPT2LMHeadModel",
     "provider": "peft-internal-testing",
     "parameter_count": "83K",
@@ -14,7 +34,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 47882,
+    "hf_downloads": 55814,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -34,7 +54,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 183600,
+    "hf_downloads": 144815,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -54,7 +74,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 41149,
+    "hf_downloads": 47224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -80,7 +100,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gptj",
-    "hf_downloads": 50736,
+    "hf_downloads": 59115,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -100,7 +120,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 752450,
+    "hf_downloads": 672103,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -130,7 +150,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 57699,
+    "hf_downloads": 56804,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -162,7 +182,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 37722,
+    "hf_downloads": 47527,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -182,7 +202,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 102471,
+    "hf_downloads": 110905,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -202,7 +222,57 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "opt",
-    "hf_downloads": 534450,
+    "hf_downloads": 615390,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zai-org/AutoGLM-Phone-9B",
+    "provider": "zai-org",
+    "parameter_count": "934K",
+    "parameters_raw": 934400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4v",
+    "hf_downloads": 11047,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "ggml-org/AutoGLM-Phone-9B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/AutoGLM-Phone-9B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "yujiepan/llama-3-tiny-random",
+    "provider": "yujiepan",
+    "parameter_count": "1M",
+    "parameters_raw": 1026500,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 26255,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -224,7 +294,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 86135,
+    "hf_downloads": 102197,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -244,10 +314,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 2107605,
+    "hf_downloads": 2680224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "optimum-intel-internal-testing/phi-3.5-moe-tiny-random",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "1M",
+    "parameters_raw": 1110112,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phimoe",
+    "hf_downloads": 26578,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 16,
+    "active_experts": 2,
+    "active_parameters": 187329
   },
   {
     "name": "peft-internal-testing/tiny-dummy-qwen2",
@@ -264,7 +358,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 135837,
+    "hf_downloads": 140023,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -284,7 +378,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 29919,
+    "hf_downloads": 42646,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -294,6 +388,32 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "np-cr/testing-qwen3-moe",
+    "provider": "np-cr",
+    "parameter_count": "2M",
+    "parameters_raw": 2435072,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 16435,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 4,
+    "active_experts": 2,
+    "active_parameters": 1278411
   },
   {
     "name": "llamafactory/tiny-random-qwen3",
@@ -312,7 +432,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 127583,
+    "hf_downloads": 143326,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -340,7 +460,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 42319,
+    "hf_downloads": 52729,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -364,10 +484,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 40866,
+    "hf_downloads": 27224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "optimum-intel-internal-testing/tiny-GptOssForCausalLM",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "3M",
+    "parameters_raw": 3431024,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 31895,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 2,
+    "active_parameters": 222479
   },
   {
     "name": "optimum-internal-testing/tiny-random-VisionEncoderDecoderModel-donut",
@@ -386,7 +530,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "vision-encoder-decoder",
-    "hf_downloads": 13749,
+    "hf_downloads": 16387,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "LongSafari/hyenadna-small-32k-seqlen-hf",
+    "provider": "longsafari",
+    "parameter_count": "4M",
+    "parameters_raw": 4069168,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "hyenadna",
+    "hf_downloads": 17181,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -406,10 +570,54 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1387332,
+    "hf_downloads": 1152461,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "optimum-intel-internal-testing/tiny-random-ArceeForCausalLM",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "4M",
+    "parameters_raw": 4129088,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "arcee",
+    "hf_downloads": 31535,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "yujiepan/deepseek-v3-tiny-random",
+    "provider": "yujiepan",
+    "parameter_count": "4M",
+    "parameters_raw": 4347024,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 14035,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 346399
   },
   {
     "name": "Maykeye/TinyLLama-v0",
@@ -426,7 +634,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 204147,
+    "hf_downloads": 136864,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -452,7 +660,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama4",
-    "hf_downloads": 23787,
+    "hf_downloads": 18620,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -460,6 +668,30 @@
     "num_experts": 4,
     "active_experts": 1,
     "active_parameters": 1889362
+  },
+  {
+    "name": "optimum-intel-internal-testing/tiny-random-gpt-oss-mxfp4",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "7M",
+    "parameters_raw": 6865444,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 27150,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 1158540
   },
   {
     "name": "hmellor/tiny-random-Gemma2ForCausalLM",
@@ -476,7 +708,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma2",
-    "hf_downloads": 283772,
+    "hf_downloads": 350161,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -496,7 +728,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "falcon_mamba",
-    "hf_downloads": 40781,
+    "hf_downloads": 51623,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "google/reformer-crime-and-punishment",
+    "provider": "Google",
+    "parameter_count": "11M",
+    "parameters_raw": 11091968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "reformer",
+    "hf_downloads": 92755,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -516,7 +768,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 48556,
+    "hf_downloads": 50854,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -542,39 +794,13 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 178710,
+    "hf_downloads": 178959,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/pythia-14m-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Xenova/llama2.c-stories15M",
-    "provider": "xenova",
-    "parameter_count": "15M",
-    "parameters_raw": 15191712,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 256,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "llama",
-    "hf_downloads": 26912,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llama2.c-stories15M-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -594,7 +820,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bloom",
-    "hf_downloads": 24895,
+    "hf_downloads": 23889,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -620,7 +846,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 84309,
+    "hf_downloads": 73978,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -640,7 +866,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 15713,
+    "hf_downloads": 15289,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -660,7 +886,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 53120,
+    "hf_downloads": 42875,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -686,7 +912,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bamba",
-    "hf_downloads": 303722,
+    "hf_downloads": 380002,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -706,7 +932,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mixtral",
-    "hf_downloads": 98507,
+    "hf_downloads": 100702,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -730,7 +956,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 259322,
+    "hf_downloads": 250266,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -740,6 +966,46 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "JackFram/llama-68m",
+    "provider": "jackfram",
+    "parameter_count": "39M",
+    "parameters_raw": 38731776,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 178907,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "EleutherAI/pythia-14m-deduped",
+    "provider": "eleutherai",
+    "parameter_count": "39M",
+    "parameters_raw": 39233560,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 14852,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/gemma-3-270m-it-qat-MLX-4bit",
@@ -756,7 +1022,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 41334,
+    "hf_downloads": 22818,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -776,10 +1042,36 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 38185,
+    "hf_downloads": 55158,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "distilbert/distilgpt2",
+    "provider": "distilbert",
+    "parameter_count": "88M",
+    "parameters_raw": 88204032,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 2720359,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/distilgpt2-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "EleutherAI/pythia-70m-deduped",
@@ -796,7 +1088,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 1410678,
+    "hf_downloads": 1752140,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -806,6 +1098,66 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "xlnet/xlnet-base-cased",
+    "provider": "xlnet",
+    "parameter_count": "110M",
+    "parameters_raw": 109510656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "xlnet",
+    "hf_downloads": 180001,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ethicalabs/Echo-DSRN-114M-v0.1.2",
+    "provider": "ethicalabs",
+    "parameter_count": "115M",
+    "parameters_raw": 114656768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "echo",
+    "hf_downloads": 24940,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "openai-community/openai-gpt",
+    "provider": "openai-community",
+    "parameter_count": "120M",
+    "parameters_raw": 119680512,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 512,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "openai-gpt",
+    "hf_downloads": 198329,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/gemma-3-270m-it-MLX-8bit",
@@ -822,7 +1174,93 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 32147,
+    "hf_downloads": 20183,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "facebook/opt-125m",
+    "provider": "facebook",
+    "parameter_count": "124M",
+    "parameters_raw": 123543552,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 8164150,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "optimum-intel-internal-testing/opt-125m",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "124M",
+    "parameters_raw": 123543552,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 62305,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "EleutherAI/pythia-160m",
+    "provider": "eleutherai",
+    "parameter_count": "124M",
+    "parameters_raw": 123568128,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 3155849,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/pythia-160m-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "gratefulasi/lumeleto",
+    "provider": "gratefulasi",
+    "parameter_count": "124M",
+    "parameters_raw": 124439808,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 15496,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -842,7 +1280,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "opt",
-    "hf_downloads": 199043,
+    "hf_downloads": 227714,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -862,7 +1300,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mamba",
-    "hf_downloads": 314035,
+    "hf_downloads": 389338,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -888,7 +1326,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1407123,
+    "hf_downloads": 1492003,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -922,7 +1360,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1224827,
+    "hf_downloads": 1160430,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -948,7 +1386,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 153128,
+    "hf_downloads": 148127,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -974,7 +1412,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 32797,
+    "hf_downloads": 37108,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -984,6 +1422,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "modularai/SmolLM-135M-Instruct-FP32",
+    "provider": "modularai",
+    "parameter_count": "135M",
+    "parameters_raw": 134515008,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14152,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "nomic-ai/nomic-embed-text-v1.5",
@@ -1000,8 +1458,8 @@
     "capabilities": [],
     "pipeline_tag": "sentence-similarity",
     "architecture": "nomic_bert",
-    "hf_downloads": 13883372,
-    "hf_likes": 807,
+    "hf_downloads": 15512738,
+    "hf_likes": 812,
     "release_date": "2024-02-10",
     "num_hidden_layers": 12,
     "num_attention_heads": 12,
@@ -1013,6 +1471,78 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "openai-community/gpt2",
+    "provider": "openai-community",
+    "parameter_count": "137M",
+    "parameters_raw": 137022720,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 15627413,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/gpt2-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Gustavosta/MagicPrompt-Stable-Diffusion",
+    "provider": "gustavosta",
+    "parameter_count": "137M",
+    "parameters_raw": 137022720,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 23714,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/MagicPrompt-Stable-Diffusion-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "aubmindlab/aragpt2-base",
+    "provider": "aubmindlab",
+    "parameter_count": "148M",
+    "parameters_raw": 147577344,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 31806,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "EleutherAI/gpt-neo-125m",
@@ -1029,7 +1559,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neo",
-    "hf_downloads": 467624,
+    "hf_downloads": 465905,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hugohrban/progen2-small",
+    "provider": "hugohrban",
+    "parameter_count": "151M",
+    "parameters_raw": 151148576,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "progen",
+    "hf_downloads": 22487,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1049,7 +1599,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 31001,
+    "hf_downloads": 33478,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "FrontiersMind/Nandi-Mini-150M-Instruct",
+    "provider": "frontiersmind",
+    "parameter_count": "153M",
+    "parameters_raw": 153412928,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nandi",
+    "hf_downloads": 14188,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1069,7 +1639,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 75763,
+    "hf_downloads": 97381,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1089,7 +1659,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_bigcode",
-    "hf_downloads": 123027,
+    "hf_downloads": 203309,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1115,7 +1685,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 68858,
+    "hf_downloads": 68441,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1135,7 +1705,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2",
-    "hf_downloads": 144676,
+    "hf_downloads": 136888,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "183M",
+    "parameters_raw": 182975232,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 62354,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1155,7 +1745,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 44767,
+    "hf_downloads": 21070,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "193M",
+    "parameters_raw": 193153024,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 67529,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1175,7 +1787,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 87163,
+    "hf_downloads": 128887,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "KomeijiForce/bart-large-emojilm",
+    "provider": "komeijiforce",
+    "parameter_count": "205M",
+    "parameters_raw": 204747776,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "bart",
+    "hf_downloads": 609036,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1195,7 +1827,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 88866,
+    "hf_downloads": 99096,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1205,6 +1837,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "nvidia/gpt-oss-120b-Eagle3-long-context",
+    "provider": "nvidia",
+    "parameter_count": "215M",
+    "parameters_raw": 215481600,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15250,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "humarin/chatgpt_paraphraser_on_T5_base",
@@ -1221,7 +1873,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 232268,
+    "hf_downloads": 359668,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1241,7 +1893,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 40950,
+    "hf_downloads": 33206,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1267,7 +1919,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 107070,
+    "hf_downloads": 119921,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1287,7 +1939,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 23035,
+    "hf_downloads": 27208,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1307,7 +1959,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 671671,
+    "hf_downloads": 1326276,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1327,7 +1979,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 49818,
+    "hf_downloads": 53695,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1347,7 +1999,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mixtral",
-    "hf_downloads": 104322,
+    "hf_downloads": 114610,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1355,6 +2007,46 @@
     "num_experts": 8,
     "active_experts": 2,
     "active_parameters": 71001329
+  },
+  {
+    "name": "nm-testing/tinyllama-oneshot-w4a16-channel-v2",
+    "provider": "nm-testing",
+    "parameter_count": "253M",
+    "parameters_raw": 252669236,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14216,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "BabyLM-community/babylm-multimodal-baseline-flamingo",
+    "provider": "babylm-community",
+    "parameter_count": "255M",
+    "parameters_raw": 255487500,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 15051,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/LFM2.5-1.2B-Instruct-MLX-6bit",
@@ -1371,7 +2063,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2",
-    "hf_downloads": 144362,
+    "hf_downloads": 136473,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1391,7 +2083,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics3",
-    "hf_downloads": 615462,
+    "hf_downloads": 723770,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1421,7 +2113,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "smolvlm",
-    "hf_downloads": 119300,
+    "hf_downloads": 117565,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1451,13 +2143,39 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics3",
-    "hf_downloads": 101891,
+    "hf_downloads": 232199,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "ggml-org/granite-docling-258M-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3-270m",
+    "provider": "Google",
+    "parameter_count": "268M",
+    "parameters_raw": 268098176,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 546009,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "ggml-org/gemma-3-270m-GGUF",
         "provider": "ggml-org"
       }
     ]
@@ -1477,40 +2195,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 454416,
+    "hf_downloads": 187065,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "google/gemma-3-270m",
-    "provider": "Google",
-    "parameter_count": "268M",
-    "parameters_raw": 268098176,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma3_text",
-    "hf_downloads": 99776,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/gemma-3-270m-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
-  },
-  {
-    "name": "jakobhuss/pii-extractor-gemma-3-270m-it",
-    "provider": "jakobhuss",
+    "name": "unsloth/gemma-3-270m-it",
+    "provider": "unsloth",
     "parameter_count": "268M",
     "parameters_raw": 268098176,
     "min_ram_gb": 1.0,
@@ -1525,10 +2217,20 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 78088,
+    "hf_downloads": 25862,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3-270m-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3-270m-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
   },
   {
     "name": "lmstudio-community/Qwen3-1.7B-MLX-4bit",
@@ -1547,7 +2249,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 28937,
+    "hf_downloads": 29921,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1567,7 +2269,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 38465,
+    "hf_downloads": 28829,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1587,10 +2289,60 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 37281,
+    "hf_downloads": 27756,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/gemma-3-270m-it-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "271M",
+    "parameters_raw": 271190048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 17634,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "baidu/ERNIE-4.5-0.3B-PT",
+    "provider": "baidu",
+    "parameter_count": "295M",
+    "parameters_raw": 294649856,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ernie4_5",
+    "hf_downloads": 18981,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/ERNIE-4.5-0.3B-PT-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/ERNIE-4.5-0.3B-PT-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "vikp/texify",
@@ -1607,7 +2359,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "vision-encoder-decoder",
-    "hf_downloads": 171349,
+    "hf_downloads": 162708,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1627,10 +2379,70 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5gemma",
-    "hf_downloads": 1344302,
+    "hf_downloads": 1519260,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "HuggingFaceTB/SmolLM2-360M-Instruct",
+    "provider": "huggingfacetb",
+    "parameter_count": "322M",
+    "parameters_raw": 322437119,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 186418,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/SmolLM2-360M-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/SmolLM2-360M-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/SmolLM2-360M-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "HuggingFaceTB/SmolLM-360M",
+    "provider": "huggingfacetb",
+    "parameter_count": "322M",
+    "parameters_raw": 322437119,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 17903,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/SmolLM-360M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "lmstudio-community/LFM2.5-1.2B-Instruct-MLX-8bit",
@@ -1647,7 +2459,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2",
-    "hf_downloads": 147277,
+    "hf_downloads": 138933,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/LFM2-1.2B-MLX-8bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "329M",
+    "parameters_raw": 329251584,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 24881,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1667,8 +2499,8 @@
     "capabilities": [],
     "pipeline_tag": "feature-extraction",
     "architecture": "bert",
-    "hf_downloads": 12920790,
-    "hf_likes": 654,
+    "hf_downloads": 15072818,
+    "hf_likes": 657,
     "release_date": "2023-09-12",
     "num_hidden_layers": 24,
     "num_attention_heads": 16,
@@ -1680,6 +2512,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "microsoft/biogpt",
+    "provider": "Microsoft",
+    "parameter_count": "345M",
+    "parameters_raw": 345391104,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "biogpt",
+    "hf_downloads": 120393,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "ibm-granite/granite-4.0-350m",
@@ -1696,7 +2548,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granitemoehybrid",
-    "hf_downloads": 74355,
+    "hf_downloads": 56806,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1706,6 +2558,26 @@
         "provider": "unsloth"
       }
     ]
+  },
+  {
+    "name": "ibm-granite/granite-4.0-350m-base",
+    "provider": "ibm-granite",
+    "parameter_count": "352M",
+    "parameters_raw": 352379904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 16826,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LiquidAI/LFM2-ColBERT-350M",
@@ -1722,13 +2594,33 @@
     "capabilities": [],
     "pipeline_tag": "sentence-similarity",
     "architecture": "lfm2",
-    "hf_downloads": 78115,
-    "hf_likes": 129,
+    "hf_downloads": 93350,
+    "hf_likes": 130,
     "release_date": "2025-10-28",
     "num_hidden_layers": 16,
     "num_attention_heads": 16,
     "num_key_value_heads": 8,
     "head_dim": 64
+  },
+  {
+    "name": "facebook/opt-350m",
+    "provider": "facebook",
+    "parameter_count": "353M",
+    "parameters_raw": 353468416,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 143020,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LiquidAI/LFM2-350M",
@@ -1745,7 +2637,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 25656,
+    "hf_downloads": 21730,
     "hf_likes": 249,
     "release_date": "2025-07-10",
     "num_hidden_layers": 16,
@@ -1778,7 +2670,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 1669,
+    "hf_downloads": 1232,
     "hf_likes": 78,
     "release_date": "2025-09-03",
     "num_hidden_layers": 16,
@@ -1807,8 +2699,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 612,
-    "hf_likes": 58,
+    "hf_downloads": 455,
+    "hf_likes": 59,
     "release_date": "2025-08-25",
     "num_hidden_layers": 16,
     "num_attention_heads": 16,
@@ -1836,7 +2728,7 @@
     "capabilities": [],
     "pipeline_tag": "translation",
     "architecture": "lfm2",
-    "hf_downloads": 1376,
+    "hf_downloads": 1236,
     "hf_likes": 88,
     "release_date": "2025-09-03",
     "num_hidden_layers": 16,
@@ -1865,8 +2757,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 1169,
-    "hf_likes": 54,
+    "hf_downloads": 650,
+    "hf_likes": 55,
     "release_date": "2025-09-30",
     "num_hidden_layers": 16,
     "num_attention_heads": 16,
@@ -1878,6 +2770,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "distil-labs/distil-lfm25-shellper",
+    "provider": "distil-labs",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 173425,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LiquidAI/LFM2.5-350M",
@@ -1894,7 +2806,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2",
-    "hf_downloads": 58272,
+    "hf_downloads": 102541,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1920,7 +2832,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 165142,
+    "hf_downloads": 165225,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1946,13 +2858,39 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 61852,
+    "hf_downloads": 68732,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/SmolLM2-360M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "openai-community/gpt2-medium",
+    "provider": "openai-community",
+    "parameter_count": "380M",
+    "parameters_raw": 379988992,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 815458,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/gpt2-medium-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -1972,7 +2910,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 55201,
+    "hf_downloads": 31325,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1992,7 +2930,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 54845,
+    "hf_downloads": 66037,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2018,10 +2956,166 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 57934,
+    "hf_downloads": 85987,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2-0.5B",
+    "provider": "Alibaba",
+    "parameter_count": "422M",
+    "parameters_raw": 422395904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 441313,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen2-0.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "onnx-community/Qwen2.5-0.5B-Instruct",
+    "provider": "onnx-community",
+    "parameter_count": "422M",
+    "parameters_raw": 422395904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 47738,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mlx-community/Qwen2.5-0.5B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "422M",
+    "parameters_raw": 422395904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14783,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/SmolLM-1.7B-Instruct-quantized.w4a16",
+    "provider": "nm-testing",
+    "parameter_count": "428M",
+    "parameters_raw": 427919696,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 400467,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "openbmb/MiniCPM4-0.5B",
+    "provider": "openbmb",
+    "parameter_count": "434M",
+    "parameters_raw": 433873920,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 31985,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/MiniCPM4-0.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "allenai/OLMoE-1B-7B-0924",
+    "provider": "allenai",
+    "parameter_count": "439M",
+    "parameters_raw": 438566912,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmoe",
+    "hf_downloads": 100836,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 8,
+    "active_parameters": 74008161,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/OLMoE-1B-7B-0924-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "LiquidAI/LFM2.5-VL-450M",
@@ -2040,7 +3134,171 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_vl",
-    "hf_downloads": 32493,
+    "hf_downloads": 49341,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ",
+    "provider": "mlx-community",
+    "parameter_count": "449M",
+    "parameters_raw": 448910336,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Text embeddings for RAG",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 33642,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "farbodtavakkoli/OTel-LLM-0.6B-IT",
+    "provider": "farbodtavakkoli",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 428160,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-0.6B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 278305,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-0.6B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen3-0.6B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 151601,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-0.6B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 75863,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-0.6B-Base",
+    "provider": "unsloth",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 16630,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-0.6B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mlx-community/Qwen3-0.6B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 16394,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2062,8 +3320,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "lfm2_vl",
-    "hf_downloads": 54869,
-    "hf_likes": 146,
+    "hf_downloads": 80248,
+    "hf_likes": 147,
     "release_date": "2025-08-12",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -2076,6 +3334,32 @@
       },
       {
         "repo": "mradermacher/LFM2-VL-450M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "numind/NuExtract-tiny",
+    "provider": "numind",
+    "parameter_count": "464M",
+    "parameters_raw": 463987712,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 18952,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/NuExtract-tiny-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -2097,7 +3381,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 30002,
+    "hf_downloads": 54117,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2119,7 +3403,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 30196,
+    "hf_downloads": 31075,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2141,7 +3425,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 6089483,
+    "hf_downloads": 6054782,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2173,7 +3457,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1825184,
+    "hf_downloads": 2155138,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2199,7 +3483,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 645643,
+    "hf_downloads": 909889,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2231,7 +3515,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 245178,
+    "hf_downloads": 183161,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2246,6 +3530,66 @@
       },
       {
         "repo": "mradermacher/Qwen2.5-Coder-0.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen2.5-0.5B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "494M",
+    "parameters_raw": 494032768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 130765,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen2.5-0.5B",
+    "provider": "unsloth",
+    "parameter_count": "494M",
+    "parameters_raw": 494032768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 63502,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen2.5-0.5B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -2267,7 +3611,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 48075,
+    "hf_downloads": 48293,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2289,7 +3633,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 31416,
+    "hf_downloads": 36504,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2303,6 +3647,72 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "502M",
+    "parameters_raw": 502139904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 42575,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-0.5B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "504M",
+    "parameters_raw": 503634940,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 48809,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-0.5B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "504M",
+    "parameters_raw": 503986238,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 175675,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "EleutherAI/pythia-410m",
@@ -2319,13 +3729,39 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 167504,
+    "hf_downloads": 177834,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/pythia-410m-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "EleutherAI/pythia-410m-deduped",
+    "provider": "eleutherai",
+    "parameter_count": "506M",
+    "parameters_raw": 505997504,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 25502,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/pythia-410m-deduped-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -2345,7 +3781,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics3",
-    "hf_downloads": 107458,
+    "hf_downloads": 156931,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2375,13 +3811,93 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 57488,
+    "hf_downloads": 59169,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/TIPO-500M-ft-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "KBlueLeaf/TIPO-500M",
+    "provider": "kblueleaf",
+    "parameter_count": "508M",
+    "parameters_raw": 507989760,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14894,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "h2oai/h2o-danube3-500m-chat",
+    "provider": "h2oai",
+    "parameter_count": "514M",
+    "parameters_raw": 513590784,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 18395,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/h2o-danube3-500m-chat-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/h2o-danube3-500m-chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "ibm-granite/granite-4.0-tiny-preview",
+    "provider": "ibm-granite",
+    "parameter_count": "516M",
+    "parameters_raw": 515911680,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 73832,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 62,
+    "active_experts": 6,
+    "active_parameters": 73226172,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/granite-4.0-tiny-preview-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -2401,7 +3917,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "falcon_h1",
-    "hf_downloads": 52520,
+    "hf_downloads": 63468,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2429,7 +3945,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 118024,
+    "hf_downloads": 74883,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "z-lab/Qwen3.5-4B-DFlash",
+    "provider": "z-lab",
+    "parameter_count": "537M",
+    "parameters_raw": 537427200,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 19732,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2449,7 +3987,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granite",
-    "hf_downloads": 56797,
+    "hf_downloads": 80205,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2469,7 +4007,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bloom",
-    "hf_downloads": 1281786,
+    "hf_downloads": 1175131,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2495,7 +4033,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bloom",
-    "hf_downloads": 295175,
+    "hf_downloads": 408630,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2521,7 +4059,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "got_ocr2",
-    "hf_downloads": 28321,
+    "hf_downloads": 30400,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2543,7 +4081,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 71933,
+    "hf_downloads": 75058,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2563,7 +4101,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5gemma",
-    "hf_downloads": 39991,
+    "hf_downloads": 36436,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2583,7 +4121,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 52069,
+    "hf_downloads": 54293,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2603,7 +4141,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 81474,
+    "hf_downloads": 82366,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2629,7 +4167,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 33430,
+    "hf_downloads": 44349,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2639,6 +4177,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "KamilaMila/FastVLM-0.5B",
+    "provider": "kamilamila",
+    "parameter_count": "620M",
+    "parameters_raw": 620397152,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "fast_vlm",
+    "hf_downloads": 10046,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/Qwen3-4B-Thinking-2507-MLX-4bit",
@@ -2657,7 +4215,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 69266,
+    "hf_downloads": 67500,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2679,7 +4237,111 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 60275,
+    "hf_downloads": 59335,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Qwen3-4B-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "629M",
+    "parameters_raw": 628676096,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 22287,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "629M",
+    "parameters_raw": 628676096,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17205,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
+    "provider": "prism-ml",
+    "parameter_count": "640M",
+    "parameters_raw": 640014464,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 20044,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hyper-accel/ci-random-llama2-7b",
+    "provider": "hyper-accel",
+    "parameter_count": "667M",
+    "parameters_raw": 666914816,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 20286,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "yuhuili/EAGLE-LLaMA3-Instruct-8B",
+    "provider": "yuhuili",
+    "parameter_count": "710M",
+    "parameters_raw": 709885952,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 101493,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2699,7 +4361,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "udop",
-    "hf_downloads": 73565,
+    "hf_downloads": 75386,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2719,8 +4381,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 10246,
-    "hf_likes": 110,
+    "hf_downloads": 9487,
+    "hf_likes": 111,
     "release_date": "2025-07-10",
     "num_hidden_layers": 16,
     "num_attention_heads": 24,
@@ -2730,6 +4392,32 @@
       {
         "repo": "unsloth/LFM2-700M-GGUF",
         "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "Etherll/Tashkeel-700M",
+    "provider": "etherll",
+    "parameter_count": "742M",
+    "parameters_raw": 742489344,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 22699,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Tashkeel-700M-GGUF",
+        "provider": "mradermacher"
       }
     ]
   },
@@ -2750,8 +4438,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3",
-    "hf_downloads": 18497766,
-    "hf_likes": 1215,
+    "hf_downloads": 19084802,
+    "hf_likes": 1224,
     "release_date": "2025-04-27",
     "num_hidden_layers": 28,
     "num_attention_heads": 16,
@@ -2789,7 +4477,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 340288,
+    "hf_downloads": 1735643,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2817,7 +4505,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 24923,
+    "hf_downloads": 22403,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2853,7 +4541,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 1885388,
+    "hf_downloads": 2219177,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2875,7 +4563,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 57594,
+    "hf_downloads": 57352,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "apple/FastVLM-0.5B",
+    "provider": "apple",
+    "parameter_count": "759M",
+    "parameters_raw": 758833760,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llava_qwen2",
+    "hf_downloads": 15319,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2895,7 +4603,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 32903,
+    "hf_downloads": 24948,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2915,7 +4623,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 58868,
+    "hf_downloads": 78588,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2935,7 +4643,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 870915,
+    "hf_downloads": 666627,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2955,10 +4663,36 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5gemma2",
-    "hf_downloads": 23408,
+    "hf_downloads": 22291,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "openai-community/gpt2-large",
+    "provider": "openai-community",
+    "parameter_count": "812M",
+    "parameters_raw": 811778816,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 2153999,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/gpt2-large-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "h2oai/h2ovl-mississippi-800m",
@@ -2975,7 +4709,67 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "h2ovl_chat",
-    "hf_downloads": 944582,
+    "hf_downloads": 992556,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "microsoft/bitnet-b1.58-2B-4T",
+    "provider": "Microsoft",
+    "parameter_count": "850M",
+    "parameters_raw": 849787090,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "bitnet",
+    "hf_downloads": 17655,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/gemma-3-1b-it-qat-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "854M",
+    "parameters_raw": 854065152,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 91751,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/gemma-3-1b-it-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "854M",
+    "parameters_raw": 854065152,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 60775,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2995,7 +4789,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 35731,
+    "hf_downloads": 61231,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3017,7 +4811,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 195262,
+    "hf_downloads": 126211,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3040,8 +4834,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 2956012,
-    "hf_likes": 512,
+    "hf_downloads": 3031961,
+    "hf_likes": 523,
     "release_date": "2026-02-28",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -3051,6 +4845,10 @@
       {
         "repo": "unsloth/Qwen3.5-0.8B-GGUF",
         "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3.5-0.8B-GGUF",
+        "provider": "ggml-org"
       },
       {
         "repo": "mradermacher/Qwen3.5-0.8B-GGUF",
@@ -3076,14 +4874,18 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 136205,
-    "hf_likes": 70,
+    "hf_downloads": 153434,
+    "hf_likes": 73,
     "release_date": "2026-02-28",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
     "head_dim": null,
     "gguf_sources": [
+      {
+        "repo": "ggml-org/Qwen3.5-0.8B-Base-GGUF",
+        "provider": "ggml-org"
+      },
       {
         "repo": "mradermacher/Qwen3.5-0.8B-Base-GGUF",
         "provider": "mradermacher"
@@ -3107,7 +4909,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 67135,
+    "hf_downloads": 65451,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3129,7 +4931,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 57680,
+    "hf_downloads": 57438,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3151,10 +4953,36 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_onevision",
-    "hf_downloads": 489465,
+    "hf_downloads": 556065,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "EleutherAI/pythia-1b-deduped",
+    "provider": "eleutherai",
+    "parameter_count": "908M",
+    "parameters_raw": 908328960,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 25695,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/pythia-1b-deduped-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "turing-motors/Heron-NVILA-Lite-1B-hf",
@@ -3171,7 +4999,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "heron",
-    "hf_downloads": 23197,
+    "hf_downloads": 17645,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3191,7 +5019,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_parse",
-    "hf_downloads": 13119,
+    "hf_downloads": 20528,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3211,7 +5039,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 550976,
+    "hf_downloads": 650514,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3237,7 +5065,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl",
-    "hf_downloads": 222577,
+    "hf_downloads": 250861,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3257,7 +5085,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 130361,
+    "hf_downloads": 132673,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3287,7 +5115,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 11813,
+    "hf_downloads": 10310,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3301,6 +5129,130 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
+    "provider": "Community",
+    "parameter_count": "942M",
+    "parameters_raw": 942145536,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 99595,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/TinyLlama-1.1B-intermediate-step-1431k-3T-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/TinyLlama-1.1B-intermediate-step-1431k-3T-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "TinyLlama/TinyLlama_v1.1",
+    "provider": "Community",
+    "parameter_count": "942M",
+    "parameters_raw": 942145536,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 32690,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/TinyLlama_v1.1-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lightblue/karasu-1.1B",
+    "provider": "lightblue",
+    "parameter_count": "942M",
+    "parameters_raw": 942145536,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 20191,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/karasu-1.1B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LnL-AI/TinyLlama-1.1B-Chat-v1.0-GPTQ-4bit",
+    "provider": "lnl-ai",
+    "parameter_count": "942M",
+    "parameters_raw": 942145536,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 18273,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3",
+    "provider": "redhatai",
+    "parameter_count": "950M",
+    "parameters_raw": 950186496,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 25867,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "PaddlePaddle/PaddleOCR-VL-1.5",
@@ -3319,7 +5271,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "paddleocr_vl",
-    "hf_downloads": 138714,
+    "hf_downloads": 91160,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3339,7 +5291,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hunyuan_vl",
-    "hf_downloads": 184491,
+    "hf_downloads": 196515,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3371,13 +5323,49 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "gemma3_text",
-    "hf_downloads": 531764,
-    "hf_likes": 936,
+    "hf_downloads": 581880,
+    "hf_likes": 945,
     "release_date": "2025-03-10",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
     "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3-1b-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3-1b-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-3-1b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/gemma-3-1b-it",
+    "provider": "unsloth",
+    "parameter_count": "1000M",
+    "parameters_raw": 999885952,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 216040,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
     "gguf_sources": [
       {
         "repo": "unsloth/gemma-3-1b-it-GGUF",
@@ -3408,7 +5396,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 517843,
+    "hf_downloads": 192306,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3428,7 +5416,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral3",
-    "hf_downloads": 831415,
+    "hf_downloads": 753437,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3442,6 +5430,106 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "deepseek-ai/deepseek-coder-1.3b-instruct",
+    "provider": "DeepSeek",
+    "parameter_count": "1.0B",
+    "parameters_raw": 1009778688,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 40023,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/deepseek-coder-1.3b-instruct-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/deepseek-coder-1.3b-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/deepseek-coder-1.3b-base",
+    "provider": "DeepSeek",
+    "parameter_count": "1.0B",
+    "parameters_raw": 1009778688,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21767,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/deepseek-coder-1.3b-base-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/deepseek-coder-1.3b-base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/gemma-3-1b-it-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.0B",
+    "parameters_raw": 1021095818,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 26147,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mtgv/MobileLLaMA-1.4B-Chat",
+    "provider": "mtgv",
+    "parameter_count": "1.0B",
+    "parameters_raw": 1021837312,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 189841,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "RedHatAI/Qwen3-8B-speculator.eagle3",
@@ -3460,7 +5548,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 70275,
+    "hf_downloads": 71052,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3483,7 +5571,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 176830,
+    "hf_downloads": 172929,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3505,7 +5593,99 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 29000,
+    "hf_downloads": 40965,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ByteDance/Ouro-1.4B",
+    "provider": "bytedance",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1056964608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ouro",
+    "hf_downloads": 44647,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "argilla/Llama-3.2-1B-Instruct-APIGen-FC-v0.1",
+    "provider": "argilla",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1067974656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 49099,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-1B-Instruct-APIGen-FC-v0.1-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "argilla-warehouse/Llama-3.2-1B-Instruct-v2-FC",
+    "provider": "argilla-warehouse",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1067974656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 48326,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1067974656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 31595,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3525,7 +5705,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 110269,
+    "hf_downloads": 112704,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3551,8 +5731,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 3172589,
-    "hf_likes": 1575,
+    "hf_downloads": 3046637,
+    "hf_likes": 1578,
     "release_date": "2023-12-30",
     "num_hidden_layers": 22,
     "num_attention_heads": 32,
@@ -3584,7 +5764,47 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 58094,
+    "hf_downloads": 160504,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TinyLlama/TinyLlama-1.1B-step-50K-105b",
+    "provider": "Community",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100048384,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15694,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/tinyllama-oneshot-w8a8-dynamic-token-v2",
+    "provider": "nm-testing",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100048538,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14306,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3604,7 +5824,113 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 44840,
+    "hf_downloads": 55586,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "QuixiAI/TinyDolphin-2.8-1.1b",
+    "provider": "quixiai",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100056576,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16527,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/TinyDolphin-2.8-1.1b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "TheBloke/TinyLlama-1.1B-Chat-v0.3-AWQ",
+    "provider": "thebloke",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100060672,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 84806,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/TinyLlama-1.1B-Chat-v1.0-GPTQ",
+    "provider": "thebloke",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100442624,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 90179,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/tinyllama-oneshot-w8a8-channel-dynamic-token-v2",
+    "provider": "nm-testing",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100442624,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 18987,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/TinyLlama-1.1B-Chat-v0.3-GPTQ",
+    "provider": "thebloke",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100454912,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 804521,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3624,7 +5950,47 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_bigcode",
-    "hf_downloads": 41852,
+    "hf_downloads": 41618,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/tinyllama-chat-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1130479622,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13566,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/tinyllama-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1130479968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 57465,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3646,7 +6012,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 68335,
+    "hf_downloads": 66476,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3668,7 +6034,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 58808,
+    "hf_downloads": 58374,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Qwen3-4B-MLX-8bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1131460096,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 20914,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3688,7 +6076,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 1564624,
+    "hf_downloads": 1487774,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3714,7 +6102,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 43480,
+    "hf_downloads": 155419,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3743,7 +6131,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 168337,
+    "hf_downloads": 164425,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3763,7 +6151,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 58765,
+    "hf_downloads": 71913,
     "hf_likes": 352,
     "release_date": "2025-07-10",
     "num_hidden_layers": 16,
@@ -3792,8 +6180,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 22079,
-    "hf_likes": 124,
+    "hf_downloads": 19193,
+    "hf_likes": 125,
     "release_date": "2026-01-05",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3821,8 +6209,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 424907,
-    "hf_likes": 574,
+    "hf_downloads": 408739,
+    "hf_likes": 580,
     "release_date": "2026-01-06",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3854,8 +6242,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 28913,
-    "hf_likes": 335,
+    "hf_downloads": 37247,
+    "hf_likes": 341,
     "release_date": "2026-01-20",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3887,7 +6275,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 1904,
+    "hf_downloads": 2542,
     "hf_likes": 145,
     "release_date": "2026-01-04",
     "num_hidden_layers": 16,
@@ -3916,8 +6304,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 772,
-    "hf_likes": 102,
+    "hf_downloads": 727,
+    "hf_likes": 103,
     "release_date": "2025-09-03",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3945,7 +6333,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 873,
+    "hf_downloads": 688,
     "hf_likes": 118,
     "release_date": "2025-09-03",
     "num_hidden_layers": 16,
@@ -3974,8 +6362,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 1775,
-    "hf_likes": 107,
+    "hf_downloads": 2418,
+    "hf_likes": 108,
     "release_date": "2025-08-22",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3984,6 +6372,56 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/LFM2-1.2B-Extract-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lmstudio-community/LFM2-1.2B-MLX-bf16",
+    "provider": "lmstudio-community",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 24610,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tiiuae/Falcon3-1B-Base",
+    "provider": "TII",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1174405120,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15515,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Falcon3-1B-Base-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Falcon3-1B-Base-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4003,13 +6441,61 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo",
-    "hf_downloads": 30889,
+    "hf_downloads": 35054,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/OLMo-1B-hf-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lmstudio-community/Qwen2.5-Coder-7B-Instruct-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1190221312,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 19176,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "farbodtavakkoli/OTel-LLM-1.2B-IT",
+    "provider": "farbodtavakkoli",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1207959552,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 620610,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/OTel-LLM-1.2B-IT-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4029,7 +6515,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "zamba2",
-    "hf_downloads": 132669,
+    "hf_downloads": 166109,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4049,8 +6535,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 1337696,
-    "hf_likes": 2375,
+    "hf_downloads": 1596915,
+    "hf_likes": 2378,
     "release_date": "2024-09-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -4080,7 +6566,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 5344861,
+    "hf_downloads": 6482378,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4114,7 +6600,91 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ilama",
-    "hf_downloads": 153404,
+    "hf_downloads": 199931,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 191141,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Llama-3.2-1B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Llama-3.2-1B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Llama-3.2-1B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B",
+    "provider": "unsloth",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 80999,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-1B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "ShahriarFerdoush/llama-3.2-1b-code-instruct",
+    "provider": "shahriarferdoush",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 49750,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4136,7 +6706,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 63482,
+    "hf_downloads": 49094,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4156,7 +6726,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 56558,
+    "hf_downloads": 47895,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4182,7 +6752,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 56330,
+    "hf_downloads": 47736,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4192,28 +6762,6 @@
         "provider": "mradermacher"
       }
     ]
-  },
-  {
-    "name": "ShahriarFerdoush/llama-3.2-1b-code-instruct",
-    "provider": "shahriarferdoush",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1235814400,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 1048576,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "llama",
-    "hf_downloads": 53982,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
   },
   {
     "name": "Vikhrmodels/Vikhr-Llama-3.2-1B-Instruct",
@@ -4232,13 +6780,39 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 51769,
+    "hf_downloads": 47707,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/Vikhr-Llama-3.2-1B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "NousResearch/Llama-3.2-1B",
+    "provider": "NousResearch",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14836,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-1B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4258,7 +6832,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 49154,
+    "hf_downloads": 47914,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4268,6 +6842,28 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "RedHatAI/Qwen3-4B-quantized.w4a16",
+    "provider": "redhatai",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1260658680,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 20614,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-4B-Instruct-2507-AWQ-4bit",
@@ -4286,7 +6882,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 72297,
+    "hf_downloads": 150384,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4306,7 +6902,71 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 62514,
+    "hf_downloads": 21835,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1264773664,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15141,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1264773672,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 86227,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1266351458,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 28789,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4326,7 +6986,79 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis",
-    "hf_downloads": 57411,
+    "hf_downloads": 76079,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1267466240,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_moe",
+    "hf_downloads": 47156,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 60,
+    "active_experts": 4,
+    "active_parameters": 143646172
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-1.5B",
+    "provider": "Alibaba",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1268318208,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 589942,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-1.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1268318208,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 88788,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4346,7 +7078,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "exaone4",
-    "hf_downloads": 21111,
+    "hf_downloads": 16428,
     "hf_likes": 181,
     "release_date": "2025-07-11",
     "num_hidden_layers": 30,
@@ -4377,7 +7109,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 396618,
+    "hf_downloads": 442980,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4399,7 +7131,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 27893,
+    "hf_downloads": 28326,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Josiefied-Qwen3-8B-abliterated-v1-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1280062464,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17444,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4419,7 +7173,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "plamo2",
-    "hf_downloads": 61967,
+    "hf_downloads": 48687,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4442,7 +7196,81 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 168415,
+    "hf_downloads": 164460,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "HuggingFaceTB/SmolLM2-1.7B-Instruct",
+    "provider": "huggingfacetb",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1308622848,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 166113,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/SmolLM2-1.7B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/SmolLM2-1.7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/SmolLM2-1.7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "facebook/opt-1.3b",
+    "provider": "facebook",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1310916608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 213528,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tiiuae/falcon-rw-1b",
+    "provider": "TII",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1310982144,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "falcon",
+    "hf_downloads": 24969,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4462,7 +7290,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "moondream1",
-    "hf_downloads": 18281,
+    "hf_downloads": 19517,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "fla-hub/transformer-1.3B-100B",
+    "provider": "fla-hub",
+    "parameter_count": "1.4B",
+    "parameters_raw": 1364297728,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "transformer",
+    "hf_downloads": 14737,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4482,7 +7330,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neo",
-    "hf_downloads": 32065,
+    "hf_downloads": 33410,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4502,7 +7350,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granitemoe",
-    "hf_downloads": 52680,
+    "hf_downloads": 68947,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4513,6 +7361,32 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/granite-3.0-1b-a400m-base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "EleutherAI/pythia-1.4b-deduped",
+    "provider": "eleutherai",
+    "parameter_count": "1.4B",
+    "parameters_raw": 1414647808,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 18122,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/pythia-1.4b-deduped-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4532,7 +7406,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi",
-    "hf_downloads": 77774,
+    "hf_downloads": 71891,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4558,7 +7432,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "starvector",
-    "hf_downloads": 53753,
+    "hf_downloads": 37209,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4578,7 +7452,7 @@
     "capabilities": [],
     "pipeline_tag": "audio-to-audio",
     "architecture": "unknown",
-    "hf_downloads": 355,
+    "hf_downloads": 286,
     "hf_likes": 346,
     "release_date": "2025-08-28",
     "num_hidden_layers": null,
@@ -4607,8 +7481,8 @@
     "capabilities": [],
     "pipeline_tag": "audio-to-audio",
     "architecture": "unknown",
-    "hf_downloads": 858,
-    "hf_likes": 390,
+    "hf_downloads": 790,
+    "hf_likes": 395,
     "release_date": "2025-12-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -4630,7 +7504,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo2",
-    "hf_downloads": 83282,
+    "hf_downloads": 94854,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4656,7 +7530,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo2",
-    "hf_downloads": 35803,
+    "hf_downloads": 38579,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4667,6 +7541,166 @@
       },
       {
         "repo": "mradermacher/OLMo-2-0425-1B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "onnx-community/Bonsai-1.7B-ONNX",
+    "provider": "onnx-community",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485023232,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 19624,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "farbodtavakkoli/OTel-LLM-1.7B-IT",
+    "provider": "farbodtavakkoli",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 84482,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-1.7B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 49809,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-1.7B-Base",
+    "provider": "unsloth",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 35749,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-1.7B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen3-1.7B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 35014,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3-1.7B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 23232,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tomg-group-umd/DynaGuard-1.7B",
+    "provider": "tomg-group-umd",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 19061,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/DynaGuard-1.7B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4686,7 +7720,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 52980,
+    "hf_downloads": 58412,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4714,7 +7748,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 902103,
+    "hf_downloads": 971825,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4736,10 +7770,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1714729,
+    "hf_downloads": 2015070,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Llama-3.2-1B-Instruct-quantized.w8a8",
+    "provider": "redhatai",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1498859520,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 23277,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "shoumenchougou/RWKV7-G1f-1.5B-GGUF",
+    "provider": "RWKV",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1500000000,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "rwkv",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
   },
   {
     "name": "EleutherAI/pythia-1.4b",
@@ -4756,7 +7831,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 68121,
+    "hf_downloads": 83238,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4784,7 +7859,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 206886,
+    "hf_downloads": 216895,
     "hf_likes": 118,
     "release_date": "2024-09-18",
     "num_hidden_layers": 28,
@@ -4823,7 +7898,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 9813491,
+    "hf_downloads": 10816120,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4853,7 +7928,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 3487346,
+    "hf_downloads": 4220156,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4881,7 +7956,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1049844,
+    "hf_downloads": 914961,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4909,7 +7984,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 345107,
+    "hf_downloads": 505522,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4935,36 +8010,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 232884,
+    "hf_downloads": 207575,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2-1.5B",
-    "provider": "Alibaba",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1543714304,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 139489,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2-1.5B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-Math-1.5B-Instruct",
@@ -4983,7 +8032,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 110662,
+    "hf_downloads": 179134,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4994,6 +8043,58 @@
       },
       {
         "repo": "mradermacher/Qwen2.5-Math-1.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2-1.5B",
+    "provider": "Alibaba",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 127243,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen2-1.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "jinaai/ReaderLM-v2",
+    "provider": "jinaai",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 512768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 99842,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/ReaderLM-v2-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -5013,10 +8114,68 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35824,
+    "hf_downloads": 44021,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-1.5B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 29410,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-1.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-1.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "open-thoughts/OpenThinker3-1.5B",
+    "provider": "open-thoughts",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 15521,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/OpenThinker3-1.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "lmstudio-community/Qwen3-VL-4B-Instruct-MLX-8bit",
@@ -5036,7 +8195,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 168968,
+    "hf_downloads": 164984,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-1.5B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1576741182,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 74530,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-1.5B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1579330356,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 29652,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5058,7 +8261,7 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "lfm2_vl",
-    "hf_downloads": 4462,
+    "hf_downloads": 4256,
     "hf_likes": 226,
     "release_date": "2025-08-12",
     "num_hidden_layers": null,
@@ -5071,6 +8274,28 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "unsloth/Qwen2.5-1.5B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1584858476,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 34461,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LiquidAI/LFM2.5-VL-1.6B",
@@ -5089,8 +8314,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "lfm2_vl",
-    "hf_downloads": 130562,
-    "hf_likes": 277,
+    "hf_downloads": 114767,
+    "hf_likes": 281,
     "release_date": "2026-01-05",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -5102,6 +8327,52 @@
         "provider": "unsloth"
       }
     ]
+  },
+  {
+    "name": "openai-community/gpt2-xl",
+    "provider": "openai-community",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1607942848,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 201909,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/gpt2-xl-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lightseekorg/kimi-k2.5-eagle3-mla",
+    "provider": "lightseekorg",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1644167168,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "kimi_k2",
+    "hf_downloads": 42610,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "stabilityai/stablelm-2-1_6b-chat",
@@ -5118,7 +8389,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "stablelm",
-    "hf_downloads": 2905,
+    "hf_downloads": 2732,
     "hf_likes": 35,
     "release_date": "2024-04-08",
     "num_hidden_layers": 24,
@@ -5147,7 +8418,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 71652,
+    "hf_downloads": 113189,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5173,41 +8444,13 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 46052,
+    "hf_downloads": 47474,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/SmolLM-1.7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3-1.7B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "1.7B",
-    "parameters_raw": 1720574976,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3",
-    "hf_downloads": 542341,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-1.7B-Base-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -5227,10 +8470,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 520722,
+    "hf_downloads": 795984,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-1.7B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1720574976,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 558211,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-1.7B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "Qwen/Qwen3-1.7B-GPTQ-Int8",
@@ -5249,7 +8520,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 493596,
+    "hf_downloads": 516143,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5269,7 +8540,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 43388,
+    "hf_downloads": 43366,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5297,7 +8568,79 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 28608,
+    "hf_downloads": 29600,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "bigatuna/Qwen3-1.7B-Sushi-Coder",
+    "provider": "bigatuna",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1720574976,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 18509,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-1.7B-Sushi-Coder-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "activeDap/Qwen3-1.7B_hh_harmful",
+    "provider": "activedap",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1720574976,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17075,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "contextboxai/Qwen3-1.7B-FC",
+    "provider": "contextboxai",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1720574976,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 15574,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5317,7 +8660,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bloom",
-    "hf_downloads": 47595,
+    "hf_downloads": 48502,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5327,6 +8670,70 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "speakleash/Bielik-11B-v3.0-Instruct-awq",
+    "provider": "speakleash",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1722602172,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 71267,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "z-lab/Qwen3.6-27B-DFlash",
+    "provider": "z-lab",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1730213120,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 26361,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "z-lab/Qwen3.5-27B-DFlash",
+    "provider": "z-lab",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1730213120,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 25220,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-VL-4B-Instruct-AWQ-4bit",
@@ -5346,7 +8753,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 151331,
+    "hf_downloads": 94463,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5359,17 +8766,105 @@
     "min_ram_gb": 1.0,
     "recommended_ram_gb": 2.0,
     "min_vram_gb": 0.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
+    "quantization": "AutoRound-4bit",
+    "format": "autoround",
     "context_length": 128000,
     "use_case": "General purpose",
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 47053,
+    "hf_downloads": 10813,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/gpt-oss-20b-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "1.8B",
+    "parameters_raw": 1773527040,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 295100,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 299282688
+  },
+  {
+    "name": "openai/gpt-oss-safeguard-20b",
+    "provider": "openai",
+    "parameter_count": "1.8B",
+    "parameters_raw": 1773527040,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 82112,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 299282688,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gpt-oss-safeguard-20b-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/gpt-oss-safeguard-20b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "huihui-ai/Huihui-gpt-oss-20b-BF16-abliterated",
+    "provider": "huihui-ai",
+    "parameter_count": "1.8B",
+    "parameters_raw": 1773527040,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 40560,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 299282688,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Huihui-gpt-oss-20b-BF16-abliterated-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
@@ -5388,7 +8883,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 782033,
+    "hf_downloads": 925358,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5408,7 +8903,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 502546,
+    "hf_downloads": 426774,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5444,7 +8939,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 122897,
+    "hf_downloads": 130341,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5464,7 +8959,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35750,
+    "hf_downloads": 43923,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5484,7 +8979,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35594,
+    "hf_downloads": 43714,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5506,7 +9001,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1011746,
+    "hf_downloads": 1178375,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5526,7 +9021,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 49545,
+    "hf_downloads": 40637,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5552,7 +9047,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 32226,
+    "hf_downloads": 33408,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5578,7 +9073,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "moondream1",
-    "hf_downloads": 2608010,
+    "hf_downloads": 2662742,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5598,7 +9093,47 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "video_llama_3",
-    "hf_downloads": 91163,
+    "hf_downloads": 94624,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ByteDance/Ouro-2.6B",
+    "provider": "bytedance",
+    "parameter_count": "2.0B",
+    "parameters_raw": 2013265920,
+    "min_ram_gb": 1.1,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ouro",
+    "hf_downloads": 35520,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ByteDance/Ouro-2.6B-Thinking",
+    "provider": "bytedance",
+    "parameter_count": "2.0B",
+    "parameters_raw": 2013265920,
+    "min_ram_gb": 1.1,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ouro",
+    "hf_downloads": 18722,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5620,8 +9155,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3",
-    "hf_downloads": 6077216,
-    "hf_likes": 454,
+    "hf_downloads": 4253852,
+    "hf_likes": 457,
     "release_date": "2025-04-27",
     "num_hidden_layers": 28,
     "num_attention_heads": 16,
@@ -5643,8 +9178,8 @@
     ]
   },
   {
-    "name": "JetLM/SDAR-1.7B-Chat",
-    "provider": "jetlm",
+    "name": "guangyangnlp/Qwen3-1.7B-SFT-science-2e-5",
+    "provider": "guangyangnlp",
     "parameter_count": "2.0B",
     "parameters_raw": 2031739904,
     "min_ram_gb": 1.1,
@@ -5652,12 +9187,36 @@
     "min_vram_gb": 1.0,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
     "pipeline_tag": "unknown",
-    "architecture": "sdar",
-    "hf_downloads": 40710,
+    "architecture": "qwen3",
+    "hf_downloads": 15346,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-1.7B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "2.0B",
+    "parameters_raw": 2031825920,
+    "min_ram_gb": 1.1,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 20060,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5677,7 +9236,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 15829,
+    "hf_downloads": 19794,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5697,6 +9256,56 @@
     ]
   },
   {
+    "name": "OpenGVLab/InternVL3-2B-hf",
+    "provider": "opengvlab",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2088957440,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internvl",
+    "hf_downloads": 14310,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-3.3-2b-instruct",
+    "provider": "ibm-granite",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2113943552,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granite",
+    "hf_downloads": 32733,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/granite-3.3-2b-instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/granite-3.3-2b-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
     "name": "google/t5gemma-2-1b-1b",
     "provider": "Google",
     "parameter_count": "2.1B",
@@ -5711,10 +9320,176 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5gemma2",
-    "hf_downloads": 52082,
+    "hf_downloads": 50479,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Qwen3-Coder-Next-NVFP4",
+    "provider": "redhatai",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 48812,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
+  },
+  {
+    "name": "Qwen/Qwen3-Next-80B-A3B-Thinking",
+    "provider": "Alibaba",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 32388,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-Next-80B-A3B-Thinking-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3-Next-80B-A3B-Thinking-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen3-Coder-Next-FP8",
+    "provider": "unsloth",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 23545,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
+  },
+  {
+    "name": "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 22570,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
+  },
+  {
+    "name": "unsloth/Qwen3-Next-80B-A3B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 17224,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
+  },
+  {
+    "name": "unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 16596,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
   },
   {
     "name": "Qwen/Qwen3-VL-2B-Instruct",
@@ -5734,7 +9509,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 165732702,
+    "hf_downloads": 186982016,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5771,7 +9546,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 108320,
+    "hf_downloads": 100495,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5801,16 +9576,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 17005,
+    "hf_downloads": 53113,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/typhoon-ocr1.5-2b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "embedl/Cosmos-Reason2-2B-W4A16-Edge2",
@@ -5827,7 +9596,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 11921,
+    "hf_downloads": 12128,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5847,7 +9616,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "h2ovl_chat",
-    "hf_downloads": 925509,
+    "hf_downloads": 969149,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "openbmb/MiniCPM-2B-sft-bf16",
+    "provider": "openbmb",
+    "parameter_count": "2.2B",
+    "parameters_raw": 2193852672,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 55230,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5867,7 +9656,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 1138876,
+    "hf_downloads": 1168150,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5887,32 +9676,40 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 61533,
+    "hf_downloads": 56263,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "NAMAA-Space/Qari-OCR-v0.3-VL-2B-Instruct",
-    "provider": "namaa-space",
+    "name": "UnfilteredAI/NSFW-flash",
+    "provider": "unfilteredai",
     "parameter_count": "2.2B",
-    "parameters_raw": 2208985600,
-    "min_ram_gb": 1.2,
+    "parameters_raw": 2240163840,
+    "min_ram_gb": 1.3,
     "recommended_ram_gb": 2.1,
     "min_vram_gb": 1.1,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision"
-    ],
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "qwen2_vl",
-    "hf_downloads": 20310,
+    "architecture": "stablelm",
+    "hf_downloads": 13790,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 644047104,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/NSFW-flash-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "HuggingFaceTB/SmolVLM-Instruct",
@@ -5929,7 +9726,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics3",
-    "hf_downloads": 22913,
+    "hf_downloads": 28837,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5937,10 +9734,6 @@
       {
         "repo": "ggml-org/SmolVLM-Instruct-GGUF",
         "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/SmolVLM-Instruct-GGUF",
-        "provider": "mradermacher"
       }
     ]
   },
@@ -5962,8 +9755,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 1701802,
-    "hf_likes": 265,
+    "hf_downloads": 1727304,
+    "hf_likes": 267,
     "release_date": "2026-02-28",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -5998,32 +9791,36 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 64466,
-    "hf_likes": 66,
+    "hf_downloads": 73441,
+    "hf_likes": 68,
     "release_date": "2026-02-28",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
-    "head_dim": null
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-2B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
-    "name": "QuantTrio/Qwen3.5-2B-AWQ",
-    "provider": "quanttrio",
+    "name": "raxcore-dev/rax-3.5-chat",
+    "provider": "raxcore-dev",
     "parameter_count": "2.3B",
     "parameters_raw": 2274069824,
     "min_ram_gb": 1.3,
     "recommended_ram_gb": 2.1,
     "min_vram_gb": 1.2,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 24999,
+    "hf_downloads": 12213,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6043,7 +9840,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 39628,
+    "hf_downloads": 40449,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6065,7 +9862,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 368169,
+    "hf_downloads": 401807,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6087,7 +9884,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 26366,
+    "hf_downloads": 26853,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6109,7 +9906,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 42416,
+    "hf_downloads": 45178,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6131,7 +9928,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 138810,
+    "hf_downloads": 153189,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6153,10 +9950,150 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 15021,
+    "hf_downloads": 22576,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 1121574,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3-30B-A3B-Instruct-2507-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-30B-A3B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 177177,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622
+  },
+  {
+    "name": "mlx-community/Qwen3-30B-A3B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 66786,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622
+  },
+  {
+    "name": "Qwen/Qwen3-30B-A3B-Thinking-2507-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 63256,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622
+  },
+  {
+    "name": "unsloth/Qwen3-30B-A3B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 37927,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622
   },
   {
     "name": "OpenGVLab/InternVL3_5-2B-HF",
@@ -6173,10 +10110,90 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl",
-    "hf_downloads": 10588,
+    "hf_downloads": 11262,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/gpt-oss-120b-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "2.4B",
+    "parameters_raw": 2370723840,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 269328,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 4,
+    "active_parameters": 188917056
+  },
+  {
+    "name": "openai/gpt-oss-safeguard-120b",
+    "provider": "openai",
+    "parameter_count": "2.4B",
+    "parameters_raw": 2370723840,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 23882,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 4,
+    "active_parameters": 188917056,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gpt-oss-safeguard-120b-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-3.5-2.4B-Instruct",
+    "provider": "lgai-exaone",
+    "parameter_count": "2.4B",
+    "parameters_raw": 2405327360,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "exaone",
+    "hf_downloads": 23797,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/EXAONE-3.5-2.4B-Instruct-GGUF",
+        "provider": "bartowski"
+      }
+    ]
   },
   {
     "name": "Qwen/Qwen3-VL-2B-Instruct-FP8",
@@ -6196,7 +10213,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 130508,
+    "hf_downloads": 231022,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6219,7 +10236,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 45640,
+    "hf_downloads": 46183,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6241,7 +10258,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 130763,
+    "hf_downloads": 156223,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6261,16 +10278,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma",
-    "hf_downloads": 159083,
+    "hf_downloads": 188880,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-2b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "google/gemma-1.1-2b-it",
@@ -6287,20 +10298,62 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma",
-    "hf_downloads": 108002,
+    "hf_downloads": 137091,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "google/codegemma-2b",
+    "provider": "Google",
+    "parameter_count": "2.5B",
+    "parameters_raw": 2506172416,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.3,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma",
+    "hf_downloads": 19217,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "bartowski/gemma-1.1-2b-it-GGUF",
+        "repo": "bartowski/codegemma-2b-GGUF",
         "provider": "bartowski"
       },
       {
-        "repo": "mradermacher/gemma-1.1-2b-it-GGUF",
+        "repo": "mradermacher/codegemma-2b-GGUF",
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "mlx-community/Qwen2.5-3B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "2.5B",
+    "parameters_raw": 2538340352,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 22950,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "PerceptronAI/Isaac-0.2-2B-Preview",
@@ -6317,7 +10370,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "isaac",
-    "hf_downloads": 52856,
+    "hf_downloads": 37184,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6337,7 +10390,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "isaac",
-    "hf_downloads": 44030,
+    "hf_downloads": 36407,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6357,8 +10410,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 5777,
-    "hf_likes": 187,
+    "hf_downloads": 4757,
+    "hf_likes": 188,
     "release_date": "2025-09-22",
     "num_hidden_layers": 30,
     "num_attention_heads": 32,
@@ -6386,7 +10439,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 10158,
+    "hf_downloads": 7236,
     "hf_likes": 339,
     "release_date": "2025-12-25",
     "num_hidden_layers": 30,
@@ -6419,8 +10472,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 586,
-    "hf_likes": 163,
+    "hf_downloads": 648,
+    "hf_likes": 164,
     "release_date": "2026-01-05",
     "num_hidden_layers": 30,
     "num_attention_heads": 32,
@@ -6448,7 +10501,47 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis2_5",
-    "hf_downloads": 82785,
+    "hf_downloads": 62968,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "abeja/gpt-neox-japanese-2.7b",
+    "provider": "abeja",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2598502400,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox_japanese",
+    "hf_downloads": 86863,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "pfnet/plamo-3-nict-2b-base",
+    "provider": "pfnet",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2603344384,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "plamo3",
+    "hf_downloads": 22958,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6468,8 +10561,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "gemma2",
-    "hf_downloads": 350168,
-    "hf_likes": 1342,
+    "hf_downloads": 367586,
+    "hf_likes": 1348,
     "release_date": "2024-07-16",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -6501,20 +10594,112 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma2",
-    "hf_downloads": 123694,
+    "hf_downloads": 135617,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/gemma-2-2b-it-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/gemma-2-2b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "yujiepan/ui-tars-1.5-7B-GPTQ-W4A16g128",
+    "provider": "yujiepan",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2633518472,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.3,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 66580,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "facebook/opt-2.7b",
+    "provider": "facebook",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2645278720,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 23735,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyberagent/open-calm-3b",
+    "provider": "cyberagent",
+    "parameter_count": "2.7B",
+    "parameters_raw": 2650275840,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 229238,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/gemma-2-2b-it-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "2.7B",
+    "parameters_raw": 2677836404,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma2",
+    "hf_downloads": 61073,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Harvard-DCML/boomerang-qwen3-2.3B",
+    "provider": "harvard-dcml",
+    "parameter_count": "2.7B",
+    "parameters_raw": 2695600384,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 28160,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "EleutherAI/gpt-neo-2.7B",
@@ -6531,10 +10716,40 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neo",
-    "hf_downloads": 335941,
+    "hf_downloads": 212323,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "baidu/ERNIE-4.5-21B-A3B-PT",
+    "provider": "baidu",
+    "parameter_count": "2.8B",
+    "parameters_raw": 2760376320,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.6,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ernie4_5_moe",
+    "hf_downloads": 49422,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/ERNIE-4.5-21B-A3B-PT-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/ERNIE-4.5-21B-A3B-PT-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "microsoft/phi-2",
@@ -6551,16 +10766,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi",
-    "hf_downloads": 632963,
+    "hf_downloads": 527254,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/phi-2-GGUF",
-        "provider": "TheBloke"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "stabilityai/stablelm-3b-4e1t",
@@ -6577,14 +10786,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "stablelm",
-    "hf_downloads": 53770,
+    "hf_downloads": 64532,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "stabilityai/stablelm-zephyr-3b",
+    "provider": "Stability AI",
+    "parameter_count": "2.8B",
+    "parameters_raw": 2795443200,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.6,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "stablelm",
+    "hf_downloads": 30179,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "mradermacher/stablelm-3b-4e1t-GGUF",
-        "provider": "mradermacher"
+        "repo": "TheBloke/stablelm-zephyr-3b-GGUF",
+        "provider": "TheBloke"
       }
     ]
   },
@@ -6603,10 +10832,51 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 119928,
+    "hf_downloads": 121551,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "2.9B",
+    "parameters_raw": 2860253183,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.7,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 79588,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "shoumenchougou/RWKV7-G1f-2.9B-GGUF",
+    "provider": "RWKV",
+    "parameter_count": "2.9B",
+    "parameters_raw": 2900000000,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.7,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "rwkv",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
   },
   {
     "name": "cyankiwi/Qwen3-VL-8B-Instruct-AWQ-4bit",
@@ -6626,7 +10896,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 124769,
+    "hf_downloads": 193832,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6646,16 +10916,58 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 85804,
+    "hf_downloads": 86306,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "microsoft/Phi-3-mini-128k-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "2.9B",
+    "parameters_raw": 2917072895,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.7,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phi3",
+    "hf_downloads": 242071,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "mradermacher/pythia-2.8b-GGUF",
+        "repo": "mradermacher/Phi-3-mini-128k-instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "microsoft/Phi-3-vision-128k-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "2.9B",
+    "parameters_raw": 2917072895,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.7,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "phi3_v",
+    "hf_downloads": 169091,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "google/paligemma-3b-mix-224",
@@ -6672,7 +10984,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 184216,
+    "hf_downloads": 200766,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6692,10 +11004,40 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 14924,
+    "hf_downloads": 14553,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-4.0-micro",
+    "provider": "ibm-granite",
+    "parameter_count": "3.0B",
+    "parameters_raw": 2983198720,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.8,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 410511,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/granite-4.0-micro-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/granite-4.0-micro-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "LiquidAI/LFM2-VL-3B",
@@ -6714,7 +11056,7 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "lfm2_vl",
-    "hf_downloads": 11348,
+    "hf_downloads": 10595,
     "hf_likes": 133,
     "release_date": "2025-10-22",
     "num_hidden_layers": null,
@@ -6737,16 +11079,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "starcoder2",
-    "hf_downloads": 86653,
+    "hf_downloads": 93418,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/starcoder2-3b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "TechxGenus/gemma-1.1-2b-it-GPTQ",
+    "provider": "techxgenus",
+    "parameter_count": "3.0B",
+    "parameters_raw": 3031170048,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.8,
+    "min_vram_gb": 1.6,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma",
+    "hf_downloads": 26810,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "google/paligemma2-3b-mix-224",
@@ -6763,7 +11119,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 29188,
+    "hf_downloads": 35019,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6783,7 +11139,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 45790,
+    "hf_downloads": 60085,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6803,7 +11159,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 34858,
+    "hf_downloads": 38514,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6823,20 +11179,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "dots_ocr",
-    "hf_downloads": 181140,
+    "hf_downloads": 201850,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/dots.ocr-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/dots.ocr-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "rednote-hilab/dots.mocr",
@@ -6853,7 +11199,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "dots_ocr",
-    "hf_downloads": 111016,
+    "hf_downloads": 148593,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6873,7 +11219,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "dots_ocr",
-    "hf_downloads": 45605,
+    "hf_downloads": 39105,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6893,8 +11239,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "smollm3",
-    "hf_downloads": 164139,
-    "hf_likes": 942,
+    "hf_downloads": 112754,
+    "hf_likes": 946,
     "release_date": "2025-07-08",
     "num_hidden_layers": 36,
     "num_attention_heads": 16,
@@ -6930,16 +11276,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "smollm3",
-    "hf_downloads": 36767,
+    "hf_downloads": 88599,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "GadflyII/GLM-4.7-Flash-NVFP4",
+    "provider": "gadflyii",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3077046272,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe_lite",
+    "hf_downloads": 70906,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/SmolLM3-3B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 4,
+    "active_parameters": 336551933
   },
   {
     "name": "Qwen/Qwen2.5-3B-Instruct",
@@ -6958,56 +11322,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 9143309,
+    "hf_downloads": 9596868,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-3B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-3B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "3.1B",
-    "parameters_raw": 3085938688,
-    "min_ram_gb": 1.7,
-    "recommended_ram_gb": 2.9,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 446815,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-3B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-3B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-3B",
@@ -7026,20 +11344,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 382920,
+    "hf_downloads": 453563,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-3B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-3B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3085938688,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 425057,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-Coder-3B",
@@ -7058,20 +11388,344 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 57821,
+    "hf_downloads": 168886,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-3B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3085938688,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 59874,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "bartowski/Qwen2.5-Coder-3B-GGUF",
+        "repo": "bartowski/Qwen2.5-3B-Instruct-GGUF",
         "provider": "bartowski"
       },
       {
-        "repo": "mradermacher/Qwen2.5-Coder-3B-GGUF",
+        "repo": "mradermacher/Qwen2.5-3B-Instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "Qwen/Qwen3-4B-Thinking-2507-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 189752,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-4B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 164165,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-4B-Instruct-2507",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 100747,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-4B-Instruct-2507-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3-4B-Instruct-2507-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen3-4B-Instruct-2507-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 94818,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "khazarai/Qwen3-4B-Qwen3.6-plus-Reasoning-Distilled-GGUF",
+    "provider": "khazarai",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 93721,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-4B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 73248,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-4B-Base",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 24022,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-4B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mlx-community/Qwen3-4B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17922,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "khazarai/Qwen3-4B-Kimi2.5-Reasoning-Distilled-GGUF",
+    "provider": "khazarai",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 14401,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-3B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3162369808,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 13568,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-3B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3166608872,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 153454,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-3B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3172967424,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 118038,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-Coder-3B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3172967424,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 21823,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "ibm-granite/granite-4.0-h-micro",
@@ -7088,7 +11742,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "granitemoehybrid",
-    "hf_downloads": 17984,
+    "hf_downloads": 6010,
     "hf_likes": 142,
     "release_date": "2025-09-16",
     "num_hidden_layers": 40,
@@ -7121,8 +11775,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 1111138,
-    "hf_likes": 763,
+    "hf_downloads": 1124221,
+    "hf_likes": 770,
     "release_date": "2024-09-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -7152,7 +11806,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1988470,
+    "hf_downloads": 2267285,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3212749824,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 226261,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -7167,6 +11843,64 @@
       },
       {
         "repo": "mradermacher/Llama-3.2-3B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3212749824,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 39900,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-3B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "NousResearch/Hermes-3-Llama-3.2-3B",
+    "provider": "NousResearch",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3212749824,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14838,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Hermes-3-Llama-3.2-3B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Hermes-3-Llama-3.2-3B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -7188,7 +11922,71 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 18448,
+    "hf_downloads": 18426,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3298757260,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 96079,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3301123016,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 59743,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3301123026,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16148,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7208,20 +12006,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_vl_v2",
-    "hf_downloads": 2254853,
+    "hf_downloads": 2461220,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 463927274,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/DeepSeek-OCR-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
+    "active_parameters": 463927274
+  },
+  {
+    "name": "prithivMLmods/DeepSeek-OCR-Latest-BF16.I64",
+    "provider": "prithivmlmods",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3336106240,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "DeepseekOCR",
+    "hf_downloads": 22077,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 463927274
   },
   {
     "name": "dealignai/Gemma-4-26B-A4B-JANG_2L-CRACK",
@@ -7238,7 +12054,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 28321,
+    "hf_downloads": 27744,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -7246,6 +12062,26 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 365515866
+  },
+  {
+    "name": "CohereLabs/tiny-aya-global",
+    "provider": "coherelabs",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3349227520,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "cohere2",
+    "hf_downloads": 16072,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Isotr0py/deepseek-vl2-tiny",
@@ -7262,7 +12098,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_vl_v2",
-    "hf_downloads": 42702,
+    "hf_downloads": 56838,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7282,20 +12118,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granitemoe",
-    "hf_downloads": 922978,
+    "hf_downloads": 1167052,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 40,
     "active_experts": 8,
-    "active_parameters": 809828716,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/PowerMoE-3b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 809828716
   },
   {
     "name": "deepseek-ai/DeepSeek-OCR-2",
@@ -7312,7 +12142,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_vl_v2",
-    "hf_downloads": 1447241,
+    "hf_downloads": 1549103,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -7338,7 +12168,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 255934,
+    "hf_downloads": 435709,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-3B-Instruct-AWQ",
+    "provider": "Alibaba",
+    "parameter_count": "3.4B",
+    "parameters_raw": 3397103616,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.2,
+    "min_vram_gb": 1.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 27191,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7358,16 +12210,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granitemoehybrid",
-    "hf_downloads": 49444,
+    "hf_downloads": 46117,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/granite-4.0-micro-base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Phi-4-mini-instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "3.4B",
+    "parameters_raw": 3433168895,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.2,
+    "min_vram_gb": 1.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phi3",
+    "hf_downloads": 27865,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "z-lab/Qwen3.5-9B-PARO",
@@ -7386,7 +12252,79 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 18170,
+    "hf_downloads": 16863,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyankiwi/Qwen3.5-4B-AWQ-INT8-INT4",
+    "provider": "cyankiwi",
+    "parameter_count": "3.4B",
+    "parameters_raw": 3441633182,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.4,
+    "min_vram_gb": 3.5,
+    "quantization": "AWQ-8bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 14802,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tencent/Hunyuan-A13B-Instruct",
+    "provider": "tencent",
+    "parameter_count": "3.5B",
+    "parameters_raw": 3477762048,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.2,
+    "min_vram_gb": 1.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "hunyuan_v1_moe",
+    "hf_downloads": 28208,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Hunyuan-A13B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Hunyuan-A13B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "z-lab/Kimi-K2.5-DFlash",
+    "provider": "z-lab",
+    "parameter_count": "3.5B",
+    "parameters_raw": 3479277056,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.2,
+    "min_vram_gb": 1.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 14253,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7406,16 +12344,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 37431,
+    "hf_downloads": 39141,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/granite-3b-code-base-2k-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "ibm-research/PowerLM-3b",
@@ -7432,16 +12364,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granite",
-    "hf_downloads": 81857,
+    "hf_downloads": 114542,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/PowerLM-3b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "facebook/Perception-LM-3B",
@@ -7458,7 +12384,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "perception_lm",
-    "hf_downloads": 11391,
+    "hf_downloads": 10308,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyankiwi/InternVL3_5-8B-AWQ-8bit",
+    "provider": "cyankiwi",
+    "parameter_count": "3.5B",
+    "parameters_raw": 3536048632,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.6,
+    "min_vram_gb": 3.6,
+    "quantization": "AWQ-8bit",
+    "format": "awq",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internvl_chat",
+    "hf_downloads": 27819,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7480,7 +12426,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 29167,
+    "hf_downloads": 29284,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Chunity/gemma-4-E2B-it-AWQ-4bit",
+    "provider": "chunity",
+    "parameter_count": "3.7B",
+    "parameters_raw": 3658076899,
+    "min_ram_gb": 2.0,
+    "recommended_ram_gb": 3.4,
+    "min_vram_gb": 1.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 12120,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7500,7 +12466,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kanana-1.5-v",
-    "hf_downloads": 218359,
+    "hf_downloads": 252623,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7520,20 +12486,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 38667,
+    "hf_downloads": 151034,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/InternVL2_5-4B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/InternVL2_5-4B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "5CD-AI/Vintern-3B-R-beta",
@@ -7550,7 +12506,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 35193,
+    "hf_downloads": 43328,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7570,16 +12526,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 22211,
+    "hf_downloads": 29406,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/InternVL2_5-4B-MPO-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Salesforce/blip2-opt-2.7b",
@@ -7596,7 +12546,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "blip-2",
-    "hf_downloads": 480258,
+    "hf_downloads": 551121,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7619,8 +12569,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 3355053,
-    "hf_likes": 640,
+    "hf_downloads": 3701763,
+    "hf_likes": 642,
     "release_date": "2025-01-26",
     "num_hidden_layers": 36,
     "num_attention_heads": 16,
@@ -7656,36 +12606,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 629787,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Nanonets-OCR2-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-VL-3B-Instruct-AWQ",
-    "provider": "Alibaba",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3754622976,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.5,
-    "min_vram_gb": 1.9,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 92656,
+    "hf_downloads": 425557,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7705,20 +12626,53 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 28796,
+    "hf_downloads": 131502,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Nanonets-OCR-s-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Nanonets-OCR-s-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-VL-3B-Instruct-AWQ",
+    "provider": "Alibaba",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3754622976,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 128970,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "stanford-oval/churro-3B",
+    "provider": "stanford-oval",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3754622976,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 12096,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "microsoft/Phi-tiny-MoE-instruct",
@@ -7735,7 +12689,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phimoe",
-    "hf_downloads": 679789,
+    "hf_downloads": 688129,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -7772,6 +12726,36 @@
     ]
   },
   {
+    "name": "nvidia/Nemotron-Mini-4B-Instruct",
+    "provider": "nvidia",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3806330880,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron",
+    "hf_downloads": 22086,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Nemotron-Mini-4B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Nemotron-Mini-4B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
     "name": "microsoft/phi-3-mini-4k-instruct",
     "provider": "Microsoft",
     "parameter_count": "3.8B",
@@ -7786,8 +12770,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "phi3",
-    "hf_downloads": 746649,
-    "hf_likes": 1415,
+    "hf_downloads": 760864,
+    "hf_likes": 1416,
     "release_date": "2024-04-22",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -7819,8 +12803,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "phi3",
-    "hf_downloads": 727640,
-    "hf_likes": 973,
+    "hf_downloads": 708751,
+    "hf_likes": 975,
     "release_date": "2024-08-16",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -7852,20 +12836,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 746649,
+    "hf_downloads": 760864,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Phi-3-mini-4k-instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Phi-3-mini-4k-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "kaitchup/Phi-3-mini-4k-instruct-gptq-4bit",
@@ -7882,7 +12856,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 1174705,
+    "hf_downloads": 1099481,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7902,10 +12876,36 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ristretto",
-    "hf_downloads": 31780,
+    "hf_downloads": 37230,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "openbmb/MiniCPM3-4B",
+    "provider": "openbmb",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3844935680,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.6,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minicpm3",
+    "hf_downloads": 27718,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/MiniCPM3-4B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "RedHatAI/gemma-3-12b-it-quantized.w4a16",
@@ -7922,7 +12922,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 25266,
+    "hf_downloads": 28772,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7944,7 +12944,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 36773,
+    "hf_downloads": 36826,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7964,16 +12964,50 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 223362,
+    "hf_downloads": 232399,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Nanbeige4.1-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Phi-3-mini-4k-instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.9B",
+    "parameters_raw": 3934684862,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 35955,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Phi-3.5-mini-instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.9B",
+    "parameters_raw": 3934684872,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 29879,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Salesforce/blip2-flan-t5-xl",
@@ -7990,7 +13024,87 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "blip-2",
-    "hf_downloads": 56404,
+    "hf_downloads": 43729,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen1.5-4B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "4.0B",
+    "parameters_raw": 3950369280,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14677,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen1.5-4B-Chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-3.5-MoE-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "4.0B",
+    "parameters_raw": 3956539392,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phimoe",
+    "hf_downloads": 107782,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 16,
+    "active_experts": 2,
+    "active_parameters": 667666021,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Phi-3.5-MoE-instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Phi-3.5-MoE-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8",
+    "provider": "nvidia",
+    "parameter_count": "4.0B",
+    "parameters_raw": 3973556900,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 33671,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8010,7 +13124,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 12170,
+    "hf_downloads": 26060,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8030,7 +13144,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 68248,
+    "hf_downloads": 82586,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8052,7 +13166,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "granite4_vision",
-    "hf_downloads": 133495,
+    "hf_downloads": 169875,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8101,20 +13215,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 9888900,
+    "hf_downloads": 11083271,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-4B-Instruct-2507-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-4B-Instruct-2507-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-4B-Base",
@@ -8133,48 +13237,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 1888692,
+    "hf_downloads": 1966089,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-4B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3-4B-Thinking-2507",
-    "provider": "Alibaba",
-    "parameter_count": "4.0B",
-    "parameters_raw": 4022468096,
-    "min_ram_gb": 2.2,
-    "recommended_ram_gb": 3.7,
-    "min_vram_gb": 2.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3",
-    "hf_downloads": 893386,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-4B-Thinking-2507-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-4B-Thinking-2507-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-4B-AWQ",
@@ -8193,7 +13259,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 640991,
+    "hf_downloads": 626352,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8213,35 +13279,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 185257,
+    "hf_downloads": 618788,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Rio-3.0-Open-Mini-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "JunHowie/Qwen3-4B-Instruct-2507-GPTQ-Int4",
-    "provider": "junhowie",
+    "name": "Qwen/Qwen3-4B-Thinking-2507",
+    "provider": "Alibaba",
     "parameter_count": "4.0B",
     "parameters_raw": 4022468096,
     "min_ram_gb": 2.2,
     "recommended_ram_gb": 3.7,
     "min_vram_gb": 2.1,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 262144,
-    "use_case": "Instruction following, chat",
+    "use_case": "General purpose",
     "capabilities": [
       "tool_use"
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 75040,
+    "hf_downloads": 471622,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8263,7 +13323,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 48301,
+    "hf_downloads": 51136,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "JunHowie/Qwen3-4B-Instruct-2507-GPTQ-Int4",
+    "provider": "junhowie",
+    "parameter_count": "4.0B",
+    "parameters_raw": 4022468096,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.1,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 43617,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8283,7 +13365,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 133730,
+    "hf_downloads": 167584,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8303,7 +13385,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 36297,
+    "hf_downloads": 41722,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8326,7 +13408,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 41204,
+    "hf_downloads": 61293,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8349,7 +13431,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 25164,
+    "hf_downloads": 34387,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8369,7 +13451,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis",
-    "hf_downloads": 42879,
+    "hf_downloads": 57137,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8389,7 +13471,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3_v",
-    "hf_downloads": 154671,
+    "hf_downloads": 223911,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8411,7 +13493,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 37972,
+    "hf_downloads": 40221,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8433,7 +13515,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 115902,
+    "hf_downloads": 124489,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8453,7 +13535,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 31580,
+    "hf_downloads": 31231,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "bg-digitalservices/Gemma-4-E2B-it-NVFP4",
+    "provider": "bg-digitalservices",
+    "parameter_count": "4.3B",
+    "parameters_raw": 4293811779,
+    "min_ram_gb": 2.4,
+    "recommended_ram_gb": 4.0,
+    "min_vram_gb": 2.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 15220,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8476,8 +13578,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "gemma3",
-    "hf_downloads": 2130064,
-    "hf_likes": 1314,
+    "hf_downloads": 2235493,
+    "hf_likes": 1320,
     "release_date": "2025-02-20",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -8513,16 +13615,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 202116,
+    "hf_downloads": 269605,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-3-4b-pt-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "google/medgemma-1.5-4b-it",
@@ -8539,17 +13635,53 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 102908,
+    "hf_downloads": 120144,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/Nemotron-3-Content-Safety",
+    "provider": "nvidia",
+    "parameter_count": "4.3B",
+    "parameters_raw": 4300079472,
+    "min_ram_gb": 2.4,
+    "recommended_ram_gb": 4.0,
+    "min_vram_gb": 2.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3",
+    "hf_downloads": 14339,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zai-org/glm-edge-4b-chat",
+    "provider": "zai-org",
+    "parameter_count": "4.3B",
+    "parameters_raw": 4327984128,
+    "min_ram_gb": 2.4,
+    "recommended_ram_gb": 4.0,
+    "min_vram_gb": 2.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm",
+    "hf_downloads": 24535,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "unsloth/medgemma-1.5-4b-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/medgemma-1.5-4b-it-GGUF",
+        "repo": "mradermacher/glm-edge-4b-chat-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -8571,13 +13703,35 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 45457,
+    "hf_downloads": 30418,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3Guard-Gen-4B",
+    "provider": "Alibaba",
+    "parameter_count": "4.4B",
+    "parameters_raw": 4411424256,
+    "min_ram_gb": 2.5,
+    "recommended_ram_gb": 4.1,
+    "min_vram_gb": 2.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17195,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "mradermacher/Qwen3-4B-SafeRL-GGUF",
+        "repo": "mradermacher/Qwen3Guard-Gen-4B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -8599,7 +13753,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 596189,
+    "hf_downloads": 733046,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8621,7 +13775,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 55530,
+    "hf_downloads": 54237,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8644,20 +13798,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 2304311,
+    "hf_downloads": 2347064,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-4B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-4B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-VL-4B-Thinking",
@@ -8677,20 +13821,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 479962,
+    "hf_downloads": 1472471,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-4B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-4B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "huihui-ai/Huihui-Qwen3.5-4B-abliterated",
@@ -8709,16 +13843,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 13127,
+    "hf_downloads": 12573,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-4B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/gemma-4-26B-A4B-it-MLX-4bit",
@@ -8735,7 +13863,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 129130,
+    "hf_downloads": 147835,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -8761,7 +13889,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 31094,
+    "hf_downloads": 31550,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 503765510
+  },
+  {
+    "name": "stelterlab/Qwen3-Coder-30B-A3B-Instruct-AWQ",
+    "provider": "stelterlab",
+    "parameter_count": "4.6B",
+    "parameters_raw": 4605856128,
+    "min_ram_gb": 2.6,
+    "recommended_ram_gb": 4.3,
+    "min_vram_gb": 2.4,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 28256,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -8785,7 +13939,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis",
-    "hf_downloads": 70341,
+    "hf_downloads": 80464,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "arcee-ai/AFM-4.5B-Base",
+    "provider": "arcee-ai",
+    "parameter_count": "4.6B",
+    "parameters_raw": 4619184640,
+    "min_ram_gb": 2.6,
+    "recommended_ram_gb": 4.3,
+    "min_vram_gb": 2.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1310720,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "arcee",
+    "hf_downloads": 21313,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8808,8 +13982,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 3966264,
-    "hf_likes": 503,
+    "hf_downloads": 5193094,
+    "hf_likes": 518,
     "release_date": "2026-02-27",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -8844,13 +14018,19 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 134173,
-    "hf_likes": 64,
+    "hf_downloads": 161928,
+    "hf_likes": 65,
     "release_date": "2026-02-27",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
-    "head_dim": null
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-4B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "QuantTrio/Qwen3.5-4B-AWQ",
@@ -8869,7 +14049,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 42743,
+    "hf_downloads": 40077,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8891,7 +14071,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 15711,
+    "hf_downloads": 10461,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8913,7 +14093,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 39432,
+    "hf_downloads": 19522,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8935,7 +14115,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 46376,
+    "hf_downloads": 48105,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8955,7 +14135,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 42005,
+    "hf_downloads": 41393,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -8981,7 +14161,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral3",
-    "hf_downloads": 30344,
+    "hf_downloads": 21534,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9001,16 +14181,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qianfan_ocr",
-    "hf_downloads": 363059,
+    "hf_downloads": 424056,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/Qianfan-OCR-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "lmms-lab/LLaVA-OneVision-1.5-4B-Base",
@@ -9029,29 +14203,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 87202,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "cyankiwi/Qwen3.5-4B-AWQ-BF16-INT4",
-    "provider": "cyankiwi",
-    "parameter_count": "4.7B",
-    "parameters_raw": 4743177998,
-    "min_ram_gb": 2.7,
-    "recommended_ram_gb": 4.4,
-    "min_vram_gb": 2.4,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 12612,
+    "hf_downloads": 137946,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9071,10 +14223,36 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 84601,
+    "hf_downloads": 84606,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Qwen3-30B-A3B-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "4.8B",
+    "parameters_raw": 4770822144,
+    "min_ram_gb": 2.7,
+    "recommended_ram_gb": 4.4,
+    "min_vram_gb": 2.4,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 14092,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 521808667
   },
   {
     "name": "cyankiwi/Qwen3.5-4B-AWQ-4bit",
@@ -9093,7 +14271,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 218343,
+    "hf_downloads": 289427,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Chunity/gemma-4-E4B-it-AWQ-4bit",
+    "provider": "chunity",
+    "parameter_count": "4.8B",
+    "parameters_raw": 4805237482,
+    "min_ram_gb": 2.7,
+    "recommended_ram_gb": 4.5,
+    "min_vram_gb": 2.5,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 13224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9113,7 +14311,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "R",
-    "hf_downloads": 92190,
+    "hf_downloads": 124740,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9136,7 +14334,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 75610,
+    "hf_downloads": 83844,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9156,7 +14354,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "apriel",
-    "hf_downloads": 134702,
+    "hf_downloads": 28363,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9176,7 +14374,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hulumed_qwen3",
-    "hf_downloads": 31765,
+    "hf_downloads": 26549,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9198,16 +14396,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 144909,
+    "hf_downloads": 258663,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/translategemma-4b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Infomaniak-AI/vllm-translategemma-4b-it",
@@ -9226,7 +14418,49 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 27600,
+    "hf_downloads": 24339,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Llama-3.1-8B-Instruct-NVFP4",
+    "provider": "redhatai",
+    "parameter_count": "5.0B",
+    "parameters_raw": 4976808384,
+    "min_ram_gb": 2.8,
+    "recommended_ram_gb": 4.6,
+    "min_vram_gb": 2.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 19265,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "allenai/Olmo-Hybrid-7B",
+    "provider": "allenai",
+    "parameter_count": "5.0B",
+    "parameters_raw": 4978114560,
+    "min_ram_gb": 2.8,
+    "recommended_ram_gb": 4.6,
+    "min_vram_gb": 2.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmo_hybrid",
+    "hf_downloads": 33527,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9249,7 +14483,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 53163,
+    "hf_downloads": 71143,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "dealignai/Qwen3.6-27B-JANG_4M-CRACK",
+    "provider": "dealignai",
+    "parameter_count": "5.0B",
+    "parameters_raw": 5034102000,
+    "min_ram_gb": 2.8,
+    "recommended_ram_gb": 4.7,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 10181,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9269,7 +14525,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 197630,
+    "hf_downloads": 109778,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9293,7 +14549,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 29302,
+    "hf_downloads": 28703,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9301,6 +14557,28 @@
     "num_experts": 128,
     "active_experts": 6,
     "active_parameters": 477744593
+  },
+  {
+    "name": "lmstudio-community/Qwen3-32B-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5119652864,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17790,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/Qwen2.5-Coder-32B-Instruct-MLX-4bit",
@@ -9319,7 +14597,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 70143,
+    "hf_downloads": 71387,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9339,7 +14617,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35908,
+    "hf_downloads": 39299,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9362,8 +14640,8 @@
     ],
     "pipeline_tag": "any-to-any",
     "architecture": "gemma4",
-    "hf_downloads": 2717607,
-    "hf_likes": 542,
+    "hf_downloads": 3384168,
+    "hf_likes": 574,
     "release_date": "2026-03-02",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -9385,6 +14663,128 @@
     ]
   },
   {
+    "name": "deepseek-ai/deepseek-llm-7b-chat",
+    "provider": "DeepSeek",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5138022400,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 53218,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/deepseek-math-7b-instruct",
+    "provider": "DeepSeek",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5138022400,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 41162,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/deepseek-llm-7b-base",
+    "provider": "DeepSeek",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5138022400,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 39319,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "baffo32/decapoda-research-llama-7B-hf",
+    "provider": "baffo32",
+    "parameter_count": "5.2B",
+    "parameters_raw": 5164236800,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 52145,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "wisdomik/Quilt-Llava-v1.5-7b",
+    "provider": "wisdomik",
+    "parameter_count": "5.2B",
+    "parameters_raw": 5164236800,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llava",
+    "hf_downloads": 35041,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "selfrag/selfrag_llama2_7b",
+    "provider": "selfrag",
+    "parameter_count": "5.2B",
+    "parameters_raw": 5164302336,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16417,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "ISTA-DASLab/gemma-3-27b-it-GPTQ-4b-128g",
     "provider": "ista-daslab",
     "parameter_count": "5.2B",
@@ -9399,7 +14799,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 342232,
+    "hf_downloads": 273573,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "baichuan-inc/Baichuan-7B",
+    "provider": "baichuan-inc",
+    "parameter_count": "5.3B",
+    "parameters_raw": 5295308800,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 4.9,
+    "min_vram_gb": 2.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "baichuan",
+    "hf_downloads": 44659,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9419,16 +14839,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 243183,
+    "hf_downloads": 598255,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/chandra-ocr-2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit",
@@ -9447,7 +14861,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 58715,
+    "hf_downloads": 252879,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9473,7 +14887,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 37259,
+    "hf_downloads": 54751,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9481,6 +14895,126 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 580405768
+  },
+  {
+    "name": "kyujinpy/Ko-PlatYi-6B",
+    "provider": "kyujinpy",
+    "parameter_count": "5.4B",
+    "parameters_raw": 5354553344,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.0,
+    "min_vram_gb": 2.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 36419,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
+    "provider": "nvidia",
+    "parameter_count": "5.4B",
+    "parameters_raw": 5367627776,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.0,
+    "min_vram_gb": 2.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 113983,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/NVIDIA-Nemotron-3-Nano-4B",
+    "provider": "unsloth",
+    "parameter_count": "5.4B",
+    "parameters_raw": 5367627776,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.0,
+    "min_vram_gb": 2.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 17399,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "BAAI/AquilaChat2-7B",
+    "provider": "BAAI",
+    "parameter_count": "5.4B",
+    "parameters_raw": 5442797568,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.1,
+    "min_vram_gb": 2.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "aquila",
+    "hf_downloads": 20832,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm-chat-7b",
+    "provider": "internlm",
+    "parameter_count": "5.5B",
+    "parameters_raw": 5455740928,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.1,
+    "min_vram_gb": 2.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm",
+    "hf_downloads": 52556,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "baichuan-inc/Baichuan2-7B-Chat",
+    "provider": "baichuan-inc",
+    "parameter_count": "5.5B",
+    "parameters_raw": 5548015616,
+    "min_ram_gb": 3.1,
+    "recommended_ram_gb": 5.2,
+    "min_vram_gb": 2.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "baichuan",
+    "hf_downloads": 63959,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "microsoft/Phi-4-multimodal-instruct",
@@ -9497,13 +15031,35 @@
     "capabilities": [],
     "pipeline_tag": "automatic-speech-recognition",
     "architecture": "phi4mm",
-    "hf_downloads": 375170,
+    "hf_downloads": 410265,
     "hf_likes": 1597,
     "release_date": "2025-02-24",
     "num_hidden_layers": 32,
     "num_attention_heads": 24,
     "num_key_value_heads": 8,
     "head_dim": 128
+  },
+  {
+    "name": "Qwen/Qwen2.5-7B-Instruct-AWQ",
+    "provider": "Alibaba",
+    "parameter_count": "5.8B",
+    "parameters_raw": 5785780224,
+    "min_ram_gb": 3.2,
+    "recommended_ram_gb": 5.4,
+    "min_vram_gb": 3.0,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 1602299,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-VL-30B-A3B-Instruct-AWQ-4bit",
@@ -9523,7 +15079,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 23899,
+    "hf_downloads": 27524,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9547,7 +15103,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 28193,
+    "hf_downloads": 104174,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9567,7 +15123,111 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 13637,
+    "hf_downloads": 14848,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mistralai/Mistral-7B-Instruct-v0.1",
+    "provider": "Mistral AI",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036652032,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 397723,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "BioMistral/BioMistral-7B",
+    "provider": "biomistral",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036652032,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 184555,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
+    "provider": "ttimofeyka",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036652032,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 32401,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "teknium/OpenHermes-2.5-Mistral-7B",
+    "provider": "teknium",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036660224,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 74646,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "openchat/openchat_3.5",
+    "provider": "OpenChat",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036660224,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 39997,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9587,7 +15247,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 24454,
+    "hf_downloads": 19094,
     "hf_likes": 70,
     "release_date": "2023-11-22",
     "num_hidden_layers": 32,
@@ -9600,6 +15260,30 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "arcee-ai/Trinity-Nano-Preview",
+    "provider": "arcee-ai",
+    "parameter_count": "6.1B",
+    "parameters_raw": 6120003328,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.7,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "afmoe",
+    "hf_downloads": 19900,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 669375358
   },
   {
     "name": "lmstudio-community/gemma-4-26B-A4B-it-MLX-6bit",
@@ -9616,7 +15300,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 111097,
+    "hf_downloads": 115209,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9640,7 +15324,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 36168,
+    "hf_downloads": 46228,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9653,8 +15337,8 @@
     "min_ram_gb": 3.5,
     "recommended_ram_gb": 5.9,
     "min_vram_gb": 3.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
+    "quantization": "AutoRound-4bit",
+    "format": "autoround",
     "context_length": 262144,
     "use_case": "General purpose",
     "capabilities": [
@@ -9662,7 +15346,299 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 119168,
+    "hf_downloads": 320204,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zhiqing/Huihui-Qwen3.6-27B-abliterated-AWQ",
+    "provider": "zhiqing",
+    "parameter_count": "6.3B",
+    "parameters_raw": 6284446960,
+    "min_ram_gb": 3.5,
+    "recommended_ram_gb": 5.9,
+    "min_vram_gb": 3.2,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 15312,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-chat-7b",
+    "provider": "internlm",
+    "parameter_count": "6.3B",
+    "parameters_raw": 6284640256,
+    "min_ram_gb": 3.5,
+    "recommended_ram_gb": 5.9,
+    "min_vram_gb": 3.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 54555,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-7b",
+    "provider": "internlm",
+    "parameter_count": "6.3B",
+    "parameters_raw": 6284640256,
+    "min_ram_gb": 3.5,
+    "recommended_ram_gb": 5.9,
+    "min_vram_gb": 3.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 25804,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-base-7b",
+    "provider": "internlm",
+    "parameter_count": "6.3B",
+    "parameters_raw": 6284640256,
+    "min_ram_gb": 3.5,
+    "recommended_ram_gb": 5.9,
+    "min_vram_gb": 3.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 20075,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tencent/Hunyuan-7B-Instruct",
+    "provider": "tencent",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430552064,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "hunyuan_v1_dense",
+    "hf_downloads": 16135,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+    "provider": "DeepSeek",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 1891196,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4",
+    "provider": "hugging-quants",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 382229,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 53923,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "NousResearch/Meta-Llama-3-8B-Instruct",
+    "provider": "NousResearch",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 48446,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "modularai/Llama-3.1-8B-Instruct-GGUF",
+    "provider": "modularai",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 27617,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "casperhansen/llama-3-8b-instruct-awq",
+    "provider": "casperhansen",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 24129,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.1-8B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15678,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "S4nfs/Neeto-1.0-8b",
+    "provider": "s4nfs",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430920704,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14921,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "dealignai/Gemma-4-31B-JANG_4M-Uncensored",
+    "provider": "dealignai",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6433044332,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 19283,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9682,7 +15658,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 188142,
+    "hf_downloads": 182625,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9704,7 +15680,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 33063,
+    "hf_downloads": 29478,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9724,7 +15700,137 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 16420,
+    "hf_downloads": 13723,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "facebook/opt-6.7b",
+    "provider": "facebook",
+    "parameter_count": "6.6B",
+    "parameters_raw": 6648365056,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 38687,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-8B",
+    "provider": "unsloth",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 96281,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-8B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 60797,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 51987,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-8B-Base",
+    "provider": "unsloth",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 26517,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3-8B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 15258,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9771,7 +15877,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 35217,
+    "hf_downloads": 36841,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "kifai/GECKO-7B",
+    "provider": "kifai",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6738415616,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.3,
+    "min_vram_gb": 3.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14746,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9791,16 +15917,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1937898,
+    "hf_downloads": 1519527,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-2-7b-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "huggyllama/llama-7b",
@@ -9817,16 +15937,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 217705,
+    "hf_downloads": 192844,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/llama-7b-GGUF",
-        "provider": "TheBloke"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "NousResearch/Llama-2-7b-hf",
@@ -9843,16 +15957,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 99323,
+    "hf_downloads": 114122,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-2-7b-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "NousResearch/Llama-2-7b-chat-hf",
@@ -9869,16 +15977,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 33437,
+    "hf_downloads": 32351,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-2-7b-chat-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "meta-llama/CodeLlama-7b-Instruct-hf",
@@ -9895,8 +15997,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 2709,
-    "hf_likes": 59,
+    "hf_downloads": 2156,
+    "hf_likes": 60,
     "release_date": "2024-03-13",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -9924,16 +16026,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 134709,
+    "hf_downloads": 203298,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-7b-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "codellama/CodeLlama-7b-Instruct-hf",
@@ -9950,16 +16046,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 108702,
+    "hf_downloads": 45380,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-7b-Instruct-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "defog/sqlcoder-7b-2",
@@ -9976,16 +16066,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 34346,
+    "hf_downloads": 27994,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/sqlcoder-7b-2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/Llama-2-7B-Chat-GPTQ",
+    "provider": "thebloke",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6739777536,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.3,
+    "min_vram_gb": 3.5,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 22028,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "deepseek-ai/deepseek-coder-6.7b-instruct",
@@ -10002,20 +16106,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 214722,
+    "hf_downloads": 237005,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/deepseek-coder-6.7b-instruct-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/deepseek-coder-6.7b-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "deepseek-ai/deepseek-coder-6.7b-base",
@@ -10032,20 +16126,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 33266,
+    "hf_downloads": 41121,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/deepseek-coder-6.7b-base-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/deepseek-coder-6.7b-base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "deepseek-ai/deepseek-coder-7b-instruct-v1.5",
@@ -10062,16 +16146,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 41756,
+    "hf_downloads": 108133,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/deepseek-coder-7b-instruct-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/OLMoE-1B-7B-0125-Instruct",
@@ -10088,20 +16166,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmoe",
-    "hf_downloads": 79719,
+    "hf_downloads": 91071,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 8,
-    "active_parameters": 1167608556,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/OLMoE-1B-7B-0125-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 1167608556
   },
   {
     "name": "allenai/OLMoE-1B-7B-0924-Instruct",
@@ -10118,24 +16190,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmoe",
-    "hf_downloads": 35782,
+    "hf_downloads": 37916,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 8,
-    "active_parameters": 1167608556,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/OLMoE-1B-7B-0924-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/OLMoE-1B-7B-0924-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 1167608556
+  },
+  {
+    "name": "allenai/OLMoE-1B-7B-0125",
+    "provider": "allenai",
+    "parameter_count": "6.9B",
+    "parameters_raw": 6919161856,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.4,
+    "min_vram_gb": 3.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmoe",
+    "hf_downloads": 18068,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 8,
+    "active_parameters": 1167608556
   },
   {
     "name": "ibm-granite/granite-4.0-h-tiny",
@@ -10152,7 +16238,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "granitemoehybrid",
-    "hf_downloads": 88464,
+    "hf_downloads": 75159,
     "hf_likes": 201,
     "release_date": "2025-09-16",
     "num_hidden_layers": 40,
@@ -10175,6 +16261,46 @@
     ]
   },
   {
+    "name": "unsloth/llama-2-7b-chat-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "6.9B",
+    "parameters_raw": 6941323894,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14024,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "farbodtavakkoli/OTel-LLM-8.3B-IT",
+    "provider": "farbodtavakkoli",
+    "parameter_count": "7.0B",
+    "parameters_raw": 6967787520,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 809696,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "EleutherAI/pythia-6.9b",
     "provider": "eleutherai",
     "parameter_count": "7.0B",
@@ -10189,16 +16315,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 138579,
+    "hf_downloads": 116108,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/pythia-6.9b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "openchat/openchat-3.5-0106",
@@ -10245,6 +16365,26 @@
     "release_date": "2025-05-01"
   },
   {
+    "name": "humain-ai/ALLaM-7B-Instruct-preview",
+    "provider": "humain-ai",
+    "parameter_count": "7.0B",
+    "parameters_raw": 7000559616,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15787,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "microsoft/Orca-2-7b",
     "provider": "Microsoft",
     "parameter_count": "7.0B",
@@ -10286,16 +16426,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "chameleon",
-    "hf_downloads": 117790,
+    "hf_downloads": 152505,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/chameleon-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "liuhaotian/llava-v1.6-vicuna-7b",
@@ -10314,7 +16448,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 30136,
+    "hf_downloads": 32654,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10334,7 +16468,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 107537,
+    "hf_downloads": 120141,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10356,7 +16490,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 2648883,
+    "hf_downloads": 3047197,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10378,7 +16512,67 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 43342,
+    "hf_downloads": 45213,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-3.0-8b-instruct",
+    "provider": "ibm-granite",
+    "parameter_count": "7.1B",
+    "parameters_raw": 7079997440,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.6,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granite",
+    "hf_downloads": 37050,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-guardian-3.3-8b",
+    "provider": "ibm-granite",
+    "parameter_count": "7.1B",
+    "parameters_raw": 7080013824,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.6,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granite",
+    "hf_downloads": 14069,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RekaAI/reka-edge-2603",
+    "provider": "rekaai",
+    "parameter_count": "7.1B",
+    "parameters_raw": 7128509568,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.6,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "yasa2",
+    "hf_downloads": 11536,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10398,13 +16592,58 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "starcoder2",
-    "hf_downloads": 15700,
+    "hf_downloads": 14467,
     "hf_likes": 215,
     "release_date": "2024-02-20",
     "num_hidden_layers": 32,
     "num_attention_heads": 36,
     "num_key_value_heads": 4,
     "head_dim": 128
+  },
+  {
+    "name": "shoumenchougou/RWKV7-G1f-7.2B-GGUF",
+    "provider": "RWKV",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7200000000,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "rwkv",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
+  },
+  {
+    "name": "Chunity/Qwen3.6-35B-A3B-AutoRound-AWQ-4bit",
+    "provider": "chunity",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7204574576,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 13329,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 574114528
   },
   {
     "name": "tiiuae/falcon-7b-instruct",
@@ -10421,7 +16660,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "falcon",
-    "hf_downloads": 53333,
+    "hf_downloads": 52538,
     "hf_likes": 1032,
     "release_date": "2023-04-25",
     "num_hidden_layers": 32,
@@ -10450,16 +16689,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "falcon",
-    "hf_downloads": 220831,
+    "hf_downloads": 283814,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/falcon-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "HuggingFaceH4/zephyr-7b-beta",
@@ -10476,8 +16709,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "mistral",
-    "hf_downloads": 119699,
-    "hf_likes": 1843,
+    "hf_downloads": 145707,
+    "hf_likes": 1842,
     "release_date": "2023-10-26",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -10511,20 +16744,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 2067579,
+    "hf_downloads": 2585420,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Mistral-7B-Instruct-v0.2-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Mistral-7B-Instruct-v0.2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "mistralai/Mistral-7B-v0.1",
@@ -10541,20 +16764,32 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 992414,
+    "hf_downloads": 1041293,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Mistral-7B-v0.1-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Mistral-7B-v0.1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/Mistral-7B-Instruct-v0.2-AWQ",
+    "provider": "thebloke",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 166342,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "SanjiWatsuki/Kunoichi-DPO-v2-7B",
@@ -10571,16 +16806,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 120104,
+    "hf_downloads": 134208,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Kunoichi-DPO-v2-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "parasail-ai/GritLM-7B-vllm",
@@ -10597,7 +16826,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 48217,
+    "hf_downloads": 57825,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10617,16 +16846,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 44578,
+    "hf_downloads": 42317,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/prometheus-7b-v2.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "mlabonne/NeuralMonarch-7B",
@@ -10643,16 +16866,134 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 29091,
+    "hf_downloads": 29874,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/NeuralMonarch-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "GritLM/GritLM-7B",
+    "provider": "gritlm",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 21029,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lex-hue/Delexa-7b",
+    "provider": "lex-hue",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 15711,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "pucpr-br/Clinical-BR-Mistral-7B-v0.2",
+    "provider": "pucpr-br",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 15418,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlabonne/AlphaMonarch-7B",
+    "provider": "mlabonne",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 13498,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/OpenHermes-2.5-Mistral-7B-AWQ",
+    "provider": "thebloke",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241748480,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 18140,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/Mistral-7B-Instruct-v0.2-GPTQ",
+    "provider": "thebloke",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7243108352,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 88650,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "mistralai/Mistral-7B-Instruct-v0.3",
@@ -10671,8 +17012,8 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 3103899,
-    "hf_likes": 2541,
+    "hf_downloads": 3599033,
+    "hf_likes": 2557,
     "release_date": "2024-05-22",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -10704,7 +17045,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 75507,
+    "hf_downloads": 70202,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10726,7 +17067,67 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 106057,
+    "hf_downloads": 129182,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/CodeQwen1.5-7B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "7.3B",
+    "parameters_raw": 7250284544,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 23801,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "skt/A.X-4.0-Light",
+    "provider": "skt",
+    "parameter_count": "7.3B",
+    "parameters_raw": 7259624960,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 13962,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tiiuae/falcon-mamba-7b-instruct",
+    "provider": "TII",
+    "parameter_count": "7.3B",
+    "parameters_raw": 7272665088,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "falcon_mamba",
+    "hf_downloads": 16718,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10746,16 +17147,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 121152,
+    "hf_downloads": 192664,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Olmo-3-1025-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/Olmo-3-7B-Instruct-SFT",
@@ -10772,16 +17167,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 81799,
+    "hf_downloads": 82888,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Olmo-3-7B-Instruct-SFT-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/OLMo-2-1124-7B-Instruct",
@@ -10798,20 +17187,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo2",
-    "hf_downloads": 27977,
+    "hf_downloads": 33598,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/OLMo-2-1124-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/OLMo-2-1124-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Zyphra/Zamba2-7B-Instruct",
+    "provider": "zyphra",
+    "parameter_count": "7.4B",
+    "parameters_raw": 7356749648,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "zamba2",
+    "hf_downloads": 21587,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LanguageBind/Video-LLaVA-7B-hf",
@@ -10830,7 +17229,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "video_llava",
-    "hf_downloads": 13391,
+    "hf_downloads": 14563,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "microsoft/Phi-3-small-8k-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "7.4B",
+    "parameters_raw": 7392274432,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phi3small",
+    "hf_downloads": 17456,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10850,7 +17269,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 17529,
+    "hf_downloads": 13800,
     "hf_likes": 79,
     "release_date": "2024-11-29",
     "num_hidden_layers": 28,
@@ -10869,6 +17288,130 @@
     ]
   },
   {
+    "name": "unsloth/mistral-7b-instruct-v0.2-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7460400036,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 13465,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/mistral-7b-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7460400452,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 31116,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/mistral-7b-instruct-v0.3-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7466691910,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 7.0,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 51294,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/mistral-7b-v0.3-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7466691914,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 7.0,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 396946,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/Minitron-8B-Base",
+    "provider": "nvidia",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7491026944,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 7.0,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron",
+    "hf_downloads": 21315,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-4.5-33B-AWQ",
+    "provider": "lgai-exaone",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7507208320,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 7.0,
+    "min_vram_gb": 3.8,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "exaone4_5",
+    "hf_downloads": 14700,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "openvla/openvla-7b-finetuned-libero-object",
     "provider": "openvla",
     "parameter_count": "7.5B",
@@ -10883,7 +17426,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "openvla",
-    "hf_downloads": 65732,
+    "hf_downloads": 66477,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10903,7 +17446,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "openvla",
-    "hf_downloads": 12540,
+    "hf_downloads": 11976,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10925,16 +17468,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_mistral",
-    "hf_downloads": 14427,
+    "hf_downloads": 16768,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llava-med-v1.5-mistral-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "liuhaotian/llava-v1.6-mistral-7b",
@@ -10953,35 +17490,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_mistral",
-    "hf_downloads": 34189,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llava-v1.6-mistral-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "llava-hf/bakLlava-v1-hf",
-    "provider": "llava-hf",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7566743552,
-    "min_ram_gb": 4.2,
-    "recommended_ram_gb": 7.0,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "llava",
-    "hf_downloads": 10841,
+    "hf_downloads": 37803,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11003,7 +17512,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 627279,
+    "hf_downloads": 610871,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11025,8 +17534,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 12582644,
-    "hf_likes": 1245,
+    "hf_downloads": 14206853,
+    "hf_likes": 1261,
     "release_date": "2024-09-16",
     "num_hidden_layers": 28,
     "num_attention_heads": 28,
@@ -11060,8 +17569,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 2086890,
-    "hf_likes": 700,
+    "hf_downloads": 2255359,
+    "hf_likes": 704,
     "release_date": "2024-09-17",
     "num_hidden_layers": 28,
     "num_attention_heads": 28,
@@ -11097,8 +17606,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 573416,
-    "hf_likes": 827,
+    "hf_downloads": 583643,
+    "hf_likes": 830,
     "release_date": "2025-01-20",
     "num_hidden_layers": 28,
     "num_attention_heads": 28,
@@ -11120,34 +17629,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen2.5-Coder-7B",
-    "provider": "Alibaba",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 1654696,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-7B",
     "provider": "Alibaba",
     "parameter_count": "7.6B",
@@ -11164,27 +17645,21 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1651354,
+    "hf_downloads": 1926266,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "Qwen/Qwen2.5-Coder-7B-Instruct-GPTQ-Int4",
+    "name": "Qwen/Qwen2.5-Coder-7B",
     "provider": "Alibaba",
     "parameter_count": "7.6B",
     "parameters_raw": 7615616512,
     "min_ram_gb": 4.3,
     "recommended_ram_gb": 7.1,
     "min_vram_gb": 3.9,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 32768,
     "use_case": "Code generation and completion",
     "capabilities": [
@@ -11192,7 +17667,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 842230,
+    "hf_downloads": 1804792,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11212,20 +17687,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 569047,
+    "hf_downloads": 664586,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-Math-7B",
@@ -11244,16 +17709,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 432991,
+    "hf_downloads": 625591,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-Math-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-7B-Instruct-GPTQ-Int4",
+    "provider": "Alibaba",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 588928,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-Coder-7B-Instruct-AWQ",
@@ -11272,7 +17753,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 323191,
+    "hf_downloads": 331991,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-7B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 299805,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11292,35 +17795,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "Dream",
-    "hf_downloads": 150426,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Dream-v0-Instruct-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
-    "provider": "Alibaba",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 77158,
+    "hf_downloads": 169291,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11340,20 +17815,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 67131,
+    "hf_downloads": 72854,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "XCurOS/XCurOS-0.1-8B-Instruct",
-    "provider": "xcuros",
+    "name": "unsloth/Qwen2.5-7B",
+    "provider": "unsloth",
     "parameter_count": "7.6B",
     "parameters_raw": 7615616512,
     "min_ram_gb": 4.3,
@@ -11361,12 +17830,14 @@
     "min_vram_gb": 3.9,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 51017,
+    "hf_downloads": 68389,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11388,20 +17859,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 42434,
+    "hf_downloads": 66019,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-Math-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Math-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "XCurOS/XCurOS-0.1-8B-Instruct",
+    "provider": "xcuros",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 53507,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Dream-org/Dream-v0-Base-7B",
@@ -11418,16 +17899,32 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "Dream",
-    "hf_downloads": 41884,
+    "hf_downloads": 52572,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Dream-v0-Base-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
+    "provider": "Alibaba",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 47871,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-7B-Instruct-1M",
@@ -11446,20 +17943,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 30960,
+    "hf_downloads": 36221,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-7B-Instruct-1M-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-7B-Instruct-1M-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "DeepHat/DeepHat-V1-7B",
+    "provider": "deephat",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 17275,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "microsoft/Phi-mini-MoE-instruct",
@@ -11476,7 +17983,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phimoe",
-    "hf_downloads": 133227,
+    "hf_downloads": 157536,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -11500,7 +18007,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 137613,
+    "hf_downloads": 156068,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -11508,6 +18015,28 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 838664239
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD",
+    "provider": "nvidia",
+    "parameter_count": "7.7B",
+    "parameters_raw": 7699118592,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.2,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "NemotronH_Nano_VL_V2",
+    "hf_downloads": 26042,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen1.5-7B",
@@ -11524,16 +18053,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 89588,
+    "hf_downloads": 84128,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen1.5-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen-7B-Chat",
@@ -11550,16 +18073,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen",
-    "hf_downloads": 81727,
+    "hf_downloads": 66923,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen-7B-Chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen-7B",
@@ -11576,16 +18093,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen",
-    "hf_downloads": 47134,
+    "hf_downloads": 20129,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen1.5-7B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "7.7B",
+    "parameters_raw": 7721324544,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.2,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 15239,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "internlm/internlm2_5-7b-chat",
@@ -11602,20 +18133,50 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internlm2",
-    "hf_downloads": 50406,
+    "hf_downloads": 63009,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/internlm2_5-7b-chat-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/internlm2_5-7b-chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "chujiezheng/internlm2-chat-7b-ExPO",
+    "provider": "chujiezheng",
+    "parameter_count": "7.7B",
+    "parameters_raw": 7737708544,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.2,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 16277,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TurbulenceDeterministe/Carnice-9b-W8A16-AWQ",
+    "provider": "turbulencedeterministe",
+    "parameter_count": "7.7B",
+    "parameters_raw": 7742552560,
+    "min_ram_gb": 8.7,
+    "recommended_ram_gb": 14.4,
+    "min_vram_gb": 7.9,
+    "quantization": "AWQ-8bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 22789,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Salesforce/blip2-opt-6.7b",
@@ -11632,7 +18193,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "blip-2",
-    "hf_downloads": 47282,
+    "hf_downloads": 62360,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11652,7 +18213,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "molmo2",
-    "hf_downloads": 76108,
+    "hf_downloads": 102694,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11672,7 +18233,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 86237,
+    "hf_downloads": 153757,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm3-8b-instruct",
+    "provider": "internlm",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7774142464,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.2,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 196608,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm3",
+    "hf_downloads": 37290,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11692,7 +18273,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "moshi",
-    "hf_downloads": 101654,
+    "hf_downloads": 105227,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-7B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7786310038,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 141211,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11712,16 +18315,100 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone",
-    "hf_downloads": 286142,
+    "hf_downloads": 295023,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-7B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7820050908,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 195330,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-Coder-7B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7820050928,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 169571,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-7B-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7820050938,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 13364,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zai-org/GLM-4.5-Air-FP8",
+    "provider": "zai-org",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7831814144,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 29834,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/EXAONE-Deep-7.8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 856604667
   },
   {
     "name": "XiaomiMiMo/MiMo-7B-Base",
@@ -11738,7 +18425,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mimo",
-    "hf_downloads": 92320,
+    "hf_downloads": 93775,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11758,7 +18445,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3n",
-    "hf_downloads": 317754,
+    "hf_downloads": 208415,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11778,7 +18465,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "instructblip",
-    "hf_downloads": 13159,
+    "hf_downloads": 12867,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11798,7 +18485,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl",
-    "hf_downloads": 22573,
+    "hf_downloads": 28192,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11818,24 +18505,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 20205,
+    "hf_downloads": 22169,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/InternVL3-8B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/InternVL3-8B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/InternVL3-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "lingshu-medical-mllm/Lingshu-I-8B",
@@ -11852,7 +18525,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl",
-    "hf_downloads": 14737,
+    "hf_downloads": 14185,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11872,7 +18545,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 283246,
+    "hf_downloads": 290857,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11892,16 +18565,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 134773,
+    "hf_downloads": 190989,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-E4B-it-OBLITERATED-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "google/gemma-4-E4B-it",
@@ -11921,8 +18588,8 @@
     ],
     "pipeline_tag": "any-to-any",
     "architecture": "gemma4",
-    "hf_downloads": 4040361,
-    "hf_likes": 856,
+    "hf_downloads": 5455888,
+    "hf_likes": 922,
     "release_date": "2026-03-02",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -11975,6 +18642,26 @@
     ]
   },
   {
+    "name": "GSAI-ML/LLaDA-1.5",
+    "provider": "gsai-ml",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8015581184,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llada",
+    "hf_downloads": 25340,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "allenai/Molmo-7B-D-0924",
     "provider": "allenai",
     "parameter_count": "8.0B",
@@ -11989,7 +18676,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "molmo",
-    "hf_downloads": 38879,
+    "hf_downloads": 39541,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12011,20 +18698,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "cohere2",
-    "hf_downloads": 26912,
+    "hf_downloads": 29117,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/c4ai-command-r7b-12-2024-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/c4ai-command-r7b-12-2024-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "CohereLabs/aya-expanse-8b",
+    "provider": "coherelabs",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8028033024,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "cohere",
+    "hf_downloads": 21937,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "meta-llama/Llama-3.1-8B",
@@ -12041,8 +18738,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 1457060,
-    "hf_likes": 2173,
+    "hf_downloads": 1546453,
+    "hf_likes": 2180,
     "release_date": "2024-07-14",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -12066,8 +18763,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 9335798,
-    "hf_likes": 5767,
+    "hf_downloads": 9683014,
+    "hf_likes": 5792,
     "release_date": "2024-07-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -12122,16 +18819,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 3269447,
+    "hf_downloads": 3357934,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Meta-Llama-3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "meta-llama/Meta-Llama-3-8B-Instruct",
@@ -12150,20 +18841,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1460299,
+    "hf_downloads": 1665386,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Meta-Llama-3-8B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Meta-Llama-3-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Llama-3.1-8B-Instruct-FP8",
@@ -12182,7 +18863,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 783156,
+    "hf_downloads": 739804,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.1-8B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 715273,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12202,20 +18905,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 386138,
+    "hf_downloads": 403856,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/saiga_llama3_8b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "NousResearch/Meta-Llama-3.1-8B-Instruct",
-    "provider": "NousResearch",
+    "name": "unsloth/Meta-Llama-3.1-8B-Instruct",
+    "provider": "unsloth",
     "parameter_count": "8.0B",
     "parameters_raw": 8030261248,
     "min_ram_gb": 4.5,
@@ -12230,46 +18927,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 196722,
+    "hf_downloads": 281773,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Meta-Llama-3.1-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "meta-llama/Llama-Guard-3-8B",
-    "provider": "Meta",
-    "parameter_count": "8.0B",
-    "parameters_raw": 8030261248,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "llama",
-    "hf_downloads": 149672,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-Guard-3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "NousResearch/Hermes-3-Llama-3.1-8B",
@@ -12288,24 +18949,34 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 149032,
+    "hf_downloads": 189407,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Hermes-3-Llama-3.1-8B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Hermes-3-Llama-3.1-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "DeSTA-ntu/Llama-3.1-8B-Instruct",
-    "provider": "desta-ntu",
+    "name": "meta-llama/Llama-Guard-3-8B",
+    "provider": "Meta",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 154354,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "NousResearch/Meta-Llama-3.1-8B-Instruct",
+    "provider": "NousResearch",
     "parameter_count": "8.0B",
     "parameters_raw": 8030261248,
     "min_ram_gb": 4.5,
@@ -12320,16 +18991,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 77418,
+    "hf_downloads": 142895,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3.1-8B-Instruct-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "MaziyarPanahi/Meta-Llama-3-8B-Instruct-GPTQ",
@@ -12348,7 +19013,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 62126,
+    "hf_downloads": 82890,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "DeSTA-ntu/Llama-3.1-8B-Instruct",
+    "provider": "desta-ntu",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 78120,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12368,16 +19055,32 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 38863,
+    "hf_downloads": 68223,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-3.1-Nemotron-Safety-Guard-8B-v3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "solidrust/Meta-Llama-3.1-8B-Instruct-abliterated-AWQ",
+    "provider": "solidrust",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 54085,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "NousResearch/Meta-Llama-3-8B",
@@ -12394,16 +19097,116 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 34566,
+    "hf_downloads": 44869,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Meta-Llama-3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "qqlabs/llama3_1_relevance_dev",
+    "provider": "qqlabs",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 26278,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "solidrust/Hermes-3-Llama-3.1-8B-AWQ",
+    "provider": "solidrust",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 24028,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Meta-Llama-3-8B-Instruct-FP8-KV",
+    "provider": "redhatai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 23932,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/llama-3-8b-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21165,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Meta-Llama-3.1-8B",
+    "provider": "unsloth",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 20928,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "nvidia/Llama-3.1-Nemotron-Nano-8B-v1",
@@ -12420,20 +19223,130 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 33308,
+    "hf_downloads": 16930,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3.1-Nemotron-Nano-8B-v1-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Llama-3.1-Nemotron-Nano-8B-v1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "FlagAlpha/Llama3-Chinese-8B-Instruct",
+    "provider": "flagalpha",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16289,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "migtissera/Tess-2.0-Llama-3-8B",
+    "provider": "migtissera",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16182,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlabonne/NeuralDaredevil-8B-abliterated",
+    "provider": "mlabonne",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15462,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Danielbrdz/Barcenas-Llama3-8b-ORPO",
+    "provider": "danielbrdz",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13549,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "uygarkurt/llama-3-merged-linear",
+    "provider": "uygarkurt",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13484,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "DeepMount00/Llama-3-8b-Ita",
+    "provider": "deepmount00",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13354,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8",
@@ -12452,7 +19365,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 408871,
+    "hf_downloads": 477426,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12472,7 +19385,67 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 221149,
+    "hf_downloads": 225059,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/Meta-Llama-3-8B-FP8-compressed-tensors-test",
+    "provider": "nm-testing",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261696,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14132,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "allenai/Llama-3.1-Tulu-3-8B-SFT",
+    "provider": "allenai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030326784,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 24958,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "allenai/Llama-3.1-Tulu-3.1-8B",
+    "provider": "allenai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030326784,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15470,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12494,7 +19467,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 152434,
+    "hf_downloads": 140314,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12516,20 +19489,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 222370,
+    "hf_downloads": 34905,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Hermes-2-Pro-Llama-3-8B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Hermes-2-Pro-Llama-3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/Meta-Llama-3-8B-Instruct-nonuniform-test",
+    "provider": "nm-testing",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030568538,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21808,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "llava-hf/llava-onevision-qwen2-7b-ov-hf",
@@ -12548,7 +19533,49 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_onevision",
-    "hf_downloads": 60557,
+    "hf_downloads": 106871,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "fdtn-ai/Foundation-Sec-8B",
+    "provider": "fdtn-ai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8031309824,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15826,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "pearl-ai/Llama-3.1-8B-Instruct-pearl",
+    "provider": "pearl-ai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8031547392,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 50891,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12570,7 +19597,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 51346,
+    "hf_downloads": 62130,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12592,7 +19619,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 34547,
+    "hf_downloads": 38748,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12614,7 +19641,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 25134,
+    "hf_downloads": 21342,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8",
+    "provider": "redhatai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8031637504,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 19937,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "FriendliAI/Meta-Llama-3.1-8B-Instruct-int8",
+    "provider": "friendliai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8031637504,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14357,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12634,10 +19705,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hulumed_qwen2",
-    "hf_downloads": 16452,
+    "hf_downloads": 15838,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "upstage/Solar-Open-100B",
+    "provider": "Upstage",
+    "parameter_count": "8.1B",
+    "parameters_raw": 8053063680,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "solar_open",
+    "hf_downloads": 236957,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 880803840
   },
   {
     "name": "swiss-ai/Apertus-8B-Instruct-2509",
@@ -12654,20 +19749,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "apertus",
-    "hf_downloads": 205379,
+    "hf_downloads": 181872,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Apertus-8B-Instruct-2509-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Apertus-8B-Instruct-2509-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "swiss-ai/Apertus-8B-2509",
@@ -12684,16 +19769,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "apertus",
-    "hf_downloads": 27610,
+    "hf_downloads": 30838,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Apertus-8B-2509-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-8b-code-instruct-128k",
+    "provider": "ibm-granite",
+    "parameter_count": "8.1B",
+    "parameters_raw": 8054910976,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14500,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "nvidia/Eagle2.5-8B",
@@ -12710,7 +19809,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "eagle_2_5_vl",
-    "hf_downloads": 69432,
+    "hf_downloads": 86031,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12730,7 +19829,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 479094,
+    "hf_downloads": 481225,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12750,7 +19849,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 300602,
+    "hf_downloads": 311890,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "inceptionai/Jais-2-8B-Chat",
+    "provider": "inceptionai",
+    "parameter_count": "8.1B",
+    "parameters_raw": 8090401280,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "jais2",
+    "hf_downloads": 16379,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12770,16 +19889,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 134456,
+    "hf_downloads": 119195,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/MiniCPM-V-2_6-GGUF",
-        "provider": "bartowski"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Nemotron-H-8B-Base-8K",
@@ -12796,7 +19909,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 53188,
+    "hf_downloads": 51184,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12816,20 +19929,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granite",
-    "hf_downloads": 421370,
+    "hf_downloads": 75870,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/granite-3.3-8b-instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/granite-3.3-8b-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "openbmb/MiniCPM4.1-8B",
@@ -12846,16 +19949,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpm",
-    "hf_downloads": 32266,
+    "hf_downloads": 58999,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/MiniCPM4.1-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "openbmb/MiniCPM4-8B",
+    "provider": "openbmb",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8185253888,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minicpm",
+    "hf_downloads": 16536,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-8B",
@@ -12874,8 +19991,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3",
-    "hf_downloads": 9024066,
-    "hf_likes": 1067,
+    "hf_downloads": 10813873,
+    "hf_likes": 1073,
     "release_date": "2025-04-27",
     "num_hidden_layers": 36,
     "num_attention_heads": 32,
@@ -12913,7 +20030,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 1106454,
+    "hf_downloads": 1435479,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12935,16 +20052,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 474822,
+    "hf_downloads": 573569,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-8B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
@@ -12963,20 +20074,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 260565,
+    "hf_downloads": 258291,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-0528-Qwen3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3Guard-Gen-8B",
@@ -12995,16 +20096,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 191646,
+    "hf_downloads": 111035,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3Guard-Gen-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Qwen3-8B-FP8",
@@ -13023,7 +20118,47 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 37108,
+    "hf_downloads": 19438,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "JetLM/SDAR-8B-Chat",
+    "provider": "jetlm",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8190735360,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "sdar",
+    "hf_downloads": 14569,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hkust-nlp/WebExplorer-8B",
+    "provider": "hkust-nlp",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8190735360,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 23481,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13045,7 +20180,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 185789,
+    "hf_downloads": 226410,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13067,7 +20202,219 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 33304,
+    "hf_downloads": 35052,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Qwen3-8B-FP8-dynamic",
+    "provider": "redhatai",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8192136192,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 30065,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-Distill-Llama-8B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8243411700,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 18253,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Meta-Llama-3.1-8B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8243411714,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 61501,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.1-8B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8243411714,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 33310,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/meta-Llama-3.1-8B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8243411722,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 25808,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929342,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 428533,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.1-8B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929342,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 25365,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Meta-Llama-3.1-8B-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929356,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 33050,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/llama-3-8b-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929382,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 80536,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/llama-3-8b-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929386,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 81051,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13089,24 +20436,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 2054600,
+    "hf_downloads": 3258098,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2-VL-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "ggml-org/Qwen2-VL-7B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2-VL-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2-VL-7B-Instruct-AWQ",
@@ -13125,7 +20458,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 1662721,
+    "hf_downloads": 1708456,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13147,16 +20480,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 43410,
+    "hf_downloads": 35219,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2-VL-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2-VL-7B-Instruct-GPTQ-Int4",
@@ -13175,27 +20502,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 37527,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "MBZUAI/AIN",
-    "provider": "mbzuai",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8291375616,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.7,
-    "min_vram_gb": 4.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_vl",
-    "hf_downloads": 16222,
+    "hf_downloads": 11796,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13218,8 +20525,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 8847645,
-    "hf_likes": 1512,
+    "hf_downloads": 8902443,
+    "hf_likes": 1519,
     "release_date": "2025-01-26",
     "num_hidden_layers": 28,
     "num_attention_heads": 28,
@@ -13236,32 +20543,6 @@
       },
       {
         "repo": "mradermacher/Qwen2.5-VL-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "reducto/RolmOCR",
-    "provider": "reducto",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8292166656,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.7,
-    "min_vram_gb": 4.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 304708,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/RolmOCR-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -13284,7 +20565,47 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 241779,
+    "hf_downloads": 341659,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "reducto/RolmOCR",
+    "provider": "reducto",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8292166656,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 312983,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "numind/NuExtract-2.0-8B-GPTQ",
+    "provider": "numind",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8292166656,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 172124,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13304,33 +20625,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 156760,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/olmOCR-2-7B-1025-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "numind/NuExtract-2.0-8B-GPTQ",
-    "provider": "numind",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8292166656,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.7,
-    "min_vram_gb": 4.2,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 64989,
+    "hf_downloads": 68739,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13350,16 +20645,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 18743,
+    "hf_downloads": 19470,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/UI-TARS-1.5-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/olmOCR-7B-0825",
@@ -13376,20 +20665,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 16866,
+    "hf_downloads": 17425,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/olmOCR-7B-0825-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "OctoMed/OctoMed-7B",
-    "provider": "octomed",
+    "name": "Singh8898/DiegoCropper",
+    "provider": "singh8898",
     "parameter_count": "8.3B",
     "parameters_raw": 8292166656,
     "min_ram_gb": 4.6,
@@ -13402,16 +20685,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 15778,
+    "hf_downloads": 12113,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/OctoMed-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "numind/NuExtract-2.0-8B",
+    "provider": "numind",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8292166656,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 10735,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "xlangai/OpenCUA-7B",
@@ -13428,7 +20725,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "opencua",
-    "hf_downloads": 153947,
+    "hf_downloads": 145002,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13448,27 +20745,49 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 259229,
+    "hf_downloads": 277163,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "openbmb/MiniCPM-V-2_6-int4",
-    "provider": "openbmb",
+    "name": "RedHatAI/Qwen3-8B-quantized.w4a16",
+    "provider": "redhatai",
     "parameter_count": "8.3B",
-    "parameters_raw": 8315441823,
+    "parameters_raw": 8299263480,
     "min_ram_gb": 4.6,
     "recommended_ram_gb": 7.7,
     "min_vram_gb": 4.3,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Lightweight, edge deployment",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 23620,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "adept/persimmon-8b-chat",
+    "provider": "adept",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8321499136,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.8,
+    "min_vram_gb": 4.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "Instruction following, chat",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "minicpmv",
-    "hf_downloads": 18804,
+    "architecture": "persimmon",
+    "hf_downloads": 15076,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13488,8 +20807,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2_moe",
-    "hf_downloads": 111280,
-    "hf_likes": 351,
+    "hf_downloads": 112372,
+    "hf_likes": 352,
     "release_date": "2025-10-07",
     "num_hidden_layers": 24,
     "num_attention_heads": 32,
@@ -13523,7 +20842,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 22591,
+    "hf_downloads": 18801,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13545,7 +20864,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 36198,
+    "hf_downloads": 35287,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13565,7 +20884,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen",
-    "hf_downloads": 44796,
+    "hf_downloads": 63224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13585,7 +20904,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics2",
-    "hf_downloads": 105584,
+    "hf_downloads": 106490,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13607,20 +20926,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 47616,
+    "hf_downloads": 32660,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Mistral-NeMo-Minitron-8B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Mistral-NeMo-Minitron-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "KonstantinosKK/lavida-llada-v1.0-instruct-hf-transformers",
@@ -13637,7 +20946,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llava_llada",
-    "hf_downloads": 17489,
+    "hf_downloads": 13166,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13659,16 +20968,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 84252,
+    "hf_downloads": 89420,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llama-joycaption-beta-one-hf-llava-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "TIGER-Lab/Mantis-8B-siglip-llama3",
@@ -13685,7 +20988,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 56653,
+    "hf_downloads": 74442,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13707,27 +21010,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 14637,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "OpenGVLab/InternVL3_5-8B-HF",
-    "provider": "opengvlab",
-    "parameter_count": "8.5B",
-    "parameters_raw": 8528318464,
-    "min_ram_gb": 4.8,
-    "recommended_ram_gb": 7.9,
-    "min_vram_gb": 4.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "internvl",
-    "hf_downloads": 48763,
+    "hf_downloads": 132276,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13747,16 +21030,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 41399,
+    "hf_downloads": 165709,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/InternVL3_5-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "OpenGVLab/InternVL3_5-8B-HF",
+    "provider": "opengvlab",
+    "parameter_count": "8.5B",
+    "parameters_raw": 8528318464,
+    "min_ram_gb": 4.8,
+    "recommended_ram_gb": 7.9,
+    "min_vram_gb": 4.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internvl",
+    "hf_downloads": 48151,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "openbmb/MiniCPM-Llama3-V-2_5",
@@ -13773,7 +21070,71 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 39339,
+    "hf_downloads": 25511,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "google/gemma-1.1-7b-it",
+    "provider": "Google",
+    "parameter_count": "8.5B",
+    "parameters_raw": 8537680896,
+    "min_ram_gb": 4.8,
+    "recommended_ram_gb": 8.0,
+    "min_vram_gb": 4.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma",
+    "hf_downloads": 14721,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen-VL",
+    "provider": "Alibaba",
+    "parameter_count": "8.5B",
+    "parameters_raw": 8541175808,
+    "min_ram_gb": 4.8,
+    "recommended_ram_gb": 8.0,
+    "min_vram_gb": 4.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen",
+    "hf_downloads": 90484,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen-VL-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "8.5B",
+    "parameters_raw": 8541175808,
+    "min_ram_gb": 4.8,
+    "recommended_ram_gb": 8.0,
+    "min_vram_gb": 4.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen",
+    "hf_downloads": 74574,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13793,7 +21154,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 272528,
+    "hf_downloads": 276702,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13813,7 +21174,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 49275,
+    "hf_downloads": 49874,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13835,7 +21196,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "aya_vision",
-    "hf_downloads": 108072,
+    "hf_downloads": 129802,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13855,7 +21216,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "molmo2",
-    "hf_downloads": 543123,
+    "hf_downloads": 580858,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13875,7 +21236,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "Bee",
-    "hf_downloads": 91543,
+    "hf_downloads": 124069,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13895,7 +21256,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 127083,
+    "hf_downloads": 141948,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13915,7 +21276,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 30739,
+    "hf_downloads": 41348,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13935,7 +21296,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "emu3",
-    "hf_downloads": 51291,
+    "hf_downloads": 58658,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13958,20 +21319,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 3937427,
+    "hf_downloads": 5028618,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-8B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-VL-8B-Thinking",
@@ -13991,20 +21342,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 471775,
+    "hf_downloads": 797018,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-8B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-8B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Cosmos-Reason2-8B",
@@ -14021,16 +21362,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 175437,
+    "hf_downloads": 225634,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Cosmos-Reason2-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "datalab-to/chandra",
@@ -14047,7 +21382,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 101639,
+    "hf_downloads": 103682,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14067,16 +21402,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 86533,
+    "hf_downloads": 91675,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/XCurOS-1.2-8B-VLBF16-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "thelamapi/next-ocr",
@@ -14093,16 +21422,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 12077,
+    "hf_downloads": 11175,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/next-ocr-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-VL-8B-Instruct-FP8",
@@ -14122,7 +21445,110 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 453977,
+    "hf_downloads": 576836,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-VL-8B-Thinking-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "8.8B",
+    "parameters_raw": 8767547632,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_vl",
+    "hf_downloads": 42315,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-4.1-8b",
+    "provider": "ibm-granite",
+    "parameter_count": "8.8B",
+    "parameters_raw": 8791592960,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granite",
+    "hf_downloads": 21803,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "01-ai/Yi-1.5-9B-Chat",
+    "provider": "01.ai",
+    "parameter_count": "8.8B",
+    "parameters_raw": 8829407232,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21677,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "01-ai/Yi-1.5-9B",
+    "provider": "01.ai",
+    "parameter_count": "8.8B",
+    "parameters_raw": 8829407232,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14528,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tiiuae/falcon-mamba-7b",
+    "provider": "TII",
+    "parameter_count": "8.9B",
+    "parameters_raw": 8856272896,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "falcon_mamba",
+    "hf_downloads": 72129,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14142,8 +21568,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "nemotron_h",
-    "hf_downloads": 532819,
-    "hf_likes": 489,
+    "hf_downloads": 560506,
+    "hf_likes": 490,
     "release_date": "2025-08-12",
     "num_hidden_layers": 56,
     "num_attention_heads": 40,
@@ -14165,16 +21591,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 185794,
+    "hf_downloads": 141066,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/NVIDIA-Nemotron-Nano-9B-v2-Japanese-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Base",
@@ -14191,7 +21611,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 31139,
+    "hf_downloads": 24080,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14211,7 +21631,69 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 71287,
+    "hf_downloads": 81607,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "AIDC-AI/Ovis2-8B",
+    "provider": "aidc-ai",
+    "parameter_count": "8.9B",
+    "parameters_raw": 8935282678,
+    "min_ram_gb": 5.0,
+    "recommended_ram_gb": 8.3,
+    "min_vram_gb": 4.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ovis",
+    "hf_downloads": 27848,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "9.0B",
+    "parameters_raw": 8953801728,
+    "min_ram_gb": 5.0,
+    "recommended_ram_gb": 8.3,
+    "min_vram_gb": 4.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 142142,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "maxcurrent/Peagle-9b",
+    "provider": "maxcurrent",
+    "parameter_count": "9.0B",
+    "parameters_raw": 8986628096,
+    "min_ram_gb": 5.0,
+    "recommended_ram_gb": 8.4,
+    "min_vram_gb": 4.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 13401,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14233,7 +21715,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 42100,
+    "hf_downloads": 41989,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14253,7 +21735,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 317137,
+    "hf_downloads": 339120,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Qwen3-32B-MLX-8bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "9.2B",
+    "parameters_raw": 9214833664,
+    "min_ram_gb": 5.1,
+    "recommended_ram_gb": 8.6,
+    "min_vram_gb": 4.7,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 16976,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14275,7 +21779,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 65757,
+    "hf_downloads": 66555,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14295,7 +21799,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35656,
+    "hf_downloads": 39079,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14315,8 +21819,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "gemma2",
-    "hf_downloads": 459638,
-    "hf_likes": 793,
+    "hf_downloads": 521850,
+    "hf_likes": 795,
     "release_date": "2024-06-24",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -14329,6 +21833,72 @@
       },
       {
         "repo": "mradermacher/gemma-2-9b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/gemma-2-9b-it",
+    "provider": "unsloth",
+    "parameter_count": "9.2B",
+    "parameters_raw": 9241705984,
+    "min_ram_gb": 5.2,
+    "recommended_ram_gb": 8.6,
+    "min_vram_gb": 4.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma2",
+    "hf_downloads": 32998,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "moondream/moondream3-preview",
+    "provider": "moondream",
+    "parameter_count": "9.3B",
+    "parameters_raw": 9268626928,
+    "min_ram_gb": 5.2,
+    "recommended_ram_gb": 8.6,
+    "min_vram_gb": 4.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "moondream3",
+    "hf_downloads": 29461,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "speakleash/Bielik-11B-v2.3-Instruct",
+    "provider": "speakleash",
+    "parameter_count": "9.4B",
+    "parameters_raw": 9359065088,
+    "min_ram_gb": 5.2,
+    "recommended_ram_gb": 8.7,
+    "min_vram_gb": 4.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 14359,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Bielik-11B-v2.3-Instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -14348,20 +21918,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 27822,
+    "hf_downloads": 24226,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 8,
-    "active_parameters": 1580596576,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/academic-ds-9B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 1580596576
+  },
+  {
+    "name": "zai-org/glm-4-9b-chat-hf",
+    "provider": "zai-org",
+    "parameter_count": "9.4B",
+    "parameters_raw": 9399951360,
+    "min_ram_gb": 5.3,
+    "recommended_ram_gb": 8.8,
+    "min_vram_gb": 4.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm",
+    "hf_downloads": 19901,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "THUDM/glm-4-9b-chat",
@@ -14378,7 +21962,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "chatglm",
-    "hf_downloads": 426483,
+    "hf_downloads": 372499,
     "hf_likes": 706,
     "release_date": "2024-06-04",
     "num_hidden_layers": 40,
@@ -14397,6 +21981,26 @@
     ]
   },
   {
+    "name": "zai-org/GLM-4-9B-0414",
+    "provider": "zai-org",
+    "parameter_count": "9.4B",
+    "parameters_raw": 9400279040,
+    "min_ram_gb": 5.3,
+    "recommended_ram_gb": 8.8,
+    "min_vram_gb": 4.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4",
+    "hf_downloads": 22844,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "adept/fuyu-8b",
     "provider": "adept",
     "parameter_count": "9.4B",
@@ -14411,7 +22015,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "fuyu",
-    "hf_downloads": 80781,
+    "hf_downloads": 92166,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14433,7 +22037,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 20633,
+    "hf_downloads": 28840,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14455,44 +22059,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 16553,
+    "hf_downloads": 14508,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Gliese-Qwen3.5-9B-Abliterated-Caption-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "Momix-44/Qwen3.5-9B-gemini-3.1-opus-4.6-reasoning",
-    "provider": "momix-44",
-    "parameter_count": "9.4B",
-    "parameters_raw": 9409813744,
+    "name": "unsloth/gemma-2-9b-it-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "9.5B",
+    "parameters_raw": 9502508184,
     "min_ram_gb": 5.3,
     "recommended_ram_gb": 8.8,
-    "min_vram_gb": 4.8,
+    "min_vram_gb": 4.9,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 10188,
+    "architecture": "gemma2",
+    "hf_downloads": 31384,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-9B-gemini-3.1-opus-4.6-reasoning-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3.5-9B",
@@ -14512,8 +22102,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 7121429,
-    "hf_likes": 1362,
+    "hf_downloads": 7908981,
+    "hf_likes": 1388,
     "release_date": "2026-02-27",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -14548,13 +22138,51 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 130945,
+    "hf_downloads": 163939,
     "hf_likes": 73,
     "release_date": "2026-02-26",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
-    "head_dim": null
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-9B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2",
+    "provider": "jackrong",
+    "parameter_count": "9.7B",
+    "parameters_raw": 9653104368,
+    "min_ram_gb": 5.4,
+    "recommended_ram_gb": 9.0,
+    "min_vram_gb": 4.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 8766,
+    "hf_likes": 165,
+    "release_date": "2026-03-16",
+    "num_hidden_layers": null,
+    "num_attention_heads": null,
+    "num_key_value_heads": null,
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -14573,7 +22201,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 382681,
+    "hf_downloads": 379279,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14593,16 +22221,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 354821,
+    "hf_downloads": 354144,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwopus3.5-9B-v3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "QuantTrio/Qwen3.5-9B-AWQ",
@@ -14621,7 +22243,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 265356,
+    "hf_downloads": 228107,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14643,16 +22265,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 87524,
+    "hf_downloads": 45014,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-9B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "huihui-ai/Huihui-Qwen3.5-9B-Claude-4.6-Opus-abliterated",
@@ -14671,35 +22287,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 45313,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-9B-Claude-4.6-Opus-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2",
-    "provider": "jackrong",
-    "parameter_count": "9.7B",
-    "parameters_raw": 9653104368,
-    "min_ram_gb": 5.4,
-    "recommended_ram_gb": 9.0,
-    "min_vram_gb": 4.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 15066,
+    "hf_downloads": 31411,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14721,16 +22309,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 10157,
+    "hf_downloads": 12466,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "lovedheart/Qwen3.5-9B-FP8",
@@ -14749,7 +22331,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 283542,
+    "hf_downloads": 270831,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14769,7 +22351,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen",
-    "hf_downloads": 227107,
+    "hf_downloads": 231334,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-ai-platform/Bamba-9B-v1",
+    "provider": "ibm-ai-platform",
+    "parameter_count": "9.8B",
+    "parameters_raw": 9780235392,
+    "min_ram_gb": 5.5,
+    "recommended_ram_gb": 9.1,
+    "min_vram_gb": 5.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "bamba",
+    "hf_downloads": 23909,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14791,7 +22393,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 23430,
+    "hf_downloads": 26774,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14813,10 +22415,34 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 15277,
+    "hf_downloads": 19010,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "Snowflake/snowflake-arctic-instruct",
+    "provider": "snowflake",
+    "parameter_count": "9.9B",
+    "parameters_raw": 9863168000,
+    "min_ram_gb": 5.5,
+    "recommended_ram_gb": 9.2,
+    "min_vram_gb": 5.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "arctic",
+    "hf_downloads": 23546,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 2,
+    "active_parameters": 639564800
   },
   {
     "name": "cyankiwi/Qwen3.5-9B-AWQ-4bit",
@@ -14835,7 +22461,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 251801,
+    "hf_downloads": 343105,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14857,7 +22483,47 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "plamo2vl",
-    "hf_downloads": 10491,
+    "hf_downloads": 10383,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmsys/longchat-13b-16k",
+    "provider": "LMSYS",
+    "parameter_count": "10.0B",
+    "parameters_raw": 10020454400,
+    "min_ram_gb": 5.6,
+    "recommended_ram_gb": 9.3,
+    "min_vram_gb": 5.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16664,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Undi95/ReMM-SLERP-L2-13B",
+    "provider": "undi95",
+    "parameter_count": "10.0B",
+    "parameters_raw": 10020454400,
+    "min_ram_gb": 5.6,
+    "recommended_ram_gb": 9.3,
+    "min_vram_gb": 5.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14887,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14879,7 +22545,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "step_robotics",
-    "hf_downloads": 269013,
+    "hf_downloads": 342363,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14899,20 +22565,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4v",
-    "hf_downloads": 366504,
+    "hf_downloads": 390582,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.1V-9B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/GLM-4.1V-9B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "zai-org/GLM-4.6V-Flash",
@@ -14929,24 +22585,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4v",
-    "hf_downloads": 40322,
+    "hf_downloads": 43469,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.6V-Flash-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/GLM-4.6V-Flash-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/GLM-4.6V-Flash-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "dengcao/GLM-4.1V-9B-Thinking-AWQ",
@@ -14963,10 +22605,54 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4v",
-    "hf_downloads": 256742,
+    "hf_downloads": 180048,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "CausalLM/14B-DPO-alpha",
+    "provider": "causallm",
+    "parameter_count": "10.6B",
+    "parameters_raw": 10582753280,
+    "min_ram_gb": 5.9,
+    "recommended_ram_gb": 9.9,
+    "min_vram_gb": 5.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 24618,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "varjosoft/gemma-4-26B-A4B-it-TQ3-native",
+    "provider": "varjosoft",
+    "parameter_count": "10.6B",
+    "parameters_raw": 10619634222,
+    "min_ram_gb": 5.9,
+    "recommended_ram_gb": 9.9,
+    "min_vram_gb": 5.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 15028,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1161522487
   },
   {
     "name": "meta-llama/Llama-3.2-11B-Vision",
@@ -14985,7 +22671,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mllama",
-    "hf_downloads": 13070,
+    "hf_downloads": 13481,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15008,8 +22694,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "mllama",
-    "hf_downloads": 109463,
-    "hf_likes": 1587,
+    "hf_downloads": 156636,
+    "hf_likes": 1588,
     "release_date": "2024-09-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -15034,7 +22720,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mllama",
-    "hf_downloads": 30527,
+    "hf_downloads": 30475,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15054,7 +22740,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 63398,
+    "hf_downloads": 63642,
     "hf_likes": 652,
     "release_date": "2023-12-12",
     "num_hidden_layers": 48,
@@ -15087,20 +22773,90 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 29189,
+    "hf_downloads": 29551,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/SOLAR-10.7B-v1.0-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/SOLAR-10.7B-v1.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "jeonsworld/CarbonVillain-en-10.7B-v4",
+    "provider": "jeonsworld",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13566,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "kekmodel/StopCarbon-10.7B-v5",
+    "provider": "kekmodel",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13531,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "invalid-coder/Sakura-SOLAR-Instruct-CarbonVillain-en-10.7B-v2-slerp",
+    "provider": "invalid-coder",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13516,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "vicgalle/CarbonBeagle-11B-truthy",
+    "provider": "vicgalle",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 13437,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "naver-hyperclovax/HyperCLOVAX-SEED-Omni-8B",
@@ -15117,7 +22873,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "vlm",
-    "hf_downloads": 297851,
+    "hf_downloads": 260475,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "OrionStarAI/Orion-14B-Chat",
+    "provider": "orionstarai",
+    "parameter_count": "10.9B",
+    "parameters_raw": 10918952960,
+    "min_ram_gb": 6.1,
+    "recommended_ram_gb": 10.2,
+    "min_vram_gb": 5.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "orion",
+    "hf_downloads": 21615,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15137,10 +22913,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 238608,
+    "hf_downloads": 126797,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "allenai/Flex-reddit-2x7B-1T",
+    "provider": "allenai",
+    "parameter_count": "11.6B",
+    "parameters_raw": 11627401216,
+    "min_ram_gb": 6.5,
+    "recommended_ram_gb": 10.8,
+    "min_vram_gb": 6.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "flex_olmo",
+    "hf_downloads": 14461,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 2,
+    "active_experts": 2,
+    "active_parameters": 11627401216
   },
   {
     "name": "Intel/Qwen3-Coder-Next-int4-AutoRound",
@@ -15150,8 +22950,8 @@
     "min_ram_gb": 6.6,
     "recommended_ram_gb": 11.0,
     "min_vram_gb": 6.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
+    "quantization": "AutoRound-4bit",
+    "format": "autoround",
     "context_length": 262144,
     "use_case": "Code generation and completion",
     "capabilities": [
@@ -15159,7 +22959,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 70604,
+    "hf_downloads": 72209,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15167,6 +22967,26 @@
     "num_experts": 512,
     "active_experts": 10,
     "active_parameters": 810590063
+  },
+  {
+    "name": "EleutherAI/pythia-12b",
+    "provider": "eleutherai",
+    "parameter_count": "12.0B",
+    "parameters_raw": 11997067840,
+    "min_ram_gb": 6.7,
+    "recommended_ram_gb": 11.2,
+    "min_vram_gb": 6.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 20123,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "google/gemma-3-12b-it",
@@ -15218,7 +23038,95 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 29560,
+    "hf_downloads": 88649,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-14B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "12.1B",
+    "parameters_raw": 12102533120,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.3,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 179635,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-14B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "12.1B",
+    "parameters_raw": 12102533120,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.3,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 162348,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TeichAI/Qwen3-14B-Claude-4.5-Opus-High-Reasoning-Distill-GGUF",
+    "provider": "teichai",
+    "parameter_count": "12.1B",
+    "parameters_raw": 12102533120,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.3,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 46132,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-14B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "12.1B",
+    "parameters_raw": 12102533120,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.3,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 37409,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15240,7 +23148,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 140150,
+    "hf_downloads": 209562,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15260,42 +23168,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 43033,
+    "hf_downloads": 45100,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-3-12b-it-qat-q4_0-unquantized-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "google/gemma-3-12b-pt",
-    "provider": "Google",
-    "parameter_count": "12.2B",
-    "parameters_raw": 12187325040,
-    "min_ram_gb": 6.8,
-    "recommended_ram_gb": 11.4,
-    "min_vram_gb": 6.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma3",
-    "hf_downloads": 17746,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-3-12b-pt-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "gaunernst/gemma-3-12b-it-int4-awq",
@@ -15312,7 +23188,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 16212,
+    "hf_downloads": 37067,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "google/gemma-3-12b-pt",
+    "provider": "Google",
+    "parameter_count": "12.2B",
+    "parameters_raw": 12187325040,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.4,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3",
+    "hf_downloads": 18586,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15349,6 +23245,70 @@
     ]
   },
   {
+    "name": "inflatebot/MN-12B-Mag-Mell-R1",
+    "provider": "inflatebot",
+    "parameter_count": "12.2B",
+    "parameters_raw": 12247782400,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.4,
+    "min_vram_gb": 6.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024000,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 26453,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "casperhansen/mistral-nemo-instruct-2407-awq",
+    "provider": "casperhansen",
+    "parameter_count": "12.2B",
+    "parameters_raw": 12247782400,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.4,
+    "min_vram_gb": 6.3,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1024000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 14262,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen2.5-14B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "12.6B",
+    "parameters_raw": 12606504960,
+    "min_ram_gb": 7.0,
+    "recommended_ram_gb": 11.7,
+    "min_vram_gb": 6.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 70516,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "mistral-experimental/pixtral-12b",
     "provider": "mistral-experimental",
     "parameter_count": "12.7B",
@@ -15365,20 +23325,74 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 119129,
+    "hf_downloads": 125830,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "facebook/opt-13b",
+    "provider": "facebook",
+    "parameter_count": "12.8B",
+    "parameters_raw": 12840304640,
+    "min_ram_gb": 7.2,
+    "recommended_ram_gb": 12.0,
+    "min_vram_gb": 6.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 16940,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mixtao/MixTAO-7Bx2-MoE-v8.1",
+    "provider": "mixtao",
+    "parameter_count": "12.9B",
+    "parameters_raw": 12879138816,
+    "min_ram_gb": 7.2,
+    "recommended_ram_gb": 12.0,
+    "min_vram_gb": 6.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 20288,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/pixtral-12b-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/pixtral-12b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 2,
+    "active_experts": 2,
+    "active_parameters": 12879138816
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "13.0B",
+    "parameters_raw": 12950568960,
+    "min_ram_gb": 7.2,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 15890,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "microsoft/Orca-2-13b",
@@ -15476,16 +23490,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 128187,
+    "hf_downloads": 151010,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/HarmBench-Llama-2-13b-cls-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "meta-llama/CodeLlama-13b-Instruct-hf",
@@ -15502,7 +23510,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 2798,
+    "hf_downloads": 2866,
     "hf_likes": 28,
     "release_date": "2024-03-13",
     "num_hidden_layers": null,
@@ -15515,6 +23523,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "TheBloke/NexusRaven-V2-13B-AWQ",
+    "provider": "thebloke",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13016110080,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 16384,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21246,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8",
@@ -15533,7 +23561,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 642169,
+    "hf_downloads": 493102,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15555,10 +23583,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 218255,
+    "hf_downloads": 275296,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "DavidAU/gemma-3-12b-it-vl-GLM-4.7-Flash-INSTRUCT-Thinking-Hybrid-Heretic-Uncensored",
+    "provider": "davidau",
+    "parameter_count": "13.2B",
+    "parameters_raw": 13194203760,
+    "min_ram_gb": 7.4,
+    "recommended_ram_gb": 12.3,
+    "min_vram_gb": 6.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3",
+    "hf_downloads": 16446,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "shoumenchougou/RWKV7-G1f-13.3B-GGUF",
+    "provider": "RWKV",
+    "parameter_count": "13.3B",
+    "parameters_raw": 13300000000,
+    "min_ram_gb": 7.4,
+    "recommended_ram_gb": 12.4,
+    "min_vram_gb": 6.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "rwkv",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
   },
   {
     "name": "llava-hf/llava-1.5-13b-hf",
@@ -15577,16 +23646,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 11441,
+    "hf_downloads": 11662,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llava-1.5-13b-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "llava-hf/llava-v1.6-vicuna-13b-hf",
@@ -15605,7 +23668,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 29356,
+    "hf_downloads": 35915,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "allenai/OLMo-2-1124-13B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "13.7B",
+    "parameters_raw": 13716198400,
+    "min_ram_gb": 7.7,
+    "recommended_ram_gb": 12.8,
+    "min_vram_gb": 7.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmo2",
+    "hf_downloads": 19733,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15625,20 +23708,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 56332,
+    "hf_downloads": 55441,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Phi-3-medium-4k-instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Phi-3-medium-4k-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "microsoft/phi-4",
@@ -15716,6 +23789,46 @@
     ]
   },
   {
+    "name": "Qwen/Qwen1.5-14B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "14.2B",
+    "parameters_raw": 14167290880,
+    "min_ram_gb": 7.9,
+    "recommended_ram_gb": 13.2,
+    "min_vram_gb": 7.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 17892,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen1.5-14B",
+    "provider": "Alibaba",
+    "parameter_count": "14.2B",
+    "parameters_raw": 14167290880,
+    "min_ram_gb": 7.9,
+    "recommended_ram_gb": 13.2,
+    "min_vram_gb": 7.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14030,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "RedHatAI/Mistral-Small-3.2-24B-Instruct-2506-NVFP4",
     "provider": "redhatai",
     "parameter_count": "14.3B",
@@ -15732,7 +23845,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral3",
-    "hf_downloads": 49707,
+    "hf_downloads": 44963,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15752,7 +23865,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_moe",
-    "hf_downloads": 150264,
+    "hf_downloads": 166813,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15760,6 +23873,30 @@
     "num_experts": 60,
     "active_experts": 4,
     "active_parameters": 1622455541
+  },
+  {
+    "name": "nvidia/Gemma-4-26B-A4B-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "14.4B",
+    "parameters_raw": 14386941232,
+    "min_ram_gb": 8.0,
+    "recommended_ram_gb": 13.4,
+    "min_vram_gb": 7.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 98843,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1573571693
   },
   {
     "name": "cyankiwi/Qwen3-Coder-Next-AWQ-4bit",
@@ -15778,7 +23915,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 112730,
+    "hf_downloads": 114534,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15804,7 +23941,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 41839,
+    "hf_downloads": 40550,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15812,6 +23949,26 @@
     "num_experts": 512,
     "active_experts": 10,
     "active_parameters": 990253467
+  },
+  {
+    "name": "unsloth/phi-4",
+    "provider": "unsloth",
+    "parameter_count": "14.7B",
+    "parameters_raw": 14659507200,
+    "min_ram_gb": 8.2,
+    "recommended_ram_gb": 13.7,
+    "min_vram_gb": 7.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 26050,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-Next-80B-A3B-Instruct-AWQ-4bit",
@@ -15830,7 +23987,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 211029,
+    "hf_downloads": 309830,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15856,7 +24013,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 122992,
+    "hf_downloads": 125557,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15880,7 +24037,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hyperclovax",
-    "hf_downloads": 548545,
+    "hf_downloads": 337324,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15900,7 +24057,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hyperclovax",
-    "hf_downloads": 35894,
+    "hf_downloads": 39886,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15922,29 +24079,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 732814,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "OpenPipe/Qwen3-14B-Instruct",
-    "provider": "openpipe",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14768307200,
-    "min_ram_gb": 8.3,
-    "recommended_ram_gb": 13.8,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3",
-    "hf_downloads": 162308,
+    "hf_downloads": 903811,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15966,7 +24101,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 125796,
+    "hf_downloads": 125813,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "OpenPipe/Qwen3-14B-Instruct",
+    "provider": "openpipe",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14768307200,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 125288,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "JunHowie/Qwen3-14B-GPTQ-Int4",
+    "provider": "junhowie",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14768307200,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 78307,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15988,16 +24167,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 61669,
+    "hf_downloads": 69069,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-14B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "TeichAI/Qwen3-14B-Claude-4.5-Opus-High-Reasoning-Distill",
+    "provider": "teichai",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14768307200,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 21576,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-14B-Instruct",
@@ -16074,7 +24269,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 951167,
+    "hf_downloads": 1141729,
     "hf_likes": 151,
     "release_date": "2024-11-06",
     "num_hidden_layers": 48,
@@ -16113,7 +24308,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1904475,
+    "hf_downloads": 1941920,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16135,7 +24330,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 621436,
+    "hf_downloads": 1050140,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16155,24 +24350,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 462743,
+    "hf_downloads": 433379,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-14B-Instruct-GPTQ-Int4",
@@ -16191,7 +24372,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 158402,
+    "hf_downloads": 184610,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16213,16 +24394,78 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 121026,
+    "hf_downloads": 144761,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-14B-Instruct-GPTQ-Int8",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770033664,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.5,
+    "min_vram_gb": 15.1,
+    "quantization": "GPTQ-Int8",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 32755,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-14B",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770033664,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 24573,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "prithivMLmods/gemma-4-26B-A4B-it-MXFP4A16",
+    "provider": "prithivmlmods",
+    "parameter_count": "15.1B",
+    "parameters_raw": 15067525710,
+    "min_ram_gb": 8.4,
+    "recommended_ram_gb": 14.0,
+    "min_vram_gb": 7.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 10932,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-14B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1648010621
   },
   {
     "name": "bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4",
@@ -16239,7 +24482,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 300831,
+    "hf_downloads": 385977,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16265,7 +24508,73 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "phi4-siglip",
-    "hf_downloads": 135315,
+    "hf_downloads": 159013,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-14B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "15.2B",
+    "parameters_raw": 15155350546,
+    "min_ram_gb": 8.5,
+    "recommended_ram_gb": 14.1,
+    "min_vram_gb": 7.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 33330,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-Coder-14B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "15.2B",
+    "parameters_raw": 15183924206,
+    "min_ram_gb": 8.5,
+    "recommended_ram_gb": 14.1,
+    "min_vram_gb": 7.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 19634,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-14B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "15.2B",
+    "parameters_raw": 15183924272,
+    "min_ram_gb": 8.5,
+    "recommended_ram_gb": 14.1,
+    "min_vram_gb": 7.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 28548,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16310,7 +24619,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 267972,
+    "hf_downloads": 195504,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16357,8 +24666,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v2",
-    "hf_downloads": 965737,
-    "hf_likes": 589,
+    "hf_downloads": 1086169,
+    "hf_likes": 593,
     "release_date": "2024-06-14",
     "num_hidden_layers": 27,
     "num_attention_heads": 16,
@@ -16394,50 +24703,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 868178,
+    "hf_downloads": 903474,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2184182961,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/DeepSeek-V2-Lite-Chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-V2-Lite",
-    "provider": "DeepSeek",
-    "parameter_count": "15.7B",
-    "parameters_raw": 15706484224,
-    "min_ram_gb": 8.8,
-    "recommended_ram_gb": 14.6,
-    "min_vram_gb": 8.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 6553600,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "deepseek_v2",
-    "hf_downloads": 369076,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 2184182961,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/DeepSeek-V2-Lite-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2184182961
   },
   {
     "name": "TechxGenus/DeepSeek-Coder-V2-Lite-Instruct-AWQ",
@@ -16454,7 +24727,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 318177,
+    "hf_downloads": 539289,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2184182961
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V2-Lite",
+    "provider": "DeepSeek",
+    "parameter_count": "15.7B",
+    "parameters_raw": 15706484224,
+    "min_ram_gb": 8.8,
+    "recommended_ram_gb": 14.6,
+    "min_vram_gb": 8.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v2",
+    "hf_downloads": 425194,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16478,7 +24775,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 98087,
+    "hf_downloads": 116489,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16488,28 +24785,24 @@
     "active_parameters": 2184182961
   },
   {
-    "name": "moonshotai/Moonlight-16B-A3B",
-    "provider": "moonshotai",
-    "parameter_count": "16.0B",
-    "parameters_raw": 15960111936,
-    "min_ram_gb": 8.9,
-    "recommended_ram_gb": 14.9,
-    "min_vram_gb": 8.2,
+    "name": "bigcode/starcoder",
+    "provider": "BigCode",
+    "parameter_count": "15.8B",
+    "parameters_raw": 15819446272,
+    "min_ram_gb": 8.8,
+    "recommended_ram_gb": 14.7,
+    "min_vram_gb": 8.1,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "deepseek_v3",
-    "hf_downloads": 63054,
+    "architecture": "gpt_bigcode",
+    "hf_downloads": 14709,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 2219453062
+    "_discovered": true
   },
   {
     "name": "moonshotai/Moonlight-16B-A3B-Instruct",
@@ -16526,7 +24819,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 61342,
+    "hf_downloads": 56225,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2219453062
+  },
+  {
+    "name": "moonshotai/Moonlight-16B-A3B",
+    "provider": "moonshotai",
+    "parameter_count": "16.0B",
+    "parameters_raw": 15960111936,
+    "min_ram_gb": 8.9,
+    "recommended_ram_gb": 14.9,
+    "min_vram_gb": 8.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 54837,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16550,7 +24867,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_vl_v2",
-    "hf_downloads": 15362,
+    "hf_downloads": 16027,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16570,7 +24887,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llada2_moe",
-    "hf_downloads": 97464,
+    "hf_downloads": 119345,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 1295371577
+  },
+  {
+    "name": "inclusionAI/Ling-mini-2.0",
+    "provider": "inclusionai",
+    "parameter_count": "16.3B",
+    "parameters_raw": 16255643392,
+    "min_ram_gb": 9.1,
+    "recommended_ram_gb": 15.1,
+    "min_vram_gb": 8.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "bailing_moe",
+    "hf_downloads": 22637,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16594,7 +24935,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 32067,
+    "hf_downloads": 29393,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16618,20 +24959,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek",
-    "hf_downloads": 31198,
+    "hf_downloads": 34084,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2277249690,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/deepseek-moe-16b-base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2277249690
   },
   {
     "name": "deepseek-ai/deepseek-moe-16b-chat",
@@ -16648,20 +24983,66 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek",
-    "hf_downloads": 26692,
+    "hf_downloads": 25747,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2277249690,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/deepseek-moe-16b-chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2277249690
+  },
+  {
+    "name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+    "provider": "Alibaba",
+    "parameter_count": "16.4B",
+    "parameters_raw": 16392912896,
+    "min_ram_gb": 9.2,
+    "recommended_ram_gb": 15.3,
+    "min_vram_gb": 8.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 142008,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1792974844
+  },
+  {
+    "name": "Qwen/Qwen3-235B-A22B-Thinking-2507",
+    "provider": "Alibaba",
+    "parameter_count": "16.4B",
+    "parameters_raw": 16392912896,
+    "min_ram_gb": 9.2,
+    "recommended_ram_gb": 15.3,
+    "min_vram_gb": 8.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 37143,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1792974844
   },
   {
     "name": "moonshotai/Kimi-VL-A3B-Instruct",
@@ -16680,20 +25061,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "kimi_vl",
-    "hf_downloads": 244263,
+    "hf_downloads": 254749,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2281689908,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Kimi-VL-A3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2281689908
   },
   {
     "name": "moonshotai/Kimi-VL-A3B-Thinking",
@@ -16712,7 +25087,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "kimi_vl",
-    "hf_downloads": 94032,
+    "hf_downloads": 108715,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16720,6 +25095,32 @@
     "num_experts": 64,
     "active_experts": 6,
     "active_parameters": 2281689908
+  },
+  {
+    "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "16.5B",
+    "parameters_raw": 16536305663,
+    "min_ram_gb": 9.2,
+    "recommended_ram_gb": 15.4,
+    "min_vram_gb": 8.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 119783,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 1612289795
   },
   {
     "name": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -16738,7 +25139,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 30787,
+    "hf_downloads": 210715,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "osoleve/Qwen3.5-27B-Text-NVFP4-MTP",
+    "provider": "osoleve",
+    "parameter_count": "16.7B",
+    "parameters_raw": 16667329536,
+    "min_ram_gb": 9.3,
+    "recommended_ram_gb": 15.5,
+    "min_vram_gb": 8.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 18391,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Abiray/Qwen3.6-27B-NVFP4",
+    "provider": "abiray",
+    "parameter_count": "16.7B",
+    "parameters_raw": 16703361232,
+    "min_ram_gb": 9.3,
+    "recommended_ram_gb": 15.6,
+    "min_vram_gb": 8.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 17711,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16760,7 +25205,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 103179,
+    "hf_downloads": 63560,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16782,7 +25227,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 15726,
+    "hf_downloads": 15237,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16802,7 +25247,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "bailing_moe",
-    "hf_downloads": 487,
+    "hf_downloads": 353,
     "hf_likes": 79,
     "release_date": "2025-02-28",
     "num_hidden_layers": 28,
@@ -16835,20 +25280,82 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bailing_moe",
-    "hf_downloads": 25681,
+    "hf_downloads": 30477,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2336524543,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Ling-lite-1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2336524543
+  },
+  {
+    "name": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
+    "provider": "aeon-7",
+    "parameter_count": "17.1B",
+    "parameters_raw": 17128059632,
+    "min_ram_gb": 9.6,
+    "recommended_ram_gb": 16.0,
+    "min_vram_gb": 8.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 15337,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
+    "provider": "sakamakismile",
+    "parameter_count": "17.1B",
+    "parameters_raw": 17128059632,
+    "min_ram_gb": 9.6,
+    "recommended_ram_gb": 16.0,
+    "min_vram_gb": 8.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 28230,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "bharatgenai/Param2-17B-A2.4B-Thinking",
+    "provider": "bharatgenai",
+    "parameter_count": "17.2B",
+    "parameters_raw": 17151140480,
+    "min_ram_gb": 9.6,
+    "recommended_ram_gb": 16.0,
+    "min_vram_gb": 8.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "param2moe",
+    "hf_downloads": 24664,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2385080470
   },
   {
     "name": "nvidia/Qwen3-32B-NVFP4",
@@ -16867,7 +25374,73 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 131941,
+    "hf_downloads": 76408,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Qwen3-30B-A3B-NVFP4",
+    "provider": "redhatai",
+    "parameter_count": "17.5B",
+    "parameters_raw": 17452222848,
+    "min_ram_gb": 9.8,
+    "recommended_ram_gb": 16.3,
+    "min_vram_gb": 8.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 23012,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1908836870
+  },
+  {
+    "name": "internlm/internlm2-20b",
+    "provider": "internlm",
+    "parameter_count": "17.5B",
+    "parameters_raw": 17480024064,
+    "min_ram_gb": 9.8,
+    "recommended_ram_gb": 16.3,
+    "min_vram_gb": 9.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 20141,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-base-20b",
+    "provider": "internlm",
+    "parameter_count": "17.5B",
+    "parameters_raw": 17480024064,
+    "min_ram_gb": 9.8,
+    "recommended_ram_gb": 16.3,
+    "min_vram_gb": 9.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 16666,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16889,7 +25462,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 21831,
+    "hf_downloads": 39925,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16909,7 +25482,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 342930,
+    "hf_downloads": 359806,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16917,6 +25490,50 @@
     "num_experts": 128,
     "active_experts": 6,
     "active_parameters": 1724039438
+  },
+  {
+    "name": "upstage/solar-pro-preview-instruct",
+    "provider": "Upstage",
+    "parameter_count": "18.6B",
+    "parameters_raw": 18619432960,
+    "min_ram_gb": 10.4,
+    "recommended_ram_gb": 17.3,
+    "min_vram_gb": 9.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "solar",
+    "hf_downloads": 29287,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyankiwi/GLM-4.5-Air-AWQ-4bit",
+    "provider": "cyankiwi",
+    "parameter_count": "18.6B",
+    "parameters_raw": 18626406504,
+    "min_ram_gb": 10.4,
+    "recommended_ram_gb": 17.3,
+    "min_vram_gb": 9.5,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 15938,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 2037263205
   },
   {
     "name": "RedHatAI/Qwen3-32B-NVFP4",
@@ -16935,34 +25552,72 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 48780,
+    "hf_downloads": 66222,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16",
-    "provider": "redhatai",
-    "parameter_count": "19.6B",
-    "parameters_raw": 19601967392,
-    "min_ram_gb": 11.0,
-    "recommended_ram_gb": 18.3,
-    "min_vram_gb": 10.0,
+    "name": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
+    "provider": "aeon-7",
+    "parameter_count": "19.1B",
+    "parameters_raw": 19135893232,
+    "min_ram_gb": 10.7,
+    "recommended_ram_gb": 17.8,
+    "min_vram_gb": 9.8,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 167772160,
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 25376,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-chat-20b",
+    "provider": "internlm",
+    "parameter_count": "19.9B",
+    "parameters_raw": 19861149696,
+    "min_ram_gb": 11.1,
+    "recommended_ram_gb": 18.5,
+    "min_vram_gb": 10.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
     "use_case": "Instruction following, chat",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "llama4",
-    "hf_downloads": 25023,
+    "architecture": "internlm2",
+    "hf_downloads": 20986,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 16,
-    "active_experts": 1,
-    "active_parameters": 2143965182
+    "_discovered": true
+  },
+  {
+    "name": "chujiezheng/internlm2-chat-20b-ExPO",
+    "provider": "chujiezheng",
+    "parameter_count": "19.9B",
+    "parameters_raw": 19861149696,
+    "min_ram_gb": 11.1,
+    "recommended_ram_gb": 18.5,
+    "min_vram_gb": 10.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 16210,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "RedHatAI/gemma-4-31B-it-NVFP4",
@@ -16979,7 +25634,71 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 79892,
+    "hf_downloads": 174857,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "MaziyarPanahi/Mixtral-8x22B-v0.1-GGUF",
+    "provider": "maziyarpanahi",
+    "parameter_count": "19.9B",
+    "parameters_raw": 19926614015,
+    "min_ram_gb": 11.1,
+    "recommended_ram_gb": 18.6,
+    "min_vram_gb": 10.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 69149,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 5728901528
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-Nano-12B-v2",
+    "provider": "nvidia",
+    "parameter_count": "20.2B",
+    "parameters_raw": 20174602240,
+    "min_ram_gb": 11.3,
+    "recommended_ram_gb": 18.8,
+    "min_vram_gb": 10.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 14379,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "EleutherAI/gpt-neox-20b",
+    "provider": "eleutherai",
+    "parameter_count": "20.2B",
+    "parameters_raw": 20241186816,
+    "min_ram_gb": 11.3,
+    "recommended_ram_gb": 18.9,
+    "min_vram_gb": 10.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 269895,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17001,7 +25720,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 47596,
+    "hf_downloads": 63459,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17021,10 +25740,58 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 1851495,
+    "hf_downloads": 2227074,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "mlx-community/gpt-oss-20b-MXFP4-Q8",
+    "provider": "mlx-community",
+    "parameter_count": "20.9B",
+    "parameters_raw": 20914755648,
+    "min_ram_gb": 11.7,
+    "recommended_ram_gb": 19.5,
+    "min_vram_gb": 10.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 570903,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3529365014
+  },
+  {
+    "name": "unsloth/gpt-oss-20b-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "20.9B",
+    "parameters_raw": 20914757184,
+    "min_ram_gb": 11.7,
+    "recommended_ram_gb": 19.5,
+    "min_vram_gb": 10.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 200252,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3529365271
   },
   {
     "name": "ArliAI/gpt-oss-20b-Derestricted",
@@ -17041,20 +25808,62 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 50651,
+    "hf_downloads": 141378,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 32,
     "active_experts": 4,
-    "active_parameters": 3529365271,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gpt-oss-20b-Derestricted-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3529365271
+  },
+  {
+    "name": "unsloth/gpt-oss-20b-BF16",
+    "provider": "unsloth",
+    "parameter_count": "20.9B",
+    "parameters_raw": 20914757184,
+    "min_ram_gb": 11.7,
+    "recommended_ram_gb": 19.5,
+    "min_vram_gb": 10.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 70955,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3529365271
+  },
+  {
+    "name": "unsloth/gpt-oss-20b-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "20.9B",
+    "parameters_raw": 20914757184,
+    "min_ram_gb": 11.7,
+    "recommended_ram_gb": 19.5,
+    "min_vram_gb": 10.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 31497,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3529365271
   },
   {
     "name": "shieldstar/Qwen3.5-122B-A10B-int4-AutoRound-EC",
@@ -17063,6 +25872,32 @@
     "parameters_raw": 21060726512,
     "min_ram_gb": 11.8,
     "recommended_ram_gb": 19.6,
+    "min_vram_gb": 10.8,
+    "quantization": "AutoRound-4bit",
+    "format": "autoround",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 183458,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 1678276637
+  },
+  {
+    "name": "rdtand/Qwen3.6-35B-A3B-PrismaQuant-4.75bit-vllm",
+    "provider": "rdtand",
+    "parameter_count": "21.1B",
+    "parameters_raw": 21124964170,
+    "min_ram_gb": 11.8,
+    "recommended_ram_gb": 19.7,
     "min_vram_gb": 10.8,
     "quantization": "Q4_K_M",
     "format": "gguf",
@@ -17073,14 +25908,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 182229,
+    "hf_downloads": 33686,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 1678276637
+    "active_parameters": 1683395576
   },
   {
     "name": "openai/gpt-oss-20b",
@@ -17097,28 +25932,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 6507411,
+    "hf_downloads": 7160610,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 32,
     "active_experts": 4,
-    "active_parameters": 3630142231,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gpt-oss-20b-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gpt-oss-20b-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gpt-oss-20b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3630142231
   },
   {
     "name": "RedHatAI/gpt-oss-20b",
@@ -17135,28 +25956,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 26380,
+    "hf_downloads": 39534,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 32,
     "active_experts": 4,
-    "active_parameters": 3630142231,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gpt-oss-20b-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gpt-oss-20b-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gpt-oss-20b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3630142231
+  },
+  {
+    "name": "unsloth/gpt-oss-20b",
+    "provider": "unsloth",
+    "parameter_count": "21.5B",
+    "parameters_raw": 21511953984,
+    "min_ram_gb": 12.0,
+    "recommended_ram_gb": 20.0,
+    "min_vram_gb": 11.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 26861,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3630142231
   },
   {
     "name": "lmstudio-community/ERNIE-4.5-21B-A3B-MLX-4bit",
@@ -17173,7 +26004,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ernie4_5_moe",
-    "hf_downloads": 31407,
+    "hf_downloads": 32196,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17193,7 +26024,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ernie4_5_moe",
-    "hf_downloads": 31049,
+    "hf_downloads": 31843,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17213,10 +26044,148 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ernie4_5_moe",
-    "hf_downloads": 31012,
+    "hf_downloads": 31823,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "baidu/ERNIE-4.5-21B-A3B-Thinking",
+    "provider": "baidu",
+    "parameter_count": "21.8B",
+    "parameters_raw": 21825437888,
+    "min_ram_gb": 12.2,
+    "recommended_ram_gb": 20.3,
+    "min_vram_gb": 11.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ernie4_5_moe",
+    "hf_downloads": 37511,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zai-org/GLM-4.7-FP8",
+    "provider": "zai-org",
+    "parameter_count": "22.0B",
+    "parameters_raw": 21999124480,
+    "min_ram_gb": 12.3,
+    "recommended_ram_gb": 20.5,
+    "min_vram_gb": 11.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 309329,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 2144914632
+  },
+  {
+    "name": "zai-org/GLM-4.6-FP8",
+    "provider": "zai-org",
+    "parameter_count": "22.0B",
+    "parameters_raw": 21999124480,
+    "min_ram_gb": 12.3,
+    "recommended_ram_gb": 20.5,
+    "min_vram_gb": 11.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 14180,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 2144914632
+  },
+  {
+    "name": "mconcat/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-NVFP4",
+    "provider": "mconcat",
+    "parameter_count": "22.1B",
+    "parameters_raw": 22146895376,
+    "min_ram_gb": 12.4,
+    "recommended_ram_gb": 20.6,
+    "min_vram_gb": 11.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 14303,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "MiniMaxAI/MiniMax-M1-40k",
+    "provider": "minimaxai",
+    "parameter_count": "22.4B",
+    "parameters_raw": 22368485376,
+    "min_ram_gb": 12.5,
+    "recommended_ram_gb": 20.8,
+    "min_vram_gb": 11.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 10240000,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minimax_m1",
+    "hf_downloads": 38223,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 2,
+    "active_parameters": 2446553086
+  },
+  {
+    "name": "MiniMaxAI/MiniMax-Text-01-hf",
+    "provider": "minimaxai",
+    "parameter_count": "22.4B",
+    "parameters_raw": 22368485376,
+    "min_ram_gb": 12.5,
+    "recommended_ram_gb": 20.8,
+    "min_vram_gb": 11.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 10240000,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minimax",
+    "hf_downloads": 25029,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 2,
+    "active_parameters": 2446553086
   },
   {
     "name": "cyankiwi/MiniMax-M2.5-REAP-139B-A10B-AWQ-4bit",
@@ -17233,7 +26202,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 97045,
+    "hf_downloads": 124334,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17241,40 +26210,6 @@
     "num_experts": 154,
     "active_experts": 8,
     "active_parameters": 2265661607
-  },
-  {
-    "name": "cerebras/GLM-4.7-Flash-REAP-23B-A3B",
-    "provider": "cerebras",
-    "parameter_count": "23.0B",
-    "parameters_raw": 22996118432,
-    "min_ram_gb": 12.9,
-    "recommended_ram_gb": 21.4,
-    "min_vram_gb": 11.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 202752,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "glm4_moe_lite",
-    "hf_downloads": 81075,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 48,
-    "active_experts": 4,
-    "active_parameters": 2970331961,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "stelterlab/Mistral-Small-24B-Instruct-2501-AWQ",
@@ -17293,21 +26228,101 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 435636,
+    "hf_downloads": 389647,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "gghfez/Mistral-Small-3.2-24B-Instruct-hf-AWQ",
-    "provider": "gghfez",
+    "name": "lmstudio-community/Devstral-Small-2507-MLX-8bit",
+    "provider": "lmstudio-community",
     "parameter_count": "23.6B",
     "parameters_raw": 23572403200,
     "min_ram_gb": 13.2,
     "recommended_ram_gb": 22.0,
     "min_vram_gb": 12.1,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 22819,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Devstral-Small-2507-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23572403200,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 21539,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Devstral-Small-2507-MLX-6bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23572403200,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 21322,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Devstral-Small-2507-MLX-bf16",
+    "provider": "lmstudio-community",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23572403200,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 21229,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w8a8",
+    "provider": "redhatai",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23575680000,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 32768,
     "use_case": "Instruction following, chat",
     "capabilities": [
@@ -17315,7 +26330,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 44237,
+    "hf_downloads": 18831,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17335,7 +26350,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_moe",
-    "hf_downloads": 423232,
+    "hf_downloads": 395200,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17359,7 +26374,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_moe",
-    "hf_downloads": 419532,
+    "hf_downloads": 391582,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17383,7 +26398,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_moe",
-    "hf_downloads": 418897,
+    "hf_downloads": 391147,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17407,7 +26422,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_moe",
-    "hf_downloads": 418568,
+    "hf_downloads": 390790,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17431,8 +26446,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2_moe",
-    "hf_downloads": 32082,
-    "hf_likes": 315,
+    "hf_downloads": 24892,
+    "hf_likes": 322,
     "release_date": "2026-02-24",
     "num_hidden_layers": 40,
     "num_attention_heads": 32,
@@ -17495,16 +26510,118 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral3",
-    "hf_downloads": 85062,
+    "hf_downloads": 16621,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Dolphin-Mistral-24B-Venice-Edition-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Mistral-Small-24B-Instruct-2501-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24252853524,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 25098,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-32B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24266014720,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 285524,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "microsoft/FrogBoss-32B-2510",
+    "provider": "Microsoft",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24266014720,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 76121,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-32B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24266014720,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 38384,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-32B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24266014720,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 16189,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3.5-122B-A10B-AWQ-4bit",
@@ -17523,7 +26640,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 85342,
+    "hf_downloads": 82274,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17547,7 +26664,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 26626,
+    "hf_downloads": 32662,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17571,7 +26688,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "aria",
-    "hf_downloads": 88854,
+    "hf_downloads": 91858,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17591,10 +26708,114 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "aria",
-    "hf_downloads": 73139,
+    "hf_downloads": 87834,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "allenai/Olmo-3.1-32B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "25.3B",
+    "parameters_raw": 25343703040,
+    "min_ram_gb": 14.2,
+    "recommended_ram_gb": 23.6,
+    "min_vram_gb": 13.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmo3",
+    "hf_downloads": 25310,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepcogito/cogito-v1-preview-qwen-32B",
+    "provider": "deepcogito",
+    "parameter_count": "25.6B",
+    "parameters_raw": 25606804480,
+    "min_ram_gb": 14.3,
+    "recommended_ram_gb": 23.8,
+    "min_vram_gb": 13.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 53524,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Valdemardi/DeepSeek-R1-Distill-Qwen-32B-AWQ",
+    "provider": "valdemardi",
+    "parameter_count": "25.6B",
+    "parameters_raw": 25608847360,
+    "min_ram_gb": 14.3,
+    "recommended_ram_gb": 23.9,
+    "min_vram_gb": 13.1,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14777,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ByteDance-Seed/Seed-OSS-36B-Instruct",
+    "provider": "bytedance-seed",
+    "parameter_count": "25.6B",
+    "parameters_raw": 25624576000,
+    "min_ram_gb": 14.3,
+    "recommended_ram_gb": 23.9,
+    "min_vram_gb": 13.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "seed_oss",
+    "hf_downloads": 23427,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TrevorJS/gemma-4-26B-A4B-it-uncensored",
+    "provider": "trevorjs",
+    "parameter_count": "25.8B",
+    "parameters_raw": 25805933872,
+    "min_ram_gb": 14.4,
+    "recommended_ram_gb": 24.0,
+    "min_vram_gb": 13.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 82769,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 2822524013
   },
   {
     "name": "coder3101/gemma-4-26B-A4B-it-heretic",
@@ -17611,20 +26832,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 57906,
+    "hf_downloads": 56089,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 2822524013,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-26B-A4B-it-heretic-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2822524013
   },
   {
     "name": "jenerallee78/gemma-4-26B-A4B-it-ara-abliterated",
@@ -17641,7 +26856,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 22318,
+    "hf_downloads": 24470,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17649,6 +26864,30 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 2822524013
+  },
+  {
+    "name": "Jiunsong/supergemma4-26b-abliterated-multimodal",
+    "provider": "jiunsong",
+    "parameter_count": "25.8B",
+    "parameters_raw": 25805936206,
+    "min_ram_gb": 14.4,
+    "recommended_ram_gb": 24.0,
+    "min_vram_gb": 13.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 13983,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 2822524266
   },
   {
     "name": "LargitData/gemma-4-26b-a4b-it-fp8",
@@ -17665,7 +26904,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 32183,
+    "hf_downloads": 35522,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17689,7 +26928,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 11391,
+    "hf_downloads": 13805,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17716,8 +26955,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "gemma4",
-    "hf_downloads": 5053655,
-    "hf_likes": 841,
+    "hf_downloads": 6654508,
+    "hf_likes": 885,
     "release_date": "2026-03-11",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -17757,44 +26996,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 226839,
+    "hf_downloads": 243518,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 2903264368,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-26B-A4B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
-    "provider": "cyankiwi",
-    "parameter_count": "26.6B",
-    "parameters_raw": 26554316366,
-    "min_ram_gb": 14.8,
-    "recommended_ram_gb": 24.7,
-    "min_vram_gb": 13.6,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 1059059,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 128,
-    "active_experts": 8,
-    "active_parameters": 2904378346
+    "active_parameters": 2903264368
   },
   {
     "name": "cyankiwi/gemma-4-26B-A4B-it-AWQ-8bit",
@@ -17811,7 +27020,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 36161,
+    "hf_downloads": 45108,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17819,6 +27028,72 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 2904378346
+  },
+  {
+    "name": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
+    "provider": "cyankiwi",
+    "parameter_count": "26.6B",
+    "parameters_raw": 26554339636,
+    "min_ram_gb": 14.8,
+    "recommended_ram_gb": 24.7,
+    "min_vram_gb": 13.6,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 1903463,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 2904380893
+  },
+  {
+    "name": "Jackrong/MLX-Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2-4bit",
+    "provider": "jackrong",
+    "parameter_count": "26.9B",
+    "parameters_raw": 26895993856,
+    "min_ram_gb": 15.0,
+    "recommended_ram_gb": 25.0,
+    "min_vram_gb": 13.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 16206,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Jackrong/Qwopus3.5-27B-v3-FP8-vllm-ready",
+    "provider": "jackrong",
+    "parameter_count": "26.9B",
+    "parameters_raw": 26899902464,
+    "min_ram_gb": 15.0,
+    "recommended_ram_gb": 25.1,
+    "min_vram_gb": 13.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_text",
+    "hf_downloads": 14301,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "google/gemma-2-27b-it",
@@ -17835,7 +27110,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "gemma2",
-    "hf_downloads": 44572,
+    "hf_downloads": 48420,
     "hf_likes": 565,
     "release_date": "2024-06-24",
     "num_hidden_layers": null,
@@ -17854,30 +27129,24 @@
     ]
   },
   {
-    "name": "Jackrong/Qwopus3.5-27B-v3",
-    "provider": "jackrong",
-    "parameter_count": "27.4B",
-    "parameters_raw": 27356728560,
-    "min_ram_gb": 15.3,
-    "recommended_ram_gb": 25.5,
-    "min_vram_gb": 14.0,
+    "name": "unsloth/gemma-2-27b-it",
+    "provider": "unsloth",
+    "parameter_count": "27.2B",
+    "parameters_raw": 27227128320,
+    "min_ram_gb": 15.2,
+    "recommended_ram_gb": 25.4,
+    "min_vram_gb": 13.9,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 262144,
+    "context_length": 8192,
     "use_case": "General purpose",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 36226,
+    "architecture": "gemma2",
+    "hf_downloads": 22628,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwopus3.5-27B-v3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "groxaxo/Qwen3.6-27B-GPTQ-Pro-4bit",
@@ -17896,7 +27165,49 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 26547,
+    "hf_downloads": 76493,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
+    "provider": "llmfan46",
+    "parameter_count": "27.4B",
+    "parameters_raw": 27356728560,
+    "min_ram_gb": 15.3,
+    "recommended_ram_gb": 25.5,
+    "min_vram_gb": 14.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 58850,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Jackrong/Qwopus3.5-27B-v3",
+    "provider": "jackrong",
+    "parameter_count": "27.4B",
+    "parameters_raw": 27356728560,
+    "min_ram_gb": 15.3,
+    "recommended_ram_gb": 25.5,
+    "min_vram_gb": 14.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 27138,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17916,29 +27227,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 24281,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "HarleyWang/Qwen3.5-27B-Claude-Opus-4.6-High-Reasoning",
-    "provider": "harleywang",
-    "parameter_count": "27.4B",
-    "parameters_raw": 27356728560,
-    "min_ram_gb": 15.3,
-    "recommended_ram_gb": 25.5,
-    "min_vram_gb": 14.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 24231,
+    "hf_downloads": 20228,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17960,7 +27249,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 59882,
+    "hf_downloads": 39710,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17983,8 +27272,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "gemma3",
-    "hf_downloads": 510045,
-    "hf_likes": 1958,
+    "hf_downloads": 603039,
+    "hf_likes": 1964,
     "release_date": "2025-03-01",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -18020,7 +27309,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 63527,
+    "hf_downloads": 62381,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18042,7 +27331,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 18587,
+    "hf_downloads": 18011,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18065,8 +27354,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 3266173,
-    "hf_likes": 962,
+    "hf_downloads": 3295812,
+    "hf_likes": 967,
     "release_date": "2026-02-24",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -18079,6 +27368,38 @@
       },
       {
         "repo": "mradermacher/Qwen3.5-27B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
+    "provider": "jackrong",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 280937,
+    "hf_likes": 2818,
+    "release_date": "2026-02-27",
+    "num_hidden_layers": null,
+    "num_attention_heads": null,
+    "num_key_value_heads": null,
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -18101,8 +27422,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 508728,
-    "hf_likes": 975,
+    "hf_downloads": 1613364,
+    "hf_likes": 1135,
     "release_date": "2026-04-21",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -18116,8 +27437,34 @@
       {
         "repo": "ggml-org/Qwen3.6-27B-GGUF",
         "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3.6-27B-GGUF",
+        "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "raydelossantos/Qwen3.6-27B-GPTQ-Int4",
+    "provider": "raydelossantos",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 17477,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
@@ -18136,38 +27483,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 609855,
+    "hf_downloads": 657976,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
-    "provider": "jackrong",
-    "parameter_count": "27.8B",
-    "parameters_raw": 27781427952,
-    "min_ram_gb": 15.5,
-    "recommended_ram_gb": 25.9,
-    "min_vram_gb": 14.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 469629,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen3.5-27B-GPTQ-Int4",
@@ -18186,7 +27505,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 372476,
+    "hf_downloads": 422976,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18208,7 +27527,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 342820,
+    "hf_downloads": 332309,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18230,35 +27549,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 208145,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-27B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "QuantTrio/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2-AWQ",
-    "provider": "quanttrio",
-    "parameter_count": "27.8B",
-    "parameters_raw": 27781427952,
-    "min_ram_gb": 15.5,
-    "recommended_ram_gb": 25.9,
-    "min_vram_gb": 14.2,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 93796,
+    "hf_downloads": 238154,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18280,7 +27571,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 32081,
+    "hf_downloads": 170406,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "QuantTrio/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2-AWQ",
+    "provider": "quanttrio",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 116412,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18302,22 +27615,38 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 16487,
+    "hf_downloads": 21020,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-27B-Claude-4.6-Opus-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "Qwen/Qwen3.5-27B-FP8",
-    "provider": "Alibaba",
+    "name": "TheCluster/Qwen3.6-27B-Heretic-MLX-bf16",
+    "provider": "thecluster",
     "parameter_count": "27.8B",
-    "parameters_raw": 27782935472,
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 18848,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
+    "provider": "huihui-ai",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
     "min_ram_gb": 15.5,
     "recommended_ram_gb": 25.9,
     "min_vram_gb": 14.2,
@@ -18330,7 +27659,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 1266239,
+    "hf_downloads": 18461,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "QuantTrio/Qwen3.6-27B-AWQ-6Bit",
+    "provider": "quanttrio",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 10760,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18352,7 +27703,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 745458,
+    "hf_downloads": 2294833,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3.5-27B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27782935472,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 1544344,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18374,7 +27747,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 28661,
+    "hf_downloads": 21751,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ig1/medgemma-27b-text-it-FP8-Dynamic",
+    "provider": "ig1",
+    "parameter_count": "28.4B",
+    "parameters_raw": 28422129408,
+    "min_ram_gb": 15.9,
+    "recommended_ram_gb": 26.5,
+    "min_vram_gb": 14.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 36621,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18396,7 +27789,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 118392,
+    "hf_downloads": 242269,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18418,7 +27811,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 13925,
+    "hf_downloads": 13505,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18440,7 +27833,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 31977,
+    "hf_downloads": 139355,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18462,7 +27855,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 196379,
+    "hf_downloads": 753773,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18484,10 +27877,154 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "ernie4_5_moe_vl",
-    "hf_downloads": 94903,
+    "hf_downloads": 128239,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3.2-Exp",
+    "provider": "DeepSeek",
+    "parameter_count": "29.6B",
+    "parameters_raw": 29582163968,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.6,
+    "min_vram_gb": 15.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v32",
+    "hf_downloads": 194549,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2357328686
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3.1",
+    "provider": "DeepSeek",
+    "parameter_count": "29.6B",
+    "parameters_raw": 29582163968,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.6,
+    "min_vram_gb": 15.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 180081,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2357328686
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "29.6B",
+    "parameters_raw": 29582163968,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.6,
+    "min_vram_gb": 15.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 75494,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2357328686
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-0528-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "29.6B",
+    "parameters_raw": 29582163968,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.6,
+    "min_vram_gb": 15.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 16102,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2357328686
+  },
+  {
+    "name": "unsloth/Kimi-K2-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "29.8B",
+    "parameters_raw": 29829890048,
+    "min_ram_gb": 16.7,
+    "recommended_ram_gb": 27.8,
+    "min_vram_gb": 15.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 30020,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 384,
+    "active_experts": 8,
+    "active_parameters": 2081877742
+  },
+  {
+    "name": "nvidia/Kimi-K2-Thinking-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "29.8B",
+    "parameters_raw": 29829890048,
+    "min_ram_gb": 16.7,
+    "recommended_ram_gb": 27.8,
+    "min_vram_gb": 15.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 27129,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 384,
+    "active_experts": 8,
+    "active_parameters": 2081877742
   },
   {
     "name": "lmstudio-community/GLM-4.7-Flash-MLX-8bit",
@@ -18504,7 +28041,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 347909,
+    "hf_downloads": 327748,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18528,7 +28065,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 325580,
+    "hf_downloads": 304843,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18536,6 +28073,26 @@
     "num_experts": 64,
     "active_experts": 4,
     "active_parameters": 3275058708
+  },
+  {
+    "name": "facebook/opt-30b",
+    "provider": "facebook",
+    "parameter_count": "30.0B",
+    "parameters_raw": 29955358720,
+    "min_ram_gb": 16.7,
+    "recommended_ram_gb": 27.9,
+    "min_vram_gb": 15.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 17443,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -18554,24 +28111,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 2601330,
+    "hf_downloads": 2745230,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "bineric/lynx-instruct-30b",
@@ -18588,20 +28135,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 360455,
+    "hf_downloads": 524626,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/lynx-instruct-30b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ",
@@ -18620,7 +28161,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 356052,
+    "hf_downloads": 508638,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18646,7 +28187,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 250360,
+    "hf_downloads": 219857,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18672,7 +28213,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 220152,
+    "hf_downloads": 215672,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18698,7 +28239,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 209765,
+    "hf_downloads": 206157,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18724,7 +28265,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 199024,
+    "hf_downloads": 194690,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18750,7 +28291,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 196351,
+    "hf_downloads": 191139,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18776,24 +28317,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 126824,
+    "hf_downloads": 137036,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-30B-A3B-Thinking-2507-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-30B-A3B-Thinking-2507-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "Alibaba-NLP/Tongyi-DeepResearch-30B-A3B",
@@ -18810,20 +28341,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 94346,
+    "hf_downloads": 106571,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Tongyi-DeepResearch-30B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "Qwen/Qwen3-30B-A3B-Base",
@@ -18842,20 +28367,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 57001,
+    "hf_downloads": 75353,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-30B-A3B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "lmstudio-community/Qwen3-30B-A3B-Instruct-2507-MLX-4bit",
@@ -18874,7 +28393,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 32533,
+    "hf_downloads": 32280,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18900,7 +28419,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 31569,
+    "hf_downloads": 31051,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18926,7 +28445,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 30344,
+    "hf_downloads": 29861,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18952,7 +28471,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 27112,
+    "hf_downloads": 25687,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 3339450907
+  },
+  {
+    "name": "QuixiAI/Qwen3-30B-A3B-AWQ",
+    "provider": "quixiai",
+    "parameter_count": "30.5B",
+    "parameters_raw": 30532122624,
+    "min_ram_gb": 17.1,
+    "recommended_ram_gb": 28.4,
+    "min_vram_gb": 15.6,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 16126,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18978,7 +28523,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 390124,
+    "hf_downloads": 510981,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19004,7 +28549,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 287471,
+    "hf_downloads": 276673,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19030,7 +28575,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 40822,
+    "hf_downloads": 58871,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 3341896987
+  },
+  {
+    "name": "nytopop/Qwen3-30B-A3B.w8a8",
+    "provider": "nytopop",
+    "parameter_count": "30.6B",
+    "parameters_raw": 30554486784,
+    "min_ram_gb": 17.1,
+    "recommended_ram_gb": 28.5,
+    "min_vram_gb": 15.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 20285,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19054,16 +28625,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 94880,
+    "hf_downloads": 77830,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/InternVL3_5-30B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "QuantTrio/Qwen3-VL-30B-A3B-Instruct-AWQ",
@@ -19083,7 +28648,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 658955,
+    "hf_downloads": 705645,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19110,24 +28675,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 52455,
+    "hf_downloads": 43605,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3398363717,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-30B-A3B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-30B-A3B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3398363717
   },
   {
     "name": "browser-use/bu-30b-a3b-preview",
@@ -19144,7 +28699,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 11540,
+    "hf_downloads": 11806,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19168,28 +28723,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 658187,
+    "hf_downloads": 623077,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 4,
-    "active_parameters": 3414850312,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.7-Flash-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/GLM-4.7-Flash-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/GLM-4.7-Flash-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3414850312
+  },
+  {
+    "name": "unsloth/GLM-4.7-Flash",
+    "provider": "unsloth",
+    "parameter_count": "31.2B",
+    "parameters_raw": 31221488576,
+    "min_ram_gb": 17.4,
+    "recommended_ram_gb": 29.1,
+    "min_vram_gb": 16.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe_lite",
+    "hf_downloads": 546627,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 4,
+    "active_parameters": 3414850312
   },
   {
     "name": "QuantTrio/GLM-4.7-Flash-AWQ",
@@ -19206,7 +28771,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 100374,
+    "hf_downloads": 49514,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19230,16 +28795,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 90777,
+    "hf_downloads": 92878,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Gemma-4-31B-Cognitive-Unshackled-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Momix-44/gemma-4-31B-it-heretic-v2",
@@ -19256,42 +28815,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 40364,
+    "hf_downloads": 27066,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-it-heretic-v2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "coder3101/gemma-4-31B-it-heretic",
-    "provider": "coder3101",
-    "parameter_count": "31.3B",
-    "parameters_raw": 31273086512,
-    "min_ram_gb": 17.5,
-    "recommended_ram_gb": 29.1,
-    "min_vram_gb": 16.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 18382,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-it-heretic-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -19308,16 +28835,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 16468,
+    "hf_downloads": 18000,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "llmfan46/gemma-4-31B-it-uncensored-heretic",
+    "provider": "llmfan46",
+    "parameter_count": "31.3B",
+    "parameters_raw": 31273086512,
+    "min_ram_gb": 17.5,
+    "recommended_ram_gb": 29.1,
+    "min_vram_gb": 16.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 12697,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "DavidAU/gemma-4-31B-it-Mystery-Fine-Tune-HERETIC-UNCENSORED-Thinking",
@@ -19334,16 +28875,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 10653,
+    "hf_downloads": 10788,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-it-Mystery-Fine-Tune-HERETIC-UNCENSORED-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "QuantTrio/gemma-4-31B-it-AWQ",
@@ -19360,7 +28895,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 264023,
+    "hf_downloads": 567528,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19380,7 +28915,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 14464,
+    "hf_downloads": 16251,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19400,7 +28935,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 183922,
+    "hf_downloads": 237634,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19420,7 +28955,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis2_6_moe",
-    "hf_downloads": 34453,
+    "hf_downloads": 21804,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19444,7 +28979,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 114989,
+    "hf_downloads": 105525,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19468,7 +29003,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 105938,
+    "hf_downloads": 96337,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19492,7 +29027,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 104893,
+    "hf_downloads": 95068,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19516,7 +29051,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 104615,
+    "hf_downloads": 94930,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19540,8 +29075,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "nemotron_h",
-    "hf_downloads": 1410603,
-    "hf_likes": 722,
+    "hf_downloads": 1312088,
+    "hf_likes": 727,
     "release_date": "2025-12-04",
     "num_hidden_layers": 52,
     "num_attention_heads": 32,
@@ -19573,20 +29108,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 244227,
+    "hf_downloads": 148164,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 6,
-    "active_parameters": 2985101885,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Nemotron-Cascade-2-30B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2985101885
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16",
@@ -19603,7 +29132,55 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 77298,
+    "hf_downloads": 59619,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 6,
+    "active_parameters": 2985101885
+  },
+  {
+    "name": "chankhavu/Nemotron-Cascade-2-30B-A3B-FP8",
+    "provider": "chankhavu",
+    "parameter_count": "31.6B",
+    "parameters_raw": 31577937344,
+    "min_ram_gb": 17.6,
+    "recommended_ram_gb": 29.4,
+    "min_vram_gb": 16.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 14996,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 6,
+    "active_parameters": 2985101885
+  },
+  {
+    "name": "unsloth/Nemotron-3-Nano-30B-A3B",
+    "provider": "unsloth",
+    "parameter_count": "31.6B",
+    "parameters_raw": 31577937344,
+    "min_ram_gb": 17.6,
+    "recommended_ram_gb": 29.4,
+    "min_vram_gb": 16.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 13919,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19627,7 +29204,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 786011,
+    "hf_downloads": 813276,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19635,6 +29212,26 @@
     "num_experts": 128,
     "active_experts": 6,
     "active_parameters": 2985102726
+  },
+  {
+    "name": "ebircak/gemma-4-31B-it-4bit-W4A16-GPTQ",
+    "provider": "ebircak",
+    "parameter_count": "31.7B",
+    "parameters_raw": 31730694816,
+    "min_ram_gb": 17.7,
+    "recommended_ram_gb": 29.6,
+    "min_vram_gb": 16.3,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 21241,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LGAI-EXAONE/EXAONE-3.5-32B-Instruct",
@@ -19651,20 +29248,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone",
-    "hf_downloads": 66743,
+    "hf_downloads": 61870,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/EXAONE-3.5-32B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/EXAONE-3.5-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "LGAI-EXAONE/EXAONE-3.5-32B-Instruct-AWQ",
@@ -19681,7 +29268,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone",
-    "hf_downloads": 33583,
+    "hf_downloads": 33419,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19701,8 +29288,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "exaone4",
-    "hf_downloads": 26344,
-    "hf_likes": 282,
+    "hf_downloads": 27237,
+    "hf_likes": 281,
     "release_date": "2025-07-11",
     "num_hidden_layers": 64,
     "num_attention_heads": 40,
@@ -19730,7 +29317,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone4",
-    "hf_downloads": 114011,
+    "hf_downloads": 114892,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19750,7 +29337,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone4",
-    "hf_downloads": 28076,
+    "hf_downloads": 14290,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19770,7 +29357,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 636610,
+    "hf_downloads": 802857,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19794,7 +29381,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "sarvam_moe",
-    "hf_downloads": 41041,
+    "hf_downloads": 46887,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19802,26 +29389,6 @@
     "num_experts": 128,
     "active_experts": 6,
     "active_parameters": 3039430224
-  },
-  {
-    "name": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
-    "provider": "cyankiwi",
-    "parameter_count": "32.2B",
-    "parameters_raw": 32188299936,
-    "min_ram_gb": 18.0,
-    "recommended_ram_gb": 30.0,
-    "min_vram_gb": 16.5,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 938786,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
   },
   {
     "name": "cyankiwi/gemma-4-31B-it-AWQ-8bit",
@@ -19838,7 +29405,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 45128,
+    "hf_downloads": 71856,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19858,16 +29425,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 47975,
+    "hf_downloads": 44252,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Olmo-3-1125-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/OLMo-2-0325-32B-Instruct",
@@ -19884,7 +29445,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "olmo2",
-    "hf_downloads": 7146,
+    "hf_downloads": 6361,
     "hf_likes": 148,
     "release_date": "2025-03-12",
     "num_hidden_layers": 64,
@@ -19944,7 +29505,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 402414,
+    "hf_downloads": 539031,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19967,8 +29528,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "gemma4",
-    "hf_downloads": 6558301,
-    "hf_likes": 2421,
+    "hf_downloads": 8403901,
+    "hf_likes": 2530,
     "release_date": "2026-03-11",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -19990,6 +29551,26 @@
     ]
   },
   {
+    "name": "TrevorJS/gemma-4-31B-it-uncensored",
+    "provider": "trevorjs",
+    "parameter_count": "32.7B",
+    "parameters_raw": 32682372656,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.4,
+    "min_vram_gb": 16.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 15746,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "google/gemma-4-31B",
     "provider": "Google",
     "parameter_count": "32.7B",
@@ -20004,16 +29585,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 437603,
+    "hf_downloads": 475351,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "prithivMLmods/gemma-4-31B-it-FP8",
@@ -20030,7 +29605,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 29611,
+    "hf_downloads": 26658,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20050,7 +29625,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 42537,
+    "hf_downloads": 42637,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20072,7 +29647,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 630332,
+    "hf_downloads": 780086,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20094,7 +29669,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 28481,
+    "hf_downloads": 28919,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20116,8 +29691,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 1291147,
-    "hf_likes": 2012,
+    "hf_downloads": 1237772,
+    "hf_likes": 2016,
     "release_date": "2024-11-06",
     "num_hidden_layers": 64,
     "num_attention_heads": 40,
@@ -20153,8 +29728,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 1121586,
-    "hf_likes": 1552,
+    "hf_downloads": 976959,
+    "hf_likes": 1555,
     "release_date": "2025-01-20",
     "num_hidden_layers": 64,
     "num_attention_heads": 40,
@@ -20192,7 +29767,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1296279,
+    "hf_downloads": 1556968,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20214,7 +29789,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 902951,
+    "hf_downloads": 1132175,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20236,7 +29811,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 526107,
+    "hf_downloads": 545966,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20258,16 +29833,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 159298,
+    "hf_downloads": 147868,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated",
@@ -20284,39 +29853,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 123091,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-32B-abliterated-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-32B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-32B-Instruct-GPTQ-Int8",
-    "provider": "Alibaba",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 36.6,
-    "recommended_ram_gb": 61.0,
-    "min_vram_gb": 33.6,
-    "quantization": "GPTQ-Int8",
-    "format": "gptq",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 113897,
+    "hf_downloads": 145382,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20336,7 +29873,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 88692,
+    "hf_downloads": 120292,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-32B-Instruct-GPTQ-Int8",
+    "provider": "Alibaba",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 36.6,
+    "recommended_ram_gb": 61.0,
+    "min_vram_gb": 33.6,
+    "quantization": "GPTQ-Int8",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 118189,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20356,50 +29915,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 66135,
+    "hf_downloads": 65418,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/QwQ-32B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/QwQ-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "nvidia/OpenReasoning-Nemotron-32B",
-    "provider": "nvidia",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.5,
-    "min_vram_gb": 16.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 55235,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/OpenReasoning-Nemotron-32B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/OpenReasoning-Nemotron-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-Coder-32B",
@@ -20418,39 +29937,69 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 37826,
+    "hf_downloads": 39820,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-Coder-32B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "RedHatAI/Qwen3-32B-FP8-dynamic",
-    "provider": "redhatai",
+    "name": "unsloth/Qwen2.5-32B-Instruct",
+    "provider": "unsloth",
     "parameter_count": "32.8B",
-    "parameters_raw": 32766710784,
+    "parameters_raw": 32763876352,
     "min_ram_gb": 18.3,
     "recommended_ram_gb": 30.5,
     "min_vram_gb": 16.8,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
     "capabilities": [
       "tool_use"
     ],
     "pipeline_tag": "unknown",
-    "architecture": "qwen3",
-    "hf_downloads": 67182,
+    "architecture": "qwen2",
+    "hf_downloads": 16175,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/OpenReasoning-Nemotron-32B",
+    "provider": "nvidia",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.5,
+    "min_vram_gb": 16.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14942,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
+    "provider": "cyankiwi",
+    "parameter_count": "33.1B",
+    "parameters_raw": 33103510176,
+    "min_ram_gb": 18.5,
+    "recommended_ram_gb": 30.8,
+    "min_vram_gb": 17.0,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 1400255,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20470,7 +30019,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "vlm",
-    "hf_downloads": 74723,
+    "hf_downloads": 88118,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20493,20 +30042,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 1519467,
+    "hf_downloads": 1159400,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-32B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-VL-32B-Thinking",
@@ -20526,20 +30065,57 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 76808,
+    "hf_downloads": 85296,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "huihui-ai/Huihui-Qwen3-VL-32B-Instruct-abliterated",
+    "provider": "huihui-ai",
+    "parameter_count": "33.4B",
+    "parameters_raw": 33357390064,
+    "min_ram_gb": 18.6,
+    "recommended_ram_gb": 31.1,
+    "min_vram_gb": 17.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_vl",
+    "hf_downloads": 69460,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "poolside/Laguna-XS.2",
+    "provider": "poolside",
+    "parameter_count": "33.4B",
+    "parameters_raw": 33442617088,
+    "min_ram_gb": 18.7,
+    "recommended_ram_gb": 31.1,
+    "min_vram_gb": 17.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "laguna",
+    "hf_downloads": 14457,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-32B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-32B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2664958542
   },
   {
     "name": "Qwen/Qwen2.5-VL-32B-Instruct-AWQ",
@@ -20559,7 +30135,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 149003,
+    "hf_downloads": 140434,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20582,24 +30158,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 101303,
+    "hf_downloads": 107521,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-VL-32B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen2.5-VL-32B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "karakuri-ai/karakuri-vl-32b-thinking-2507-exp",
@@ -20618,16 +30180,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 14988,
+    "hf_downloads": 22283,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/karakuri-vl-32b-thinking-2507-exp-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-32B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "33.7B",
+    "parameters_raw": 33741233162,
+    "min_ram_gb": 18.9,
+    "recommended_ram_gb": 31.4,
+    "min_vram_gb": 17.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 22315,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "meta-llama/CodeLlama-34b-Instruct-hf",
@@ -20646,7 +30224,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 729,
+    "hf_downloads": 607,
     "hf_likes": 19,
     "release_date": "2024-03-14",
     "num_hidden_layers": null,
@@ -20675,7 +30253,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone4_5",
-    "hf_downloads": 62332,
+    "hf_downloads": 964972,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20695,7 +30273,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone4_5",
-    "hf_downloads": 23283,
+    "hf_downloads": 24153,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20742,20 +30320,102 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 4510689,
+    "hf_downloads": 4716266,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "01-ai/Yi-1.5-34B-Chat",
+    "provider": "01.ai",
+    "parameter_count": "34.4B",
+    "parameters_raw": 34388917248,
+    "min_ram_gb": 19.2,
+    "recommended_ram_gb": 32.0,
+    "min_vram_gb": 17.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16613,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "altomek/YiSM-34B-0rn",
+    "provider": "altomek",
+    "parameter_count": "34.4B",
+    "parameters_raw": 34388917248,
+    "min_ram_gb": 19.2,
+    "recommended_ram_gb": 32.0,
+    "min_vram_gb": 17.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16252,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Youssofal/Qwen3.6-35B-A3B-Abliterated-Heretic-MLX-4bit",
+    "provider": "youssofal",
+    "parameter_count": "34.7B",
+    "parameters_raw": 34660608768,
+    "min_ram_gb": 19.4,
+    "recommended_ram_gb": 32.3,
+    "min_vram_gb": 17.8,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 18891,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/dolphin-2.9.1-yi-1.5-34b-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/dolphin-2.9.1-yi-1.5-34b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2762017254
+  },
+  {
+    "name": "mlx-community/Qwen3.6-35B-A3B-4bit-DWQ",
+    "provider": "mlx-community",
+    "parameter_count": "34.7B",
+    "parameters_raw": 34660608768,
+    "min_ram_gb": 19.4,
+    "recommended_ram_gb": 32.3,
+    "min_vram_gb": 17.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 16997,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2762017254
   },
   {
     "name": "liuhaotian/llava-v1.6-34b",
@@ -20774,7 +30434,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 24925,
+    "hf_downloads": 18834,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20796,7 +30456,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 20696,
+    "hf_downloads": 14485,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20829,6 +30489,30 @@
     ]
   },
   {
+    "name": "Hcompany/Holo3-35B-A3B",
+    "provider": "hcompany",
+    "parameter_count": "35.1B",
+    "parameters_raw": 35107181936,
+    "min_ram_gb": 19.6,
+    "recommended_ram_gb": 32.7,
+    "min_vram_gb": 18.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 73953,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2797603552
+  },
+  {
     "name": "llmfan46/Qwen3.5-35B-A3B-uncensored-heretic",
     "provider": "llmfan46",
     "parameter_count": "35.1B",
@@ -20845,7 +30529,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 35652,
+    "hf_downloads": 56139,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -20855,8 +30539,8 @@
     "active_parameters": 2797603552
   },
   {
-    "name": "Hcompany/Holo3-35B-A3B",
-    "provider": "hcompany",
+    "name": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
+    "provider": "llmfan46",
     "parameter_count": "35.1B",
     "parameters_raw": 35107181936,
     "min_ram_gb": 19.6,
@@ -20866,23 +30550,19 @@
     "format": "gguf",
     "context_length": 262144,
     "use_case": "General purpose",
-    "capabilities": [],
+    "capabilities": [
+      "tool_use"
+    ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 12560,
+    "hf_downloads": 45960,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 2797603552,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Holo3-35B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2797603552
   },
   {
     "name": "prithivMLmods/Qwen3.6-35B-A3B-FP8",
@@ -20901,7 +30581,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 16264,
+    "hf_downloads": 16386,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -20927,7 +30607,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "cohere",
-    "hf_downloads": 146021,
+    "hf_downloads": 161102,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20950,8 +30630,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 3634694,
-    "hf_likes": 1408,
+    "hf_downloads": 3564034,
+    "hf_likes": 1418,
     "release_date": "2026-02-24",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -20977,6 +30657,41 @@
     ]
   },
   {
+    "name": "Jackrong/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
+    "provider": "jackrong",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 26567,
+    "hf_likes": 128,
+    "release_date": "2026-03-07",
+    "num_hidden_layers": null,
+    "num_attention_heads": null,
+    "num_key_value_heads": null,
+    "head_dim": null,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2864910871,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
     "name": "Qwen/Qwen3.6-35B-A3B",
     "provider": "Alibaba",
     "parameter_count": "36.0B",
@@ -20994,8 +30709,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 1510129,
-    "hf_likes": 1493,
+    "hf_downloads": 3030186,
+    "hf_likes": 1632,
     "release_date": "2026-04-15",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -21013,6 +30728,10 @@
       {
         "repo": "ggml-org/Qwen3.6-35B-A3B-GGUF",
         "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3.6-35B-A3B-GGUF",
+        "provider": "mradermacher"
       }
     ]
   },
@@ -21033,52 +30752,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 91137,
+    "hf_downloads": 173593,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Jackrong/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
-    "provider": "jackrong",
-    "parameter_count": "36.0B",
-    "parameters_raw": 35951822704,
-    "min_ram_gb": 20.1,
-    "recommended_ram_gb": 33.5,
-    "min_vram_gb": 18.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 48167,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2864910871
   },
   {
     "name": "Qwen/Qwen3.5-35B-A3B-GPTQ-Int4",
@@ -21097,7 +30778,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 713914,
+    "hf_downloads": 1036077,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21123,7 +30804,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 391699,
+    "hf_downloads": 365296,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21131,38 +30812,6 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 2864910871
-  },
-  {
-    "name": "huihui-ai/Huihui-Qwen3.5-35B-A3B-Claude-4.6-Opus-abliterated",
-    "provider": "huihui-ai",
-    "parameter_count": "36.0B",
-    "parameters_raw": 35951822704,
-    "min_ram_gb": 20.1,
-    "recommended_ram_gb": 33.5,
-    "min_vram_gb": 18.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 161964,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-35B-A3B-Claude-4.6-Opus-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "QuantTrio/Qwen3.6-35B-A3B-AWQ",
@@ -21181,7 +30830,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 141805,
+    "hf_downloads": 317512,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2864910871
+  },
+  {
+    "name": "palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4",
+    "provider": "palmfuture",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 82083,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21207,31 +30882,25 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 59699,
+    "hf_downloads": 58594,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-35B-A3B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2864910871
   },
   {
-    "name": "palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4",
-    "provider": "palmfuture",
+    "name": "huihui-ai/Huihui-Qwen3.5-35B-A3B-Claude-4.6-Opus-abliterated",
+    "provider": "huihui-ai",
     "parameter_count": "36.0B",
     "parameters_raw": 35951822704,
     "min_ram_gb": 20.1,
     "recommended_ram_gb": 33.5,
     "min_vram_gb": 18.4,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 262144,
     "use_case": "General purpose",
     "capabilities": [
@@ -21239,7 +30908,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 46439,
+    "hf_downloads": 46185,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21265,20 +30934,64 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 25356,
+    "hf_downloads": 23252,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-35B-A3B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2864910871
+  },
+  {
+    "name": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
+    "provider": "huihui-ai",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 16826,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2864910871
+  },
+  {
+    "name": "voicing-ai/Voicing-Agent-V3-35B-A3B",
+    "provider": "voicing-ai",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 14817,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2864910871
   },
   {
     "name": "codgician/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GPTQ-int4",
@@ -21297,7 +31010,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 601217,
+    "hf_downloads": 575670,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21305,32 +31018,6 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 2864910875
-  },
-  {
-    "name": "Qwen/Qwen3.5-35B-A3B-FP8",
-    "provider": "Alibaba",
-    "parameter_count": "36.0B",
-    "parameters_raw": 35953925552,
-    "min_ram_gb": 20.1,
-    "recommended_ram_gb": 33.5,
-    "min_vram_gb": 18.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 1510313,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 2865078437
   },
   {
     "name": "Qwen/Qwen3.6-35B-A3B-FP8",
@@ -21349,7 +31036,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 1474432,
+    "hf_downloads": 2769535,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2865078437
+  },
+  {
+    "name": "Qwen/Qwen3.5-35B-A3B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35953925552,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 1604810,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21373,7 +31086,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "seed_oss",
-    "hf_downloads": 47473,
+    "hf_downloads": 47547,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21393,7 +31106,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "seed_oss",
-    "hf_downloads": 46442,
+    "hf_downloads": 46173,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21413,7 +31126,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "seed_oss",
-    "hf_downloads": 46092,
+    "hf_downloads": 45887,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21433,10 +31146,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "seed_oss",
-    "hf_downloads": 46023,
+    "hf_downloads": 45792,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "hpcai-tech/grok-1",
+    "provider": "hpcai-tech",
+    "parameter_count": "36.2B",
+    "parameters_raw": 36238786560,
+    "min_ram_gb": 20.2,
+    "recommended_ram_gb": 33.8,
+    "min_vram_gb": 18.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 29957,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 10418651136
   },
   {
     "name": "cyankiwi/MiniMax-M2.7-AWQ-4bit",
@@ -21453,7 +31190,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 141601,
+    "hf_downloads": 211588,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21479,7 +31216,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 486077,
+    "hf_downloads": 567876,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21505,7 +31242,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 214999,
+    "hf_downloads": 361181,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21529,16 +31266,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 109282,
+    "hf_downloads": 114854,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/InternVL3-38B-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Skywork/Skywork-R1V-38B",
@@ -21555,7 +31286,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "skywork_chat",
-    "hf_downloads": 77175,
+    "hf_downloads": 91858,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21577,16 +31308,74 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 12900,
+    "hf_downloads": 13806,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "IQuestLab/IQuest-Coder-V1-40B-Instruct",
+    "provider": "iquestlab",
+    "parameter_count": "39.8B",
+    "parameters_raw": 39794283520,
+    "min_ram_gb": 22.2,
+    "recommended_ram_gb": 37.1,
+    "min_vram_gb": 20.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "iquestcoder",
+    "hf_downloads": 20590,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "IQuestLab/IQuest-Coder-V1-40B-Loop-Instruct",
+    "provider": "iquestlab",
+    "parameter_count": "39.8B",
+    "parameters_raw": 39794696320,
+    "min_ram_gb": 22.2,
+    "recommended_ram_gb": 37.1,
+    "min_vram_gb": 20.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "iquestloopcoder",
+    "hf_downloads": 20954,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
+    "provider": "intel",
+    "parameter_count": "39.9B",
+    "parameters_raw": 39916293330,
+    "min_ram_gb": 22.3,
+    "recommended_ram_gb": 37.2,
+    "min_vram_gb": 20.4,
+    "quantization": "AutoRound-4bit",
+    "format": "autoround",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v4",
+    "hf_downloads": 23712,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 6,
+    "active_parameters": 2884575880
   },
   {
     "name": "tiiuae/falcon-40b-instruct",
@@ -21612,6 +31401,26 @@
     ]
   },
   {
+    "name": "tiiuae/falcon-40b",
+    "provider": "TII",
+    "parameter_count": "41.8B",
+    "parameters_raw": 41835970560,
+    "min_ram_gb": 23.4,
+    "recommended_ram_gb": 39.0,
+    "min_vram_gb": 21.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "falcon",
+    "hf_downloads": 22899,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
     "provider": "Mistral AI",
     "parameter_count": "46.7B",
@@ -21628,8 +31437,8 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mixtral",
-    "hf_downloads": 655515,
-    "hf_likes": 4673,
+    "hf_downloads": 687434,
+    "hf_likes": 4675,
     "release_date": "2023-12-10",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -21651,6 +31460,54 @@
     ]
   },
   {
+    "name": "RedHatAI/Mixtral-8x7B-Instruct-v0.1",
+    "provider": "redhatai",
+    "parameter_count": "46.7B",
+    "parameters_raw": 46702792704,
+    "min_ram_gb": 26.1,
+    "recommended_ram_gb": 43.5,
+    "min_vram_gb": 23.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 18596,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 13427052901
+  },
+  {
+    "name": "hugging-quants/Mixtral-8x7B-Instruct-v0.1-AWQ-INT4",
+    "provider": "hugging-quants",
+    "parameter_count": "46.7B",
+    "parameters_raw": 46702792704,
+    "min_ram_gb": 26.1,
+    "recommended_ram_gb": 43.5,
+    "min_vram_gb": 23.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 14778,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 13427052901
+  },
+  {
     "name": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
     "provider": "NousResearch",
     "parameter_count": "46.7B",
@@ -21667,7 +31524,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "mixtral",
-    "hf_downloads": 8725,
+    "hf_downloads": 8989,
     "hf_likes": 453,
     "release_date": "2024-01-11",
     "num_hidden_layers": 32,
@@ -21704,16 +31561,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kimi_linear",
-    "hf_downloads": 59205,
+    "hf_downloads": 59426,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Kimi-Linear-48B-A3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Llama-3_3-Nemotron-Super-49B-v1_5-FP8",
@@ -21730,7 +31581,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron-nas",
-    "hf_downloads": 53653,
+    "hf_downloads": 60118,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
+    "provider": "nvidia",
+    "parameter_count": "49.9B",
+    "parameters_raw": 49867145216,
+    "min_ram_gb": 27.9,
+    "recommended_ram_gb": 46.4,
+    "min_vram_gb": 25.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron-nas",
+    "hf_downloads": 38620,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21750,74 +31621,158 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron-nas",
-    "hf_downloads": 51622,
+    "hf_downloads": 33234,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3_3-Nemotron-Super-49B-v1_5-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Llama-3_3-Nemotron-Super-49B-v1_5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
-    "provider": "nvidia",
-    "parameter_count": "49.9B",
-    "parameters_raw": 49867145216,
-    "min_ram_gb": 27.9,
-    "recommended_ram_gb": 46.4,
-    "min_vram_gb": 25.5,
+    "name": "ai21labs/AI21-Jamba-Mini-1.5",
+    "provider": "ai21labs",
+    "parameter_count": "51.6B",
+    "parameters_raw": 51570323328,
+    "min_ram_gb": 28.8,
+    "recommended_ram_gb": 48.0,
+    "min_vram_gb": 26.4,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 1048576,
-    "use_case": "General purpose",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "nemotron-nas",
-    "hf_downloads": 35559,
+    "architecture": "jamba",
+    "hf_downloads": 19960,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3_3-Nemotron-Super-49B-v1-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Llama-3_3-Nemotron-Super-49B-v1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "aoxo/sarvam-105b-uncensored",
-    "provider": "aoxo",
-    "parameter_count": "55.7B",
-    "parameters_raw": 55732545631,
-    "min_ram_gb": 31.1,
-    "recommended_ram_gb": 51.9,
-    "min_vram_gb": 28.5,
+    "name": "Qwen/Qwen2-57B-A14B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "57.4B",
+    "parameters_raw": 57408658944,
+    "min_ram_gb": 32.1,
+    "recommended_ram_gb": 53.5,
+    "min_vram_gb": 29.4,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 5242880,
-    "use_case": "General purpose",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "sarvam_mla",
-    "hf_downloads": 69601,
+    "architecture": "qwen2_moe",
+    "hf_downloads": 17313,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
-    "num_experts": 128,
+    "num_experts": 64,
     "active_experts": 8,
-    "active_parameters": 6095747177
+    "active_parameters": 9687711195
+  },
+  {
+    "name": "unsloth/Llama-3.3-70B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "60.1B",
+    "parameters_raw": 60106473472,
+    "min_ram_gb": 33.6,
+    "recommended_ram_gb": 56.0,
+    "min_vram_gb": 30.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 213668,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
+    "provider": "hugging-quants",
+    "parameter_count": "60.1B",
+    "parameters_raw": 60106473472,
+    "min_ram_gb": 33.6,
+    "recommended_ram_gb": 56.0,
+    "min_vram_gb": 30.8,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 211997,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+    "provider": "DeepSeek",
+    "parameter_count": "60.1B",
+    "parameters_raw": 60106473472,
+    "min_ram_gb": 33.6,
+    "recommended_ram_gb": 56.0,
+    "min_vram_gb": 30.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 132683,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-Distill-Llama-70B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "60.1B",
+    "parameters_raw": 60106473472,
+    "min_ram_gb": 33.6,
+    "recommended_ram_gb": 56.0,
+    "min_vram_gb": 30.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14693,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/deepseek-llm-67b-base",
+    "provider": "DeepSeek",
+    "parameter_count": "60.6B",
+    "parameters_raw": 60607692800,
+    "min_ram_gb": 33.9,
+    "recommended_ram_gb": 56.4,
+    "min_vram_gb": 31.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16754,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/Qwen3.5-397B-A17B-MLX-4bit",
@@ -21836,7 +31791,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 14364,
+    "hf_downloads": 12733,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21862,7 +31817,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 209536,
+    "hf_downloads": 197082,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21886,7 +31841,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 877172,
+    "hf_downloads": 897144,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21894,6 +31849,26 @@
     "num_experts": 512,
     "active_experts": 22,
     "active_parameters": 6105718484
+  },
+  {
+    "name": "petals-team/StableBeluga2",
+    "provider": "petals-team",
+    "parameter_count": "69.0B",
+    "parameters_raw": 68976648192,
+    "min_ram_gb": 38.5,
+    "recommended_ram_gb": 64.2,
+    "min_vram_gb": 35.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21354,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "meta-llama/Llama-3.1-70B-Instruct",
@@ -21912,7 +31887,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 695826,
+    "hf_downloads": 729268,
     "hf_likes": 910,
     "release_date": "2024-07-16",
     "num_hidden_layers": null,
@@ -21937,8 +31912,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 620405,
-    "hf_likes": 2742,
+    "hf_downloads": 778123,
+    "hf_likes": 2751,
     "release_date": "2024-11-26",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -21974,16 +31949,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 669010,
+    "hf_downloads": 698141,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/L3.3-GeneticLemonade-Final-v2-70B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "kosbu/Llama-3.3-70B-Instruct-AWQ",
@@ -22002,7 +31971,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 487633,
+    "hf_downloads": 516755,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22024,7 +31993,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 360886,
+    "hf_downloads": 408815,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22046,7 +32015,49 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 156926,
+    "hf_downloads": 172782,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w4a16",
+    "provider": "redhatai",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 144258,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "meta-llama/Llama-3.1-70B",
+    "provider": "Meta",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 133962,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22066,19 +32077,13 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 144741,
+    "hf_downloads": 116526,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Meta-Llama-3-70B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "meta-llama/Llama-3.1-70B",
+    "name": "meta-llama/Meta-Llama-3-70B-Instruct",
     "provider": "Meta",
     "parameter_count": "70.6B",
     "parameters_raw": 70553706496,
@@ -22088,11 +32093,13 @@
     "quantization": "Q4_K_M",
     "format": "gguf",
     "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 129279,
+    "hf_downloads": 78131,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22112,24 +32119,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 50195,
+    "hf_downloads": 50012,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/L3.3-70B-Euryale-v2.3-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/L3.3-70B-Euryale-v2.3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "meta-llama/Meta-Llama-3-70B-Instruct",
-    "provider": "Meta",
+    "name": "unsloth/Llama-3.3-70B-Instruct",
+    "provider": "unsloth",
     "parameter_count": "70.6B",
     "parameters_raw": 70553706496,
     "min_ram_gb": 39.4,
@@ -22137,27 +32134,39 @@
     "min_vram_gb": 36.1,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 4096,
+    "context_length": 1048576,
     "use_case": "Instruction following, chat",
     "capabilities": [
       "tool_use"
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 44403,
+    "hf_downloads": 30397,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Meta-Llama-3-70B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Meta-Llama-3-70B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.3-70B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 27985,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "casperhansen/llama-3-70b-instruct-awq",
@@ -22176,7 +32185,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 30174,
+    "hf_downloads": 27638,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8",
+    "provider": "redhatai",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553707616,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 20543,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22198,7 +32229,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 37268,
+    "hf_downloads": 48131,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "NousResearch/Hermes-4-70B-FP8",
+    "provider": "NousResearch",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70560423936,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 46076,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "pearl-ai/Llama-3.3-70B-Instruct-pearl",
+    "provider": "pearl-ai",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70560710656,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 39227,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22220,7 +32295,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 48743,
+    "hf_downloads": 64846,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22246,7 +32321,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 112582,
+    "hf_downloads": 73622,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22254,6 +32329,72 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 5675147164
+  },
+  {
+    "name": "paloalma/Le_Triomphant-ECE-TW3",
+    "provider": "paloalma",
+    "parameter_count": "72.3B",
+    "parameters_raw": 72288575488,
+    "min_ram_gb": 40.4,
+    "recommended_ram_gb": 67.3,
+    "min_vram_gb": 37.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16271,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "paloalma/TW3-JRGL-v2",
+    "provider": "paloalma",
+    "parameter_count": "72.3B",
+    "parameters_raw": 72288575488,
+    "min_ram_gb": 40.4,
+    "recommended_ram_gb": 67.3,
+    "min_vram_gb": 37.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16253,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "rdtand/Qwen3.5-122B-A10B-PrismaQuant-4.75bit-vllm",
+    "provider": "rdtand",
+    "parameter_count": "72.4B",
+    "parameters_raw": 72399806340,
+    "min_ram_gb": 40.5,
+    "recommended_ram_gb": 67.4,
+    "min_vram_gb": 37.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 13565,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 5769359565
   },
   {
     "name": "Qwen/Qwen2.5-72B-Instruct",
@@ -22272,8 +32413,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 409864,
-    "hf_likes": 932,
+    "hf_downloads": 437470,
+    "hf_likes": 936,
     "release_date": "2024-09-16",
     "num_hidden_layers": 80,
     "num_attention_heads": 64,
@@ -22307,46 +32448,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 440943,
+    "hf_downloads": 461516,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-72B-Instruct-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2-72B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "72.7B",
-    "parameters_raw": 72706203648,
-    "min_ram_gb": 40.6,
-    "recommended_ram_gb": 67.7,
-    "min_vram_gb": 37.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 71819,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2-72B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2-72B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-72B",
@@ -22365,16 +32470,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 48630,
+    "hf_downloads": 48182,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-72B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2-72B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "72.7B",
+    "parameters_raw": 72706203648,
+    "min_ram_gb": 40.6,
+    "recommended_ram_gb": 67.7,
+    "min_vram_gb": 37.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 41766,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2-72B",
@@ -22391,7 +32510,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 29112,
+    "hf_downloads": 32633,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22417,20 +32536,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 26027,
+    "hf_downloads": 23405,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/magnum-v4-72b-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/magnum-v4-72b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-72B-Instruct-AWQ",
@@ -22449,7 +32558,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 599043,
+    "hf_downloads": 761719,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-72B-Instruct-GPTQ-Int4",
+    "provider": "Alibaba",
+    "parameter_count": "73.0B",
+    "parameters_raw": 72957861888,
+    "min_ram_gb": 40.8,
+    "recommended_ram_gb": 67.9,
+    "min_vram_gb": 37.4,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 18041,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22471,20 +32602,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 29643,
+    "hf_downloads": 27207,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2-VL-72B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2-VL-72B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -22504,22 +32625,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 103994,
+    "hf_downloads": 125258,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "unsloth/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
         "repo": "ggml-org/Qwen2.5-VL-72B-Instruct-GGUF",
         "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "mradermacher"
       }
     ]
   },
@@ -22541,7 +32654,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 176125,
+    "hf_downloads": 107351,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22563,7 +32676,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 427782,
+    "hf_downloads": 446552,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22589,7 +32702,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 26835,
+    "hf_downloads": 26056,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22615,7 +32728,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 25936,
+    "hf_downloads": 24992,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22641,7 +32754,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 25608,
+    "hf_downloads": 24683,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22667,7 +32780,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 25470,
+    "hf_downloads": 24515,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22693,8 +32806,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3_next",
-    "hf_downloads": 767994,
-    "hf_likes": 1332,
+    "hf_downloads": 1049903,
+    "hf_likes": 1347,
     "release_date": "2026-01-30",
     "num_hidden_layers": 48,
     "num_attention_heads": 16,
@@ -22716,6 +32829,32 @@
     ]
   },
   {
+    "name": "unsloth/Qwen3-Coder-Next",
+    "provider": "unsloth",
+    "parameter_count": "79.7B",
+    "parameters_raw": 79674391296,
+    "min_ram_gb": 44.5,
+    "recommended_ram_gb": 74.2,
+    "min_vram_gb": 40.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 18715,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 5462052994
+  },
+  {
     "name": "Qwen/Qwen3-Coder-Next-FP8",
     "provider": "Alibaba",
     "parameter_count": "79.7B",
@@ -22732,7 +32871,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 469327,
+    "hf_downloads": 283372,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22740,6 +32879,32 @@
     "num_experts": 512,
     "active_experts": 10,
     "active_parameters": 5462383530
+  },
+  {
+    "name": "unsloth/Qwen3-Coder-Next-FP8-Dynamic",
+    "provider": "unsloth",
+    "parameter_count": "79.7B",
+    "parameters_raw": 79748584192,
+    "min_ram_gb": 44.6,
+    "recommended_ram_gb": 74.3,
+    "min_vram_gb": 40.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 14589,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 5467139259
   },
   {
     "name": "Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -22758,28 +32923,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 271492,
+    "hf_downloads": 275655,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 512,
     "active_experts": 10,
-    "active_parameters": 5575200546,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-Next-80B-A3B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-Next-80B-A3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 5575200546
   },
   {
     "name": "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8",
@@ -22798,7 +32949,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 79769,
+    "hf_downloads": 112833,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22808,27 +32959,28 @@
     "active_parameters": 5575537949
   },
   {
-    "name": "meta-llama/Llama-3.2-90B-Vision-Instruct",
-    "provider": "Meta",
-    "parameter_count": "88.6B",
-    "parameters_raw": 88593355323,
-    "min_ram_gb": 49.5,
-    "recommended_ram_gb": 82.5,
-    "min_vram_gb": 45.4,
+    "name": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
+    "provider": "saricles",
+    "parameter_count": "86.9B",
+    "parameters_raw": 86887015424,
+    "min_ram_gb": 48.6,
+    "recommended_ram_gb": 80.9,
+    "min_vram_gb": 44.5,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
+    "context_length": 196608,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "mllama",
-    "hf_downloads": 12095,
+    "architecture": "minimax_m2",
+    "hf_downloads": 13940,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 192,
+    "active_experts": 8,
+    "active_parameters": 7783628459
   },
   {
     "name": "inclusionAI/LLaDA2.1-flash",
@@ -22845,7 +32997,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llada2_moe",
-    "hf_downloads": 243292,
+    "hf_downloads": 113212,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22869,7 +33021,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "sarvam_mla",
-    "hf_downloads": 25346,
+    "hf_downloads": 24052,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22893,24 +33045,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4v_moe",
-    "hf_downloads": 61811,
+    "hf_downloads": 85906,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 11780883304,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/GLM-4.5V-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/GLM-4.5V-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 11780883304
   },
   {
     "name": "jiangchengchengNLP/Llama-4-Scout-17B-16E-Instruct-abliterated-v2",
@@ -22927,20 +33069,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama4",
-    "hf_downloads": 14379,
+    "hf_downloads": 14399,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 16,
     "active_experts": 1,
-    "active_parameters": 11882696167,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-4-Scout-17B-16E-Instruct-abliterated-v2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 11882696167
   },
   {
     "name": "zai-org/GLM-4.5-Air",
@@ -22957,24 +33093,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe",
-    "hf_downloads": 395143,
+    "hf_downloads": 405604,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 12082527713,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.5-Air-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/GLM-4.5-Air-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 12082527713
   },
   {
     "name": "CohereLabs/command-a-vision-07-2025",
@@ -22993,7 +33119,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "cohere2_vision",
-    "hf_downloads": 61167,
+    "hf_downloads": 79132,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -23015,7 +33141,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 64247,
+    "hf_downloads": 55285,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23039,7 +33165,55 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 70467,
+    "hf_downloads": 92679,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 9271601628
+  },
+  {
+    "name": "nvidia/MiniMax-M2.7-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "116.3B",
+    "parameters_raw": 116349510656,
+    "min_ram_gb": 65.0,
+    "recommended_ram_gb": 108.4,
+    "min_vram_gb": 59.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 196608,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minimax_m2",
+    "hf_downloads": 72120,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 9271601628
+  },
+  {
+    "name": "amd/MiniMax-M2.5-MXFP4",
+    "provider": "amd",
+    "parameter_count": "116.3B",
+    "parameters_raw": 116349510656,
+    "min_ram_gb": 65.0,
+    "recommended_ram_gb": 108.4,
+    "min_vram_gb": 59.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 196608,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minimax_m2",
+    "hf_downloads": 14308,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23063,7 +33237,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 55021,
+    "hf_downloads": 54135,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23071,6 +33245,54 @@
     "num_experts": 128,
     "active_experts": 4,
     "active_parameters": 9309823238
+  },
+  {
+    "name": "unsloth/gpt-oss-120b-BF16",
+    "provider": "unsloth",
+    "parameter_count": "116.8B",
+    "parameters_raw": 116829156672,
+    "min_ram_gb": 65.3,
+    "recommended_ram_gb": 108.8,
+    "min_vram_gb": 59.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 190914,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 4,
+    "active_parameters": 9309823421
+  },
+  {
+    "name": "unsloth/gpt-oss-120b-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "116.8B",
+    "parameters_raw": 116829156672,
+    "min_ram_gb": 65.3,
+    "recommended_ram_gb": 108.8,
+    "min_vram_gb": 59.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 40731,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 4,
+    "active_parameters": 9309823421
   },
   {
     "name": "openai/gpt-oss-120b",
@@ -23087,24 +33309,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 3710123,
+    "hf_downloads": 4369404,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 4,
-    "active_parameters": 9595358141,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gpt-oss-120b-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gpt-oss-120b-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
+    "active_parameters": 9595358141
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -23121,20 +33333,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 662337,
+    "hf_downloads": 791172,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 512,
     "active_experts": 22,
-    "active_parameters": 11226390744,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/NVIDIA-Nemotron-3-Super-120B-A12B-BF16-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 11226390744
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -23151,7 +33357,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 235243,
+    "hf_downloads": 338538,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 22,
+    "active_parameters": 11226390744
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16",
+    "provider": "nvidia",
+    "parameter_count": "123.6B",
+    "parameters_raw": 123611012096,
+    "min_ram_gb": 69.1,
+    "recommended_ram_gb": 115.1,
+    "min_vram_gb": 63.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 23022,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23178,8 +33408,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 1117358,
-    "hf_likes": 530,
+    "hf_downloads": 893368,
+    "hf_likes": 535,
     "release_date": "2026-02-24",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -23217,7 +33447,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 300834,
+    "hf_downloads": 176332,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23243,7 +33473,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 69835,
+    "hf_downloads": 39404,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23269,7 +33499,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 626468,
+    "hf_downloads": 588460,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23295,7 +33525,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mixtral",
-    "hf_downloads": 29369,
+    "hf_downloads": 30827,
     "hf_likes": 749,
     "release_date": "2024-04-16",
     "num_hidden_layers": 56,
@@ -23306,6 +33536,30 @@
     "num_experts": 8,
     "active_experts": 2,
     "active_parameters": 39100000000
+  },
+  {
+    "name": "Salesforce/xLAM-8x22b-r",
+    "provider": "salesforce",
+    "parameter_count": "140.6B",
+    "parameters_raw": 140630071296,
+    "min_ram_gb": 78.6,
+    "recommended_ram_gb": 131.0,
+    "min_vram_gb": 72.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 22963,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 40431145496
   },
   {
     "name": "rednote-hilab/dots.llm1.inst",
@@ -23322,7 +33576,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "dots1",
-    "hf_downloads": 12399,
+    "hf_downloads": 14835,
     "hf_likes": 176,
     "release_date": "2025-05-14",
     "num_hidden_layers": 62,
@@ -23355,8 +33609,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v4",
-    "hf_downloads": 96948,
-    "hf_likes": 829,
+    "hf_downloads": 668670,
+    "hf_likes": 953,
     "release_date": "2026-04-22",
     "num_hidden_layers": 43,
     "num_attention_heads": 64,
@@ -23382,8 +33636,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "bloom",
-    "hf_downloads": 6682,
-    "hf_likes": 4998,
+    "hf_downloads": 6510,
+    "hf_likes": 5001,
     "release_date": "2022-05-19",
     "num_hidden_layers": null,
     "num_attention_heads": 112,
@@ -23405,7 +33659,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "falcon",
-    "hf_downloads": 615,
+    "hf_downloads": 97,
     "hf_likes": 547,
     "release_date": "2023-09-04",
     "num_hidden_layers": null,
@@ -23428,20 +33682,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "step3p5",
-    "hf_downloads": 225428,
+    "hf_downloads": 227378,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/Step-3.5-Flash-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Step-3.5-Flash-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "stepfun-ai/Step-3.5-Flash-FP8",
@@ -23458,7 +33702,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "step3p5",
-    "hf_downloads": 217875,
+    "hf_downloads": 152379,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -23480,7 +33724,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 17215,
+    "hf_downloads": 15236,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23504,7 +33748,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 70188,
+    "hf_downloads": 58088,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23528,7 +33772,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 48660,
+    "hf_downloads": 40809,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23552,7 +33796,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 48305,
+    "hf_downloads": 40533,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23576,7 +33820,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 88905,
+    "hf_downloads": 65145,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23600,7 +33844,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 26773,
+    "hf_downloads": 28606,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23624,8 +33868,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "minimax_m2",
-    "hf_downloads": 496055,
-    "hf_likes": 1083,
+    "hf_downloads": 632064,
+    "hf_likes": 1104,
     "release_date": "2026-04-09",
     "num_hidden_layers": 62,
     "num_attention_heads": 48,
@@ -23661,8 +33905,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "minimax_m2",
-    "hf_downloads": 924475,
-    "hf_likes": 1465,
+    "hf_downloads": 959535,
+    "hf_likes": 1471,
     "release_date": "2026-02-12",
     "num_hidden_layers": 62,
     "num_attention_heads": 48,
@@ -23684,6 +33928,30 @@
     ]
   },
   {
+    "name": "List-cloud/List-3.0-Ultra-Coder-Brain",
+    "provider": "list-cloud",
+    "parameter_count": "228.7B",
+    "parameters_raw": 228703644928,
+    "min_ram_gb": 127.8,
+    "recommended_ram_gb": 213.0,
+    "min_vram_gb": 117.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 204800,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "list_ultra_coder",
+    "hf_downloads": 279796,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 18224821702
+  },
+  {
     "name": "MiniMaxAI/MiniMax-M2",
     "provider": "minimaxai",
     "parameter_count": "228.7B",
@@ -23698,20 +33966,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 74884,
+    "hf_downloads": 85462,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 18224821702,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/MiniMax-M2-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 18224821702
   },
   {
     "name": "MiniMaxAI/MiniMax-M2.1",
@@ -23728,24 +33990,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 28863,
+    "hf_downloads": 26439,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 18224821702,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/MiniMax-M2.1-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/MiniMax-M2.1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 18224821702
   },
   {
     "name": "Qwen/Qwen3-235B-A22B",
@@ -23764,7 +34016,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3_moe",
-    "hf_downloads": 614892,
+    "hf_downloads": 569157,
     "hf_likes": 1091,
     "release_date": "2025-04-27",
     "num_hidden_layers": 94,
@@ -23787,6 +34039,30 @@
     ]
   },
   {
+    "name": "prefeitura-rio/Rio-3.0-Open",
+    "provider": "prefeitura-rio",
+    "parameter_count": "235.1B",
+    "parameters_raw": 235093634560,
+    "min_ram_gb": 131.4,
+    "recommended_ram_gb": 218.9,
+    "min_vram_gb": 120.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 46879,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 25713366280
+  },
+  {
     "name": "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
     "provider": "Alibaba",
     "parameter_count": "235.1B",
@@ -23803,7 +34079,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 313776,
+    "hf_downloads": 413524,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23829,7 +34105,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 135071,
+    "hf_downloads": 179775,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 25714927049
+  },
+  {
+    "name": "Qwen/Qwen3-235B-A22B-Thinking-2507-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "235.1B",
+    "parameters_raw": 235107904512,
+    "min_ram_gb": 131.4,
+    "recommended_ram_gb": 219.0,
+    "min_vram_gb": 120.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 20496,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23856,24 +34158,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 1268536,
+    "hf_downloads": 1446131,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 25776408752,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-235B-A22B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-235B-A22B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 25776408752
   },
   {
     "name": "Qwen/Qwen3-VL-235B-A22B-Thinking",
@@ -23893,24 +34185,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 165605,
+    "hf_downloads": 42705,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 25776408752,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-235B-A22B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-235B-A22B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 25776408752
   },
   {
     "name": "Qwen/Qwen3-VL-235B-A22B-Instruct-FP8",
@@ -23930,7 +34212,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 62698,
+    "hf_downloads": 77678,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23954,7 +34236,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 224871,
+    "hf_downloads": 178190,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23978,20 +34260,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 30511,
+    "hf_downloads": 106907,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 160,
     "active_experts": 6,
-    "active_parameters": 20185360358,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/DeepSeek-Coder-V2-Instruct-GGUF",
-        "provider": "bartowski"
-      }
-    ]
+    "active_parameters": 20185360358
   },
   {
     "name": "RedHatAI/DeepSeek-V2.5-1210-FP8",
@@ -24008,7 +34284,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 53387,
+    "hf_downloads": 53575,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24032,20 +34308,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone_moe",
-    "hf_downloads": 46842,
+    "hf_downloads": 52045,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 25932776361,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/K-EXAONE-236B-A23B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 25932776361
   },
   {
     "name": "internlm/Intern-S1",
@@ -24062,7 +34332,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "interns1",
-    "hf_downloads": 37447,
+    "hf_downloads": 24716,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24070,6 +34340,78 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 26327640510
+  },
+  {
+    "name": "mlx-community/deepseek-ai-DeepSeek-V4-Flash-8bit",
+    "provider": "mlx-community",
+    "parameter_count": "284.3B",
+    "parameters_raw": 284299262080,
+    "min_ram_gb": 158.9,
+    "recommended_ram_gb": 264.8,
+    "min_vram_gb": 145.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v4",
+    "hf_downloads": 23968,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 6,
+    "active_parameters": 20545063856
+  },
+  {
+    "name": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
+    "provider": "mlx-community",
+    "parameter_count": "284.3B",
+    "parameters_raw": 284333146519,
+    "min_ram_gb": 158.9,
+    "recommended_ram_gb": 264.8,
+    "min_vram_gb": 145.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v4",
+    "hf_downloads": 21723,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 6,
+    "active_parameters": 20547512535
+  },
+  {
+    "name": "mlx-community/DeepSeek-V4-Flash-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "284.3B",
+    "parameters_raw": 284333146519,
+    "min_ram_gb": 158.9,
+    "recommended_ram_gb": 264.8,
+    "min_vram_gb": 145.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v4",
+    "hf_downloads": 20080,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 6,
+    "active_parameters": 20547512535
   },
   {
     "name": "deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -24086,8 +34428,8 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v4",
-    "hf_downloads": 3025,
-    "hf_likes": 179,
+    "hf_downloads": 8733,
+    "hf_likes": 191,
     "release_date": "2026-04-22",
     "num_hidden_layers": 43,
     "num_attention_heads": 64,
@@ -24097,6 +34439,30 @@
     "num_experts": 256,
     "active_experts": 6,
     "active_parameters": 13000000000
+  },
+  {
+    "name": "tencent/Hy3-preview",
+    "provider": "tencent",
+    "parameter_count": "298.8B",
+    "parameters_raw": 298786155776,
+    "min_ram_gb": 167.0,
+    "recommended_ram_gb": 278.3,
+    "min_vram_gb": 153.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "hy_v3",
+    "hf_downloads": 26687,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 192,
+    "active_experts": 8,
+    "active_parameters": 26766259780
   },
   {
     "name": "baidu/ERNIE-4.5-300B-A47B-Paddle",
@@ -24113,7 +34479,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "ernie4_5_moe",
-    "hf_downloads": 368,
+    "hf_downloads": 285,
     "hf_likes": 13,
     "release_date": "2025-06-28",
     "num_hidden_layers": 54,
@@ -24136,8 +34502,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "mimo_v2_flash",
-    "hf_downloads": 88082,
-    "hf_likes": 720,
+    "hf_downloads": 98870,
+    "hf_likes": 726,
     "release_date": "2025-12-16",
     "num_hidden_layers": 48,
     "num_attention_heads": 64,
@@ -24173,7 +34539,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "step3_vl",
-    "hf_downloads": 155267,
+    "hf_downloads": 178988,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -24193,54 +34559,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe",
-    "hf_downloads": 33338,
+    "hf_downloads": 55370,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 160,
     "active_experts": 8,
-    "active_parameters": 34786625132,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.6-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "zai-org/GLM-4.7",
-    "provider": "zai-org",
-    "parameter_count": "358.3B",
-    "parameters_raw": 358337791296,
-    "min_ram_gb": 200.2,
-    "recommended_ram_gb": 333.7,
-    "min_vram_gb": 183.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 202752,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "glm4_moe",
-    "hf_downloads": 89799,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 160,
-    "active_experts": 8,
-    "active_parameters": 34937934644,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.7-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/GLM-4.7-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 34786625132
   },
   {
     "name": "zai-org/GLM-4.5",
@@ -24257,20 +34583,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe",
-    "hf_downloads": 86728,
+    "hf_downloads": 106876,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 160,
     "active_experts": 8,
-    "active_parameters": 34937934644,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.5-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 34937934644
+  },
+  {
+    "name": "zai-org/GLM-4.7",
+    "provider": "zai-org",
+    "parameter_count": "358.3B",
+    "parameters_raw": 358337791296,
+    "min_ram_gb": 200.2,
+    "recommended_ram_gb": 333.7,
+    "min_vram_gb": 183.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 96723,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 34937934644
   },
   {
     "name": "nvidia/DeepSeek-R1-0528-NVFP4-v2",
@@ -24287,7 +34631,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 1065696,
+    "hf_downloads": 1413341,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 31367615334
+  },
+  {
+    "name": "nvidia/DeepSeek-V3.1-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "393.6B",
+    "parameters_raw": 393632819968,
+    "min_ram_gb": 220.0,
+    "recommended_ram_gb": 366.6,
+    "min_vram_gb": 201.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 14668,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24311,7 +34679,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v32",
-    "hf_downloads": 58361,
+    "hf_downloads": 53854,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24335,7 +34703,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 35706,
+    "hf_downloads": 42299,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24359,7 +34727,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "afmoe",
-    "hf_downloads": 26268,
+    "hf_downloads": 24721,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24385,8 +34753,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "llama4",
-    "hf_downloads": 39219,
-    "hf_likes": 479,
+    "hf_downloads": 42748,
+    "hf_likes": 482,
     "release_date": "2025-04-01",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -24422,7 +34790,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama4",
-    "hf_downloads": 105572,
+    "hf_downloads": 114344,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24449,7 +34817,7 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 399291,
+    "hf_downloads": 586112,
     "hf_likes": 1474,
     "release_date": "2026-02-16",
     "num_hidden_layers": null,
@@ -24488,20 +34856,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 1330618,
+    "hf_downloads": 1208746,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 512,
     "active_experts": 10,
-    "active_parameters": 27656495656,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-397B-A17B-FP8-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 27656495656
   },
   {
     "name": "meta-llama/Llama-3.1-405B-Instruct",
@@ -24520,7 +34882,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 237182,
+    "hf_downloads": 246348,
     "hf_likes": 595,
     "release_date": "2024-07-16",
     "num_hidden_layers": null,
@@ -24543,7 +34905,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 152424,
+    "hf_downloads": 148654,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/Llama-3.1-405B-Instruct-FP8",
+    "provider": "nvidia",
+    "parameter_count": "405.9B",
+    "parameters_raw": 405853388800,
+    "min_ram_gb": 226.8,
+    "recommended_ram_gb": 378.0,
+    "min_vram_gb": 207.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 17950,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -24563,7 +34947,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 156889,
+    "hf_downloads": 105180,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24589,7 +34973,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3_moe",
-    "hf_downloads": 40144,
+    "hf_downloads": 41971,
     "hf_likes": 1331,
     "release_date": "2025-07-22",
     "num_hidden_layers": 62,
@@ -24608,6 +34992,30 @@
     ]
   },
   {
+    "name": "skt/A.X-K1",
+    "provider": "skt",
+    "parameter_count": "519.0B",
+    "parameters_raw": 518983059456,
+    "min_ram_gb": 290.0,
+    "recommended_ram_gb": 483.3,
+    "min_vram_gb": 265.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "AXK1",
+    "hf_downloads": 21297,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 192,
+    "active_experts": 8,
+    "active_parameters": 46492232404
+  },
+  {
     "name": "meituan-longcat/LongCat-Flash-Chat",
     "provider": "meituan-longcat",
     "parameter_count": "561.9B",
@@ -24622,7 +35030,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 52697,
+    "hf_downloads": 61388,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -24642,7 +35050,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 42779,
+    "hf_downloads": 50894,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24666,8 +35074,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v3",
-    "hf_downloads": 1045642,
-    "hf_likes": 4063,
+    "hf_downloads": 1171264,
+    "hf_likes": 4064,
     "release_date": "2024-12-25",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -24699,8 +35107,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v3",
-    "hf_downloads": 3896658,
-    "hf_likes": 13315,
+    "hf_downloads": 3805992,
+    "hf_likes": 13319,
     "release_date": "2025-01-20",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -24722,36 +35130,6 @@
     ]
   },
   {
-    "name": "deepseek-ai/DeepSeek-V3-0324",
-    "provider": "DeepSeek",
-    "parameter_count": "684.5B",
-    "parameters_raw": 684531386000,
-    "min_ram_gb": 382.5,
-    "recommended_ram_gb": 637.5,
-    "min_vram_gb": 350.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 6553600,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "deepseek_v3",
-    "hf_downloads": 659144,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 54548594820,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-V3-0324-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
     "name": "deepseek-ai/DeepSeek-R1-0528",
     "provider": "DeepSeek",
     "parameter_count": "684.5B",
@@ -24766,20 +35144,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 605074,
+    "hf_downloads": 1375563,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 54548594820,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-0528-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 54548594820
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3-0324",
+    "provider": "DeepSeek",
+    "parameter_count": "684.5B",
+    "parameters_raw": 684531386000,
+    "min_ram_gb": 382.5,
+    "recommended_ram_gb": 637.5,
+    "min_vram_gb": 350.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 633222,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 54548594820
   },
   {
     "name": "deepseek-ai/DeepSeek-V3.2-Speciale",
@@ -24803,6 +35199,30 @@
     "release_date": "2025-12-01"
   },
   {
+    "name": "QuantTrio/DeepSeek-V3.2-AWQ",
+    "provider": "quanttrio",
+    "parameter_count": "685.0B",
+    "parameters_raw": 685011996928,
+    "min_ram_gb": 382.8,
+    "recommended_ram_gb": 638.0,
+    "min_vram_gb": 350.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v32",
+    "hf_downloads": 200205,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 54586893502
+  },
+  {
     "name": "deepseek-ai/DeepSeek-V3.2",
     "provider": "DeepSeek",
     "parameter_count": "685.4B",
@@ -24817,8 +35237,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v32",
-    "hf_downloads": 11290376,
-    "hf_likes": 1424,
+    "hf_downloads": 11633275,
+    "hf_likes": 1427,
     "release_date": "2025-12-01",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -24850,8 +35270,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 442542,
-    "hf_likes": 2078,
+    "hf_downloads": 315464,
+    "hf_likes": 2082,
     "release_date": "2026-02-11",
     "num_hidden_layers": 78,
     "num_attention_heads": 64,
@@ -24883,20 +35303,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 256484,
+    "hf_downloads": 295110,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 60073548574,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-5.1-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 60073548574
   },
   {
     "name": "zai-org/GLM-5-FP8",
@@ -24913,7 +35327,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 1294393,
+    "hf_downloads": 1609767,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24937,7 +35351,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 648689,
+    "hf_downloads": 877686,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24961,8 +35375,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v4",
-    "hf_downloads": 174402,
-    "hf_likes": 3169,
+    "hf_downloads": 786631,
+    "hf_likes": 3602,
     "release_date": "2026-04-22",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -24988,7 +35402,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bailing_hybrid",
-    "hf_downloads": 28915,
+    "hf_downloads": 31310,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24996,6 +35410,54 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 80681570216
+  },
+  {
+    "name": "XiaomiMiMo/MiMo-V2.5-Pro",
+    "provider": "xiaomimimo",
+    "parameter_count": "1023.2B",
+    "parameters_raw": 1023244718976,
+    "min_ram_gb": 571.8,
+    "recommended_ram_gb": 953.0,
+    "min_vram_gb": 524.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mimo_v2",
+    "hf_downloads": 16030,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 384,
+    "active_experts": 8,
+    "active_parameters": 71413954340
+  },
+  {
+    "name": "mlx-community/Kimi-K2.6-mlx-DQ3_K_M-q8",
+    "provider": "mlx-community",
+    "parameter_count": "1026.4B",
+    "parameters_raw": 1026408232448,
+    "min_ram_gb": 573.6,
+    "recommended_ram_gb": 955.9,
+    "min_vram_gb": 525.8,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "kimi_k25",
+    "hf_downloads": 128730,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 384,
+    "active_experts": 8,
+    "active_parameters": 71634741222
   },
   {
     "name": "moonshotai/Kimi-K2-Instruct",
@@ -25012,7 +35474,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "kimi_k2",
-    "hf_downloads": 409282,
+    "hf_downloads": 720892,
     "hf_likes": 2356,
     "release_date": "2025-07-11",
     "num_hidden_layers": 61,
@@ -25045,20 +35507,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kimi_k2",
-    "hf_downloads": 578999,
+    "hf_downloads": 742257,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 384,
     "active_experts": 8,
-    "active_parameters": 71639103404,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2-Instruct-0905-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 71639103404
   },
   {
     "name": "moonshotai/Kimi-K2-Thinking",
@@ -25075,20 +35531,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kimi_k2",
-    "hf_downloads": 109593,
+    "hf_downloads": 156992,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 384,
     "active_experts": 8,
-    "active_parameters": 73847838596,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2-Thinking-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 73847838596
   },
   {
     "name": "moonshotai/Kimi-K2.5",
@@ -25107,8 +35557,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "kimi_k25",
-    "hf_downloads": 4324014,
-    "hf_likes": 2769,
+    "hf_downloads": 1958899,
+    "hf_likes": 2775,
     "release_date": "2026-01-01",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -25140,20 +35590,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kimi_k25",
-    "hf_downloads": 489001,
+    "hf_downloads": 997278,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 384,
     "active_experts": 8,
-    "active_parameters": 73880719970,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2.6-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 73880719970
   },
   {
     "name": "deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -25170,8 +35614,8 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v4",
-    "hf_downloads": 1532,
-    "hf_likes": 234,
+    "hf_downloads": 5033,
+    "hf_likes": 257,
     "release_date": "2026-04-22",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -25181,81 +35625,5 @@
     "num_experts": 384,
     "active_experts": 6,
     "active_parameters": 49000000000
-  },
-  {
-    "name": "shoumenchougou/RWKV7-G1f-1.5B-GGUF",
-    "provider": "RWKV",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1500000000,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "rwkv",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
-  },
-  {
-    "name": "shoumenchougou/RWKV7-G1f-2.9B-GGUF",
-    "provider": "RWKV",
-    "parameter_count": "2.9B",
-    "parameters_raw": 2900000000,
-    "min_ram_gb": 1.6,
-    "recommended_ram_gb": 2.7,
-    "min_vram_gb": 1.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "rwkv",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
-  },
-  {
-    "name": "shoumenchougou/RWKV7-G1f-7.2B-GGUF",
-    "provider": "RWKV",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7200000000,
-    "min_ram_gb": 4.0,
-    "recommended_ram_gb": 6.7,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "rwkv",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
-  },
-  {
-    "name": "shoumenchougou/RWKV7-G1f-13.3B-GGUF",
-    "provider": "RWKV",
-    "parameter_count": "13.3B",
-    "parameters_raw": 13300000000,
-    "min_ram_gb": 7.4,
-    "recommended_ram_gb": 12.4,
-    "min_vram_gb": 6.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "rwkv",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
   }
 ]

--- a/llmfit-core/data/hf_models.json
+++ b/llmfit-core/data/hf_models.json
@@ -1,5 +1,25 @@
 [
   {
+    "name": "echarlaix/tiny-random-PhiForCausalLM",
+    "provider": "echarlaix",
+    "parameter_count": "80K",
+    "parameters_raw": 80074,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 512,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phi",
+    "hf_downloads": 27280,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "peft-internal-testing/tiny-random-GPT2LMHeadModel",
     "provider": "peft-internal-testing",
     "parameter_count": "83K",
@@ -14,7 +34,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 47882,
+    "hf_downloads": 55814,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -34,7 +54,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 183600,
+    "hf_downloads": 144815,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -54,7 +74,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 41149,
+    "hf_downloads": 47224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -80,7 +100,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gptj",
-    "hf_downloads": 50736,
+    "hf_downloads": 59115,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -100,7 +120,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 752450,
+    "hf_downloads": 672103,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -130,7 +150,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 57699,
+    "hf_downloads": 56804,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -162,7 +182,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 37722,
+    "hf_downloads": 47527,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -182,7 +202,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 102471,
+    "hf_downloads": 110905,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -202,7 +222,57 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "opt",
-    "hf_downloads": 534450,
+    "hf_downloads": 615390,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zai-org/AutoGLM-Phone-9B",
+    "provider": "zai-org",
+    "parameter_count": "934K",
+    "parameters_raw": 934400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4v",
+    "hf_downloads": 11047,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "ggml-org/AutoGLM-Phone-9B-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/AutoGLM-Phone-9B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "yujiepan/llama-3-tiny-random",
+    "provider": "yujiepan",
+    "parameter_count": "1M",
+    "parameters_raw": 1026500,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 26255,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -224,7 +294,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 86135,
+    "hf_downloads": 102197,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -244,10 +314,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 2107605,
+    "hf_downloads": 2680224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "optimum-intel-internal-testing/phi-3.5-moe-tiny-random",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "1M",
+    "parameters_raw": 1110112,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phimoe",
+    "hf_downloads": 26578,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 16,
+    "active_experts": 2,
+    "active_parameters": 187329
   },
   {
     "name": "peft-internal-testing/tiny-dummy-qwen2",
@@ -264,7 +358,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 135837,
+    "hf_downloads": 140023,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -284,7 +378,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 29919,
+    "hf_downloads": 42646,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -294,6 +388,32 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "np-cr/testing-qwen3-moe",
+    "provider": "np-cr",
+    "parameter_count": "2M",
+    "parameters_raw": 2435072,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 16435,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 4,
+    "active_experts": 2,
+    "active_parameters": 1278411
   },
   {
     "name": "llamafactory/tiny-random-qwen3",
@@ -312,7 +432,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 127583,
+    "hf_downloads": 143326,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -340,7 +460,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 42319,
+    "hf_downloads": 52729,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -364,10 +484,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 40866,
+    "hf_downloads": 27224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "optimum-intel-internal-testing/tiny-GptOssForCausalLM",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "3M",
+    "parameters_raw": 3431024,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 31895,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 2,
+    "active_parameters": 222479
   },
   {
     "name": "optimum-internal-testing/tiny-random-VisionEncoderDecoderModel-donut",
@@ -386,7 +530,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "vision-encoder-decoder",
-    "hf_downloads": 13749,
+    "hf_downloads": 16387,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "LongSafari/hyenadna-small-32k-seqlen-hf",
+    "provider": "longsafari",
+    "parameter_count": "4M",
+    "parameters_raw": 4069168,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "hyenadna",
+    "hf_downloads": 17181,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -406,10 +570,54 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1387332,
+    "hf_downloads": 1152461,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "optimum-intel-internal-testing/tiny-random-ArceeForCausalLM",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "4M",
+    "parameters_raw": 4129088,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "arcee",
+    "hf_downloads": 31535,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "yujiepan/deepseek-v3-tiny-random",
+    "provider": "yujiepan",
+    "parameter_count": "4M",
+    "parameters_raw": 4347024,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 14035,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 346399
   },
   {
     "name": "Maykeye/TinyLLama-v0",
@@ -426,7 +634,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 204147,
+    "hf_downloads": 136864,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -452,7 +660,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama4",
-    "hf_downloads": 23787,
+    "hf_downloads": 18620,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -460,6 +668,30 @@
     "num_experts": 4,
     "active_experts": 1,
     "active_parameters": 1889362
+  },
+  {
+    "name": "optimum-intel-internal-testing/tiny-random-gpt-oss-mxfp4",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "7M",
+    "parameters_raw": 6865444,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 27150,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 1158540
   },
   {
     "name": "hmellor/tiny-random-Gemma2ForCausalLM",
@@ -476,7 +708,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma2",
-    "hf_downloads": 283772,
+    "hf_downloads": 350161,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -496,7 +728,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "falcon_mamba",
-    "hf_downloads": 40781,
+    "hf_downloads": 51623,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "google/reformer-crime-and-punishment",
+    "provider": "Google",
+    "parameter_count": "11M",
+    "parameters_raw": 11091968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "reformer",
+    "hf_downloads": 92755,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -516,7 +768,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 48556,
+    "hf_downloads": 50854,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -542,39 +794,13 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 178710,
+    "hf_downloads": 178959,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/pythia-14m-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Xenova/llama2.c-stories15M",
-    "provider": "xenova",
-    "parameter_count": "15M",
-    "parameters_raw": 15191712,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 256,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "llama",
-    "hf_downloads": 26912,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llama2.c-stories15M-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -594,7 +820,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bloom",
-    "hf_downloads": 24895,
+    "hf_downloads": 23889,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -620,7 +846,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 84309,
+    "hf_downloads": 73978,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -640,7 +866,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 15713,
+    "hf_downloads": 15289,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -660,7 +886,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 53120,
+    "hf_downloads": 42875,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -686,7 +912,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bamba",
-    "hf_downloads": 303722,
+    "hf_downloads": 380002,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -706,7 +932,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mixtral",
-    "hf_downloads": 98507,
+    "hf_downloads": 100702,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -730,7 +956,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 259322,
+    "hf_downloads": 250266,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -740,6 +966,46 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "JackFram/llama-68m",
+    "provider": "jackfram",
+    "parameter_count": "39M",
+    "parameters_raw": 38731776,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 178907,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "EleutherAI/pythia-14m-deduped",
+    "provider": "eleutherai",
+    "parameter_count": "39M",
+    "parameters_raw": 39233560,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 14852,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/gemma-3-270m-it-qat-MLX-4bit",
@@ -756,7 +1022,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 41334,
+    "hf_downloads": 22818,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -776,10 +1042,36 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 38185,
+    "hf_downloads": 55158,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "distilbert/distilgpt2",
+    "provider": "distilbert",
+    "parameter_count": "88M",
+    "parameters_raw": 88204032,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 2720359,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/distilgpt2-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "EleutherAI/pythia-70m-deduped",
@@ -796,7 +1088,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 1410678,
+    "hf_downloads": 1752140,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -806,6 +1098,66 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "xlnet/xlnet-base-cased",
+    "provider": "xlnet",
+    "parameter_count": "110M",
+    "parameters_raw": 109510656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "xlnet",
+    "hf_downloads": 180001,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ethicalabs/Echo-DSRN-114M-v0.1.2",
+    "provider": "ethicalabs",
+    "parameter_count": "115M",
+    "parameters_raw": 114656768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "echo",
+    "hf_downloads": 24940,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "openai-community/openai-gpt",
+    "provider": "openai-community",
+    "parameter_count": "120M",
+    "parameters_raw": 119680512,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 512,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "openai-gpt",
+    "hf_downloads": 198329,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/gemma-3-270m-it-MLX-8bit",
@@ -822,7 +1174,93 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 32147,
+    "hf_downloads": 20183,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "facebook/opt-125m",
+    "provider": "facebook",
+    "parameter_count": "124M",
+    "parameters_raw": 123543552,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 8164150,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "optimum-intel-internal-testing/opt-125m",
+    "provider": "optimum-intel-internal-testing",
+    "parameter_count": "124M",
+    "parameters_raw": 123543552,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 62305,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "EleutherAI/pythia-160m",
+    "provider": "eleutherai",
+    "parameter_count": "124M",
+    "parameters_raw": 123568128,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 3155849,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/pythia-160m-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "gratefulasi/lumeleto",
+    "provider": "gratefulasi",
+    "parameter_count": "124M",
+    "parameters_raw": 124439808,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 15496,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -842,7 +1280,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "opt",
-    "hf_downloads": 199043,
+    "hf_downloads": 227714,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -862,7 +1300,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mamba",
-    "hf_downloads": 314035,
+    "hf_downloads": 389338,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -888,7 +1326,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1407123,
+    "hf_downloads": 1492003,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -922,7 +1360,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1224827,
+    "hf_downloads": 1160430,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -948,7 +1386,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 153128,
+    "hf_downloads": 148127,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -974,7 +1412,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 32797,
+    "hf_downloads": 37108,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -984,6 +1422,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "modularai/SmolLM-135M-Instruct-FP32",
+    "provider": "modularai",
+    "parameter_count": "135M",
+    "parameters_raw": 134515008,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14152,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "nomic-ai/nomic-embed-text-v1.5",
@@ -1000,8 +1458,8 @@
     "capabilities": [],
     "pipeline_tag": "sentence-similarity",
     "architecture": "nomic_bert",
-    "hf_downloads": 13883372,
-    "hf_likes": 807,
+    "hf_downloads": 15512738,
+    "hf_likes": 812,
     "release_date": "2024-02-10",
     "num_hidden_layers": 12,
     "num_attention_heads": 12,
@@ -1013,6 +1471,78 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "openai-community/gpt2",
+    "provider": "openai-community",
+    "parameter_count": "137M",
+    "parameters_raw": 137022720,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 15627413,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/gpt2-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Gustavosta/MagicPrompt-Stable-Diffusion",
+    "provider": "gustavosta",
+    "parameter_count": "137M",
+    "parameters_raw": 137022720,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 23714,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/MagicPrompt-Stable-Diffusion-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "aubmindlab/aragpt2-base",
+    "provider": "aubmindlab",
+    "parameter_count": "148M",
+    "parameters_raw": 147577344,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 31806,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "EleutherAI/gpt-neo-125m",
@@ -1029,7 +1559,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neo",
-    "hf_downloads": 467624,
+    "hf_downloads": 465905,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hugohrban/progen2-small",
+    "provider": "hugohrban",
+    "parameter_count": "151M",
+    "parameters_raw": 151148576,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "progen",
+    "hf_downloads": 22487,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1049,7 +1599,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 31001,
+    "hf_downloads": 33478,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "FrontiersMind/Nandi-Mini-150M-Instruct",
+    "provider": "frontiersmind",
+    "parameter_count": "153M",
+    "parameters_raw": 153412928,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nandi",
+    "hf_downloads": 14188,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1069,7 +1639,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 75763,
+    "hf_downloads": 97381,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1089,7 +1659,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_bigcode",
-    "hf_downloads": 123027,
+    "hf_downloads": 203309,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1115,7 +1685,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 68858,
+    "hf_downloads": 68441,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1135,7 +1705,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2",
-    "hf_downloads": 144676,
+    "hf_downloads": 136888,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "183M",
+    "parameters_raw": 182975232,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 62354,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1155,7 +1745,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt2",
-    "hf_downloads": 44767,
+    "hf_downloads": 21070,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "193M",
+    "parameters_raw": 193153024,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 67529,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1175,7 +1787,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 87163,
+    "hf_downloads": 128887,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "KomeijiForce/bart-large-emojilm",
+    "provider": "komeijiforce",
+    "parameter_count": "205M",
+    "parameters_raw": 204747776,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "bart",
+    "hf_downloads": 609036,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1195,7 +1827,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 88866,
+    "hf_downloads": 99096,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1205,6 +1837,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "nvidia/gpt-oss-120b-Eagle3-long-context",
+    "provider": "nvidia",
+    "parameter_count": "215M",
+    "parameters_raw": 215481600,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15250,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "humarin/chatgpt_paraphraser_on_T5_base",
@@ -1221,7 +1873,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 232268,
+    "hf_downloads": 359668,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1241,7 +1893,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 40950,
+    "hf_downloads": 33206,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1267,7 +1919,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 107070,
+    "hf_downloads": 119921,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1287,7 +1939,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 23035,
+    "hf_downloads": 27208,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1307,7 +1959,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 671671,
+    "hf_downloads": 1326276,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1327,7 +1979,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 49818,
+    "hf_downloads": 53695,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1347,7 +1999,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mixtral",
-    "hf_downloads": 104322,
+    "hf_downloads": 114610,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1355,6 +2007,46 @@
     "num_experts": 8,
     "active_experts": 2,
     "active_parameters": 71001329
+  },
+  {
+    "name": "nm-testing/tinyllama-oneshot-w4a16-channel-v2",
+    "provider": "nm-testing",
+    "parameter_count": "253M",
+    "parameters_raw": 252669236,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14216,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "BabyLM-community/babylm-multimodal-baseline-flamingo",
+    "provider": "babylm-community",
+    "parameter_count": "255M",
+    "parameters_raw": 255487500,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 15051,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/LFM2.5-1.2B-Instruct-MLX-6bit",
@@ -1371,7 +2063,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2",
-    "hf_downloads": 144362,
+    "hf_downloads": 136473,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1391,7 +2083,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics3",
-    "hf_downloads": 615462,
+    "hf_downloads": 723770,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1421,7 +2113,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "smolvlm",
-    "hf_downloads": 119300,
+    "hf_downloads": 117565,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1451,13 +2143,39 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics3",
-    "hf_downloads": 101891,
+    "hf_downloads": 232199,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "ggml-org/granite-docling-258M-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
+  },
+  {
+    "name": "google/gemma-3-270m",
+    "provider": "Google",
+    "parameter_count": "268M",
+    "parameters_raw": 268098176,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 546009,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "ggml-org/gemma-3-270m-GGUF",
         "provider": "ggml-org"
       }
     ]
@@ -1477,40 +2195,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 454416,
+    "hf_downloads": 187065,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "google/gemma-3-270m",
-    "provider": "Google",
-    "parameter_count": "268M",
-    "parameters_raw": 268098176,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma3_text",
-    "hf_downloads": 99776,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/gemma-3-270m-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
-  },
-  {
-    "name": "jakobhuss/pii-extractor-gemma-3-270m-it",
-    "provider": "jakobhuss",
+    "name": "unsloth/gemma-3-270m-it",
+    "provider": "unsloth",
     "parameter_count": "268M",
     "parameters_raw": 268098176,
     "min_ram_gb": 1.0,
@@ -1525,10 +2217,20 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 78088,
+    "hf_downloads": 25862,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3-270m-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3-270m-it-GGUF",
+        "provider": "ggml-org"
+      }
+    ]
   },
   {
     "name": "lmstudio-community/Qwen3-1.7B-MLX-4bit",
@@ -1547,7 +2249,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 28937,
+    "hf_downloads": 29921,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1567,7 +2269,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 38465,
+    "hf_downloads": 28829,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1587,10 +2289,60 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 37281,
+    "hf_downloads": 27756,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/gemma-3-270m-it-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "271M",
+    "parameters_raw": 271190048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 17634,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "baidu/ERNIE-4.5-0.3B-PT",
+    "provider": "baidu",
+    "parameter_count": "295M",
+    "parameters_raw": 294649856,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ernie4_5",
+    "hf_downloads": 18981,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/ERNIE-4.5-0.3B-PT-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/ERNIE-4.5-0.3B-PT-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "vikp/texify",
@@ -1607,7 +2359,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "vision-encoder-decoder",
-    "hf_downloads": 171349,
+    "hf_downloads": 162708,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1627,10 +2379,70 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5gemma",
-    "hf_downloads": 1344302,
+    "hf_downloads": 1519260,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "HuggingFaceTB/SmolLM2-360M-Instruct",
+    "provider": "huggingfacetb",
+    "parameter_count": "322M",
+    "parameters_raw": 322437119,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 186418,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/SmolLM2-360M-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/SmolLM2-360M-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/SmolLM2-360M-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "HuggingFaceTB/SmolLM-360M",
+    "provider": "huggingfacetb",
+    "parameter_count": "322M",
+    "parameters_raw": 322437119,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 17903,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/SmolLM-360M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "lmstudio-community/LFM2.5-1.2B-Instruct-MLX-8bit",
@@ -1647,7 +2459,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2",
-    "hf_downloads": 147277,
+    "hf_downloads": 138933,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/LFM2-1.2B-MLX-8bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "329M",
+    "parameters_raw": 329251584,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 24881,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1667,8 +2499,8 @@
     "capabilities": [],
     "pipeline_tag": "feature-extraction",
     "architecture": "bert",
-    "hf_downloads": 12920790,
-    "hf_likes": 654,
+    "hf_downloads": 15072818,
+    "hf_likes": 657,
     "release_date": "2023-09-12",
     "num_hidden_layers": 24,
     "num_attention_heads": 16,
@@ -1680,6 +2512,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "microsoft/biogpt",
+    "provider": "Microsoft",
+    "parameter_count": "345M",
+    "parameters_raw": 345391104,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "biogpt",
+    "hf_downloads": 120393,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "ibm-granite/granite-4.0-350m",
@@ -1696,7 +2548,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granitemoehybrid",
-    "hf_downloads": 74355,
+    "hf_downloads": 56806,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1706,6 +2558,26 @@
         "provider": "unsloth"
       }
     ]
+  },
+  {
+    "name": "ibm-granite/granite-4.0-350m-base",
+    "provider": "ibm-granite",
+    "parameter_count": "352M",
+    "parameters_raw": 352379904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 16826,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LiquidAI/LFM2-ColBERT-350M",
@@ -1722,13 +2594,33 @@
     "capabilities": [],
     "pipeline_tag": "sentence-similarity",
     "architecture": "lfm2",
-    "hf_downloads": 78115,
-    "hf_likes": 129,
+    "hf_downloads": 93350,
+    "hf_likes": 130,
     "release_date": "2025-10-28",
     "num_hidden_layers": 16,
     "num_attention_heads": 16,
     "num_key_value_heads": 8,
     "head_dim": 64
+  },
+  {
+    "name": "facebook/opt-350m",
+    "provider": "facebook",
+    "parameter_count": "353M",
+    "parameters_raw": 353468416,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 143020,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LiquidAI/LFM2-350M",
@@ -1745,7 +2637,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 25656,
+    "hf_downloads": 21730,
     "hf_likes": 249,
     "release_date": "2025-07-10",
     "num_hidden_layers": 16,
@@ -1778,7 +2670,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 1669,
+    "hf_downloads": 1232,
     "hf_likes": 78,
     "release_date": "2025-09-03",
     "num_hidden_layers": 16,
@@ -1807,8 +2699,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 612,
-    "hf_likes": 58,
+    "hf_downloads": 455,
+    "hf_likes": 59,
     "release_date": "2025-08-25",
     "num_hidden_layers": 16,
     "num_attention_heads": 16,
@@ -1836,7 +2728,7 @@
     "capabilities": [],
     "pipeline_tag": "translation",
     "architecture": "lfm2",
-    "hf_downloads": 1376,
+    "hf_downloads": 1236,
     "hf_likes": 88,
     "release_date": "2025-09-03",
     "num_hidden_layers": 16,
@@ -1865,8 +2757,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 1169,
-    "hf_likes": 54,
+    "hf_downloads": 650,
+    "hf_likes": 55,
     "release_date": "2025-09-30",
     "num_hidden_layers": 16,
     "num_attention_heads": 16,
@@ -1878,6 +2770,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "distil-labs/distil-lfm25-shellper",
+    "provider": "distil-labs",
+    "parameter_count": "354M",
+    "parameters_raw": 354483968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 173425,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LiquidAI/LFM2.5-350M",
@@ -1894,7 +2806,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2",
-    "hf_downloads": 58272,
+    "hf_downloads": 102541,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1920,7 +2832,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 165142,
+    "hf_downloads": 165225,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -1946,13 +2858,39 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 61852,
+    "hf_downloads": 68732,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/SmolLM2-360M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "openai-community/gpt2-medium",
+    "provider": "openai-community",
+    "parameter_count": "380M",
+    "parameters_raw": 379988992,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 815458,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/gpt2-medium-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -1972,7 +2910,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 55201,
+    "hf_downloads": 31325,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -1992,7 +2930,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 54845,
+    "hf_downloads": 66037,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2018,10 +2956,166 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 57934,
+    "hf_downloads": 85987,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2-0.5B",
+    "provider": "Alibaba",
+    "parameter_count": "422M",
+    "parameters_raw": 422395904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 441313,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen2-0.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "onnx-community/Qwen2.5-0.5B-Instruct",
+    "provider": "onnx-community",
+    "parameter_count": "422M",
+    "parameters_raw": 422395904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 47738,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mlx-community/Qwen2.5-0.5B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "422M",
+    "parameters_raw": 422395904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14783,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/SmolLM-1.7B-Instruct-quantized.w4a16",
+    "provider": "nm-testing",
+    "parameter_count": "428M",
+    "parameters_raw": 427919696,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 400467,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "openbmb/MiniCPM4-0.5B",
+    "provider": "openbmb",
+    "parameter_count": "434M",
+    "parameters_raw": 433873920,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 31985,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/MiniCPM4-0.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "allenai/OLMoE-1B-7B-0924",
+    "provider": "allenai",
+    "parameter_count": "439M",
+    "parameters_raw": 438566912,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmoe",
+    "hf_downloads": 100836,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 8,
+    "active_parameters": 74008161,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/OLMoE-1B-7B-0924-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "LiquidAI/LFM2.5-VL-450M",
@@ -2040,7 +3134,171 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_vl",
-    "hf_downloads": 32493,
+    "hf_downloads": 49341,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ",
+    "provider": "mlx-community",
+    "parameter_count": "449M",
+    "parameters_raw": 448910336,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Text embeddings for RAG",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 33642,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "farbodtavakkoli/OTel-LLM-0.6B-IT",
+    "provider": "farbodtavakkoli",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 428160,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-0.6B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 278305,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-0.6B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen3-0.6B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 151601,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-0.6B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 75863,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-0.6B-Base",
+    "provider": "unsloth",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 16630,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-0.6B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mlx-community/Qwen3-0.6B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "449M",
+    "parameters_raw": 449183744,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 16394,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2062,8 +3320,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "lfm2_vl",
-    "hf_downloads": 54869,
-    "hf_likes": 146,
+    "hf_downloads": 80248,
+    "hf_likes": 147,
     "release_date": "2025-08-12",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -2076,6 +3334,32 @@
       },
       {
         "repo": "mradermacher/LFM2-VL-450M-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "numind/NuExtract-tiny",
+    "provider": "numind",
+    "parameter_count": "464M",
+    "parameters_raw": 463987712,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 18952,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/NuExtract-tiny-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -2097,7 +3381,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 30002,
+    "hf_downloads": 54117,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2119,7 +3403,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 30196,
+    "hf_downloads": 31075,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2141,7 +3425,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 6089483,
+    "hf_downloads": 6054782,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2173,7 +3457,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1825184,
+    "hf_downloads": 2155138,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2199,7 +3483,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 645643,
+    "hf_downloads": 909889,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2231,7 +3515,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 245178,
+    "hf_downloads": 183161,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2246,6 +3530,66 @@
       },
       {
         "repo": "mradermacher/Qwen2.5-Coder-0.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen2.5-0.5B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "494M",
+    "parameters_raw": 494032768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 130765,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-0.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen2.5-0.5B",
+    "provider": "unsloth",
+    "parameter_count": "494M",
+    "parameters_raw": 494032768,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 63502,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen2.5-0.5B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -2267,7 +3611,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 48075,
+    "hf_downloads": 48293,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2289,7 +3633,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 31416,
+    "hf_downloads": 36504,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2303,6 +3647,72 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "502M",
+    "parameters_raw": 502139904,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 42575,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-0.5B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "504M",
+    "parameters_raw": 503634940,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 48809,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-0.5B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "504M",
+    "parameters_raw": 503986238,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 175675,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "EleutherAI/pythia-410m",
@@ -2319,13 +3729,39 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 167504,
+    "hf_downloads": 177834,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/pythia-410m-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "EleutherAI/pythia-410m-deduped",
+    "provider": "eleutherai",
+    "parameter_count": "506M",
+    "parameters_raw": 505997504,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 25502,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/pythia-410m-deduped-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -2345,7 +3781,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics3",
-    "hf_downloads": 107458,
+    "hf_downloads": 156931,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2375,13 +3811,93 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 57488,
+    "hf_downloads": 59169,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/TIPO-500M-ft-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "KBlueLeaf/TIPO-500M",
+    "provider": "kblueleaf",
+    "parameter_count": "508M",
+    "parameters_raw": 507989760,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14894,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "h2oai/h2o-danube3-500m-chat",
+    "provider": "h2oai",
+    "parameter_count": "514M",
+    "parameters_raw": 513590784,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 18395,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/h2o-danube3-500m-chat-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/h2o-danube3-500m-chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "ibm-granite/granite-4.0-tiny-preview",
+    "provider": "ibm-granite",
+    "parameter_count": "516M",
+    "parameters_raw": 515911680,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 73832,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 62,
+    "active_experts": 6,
+    "active_parameters": 73226172,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/granite-4.0-tiny-preview-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -2401,7 +3917,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "falcon_h1",
-    "hf_downloads": 52520,
+    "hf_downloads": 63468,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2429,7 +3945,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 118024,
+    "hf_downloads": 74883,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "z-lab/Qwen3.5-4B-DFlash",
+    "provider": "z-lab",
+    "parameter_count": "537M",
+    "parameters_raw": 537427200,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 19732,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2449,7 +3987,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granite",
-    "hf_downloads": 56797,
+    "hf_downloads": 80205,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2469,7 +4007,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bloom",
-    "hf_downloads": 1281786,
+    "hf_downloads": 1175131,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2495,7 +4033,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bloom",
-    "hf_downloads": 295175,
+    "hf_downloads": 408630,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2521,7 +4059,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "got_ocr2",
-    "hf_downloads": 28321,
+    "hf_downloads": 30400,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2543,7 +4081,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 71933,
+    "hf_downloads": 75058,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2563,7 +4101,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5gemma",
-    "hf_downloads": 39991,
+    "hf_downloads": 36436,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2583,7 +4121,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 52069,
+    "hf_downloads": 54293,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2603,7 +4141,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 81474,
+    "hf_downloads": 82366,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2629,7 +4167,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 33430,
+    "hf_downloads": 44349,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2639,6 +4177,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "KamilaMila/FastVLM-0.5B",
+    "provider": "kamilamila",
+    "parameter_count": "620M",
+    "parameters_raw": 620397152,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "fast_vlm",
+    "hf_downloads": 10046,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/Qwen3-4B-Thinking-2507-MLX-4bit",
@@ -2657,7 +4215,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 69266,
+    "hf_downloads": 67500,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2679,7 +4237,111 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 60275,
+    "hf_downloads": 59335,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Qwen3-4B-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "629M",
+    "parameters_raw": 628676096,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 22287,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3-4B-Instruct-2507-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "629M",
+    "parameters_raw": 628676096,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17205,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "prism-ml/Ternary-Bonsai-8B-mlx-2bit",
+    "provider": "prism-ml",
+    "parameter_count": "640M",
+    "parameters_raw": 640014464,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 20044,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hyper-accel/ci-random-llama2-7b",
+    "provider": "hyper-accel",
+    "parameter_count": "667M",
+    "parameters_raw": 666914816,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 20286,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "yuhuili/EAGLE-LLaMA3-Instruct-8B",
+    "provider": "yuhuili",
+    "parameter_count": "710M",
+    "parameters_raw": 709885952,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 101493,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2699,7 +4361,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "udop",
-    "hf_downloads": 73565,
+    "hf_downloads": 75386,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2719,8 +4381,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 10246,
-    "hf_likes": 110,
+    "hf_downloads": 9487,
+    "hf_likes": 111,
     "release_date": "2025-07-10",
     "num_hidden_layers": 16,
     "num_attention_heads": 24,
@@ -2730,6 +4392,32 @@
       {
         "repo": "unsloth/LFM2-700M-GGUF",
         "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "Etherll/Tashkeel-700M",
+    "provider": "etherll",
+    "parameter_count": "742M",
+    "parameters_raw": 742489344,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 22699,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Tashkeel-700M-GGUF",
+        "provider": "mradermacher"
       }
     ]
   },
@@ -2750,8 +4438,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3",
-    "hf_downloads": 18497766,
-    "hf_likes": 1215,
+    "hf_downloads": 19084802,
+    "hf_likes": 1224,
     "release_date": "2025-04-27",
     "num_hidden_layers": 28,
     "num_attention_heads": 16,
@@ -2789,7 +4477,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 340288,
+    "hf_downloads": 1735643,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2817,7 +4505,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 24923,
+    "hf_downloads": 22403,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -2853,7 +4541,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 1885388,
+    "hf_downloads": 2219177,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2875,7 +4563,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 57594,
+    "hf_downloads": 57352,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "apple/FastVLM-0.5B",
+    "provider": "apple",
+    "parameter_count": "759M",
+    "parameters_raw": 758833760,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llava_qwen2",
+    "hf_downloads": 15319,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2895,7 +4603,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 32903,
+    "hf_downloads": 24948,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2915,7 +4623,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 58868,
+    "hf_downloads": 78588,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2935,7 +4643,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "florence2",
-    "hf_downloads": 870915,
+    "hf_downloads": 666627,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2955,10 +4663,36 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5gemma2",
-    "hf_downloads": 23408,
+    "hf_downloads": 22291,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "openai-community/gpt2-large",
+    "provider": "openai-community",
+    "parameter_count": "812M",
+    "parameters_raw": 811778816,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 2153999,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/gpt2-large-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "h2oai/h2ovl-mississippi-800m",
@@ -2975,7 +4709,67 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "h2ovl_chat",
-    "hf_downloads": 944582,
+    "hf_downloads": 992556,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "microsoft/bitnet-b1.58-2B-4T",
+    "provider": "Microsoft",
+    "parameter_count": "850M",
+    "parameters_raw": 849787090,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "bitnet",
+    "hf_downloads": 17655,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/gemma-3-1b-it-qat-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "854M",
+    "parameters_raw": 854065152,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 91751,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/gemma-3-1b-it-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "854M",
+    "parameters_raw": 854065152,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 60775,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -2995,7 +4789,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 35731,
+    "hf_downloads": 61231,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3017,7 +4811,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 195262,
+    "hf_downloads": 126211,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3040,8 +4834,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 2956012,
-    "hf_likes": 512,
+    "hf_downloads": 3031961,
+    "hf_likes": 523,
     "release_date": "2026-02-28",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -3051,6 +4845,10 @@
       {
         "repo": "unsloth/Qwen3.5-0.8B-GGUF",
         "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/Qwen3.5-0.8B-GGUF",
+        "provider": "ggml-org"
       },
       {
         "repo": "mradermacher/Qwen3.5-0.8B-GGUF",
@@ -3076,14 +4874,18 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 136205,
-    "hf_likes": 70,
+    "hf_downloads": 153434,
+    "hf_likes": 73,
     "release_date": "2026-02-28",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
     "head_dim": null,
     "gguf_sources": [
+      {
+        "repo": "ggml-org/Qwen3.5-0.8B-Base-GGUF",
+        "provider": "ggml-org"
+      },
       {
         "repo": "mradermacher/Qwen3.5-0.8B-Base-GGUF",
         "provider": "mradermacher"
@@ -3107,7 +4909,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 67135,
+    "hf_downloads": 65451,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3129,7 +4931,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 57680,
+    "hf_downloads": 57438,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3151,10 +4953,36 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_onevision",
-    "hf_downloads": 489465,
+    "hf_downloads": 556065,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "EleutherAI/pythia-1b-deduped",
+    "provider": "eleutherai",
+    "parameter_count": "908M",
+    "parameters_raw": 908328960,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 25695,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/pythia-1b-deduped-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "turing-motors/Heron-NVILA-Lite-1B-hf",
@@ -3171,7 +4999,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "heron",
-    "hf_downloads": 23197,
+    "hf_downloads": 17645,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3191,7 +5019,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_parse",
-    "hf_downloads": 13119,
+    "hf_downloads": 20528,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3211,7 +5039,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 550976,
+    "hf_downloads": 650514,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3237,7 +5065,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl",
-    "hf_downloads": 222577,
+    "hf_downloads": 250861,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3257,7 +5085,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 130361,
+    "hf_downloads": 132673,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3287,7 +5115,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 11813,
+    "hf_downloads": 10310,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3301,6 +5129,130 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
+    "provider": "Community",
+    "parameter_count": "942M",
+    "parameters_raw": 942145536,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 99595,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/TinyLlama-1.1B-intermediate-step-1431k-3T-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/TinyLlama-1.1B-intermediate-step-1431k-3T-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "TinyLlama/TinyLlama_v1.1",
+    "provider": "Community",
+    "parameter_count": "942M",
+    "parameters_raw": 942145536,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 32690,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/TinyLlama_v1.1-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lightblue/karasu-1.1B",
+    "provider": "lightblue",
+    "parameter_count": "942M",
+    "parameters_raw": 942145536,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 20191,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/karasu-1.1B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "LnL-AI/TinyLlama-1.1B-Chat-v1.0-GPTQ-4bit",
+    "provider": "lnl-ai",
+    "parameter_count": "942M",
+    "parameters_raw": 942145536,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 18273,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3",
+    "provider": "redhatai",
+    "parameter_count": "950M",
+    "parameters_raw": 950186496,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 25867,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "PaddlePaddle/PaddleOCR-VL-1.5",
@@ -3319,7 +5271,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "paddleocr_vl",
-    "hf_downloads": 138714,
+    "hf_downloads": 91160,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3339,7 +5291,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hunyuan_vl",
-    "hf_downloads": 184491,
+    "hf_downloads": 196515,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3371,13 +5323,49 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "gemma3_text",
-    "hf_downloads": 531764,
-    "hf_likes": 936,
+    "hf_downloads": 581880,
+    "hf_likes": 945,
     "release_date": "2025-03-10",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
     "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gemma-3-1b-it-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "ggml-org/gemma-3-1b-it-GGUF",
+        "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/gemma-3-1b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/gemma-3-1b-it",
+    "provider": "unsloth",
+    "parameter_count": "1000M",
+    "parameters_raw": 999885952,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 216040,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
     "gguf_sources": [
       {
         "repo": "unsloth/gemma-3-1b-it-GGUF",
@@ -3408,7 +5396,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 517843,
+    "hf_downloads": 192306,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3428,7 +5416,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral3",
-    "hf_downloads": 831415,
+    "hf_downloads": 753437,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3442,6 +5430,106 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "deepseek-ai/deepseek-coder-1.3b-instruct",
+    "provider": "DeepSeek",
+    "parameter_count": "1.0B",
+    "parameters_raw": 1009778688,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 40023,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/deepseek-coder-1.3b-instruct-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/deepseek-coder-1.3b-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "deepseek-ai/deepseek-coder-1.3b-base",
+    "provider": "DeepSeek",
+    "parameter_count": "1.0B",
+    "parameters_raw": 1009778688,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21767,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "TheBloke/deepseek-coder-1.3b-base-GGUF",
+        "provider": "TheBloke"
+      },
+      {
+        "repo": "mradermacher/deepseek-coder-1.3b-base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/gemma-3-1b-it-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.0B",
+    "parameters_raw": 1021095818,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 26147,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mtgv/MobileLLaMA-1.4B-Chat",
+    "provider": "mtgv",
+    "parameter_count": "1.0B",
+    "parameters_raw": 1021837312,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 189841,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "RedHatAI/Qwen3-8B-speculator.eagle3",
@@ -3460,7 +5548,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 70275,
+    "hf_downloads": 71052,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3483,7 +5571,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 176830,
+    "hf_downloads": 172929,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3505,7 +5593,99 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 29000,
+    "hf_downloads": 40965,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ByteDance/Ouro-1.4B",
+    "provider": "bytedance",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1056964608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ouro",
+    "hf_downloads": 44647,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "argilla/Llama-3.2-1B-Instruct-APIGen-FC-v0.1",
+    "provider": "argilla",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1067974656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 49099,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-1B-Instruct-APIGen-FC-v0.1-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "argilla-warehouse/Llama-3.2-1B-Instruct-v2-FC",
+    "provider": "argilla-warehouse",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1067974656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 48326,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1067974656,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 31595,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3525,7 +5705,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 110269,
+    "hf_downloads": 112704,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3551,8 +5731,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 3172589,
-    "hf_likes": 1575,
+    "hf_downloads": 3046637,
+    "hf_likes": 1578,
     "release_date": "2023-12-30",
     "num_hidden_layers": 22,
     "num_attention_heads": 32,
@@ -3584,7 +5764,47 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 58094,
+    "hf_downloads": 160504,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TinyLlama/TinyLlama-1.1B-step-50K-105b",
+    "provider": "Community",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100048384,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15694,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/tinyllama-oneshot-w8a8-dynamic-token-v2",
+    "provider": "nm-testing",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100048538,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14306,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3604,7 +5824,113 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 44840,
+    "hf_downloads": 55586,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "QuixiAI/TinyDolphin-2.8-1.1b",
+    "provider": "quixiai",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100056576,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16527,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/TinyDolphin-2.8-1.1b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "TheBloke/TinyLlama-1.1B-Chat-v0.3-AWQ",
+    "provider": "thebloke",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100060672,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 84806,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/TinyLlama-1.1B-Chat-v1.0-GPTQ",
+    "provider": "thebloke",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100442624,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 90179,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/tinyllama-oneshot-w8a8-channel-dynamic-token-v2",
+    "provider": "nm-testing",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100442624,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 18987,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/TinyLlama-1.1B-Chat-v0.3-GPTQ",
+    "provider": "thebloke",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1100454912,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 804521,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3624,7 +5950,47 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_bigcode",
-    "hf_downloads": 41852,
+    "hf_downloads": 41618,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/tinyllama-chat-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1130479622,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13566,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/tinyllama-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1130479968,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 57465,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3646,7 +6012,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 68335,
+    "hf_downloads": 66476,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3668,7 +6034,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 58808,
+    "hf_downloads": 58374,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Qwen3-4B-MLX-8bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "1.1B",
+    "parameters_raw": 1131460096,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 20914,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3688,7 +6076,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 1564624,
+    "hf_downloads": 1487774,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3714,7 +6102,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 43480,
+    "hf_downloads": 155419,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -3743,7 +6131,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 168337,
+    "hf_downloads": 164425,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -3763,7 +6151,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 58765,
+    "hf_downloads": 71913,
     "hf_likes": 352,
     "release_date": "2025-07-10",
     "num_hidden_layers": 16,
@@ -3792,8 +6180,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 22079,
-    "hf_likes": 124,
+    "hf_downloads": 19193,
+    "hf_likes": 125,
     "release_date": "2026-01-05",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3821,8 +6209,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 424907,
-    "hf_likes": 574,
+    "hf_downloads": 408739,
+    "hf_likes": 580,
     "release_date": "2026-01-06",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3854,8 +6242,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 28913,
-    "hf_likes": 335,
+    "hf_downloads": 37247,
+    "hf_likes": 341,
     "release_date": "2026-01-20",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3887,7 +6275,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 1904,
+    "hf_downloads": 2542,
     "hf_likes": 145,
     "release_date": "2026-01-04",
     "num_hidden_layers": 16,
@@ -3916,8 +6304,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 772,
-    "hf_likes": 102,
+    "hf_downloads": 727,
+    "hf_likes": 103,
     "release_date": "2025-09-03",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3945,7 +6333,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 873,
+    "hf_downloads": 688,
     "hf_likes": 118,
     "release_date": "2025-09-03",
     "num_hidden_layers": 16,
@@ -3974,8 +6362,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 1775,
-    "hf_likes": 107,
+    "hf_downloads": 2418,
+    "hf_likes": 108,
     "release_date": "2025-08-22",
     "num_hidden_layers": 16,
     "num_attention_heads": 32,
@@ -3984,6 +6372,56 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/LFM2-1.2B-Extract-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lmstudio-community/LFM2-1.2B-MLX-bf16",
+    "provider": "lmstudio-community",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1170340608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 24610,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tiiuae/Falcon3-1B-Base",
+    "provider": "TII",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1174405120,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15515,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Falcon3-1B-Base-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Falcon3-1B-Base-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4003,13 +6441,61 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo",
-    "hf_downloads": 30889,
+    "hf_downloads": 35054,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/OLMo-1B-hf-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lmstudio-community/Qwen2.5-Coder-7B-Instruct-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1190221312,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 19176,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "farbodtavakkoli/OTel-LLM-1.2B-IT",
+    "provider": "farbodtavakkoli",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1207959552,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "lfm2",
+    "hf_downloads": 620610,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/OTel-LLM-1.2B-IT-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4029,7 +6515,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "zamba2",
-    "hf_downloads": 132669,
+    "hf_downloads": 166109,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4049,8 +6535,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 1337696,
-    "hf_likes": 2375,
+    "hf_downloads": 1596915,
+    "hf_likes": 2378,
     "release_date": "2024-09-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -4080,7 +6566,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 5344861,
+    "hf_downloads": 6482378,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4114,7 +6600,91 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ilama",
-    "hf_downloads": 153404,
+    "hf_downloads": 199931,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 191141,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Llama-3.2-1B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/Llama-3.2-1B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Llama-3.2-1B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B",
+    "provider": "unsloth",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 80999,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-1B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "ShahriarFerdoush/llama-3.2-1b-code-instruct",
+    "provider": "shahriarferdoush",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 49750,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4136,7 +6706,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 63482,
+    "hf_downloads": 49094,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4156,7 +6726,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 56558,
+    "hf_downloads": 47895,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4182,7 +6752,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 56330,
+    "hf_downloads": 47736,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4192,28 +6762,6 @@
         "provider": "mradermacher"
       }
     ]
-  },
-  {
-    "name": "ShahriarFerdoush/llama-3.2-1b-code-instruct",
-    "provider": "shahriarferdoush",
-    "parameter_count": "1.2B",
-    "parameters_raw": 1235814400,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 1048576,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "llama",
-    "hf_downloads": 53982,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
   },
   {
     "name": "Vikhrmodels/Vikhr-Llama-3.2-1B-Instruct",
@@ -4232,13 +6780,39 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 51769,
+    "hf_downloads": 47707,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/Vikhr-Llama-3.2-1B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "NousResearch/Llama-3.2-1B",
+    "provider": "NousResearch",
+    "parameter_count": "1.2B",
+    "parameters_raw": 1235814400,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14836,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-1B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4258,7 +6832,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 49154,
+    "hf_downloads": 47914,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4268,6 +6842,28 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "RedHatAI/Qwen3-4B-quantized.w4a16",
+    "provider": "redhatai",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1260658680,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 20614,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-4B-Instruct-2507-AWQ-4bit",
@@ -4286,7 +6882,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 72297,
+    "hf_downloads": 150384,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4306,7 +6902,71 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 62514,
+    "hf_downloads": 21835,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1264773664,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15141,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1264773672,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 86227,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-1B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1266351458,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 28789,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4326,7 +6986,79 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis",
-    "hf_downloads": 57411,
+    "hf_downloads": 76079,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen1.5-MoE-A2.7B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1267466240,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_moe",
+    "hf_downloads": 47156,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 60,
+    "active_experts": 4,
+    "active_parameters": 143646172
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-1.5B",
+    "provider": "Alibaba",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1268318208,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 589942,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen2.5-Coder-1.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1268318208,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 88788,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4346,7 +7078,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "exaone4",
-    "hf_downloads": 21111,
+    "hf_downloads": 16428,
     "hf_likes": 181,
     "release_date": "2025-07-11",
     "num_hidden_layers": 30,
@@ -4377,7 +7109,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 396618,
+    "hf_downloads": 442980,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4399,7 +7131,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 27893,
+    "hf_downloads": 28326,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Josiefied-Qwen3-8B-abliterated-v1-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1280062464,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17444,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4419,7 +7173,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "plamo2",
-    "hf_downloads": 61967,
+    "hf_downloads": 48687,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4442,7 +7196,81 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 168415,
+    "hf_downloads": 164460,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "HuggingFaceTB/SmolLM2-1.7B-Instruct",
+    "provider": "huggingfacetb",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1308622848,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 166113,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/SmolLM2-1.7B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "bartowski/SmolLM2-1.7B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/SmolLM2-1.7B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "facebook/opt-1.3b",
+    "provider": "facebook",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1310916608,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 213528,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tiiuae/falcon-rw-1b",
+    "provider": "TII",
+    "parameter_count": "1.3B",
+    "parameters_raw": 1310982144,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "falcon",
+    "hf_downloads": 24969,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4462,7 +7290,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "moondream1",
-    "hf_downloads": 18281,
+    "hf_downloads": 19517,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "fla-hub/transformer-1.3B-100B",
+    "provider": "fla-hub",
+    "parameter_count": "1.4B",
+    "parameters_raw": 1364297728,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "transformer",
+    "hf_downloads": 14737,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4482,7 +7330,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neo",
-    "hf_downloads": 32065,
+    "hf_downloads": 33410,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4502,7 +7350,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granitemoe",
-    "hf_downloads": 52680,
+    "hf_downloads": 68947,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4513,6 +7361,32 @@
     "gguf_sources": [
       {
         "repo": "mradermacher/granite-3.0-1b-a400m-base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "EleutherAI/pythia-1.4b-deduped",
+    "provider": "eleutherai",
+    "parameter_count": "1.4B",
+    "parameters_raw": 1414647808,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 18122,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/pythia-1.4b-deduped-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4532,7 +7406,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi",
-    "hf_downloads": 77774,
+    "hf_downloads": 71891,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4558,7 +7432,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "starvector",
-    "hf_downloads": 53753,
+    "hf_downloads": 37209,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4578,7 +7452,7 @@
     "capabilities": [],
     "pipeline_tag": "audio-to-audio",
     "architecture": "unknown",
-    "hf_downloads": 355,
+    "hf_downloads": 286,
     "hf_likes": 346,
     "release_date": "2025-08-28",
     "num_hidden_layers": null,
@@ -4607,8 +7481,8 @@
     "capabilities": [],
     "pipeline_tag": "audio-to-audio",
     "architecture": "unknown",
-    "hf_downloads": 858,
-    "hf_likes": 390,
+    "hf_downloads": 790,
+    "hf_likes": 395,
     "release_date": "2025-12-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -4630,7 +7504,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo2",
-    "hf_downloads": 83282,
+    "hf_downloads": 94854,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4656,7 +7530,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo2",
-    "hf_downloads": 35803,
+    "hf_downloads": 38579,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4667,6 +7541,166 @@
       },
       {
         "repo": "mradermacher/OLMo-2-0425-1B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "onnx-community/Bonsai-1.7B-ONNX",
+    "provider": "onnx-community",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485023232,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 19624,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "farbodtavakkoli/OTel-LLM-1.7B-IT",
+    "provider": "farbodtavakkoli",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 84482,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-1.7B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 49809,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-1.7B-Base",
+    "provider": "unsloth",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 35749,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-1.7B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen3-1.7B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 35014,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3-1.7B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 23232,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tomg-group-umd/DynaGuard-1.7B",
+    "provider": "tomg-group-umd",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1485570048,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 19061,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/DynaGuard-1.7B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -4686,7 +7720,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 52980,
+    "hf_downloads": 58412,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4714,7 +7748,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 902103,
+    "hf_downloads": 971825,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -4736,10 +7770,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1714729,
+    "hf_downloads": 2015070,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Llama-3.2-1B-Instruct-quantized.w8a8",
+    "provider": "redhatai",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1498859520,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 23277,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "shoumenchougou/RWKV7-G1f-1.5B-GGUF",
+    "provider": "RWKV",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1500000000,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "rwkv",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
   },
   {
     "name": "EleutherAI/pythia-1.4b",
@@ -4756,7 +7831,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 68121,
+    "hf_downloads": 83238,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4784,7 +7859,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 206886,
+    "hf_downloads": 216895,
     "hf_likes": 118,
     "release_date": "2024-09-18",
     "num_hidden_layers": 28,
@@ -4823,7 +7898,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 9813491,
+    "hf_downloads": 10816120,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4853,7 +7928,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 3487346,
+    "hf_downloads": 4220156,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4881,7 +7956,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1049844,
+    "hf_downloads": 914961,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4909,7 +7984,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 345107,
+    "hf_downloads": 505522,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4935,36 +8010,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 232884,
+    "hf_downloads": 207575,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Qwen/Qwen2-1.5B",
-    "provider": "Alibaba",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1543714304,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 139489,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2-1.5B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen2.5-Math-1.5B-Instruct",
@@ -4983,7 +8032,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 110662,
+    "hf_downloads": 179134,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -4994,6 +8043,58 @@
       },
       {
         "repo": "mradermacher/Qwen2.5-Math-1.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen2-1.5B",
+    "provider": "Alibaba",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 127243,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen2-1.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "jinaai/ReaderLM-v2",
+    "provider": "jinaai",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 512768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 99842,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/ReaderLM-v2-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -5013,10 +8114,68 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35824,
+    "hf_downloads": 44021,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-1.5B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 29410,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Qwen2.5-1.5B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Qwen2.5-1.5B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "open-thoughts/OpenThinker3-1.5B",
+    "provider": "open-thoughts",
+    "parameter_count": "1.5B",
+    "parameters_raw": 1543714304,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 15521,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/OpenThinker3-1.5B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "lmstudio-community/Qwen3-VL-4B-Instruct-MLX-8bit",
@@ -5036,7 +8195,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 168968,
+    "hf_downloads": 164984,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-1.5B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1576741182,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 74530,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-1.5B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1579330356,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 29652,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5058,7 +8261,7 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "lfm2_vl",
-    "hf_downloads": 4462,
+    "hf_downloads": 4256,
     "hf_likes": 226,
     "release_date": "2025-08-12",
     "num_hidden_layers": null,
@@ -5071,6 +8274,28 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "unsloth/Qwen2.5-1.5B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1584858476,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 34461,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LiquidAI/LFM2.5-VL-1.6B",
@@ -5089,8 +8314,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "lfm2_vl",
-    "hf_downloads": 130562,
-    "hf_likes": 277,
+    "hf_downloads": 114767,
+    "hf_likes": 281,
     "release_date": "2026-01-05",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -5102,6 +8327,52 @@
         "provider": "unsloth"
       }
     ]
+  },
+  {
+    "name": "openai-community/gpt2-xl",
+    "provider": "openai-community",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1607942848,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt2",
+    "hf_downloads": 201909,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/gpt2-xl-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "lightseekorg/kimi-k2.5-eagle3-mla",
+    "provider": "lightseekorg",
+    "parameter_count": "1.6B",
+    "parameters_raw": 1644167168,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "kimi_k2",
+    "hf_downloads": 42610,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "stabilityai/stablelm-2-1_6b-chat",
@@ -5118,7 +8389,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "stablelm",
-    "hf_downloads": 2905,
+    "hf_downloads": 2732,
     "hf_likes": 35,
     "release_date": "2024-04-08",
     "num_hidden_layers": 24,
@@ -5147,7 +8418,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 71652,
+    "hf_downloads": 113189,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5173,41 +8444,13 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 46052,
+    "hf_downloads": 47474,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
         "repo": "mradermacher/SmolLM-1.7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3-1.7B-Base",
-    "provider": "Alibaba",
-    "parameter_count": "1.7B",
-    "parameters_raw": 1720574976,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3",
-    "hf_downloads": 542341,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-1.7B-Base-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -5227,10 +8470,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 520722,
+    "hf_downloads": 795984,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-1.7B-Base",
+    "provider": "Alibaba",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1720574976,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 558211,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-1.7B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "Qwen/Qwen3-1.7B-GPTQ-Int8",
@@ -5249,7 +8520,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 493596,
+    "hf_downloads": 516143,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5269,7 +8540,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 43388,
+    "hf_downloads": 43366,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5297,7 +8568,79 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 28608,
+    "hf_downloads": 29600,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "bigatuna/Qwen3-1.7B-Sushi-Coder",
+    "provider": "bigatuna",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1720574976,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 18509,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-1.7B-Sushi-Coder-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "activeDap/Qwen3-1.7B_hh_harmful",
+    "provider": "activedap",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1720574976,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17075,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "contextboxai/Qwen3-1.7B-FC",
+    "provider": "contextboxai",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1720574976,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 15574,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5317,7 +8660,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bloom",
-    "hf_downloads": 47595,
+    "hf_downloads": 48502,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5327,6 +8670,70 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "speakleash/Bielik-11B-v3.0-Instruct-awq",
+    "provider": "speakleash",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1722602172,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 71267,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "z-lab/Qwen3.6-27B-DFlash",
+    "provider": "z-lab",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1730213120,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 26361,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "z-lab/Qwen3.5-27B-DFlash",
+    "provider": "z-lab",
+    "parameter_count": "1.7B",
+    "parameters_raw": 1730213120,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 25220,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-VL-4B-Instruct-AWQ-4bit",
@@ -5346,7 +8753,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 151331,
+    "hf_downloads": 94463,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5359,17 +8766,105 @@
     "min_ram_gb": 1.0,
     "recommended_ram_gb": 2.0,
     "min_vram_gb": 0.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
+    "quantization": "AutoRound-4bit",
+    "format": "autoround",
     "context_length": 128000,
     "use_case": "General purpose",
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 47053,
+    "hf_downloads": 10813,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/gpt-oss-20b-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "1.8B",
+    "parameters_raw": 1773527040,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 295100,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 299282688
+  },
+  {
+    "name": "openai/gpt-oss-safeguard-20b",
+    "provider": "openai",
+    "parameter_count": "1.8B",
+    "parameters_raw": 1773527040,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 82112,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 299282688,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gpt-oss-safeguard-20b-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/gpt-oss-safeguard-20b-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "huihui-ai/Huihui-gpt-oss-20b-BF16-abliterated",
+    "provider": "huihui-ai",
+    "parameter_count": "1.8B",
+    "parameters_raw": 1773527040,
+    "min_ram_gb": 1.0,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 0.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 40560,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 299282688,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Huihui-gpt-oss-20b-BF16-abliterated-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
@@ -5388,7 +8883,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 782033,
+    "hf_downloads": 925358,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5408,7 +8903,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 502546,
+    "hf_downloads": 426774,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5444,7 +8939,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 122897,
+    "hf_downloads": 130341,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5464,7 +8959,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35750,
+    "hf_downloads": 43923,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5484,7 +8979,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35594,
+    "hf_downloads": 43714,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5506,7 +9001,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1011746,
+    "hf_downloads": 1178375,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5526,7 +9021,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 49545,
+    "hf_downloads": 40637,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5552,7 +9047,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 32226,
+    "hf_downloads": 33408,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5578,7 +9073,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "moondream1",
-    "hf_downloads": 2608010,
+    "hf_downloads": 2662742,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5598,7 +9093,47 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "video_llama_3",
-    "hf_downloads": 91163,
+    "hf_downloads": 94624,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ByteDance/Ouro-2.6B",
+    "provider": "bytedance",
+    "parameter_count": "2.0B",
+    "parameters_raw": 2013265920,
+    "min_ram_gb": 1.1,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ouro",
+    "hf_downloads": 35520,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ByteDance/Ouro-2.6B-Thinking",
+    "provider": "bytedance",
+    "parameter_count": "2.0B",
+    "parameters_raw": 2013265920,
+    "min_ram_gb": 1.1,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ouro",
+    "hf_downloads": 18722,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5620,8 +9155,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3",
-    "hf_downloads": 6077216,
-    "hf_likes": 454,
+    "hf_downloads": 4253852,
+    "hf_likes": 457,
     "release_date": "2025-04-27",
     "num_hidden_layers": 28,
     "num_attention_heads": 16,
@@ -5643,8 +9178,8 @@
     ]
   },
   {
-    "name": "JetLM/SDAR-1.7B-Chat",
-    "provider": "jetlm",
+    "name": "guangyangnlp/Qwen3-1.7B-SFT-science-2e-5",
+    "provider": "guangyangnlp",
     "parameter_count": "2.0B",
     "parameters_raw": 2031739904,
     "min_ram_gb": 1.1,
@@ -5652,12 +9187,36 @@
     "min_vram_gb": 1.0,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
     "pipeline_tag": "unknown",
-    "architecture": "sdar",
-    "hf_downloads": 40710,
+    "architecture": "qwen3",
+    "hf_downloads": 15346,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-1.7B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "2.0B",
+    "parameters_raw": 2031825920,
+    "min_ram_gb": 1.1,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 20060,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5677,7 +9236,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 15829,
+    "hf_downloads": 19794,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5697,6 +9256,56 @@
     ]
   },
   {
+    "name": "OpenGVLab/InternVL3-2B-hf",
+    "provider": "opengvlab",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2088957440,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internvl",
+    "hf_downloads": 14310,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-3.3-2b-instruct",
+    "provider": "ibm-granite",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2113943552,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granite",
+    "hf_downloads": 32733,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/granite-3.3-2b-instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/granite-3.3-2b-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
     "name": "google/t5gemma-2-1b-1b",
     "provider": "Google",
     "parameter_count": "2.1B",
@@ -5711,10 +9320,176 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5gemma2",
-    "hf_downloads": 52082,
+    "hf_downloads": 50479,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Qwen3-Coder-Next-NVFP4",
+    "provider": "redhatai",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 48812,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
+  },
+  {
+    "name": "Qwen/Qwen3-Next-80B-A3B-Thinking",
+    "provider": "Alibaba",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 32388,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-Next-80B-A3B-Thinking-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3-Next-80B-A3B-Thinking-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen3-Coder-Next-FP8",
+    "provider": "unsloth",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 23545,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
+  },
+  {
+    "name": "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 22570,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
+  },
+  {
+    "name": "unsloth/Qwen3-Next-80B-A3B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 17224,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
+  },
+  {
+    "name": "unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "2.1B",
+    "parameters_raw": 2123104256,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 16596,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 145548742
   },
   {
     "name": "Qwen/Qwen3-VL-2B-Instruct",
@@ -5734,7 +9509,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 165732702,
+    "hf_downloads": 186982016,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5771,7 +9546,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 108320,
+    "hf_downloads": 100495,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5801,16 +9576,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 17005,
+    "hf_downloads": 53113,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/typhoon-ocr1.5-2b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "embedl/Cosmos-Reason2-2B-W4A16-Edge2",
@@ -5827,7 +9596,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 11921,
+    "hf_downloads": 12128,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5847,7 +9616,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "h2ovl_chat",
-    "hf_downloads": 925509,
+    "hf_downloads": 969149,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "openbmb/MiniCPM-2B-sft-bf16",
+    "provider": "openbmb",
+    "parameter_count": "2.2B",
+    "parameters_raw": 2193852672,
+    "min_ram_gb": 1.2,
+    "recommended_ram_gb": 2.0,
+    "min_vram_gb": 1.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 55230,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5867,7 +9656,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 1138876,
+    "hf_downloads": 1168150,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -5887,32 +9676,40 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 61533,
+    "hf_downloads": 56263,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "NAMAA-Space/Qari-OCR-v0.3-VL-2B-Instruct",
-    "provider": "namaa-space",
+    "name": "UnfilteredAI/NSFW-flash",
+    "provider": "unfilteredai",
     "parameter_count": "2.2B",
-    "parameters_raw": 2208985600,
-    "min_ram_gb": 1.2,
+    "parameters_raw": 2240163840,
+    "min_ram_gb": 1.3,
     "recommended_ram_gb": 2.1,
     "min_vram_gb": 1.1,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision"
-    ],
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "qwen2_vl",
-    "hf_downloads": 20310,
+    "architecture": "stablelm",
+    "hf_downloads": 13790,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 644047104,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/NSFW-flash-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "HuggingFaceTB/SmolVLM-Instruct",
@@ -5929,7 +9726,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics3",
-    "hf_downloads": 22913,
+    "hf_downloads": 28837,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -5937,10 +9734,6 @@
       {
         "repo": "ggml-org/SmolVLM-Instruct-GGUF",
         "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/SmolVLM-Instruct-GGUF",
-        "provider": "mradermacher"
       }
     ]
   },
@@ -5962,8 +9755,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 1701802,
-    "hf_likes": 265,
+    "hf_downloads": 1727304,
+    "hf_likes": 267,
     "release_date": "2026-02-28",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -5998,32 +9791,36 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 64466,
-    "hf_likes": 66,
+    "hf_downloads": 73441,
+    "hf_likes": 68,
     "release_date": "2026-02-28",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
-    "head_dim": null
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-2B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
-    "name": "QuantTrio/Qwen3.5-2B-AWQ",
-    "provider": "quanttrio",
+    "name": "raxcore-dev/rax-3.5-chat",
+    "provider": "raxcore-dev",
     "parameter_count": "2.3B",
     "parameters_raw": 2274069824,
     "min_ram_gb": 1.3,
     "recommended_ram_gb": 2.1,
     "min_vram_gb": 1.2,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 24999,
+    "hf_downloads": 12213,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6043,7 +9840,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 39628,
+    "hf_downloads": 40449,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6065,7 +9862,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 368169,
+    "hf_downloads": 401807,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6087,7 +9884,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 26366,
+    "hf_downloads": 26853,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6109,7 +9906,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 42416,
+    "hf_downloads": 45178,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6131,7 +9928,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 138810,
+    "hf_downloads": 153189,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6153,10 +9950,150 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 15021,
+    "hf_downloads": 22576,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 1121574,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3-30B-A3B-Instruct-2507-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Qwen/Qwen3-30B-A3B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 177177,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622
+  },
+  {
+    "name": "mlx-community/Qwen3-30B-A3B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 66786,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622
+  },
+  {
+    "name": "Qwen/Qwen3-30B-A3B-Thinking-2507-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 63256,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622
+  },
+  {
+    "name": "unsloth/Qwen3-30B-A3B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "2.3B",
+    "parameters_raw": 2324430848,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 37927,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 254234622
   },
   {
     "name": "OpenGVLab/InternVL3_5-2B-HF",
@@ -6173,10 +10110,90 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl",
-    "hf_downloads": 10588,
+    "hf_downloads": 11262,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/gpt-oss-120b-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "2.4B",
+    "parameters_raw": 2370723840,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 269328,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 4,
+    "active_parameters": 188917056
+  },
+  {
+    "name": "openai/gpt-oss-safeguard-120b",
+    "provider": "openai",
+    "parameter_count": "2.4B",
+    "parameters_raw": 2370723840,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 23882,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 4,
+    "active_parameters": 188917056,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/gpt-oss-safeguard-120b-GGUF",
+        "provider": "unsloth"
+      }
+    ]
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-3.5-2.4B-Instruct",
+    "provider": "lgai-exaone",
+    "parameter_count": "2.4B",
+    "parameters_raw": 2405327360,
+    "min_ram_gb": 1.3,
+    "recommended_ram_gb": 2.2,
+    "min_vram_gb": 1.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "exaone",
+    "hf_downloads": 23797,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/EXAONE-3.5-2.4B-Instruct-GGUF",
+        "provider": "bartowski"
+      }
+    ]
   },
   {
     "name": "Qwen/Qwen3-VL-2B-Instruct-FP8",
@@ -6196,7 +10213,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 130508,
+    "hf_downloads": 231022,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6219,7 +10236,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 45640,
+    "hf_downloads": 46183,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6241,7 +10258,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 130763,
+    "hf_downloads": 156223,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6261,16 +10278,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma",
-    "hf_downloads": 159083,
+    "hf_downloads": 188880,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-2b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "google/gemma-1.1-2b-it",
@@ -6287,20 +10298,62 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma",
-    "hf_downloads": 108002,
+    "hf_downloads": 137091,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "google/codegemma-2b",
+    "provider": "Google",
+    "parameter_count": "2.5B",
+    "parameters_raw": 2506172416,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.3,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma",
+    "hf_downloads": 19217,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "bartowski/gemma-1.1-2b-it-GGUF",
+        "repo": "bartowski/codegemma-2b-GGUF",
         "provider": "bartowski"
       },
       {
-        "repo": "mradermacher/gemma-1.1-2b-it-GGUF",
+        "repo": "mradermacher/codegemma-2b-GGUF",
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "mlx-community/Qwen2.5-3B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "2.5B",
+    "parameters_raw": 2538340352,
+    "min_ram_gb": 1.4,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 22950,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "PerceptronAI/Isaac-0.2-2B-Preview",
@@ -6317,7 +10370,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "isaac",
-    "hf_downloads": 52856,
+    "hf_downloads": 37184,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6337,7 +10390,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "isaac",
-    "hf_downloads": 44030,
+    "hf_downloads": 36407,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6357,8 +10410,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 5777,
-    "hf_likes": 187,
+    "hf_downloads": 4757,
+    "hf_likes": 188,
     "release_date": "2025-09-22",
     "num_hidden_layers": 30,
     "num_attention_heads": 32,
@@ -6386,7 +10439,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 10158,
+    "hf_downloads": 7236,
     "hf_likes": 339,
     "release_date": "2025-12-25",
     "num_hidden_layers": 30,
@@ -6419,8 +10472,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2",
-    "hf_downloads": 586,
-    "hf_likes": 163,
+    "hf_downloads": 648,
+    "hf_likes": 164,
     "release_date": "2026-01-05",
     "num_hidden_layers": 30,
     "num_attention_heads": 32,
@@ -6448,7 +10501,47 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis2_5",
-    "hf_downloads": 82785,
+    "hf_downloads": 62968,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "abeja/gpt-neox-japanese-2.7b",
+    "provider": "abeja",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2598502400,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox_japanese",
+    "hf_downloads": 86863,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "pfnet/plamo-3-nict-2b-base",
+    "provider": "pfnet",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2603344384,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.4,
+    "min_vram_gb": 1.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "plamo3",
+    "hf_downloads": 22958,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6468,8 +10561,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "gemma2",
-    "hf_downloads": 350168,
-    "hf_likes": 1342,
+    "hf_downloads": 367586,
+    "hf_likes": 1348,
     "release_date": "2024-07-16",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -6501,20 +10594,112 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma2",
-    "hf_downloads": 123694,
+    "hf_downloads": 135617,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/gemma-2-2b-it-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/gemma-2-2b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "yujiepan/ui-tars-1.5-7B-GPTQ-W4A16g128",
+    "provider": "yujiepan",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2633518472,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.3,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 66580,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "facebook/opt-2.7b",
+    "provider": "facebook",
+    "parameter_count": "2.6B",
+    "parameters_raw": 2645278720,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 23735,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyberagent/open-calm-3b",
+    "provider": "cyberagent",
+    "parameter_count": "2.7B",
+    "parameters_raw": 2650275840,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 229238,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/gemma-2-2b-it-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "2.7B",
+    "parameters_raw": 2677836404,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma2",
+    "hf_downloads": 61073,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Harvard-DCML/boomerang-qwen3-2.3B",
+    "provider": "harvard-dcml",
+    "parameter_count": "2.7B",
+    "parameters_raw": 2695600384,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.5,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 28160,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "EleutherAI/gpt-neo-2.7B",
@@ -6531,10 +10716,40 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neo",
-    "hf_downloads": 335941,
+    "hf_downloads": 212323,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "baidu/ERNIE-4.5-21B-A3B-PT",
+    "provider": "baidu",
+    "parameter_count": "2.8B",
+    "parameters_raw": 2760376320,
+    "min_ram_gb": 1.5,
+    "recommended_ram_gb": 2.6,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ernie4_5_moe",
+    "hf_downloads": 49422,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/ERNIE-4.5-21B-A3B-PT-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/ERNIE-4.5-21B-A3B-PT-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "microsoft/phi-2",
@@ -6551,16 +10766,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi",
-    "hf_downloads": 632963,
+    "hf_downloads": 527254,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/phi-2-GGUF",
-        "provider": "TheBloke"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "stabilityai/stablelm-3b-4e1t",
@@ -6577,14 +10786,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "stablelm",
-    "hf_downloads": 53770,
+    "hf_downloads": 64532,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "stabilityai/stablelm-zephyr-3b",
+    "provider": "Stability AI",
+    "parameter_count": "2.8B",
+    "parameters_raw": 2795443200,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.6,
+    "min_vram_gb": 1.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "stablelm",
+    "hf_downloads": 30179,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "mradermacher/stablelm-3b-4e1t-GGUF",
-        "provider": "mradermacher"
+        "repo": "TheBloke/stablelm-zephyr-3b-GGUF",
+        "provider": "TheBloke"
       }
     ]
   },
@@ -6603,10 +10832,51 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 119928,
+    "hf_downloads": 121551,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "2.9B",
+    "parameters_raw": 2860253183,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.7,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 79588,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "shoumenchougou/RWKV7-G1f-2.9B-GGUF",
+    "provider": "RWKV",
+    "parameter_count": "2.9B",
+    "parameters_raw": 2900000000,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.7,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "rwkv",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
   },
   {
     "name": "cyankiwi/Qwen3-VL-8B-Instruct-AWQ-4bit",
@@ -6626,7 +10896,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 124769,
+    "hf_downloads": 193832,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6646,16 +10916,58 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 85804,
+    "hf_downloads": 86306,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "microsoft/Phi-3-mini-128k-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "2.9B",
+    "parameters_raw": 2917072895,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.7,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phi3",
+    "hf_downloads": 242071,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "mradermacher/pythia-2.8b-GGUF",
+        "repo": "mradermacher/Phi-3-mini-128k-instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "microsoft/Phi-3-vision-128k-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "2.9B",
+    "parameters_raw": 2917072895,
+    "min_ram_gb": 1.6,
+    "recommended_ram_gb": 2.7,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "phi3_v",
+    "hf_downloads": 169091,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "google/paligemma-3b-mix-224",
@@ -6672,7 +10984,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 184216,
+    "hf_downloads": 200766,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6692,10 +11004,40 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 14924,
+    "hf_downloads": 14553,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-4.0-micro",
+    "provider": "ibm-granite",
+    "parameter_count": "3.0B",
+    "parameters_raw": 2983198720,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.8,
+    "min_vram_gb": 1.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granitemoehybrid",
+    "hf_downloads": 410511,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/granite-4.0-micro-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/granite-4.0-micro-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "LiquidAI/LFM2-VL-3B",
@@ -6714,7 +11056,7 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "lfm2_vl",
-    "hf_downloads": 11348,
+    "hf_downloads": 10595,
     "hf_likes": 133,
     "release_date": "2025-10-22",
     "num_hidden_layers": null,
@@ -6737,16 +11079,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "starcoder2",
-    "hf_downloads": 86653,
+    "hf_downloads": 93418,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/starcoder2-3b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "TechxGenus/gemma-1.1-2b-it-GPTQ",
+    "provider": "techxgenus",
+    "parameter_count": "3.0B",
+    "parameters_raw": 3031170048,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.8,
+    "min_vram_gb": 1.6,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma",
+    "hf_downloads": 26810,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "google/paligemma2-3b-mix-224",
@@ -6763,7 +11119,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 29188,
+    "hf_downloads": 35019,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6783,7 +11139,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 45790,
+    "hf_downloads": 60085,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6803,7 +11159,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "paligemma",
-    "hf_downloads": 34858,
+    "hf_downloads": 38514,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6823,20 +11179,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "dots_ocr",
-    "hf_downloads": 181140,
+    "hf_downloads": 201850,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/dots.ocr-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/dots.ocr-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "rednote-hilab/dots.mocr",
@@ -6853,7 +11199,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "dots_ocr",
-    "hf_downloads": 111016,
+    "hf_downloads": 148593,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6873,7 +11219,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "dots_ocr",
-    "hf_downloads": 45605,
+    "hf_downloads": 39105,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -6893,8 +11239,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "smollm3",
-    "hf_downloads": 164139,
-    "hf_likes": 942,
+    "hf_downloads": 112754,
+    "hf_likes": 946,
     "release_date": "2025-07-08",
     "num_hidden_layers": 36,
     "num_attention_heads": 16,
@@ -6930,16 +11276,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "smollm3",
-    "hf_downloads": 36767,
+    "hf_downloads": 88599,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "GadflyII/GLM-4.7-Flash-NVFP4",
+    "provider": "gadflyii",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3077046272,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe_lite",
+    "hf_downloads": 70906,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/SmolLM3-3B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 4,
+    "active_parameters": 336551933
   },
   {
     "name": "Qwen/Qwen2.5-3B-Instruct",
@@ -6958,56 +11322,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 9143309,
+    "hf_downloads": 9596868,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-3B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-Coder-3B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "3.1B",
-    "parameters_raw": 3085938688,
-    "min_ram_gb": 1.7,
-    "recommended_ram_gb": 2.9,
-    "min_vram_gb": 1.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 446815,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-Coder-3B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/Qwen2.5-Coder-3B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-3B",
@@ -7026,20 +11344,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 382920,
+    "hf_downloads": 453563,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-3B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-3B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3085938688,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 425057,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-Coder-3B",
@@ -7058,20 +11388,344 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 57821,
+    "hf_downloads": 168886,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-3B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3085938688,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 59874,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "bartowski/Qwen2.5-Coder-3B-GGUF",
+        "repo": "bartowski/Qwen2.5-3B-Instruct-GGUF",
         "provider": "bartowski"
       },
       {
-        "repo": "mradermacher/Qwen2.5-Coder-3B-GGUF",
+        "repo": "mradermacher/Qwen2.5-3B-Instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "Qwen/Qwen3-4B-Thinking-2507-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 189752,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-4B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 164165,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-4B-Instruct-2507",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 100747,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Qwen3-4B-Instruct-2507-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Qwen3-4B-Instruct-2507-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Qwen3-4B-Instruct-2507-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 94818,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "khazarai/Qwen3-4B-Qwen3.6-plus-Reasoning-Distilled-GGUF",
+    "provider": "khazarai",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 93721,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-4B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 73248,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-4B-Base",
+    "provider": "unsloth",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 24022,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3-4B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "mlx-community/Qwen3-4B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17922,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "khazarai/Qwen3-4B-Kimi2.5-Reasoning-Distilled-GGUF",
+    "provider": "khazarai",
+    "parameter_count": "3.1B",
+    "parameters_raw": 3125739520,
+    "min_ram_gb": 1.7,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 14401,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-3B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3162369808,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 13568,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-3B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3166608872,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 2.9,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 153454,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-3B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3172967424,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 118038,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-Coder-3B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3172967424,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 21823,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "ibm-granite/granite-4.0-h-micro",
@@ -7088,7 +11742,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "granitemoehybrid",
-    "hf_downloads": 17984,
+    "hf_downloads": 6010,
     "hf_likes": 142,
     "release_date": "2025-09-16",
     "num_hidden_layers": 40,
@@ -7121,8 +11775,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 1111138,
-    "hf_likes": 763,
+    "hf_downloads": 1124221,
+    "hf_likes": 770,
     "release_date": "2024-09-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -7152,7 +11806,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1988470,
+    "hf_downloads": 2267285,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3212749824,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 226261,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -7167,6 +11843,64 @@
       },
       {
         "repo": "mradermacher/Llama-3.2-3B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B",
+    "provider": "unsloth",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3212749824,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 39900,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Llama-3.2-3B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "NousResearch/Hermes-3-Llama-3.2-3B",
+    "provider": "NousResearch",
+    "parameter_count": "3.2B",
+    "parameters_raw": 3212749824,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.0,
+    "min_vram_gb": 1.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14838,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Hermes-3-Llama-3.2-3B-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Hermes-3-Llama-3.2-3B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -7188,7 +11922,71 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 18448,
+    "hf_downloads": 18426,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3298757260,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 96079,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3301123016,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 59743,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.2-3B-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3301123026,
+    "min_ram_gb": 1.8,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16148,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7208,20 +12006,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_vl_v2",
-    "hf_downloads": 2254853,
+    "hf_downloads": 2461220,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 463927274,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/DeepSeek-OCR-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
+    "active_parameters": 463927274
+  },
+  {
+    "name": "prithivMLmods/DeepSeek-OCR-Latest-BF16.I64",
+    "provider": "prithivmlmods",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3336106240,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "DeepseekOCR",
+    "hf_downloads": 22077,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 463927274
   },
   {
     "name": "dealignai/Gemma-4-26B-A4B-JANG_2L-CRACK",
@@ -7238,7 +12054,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 28321,
+    "hf_downloads": 27744,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -7246,6 +12062,26 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 365515866
+  },
+  {
+    "name": "CohereLabs/tiny-aya-global",
+    "provider": "coherelabs",
+    "parameter_count": "3.3B",
+    "parameters_raw": 3349227520,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.1,
+    "min_vram_gb": 1.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "cohere2",
+    "hf_downloads": 16072,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Isotr0py/deepseek-vl2-tiny",
@@ -7262,7 +12098,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_vl_v2",
-    "hf_downloads": 42702,
+    "hf_downloads": 56838,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7282,20 +12118,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granitemoe",
-    "hf_downloads": 922978,
+    "hf_downloads": 1167052,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 40,
     "active_experts": 8,
-    "active_parameters": 809828716,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/PowerMoE-3b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 809828716
   },
   {
     "name": "deepseek-ai/DeepSeek-OCR-2",
@@ -7312,7 +12142,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_vl_v2",
-    "hf_downloads": 1447241,
+    "hf_downloads": 1549103,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -7338,7 +12168,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 255934,
+    "hf_downloads": 435709,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-3B-Instruct-AWQ",
+    "provider": "Alibaba",
+    "parameter_count": "3.4B",
+    "parameters_raw": 3397103616,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.2,
+    "min_vram_gb": 1.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 27191,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7358,16 +12210,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granitemoehybrid",
-    "hf_downloads": 49444,
+    "hf_downloads": 46117,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/granite-4.0-micro-base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Phi-4-mini-instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "3.4B",
+    "parameters_raw": 3433168895,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.2,
+    "min_vram_gb": 1.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phi3",
+    "hf_downloads": 27865,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "z-lab/Qwen3.5-9B-PARO",
@@ -7386,7 +12252,79 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 18170,
+    "hf_downloads": 16863,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyankiwi/Qwen3.5-4B-AWQ-INT8-INT4",
+    "provider": "cyankiwi",
+    "parameter_count": "3.4B",
+    "parameters_raw": 3441633182,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.4,
+    "min_vram_gb": 3.5,
+    "quantization": "AWQ-8bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 14802,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tencent/Hunyuan-A13B-Instruct",
+    "provider": "tencent",
+    "parameter_count": "3.5B",
+    "parameters_raw": 3477762048,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.2,
+    "min_vram_gb": 1.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "hunyuan_v1_moe",
+    "hf_downloads": 28208,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "unsloth/Hunyuan-A13B-Instruct-GGUF",
+        "provider": "unsloth"
+      },
+      {
+        "repo": "mradermacher/Hunyuan-A13B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "z-lab/Kimi-K2.5-DFlash",
+    "provider": "z-lab",
+    "parameter_count": "3.5B",
+    "parameters_raw": 3479277056,
+    "min_ram_gb": 1.9,
+    "recommended_ram_gb": 3.2,
+    "min_vram_gb": 1.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 14253,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7406,16 +12344,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 37431,
+    "hf_downloads": 39141,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/granite-3b-code-base-2k-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "ibm-research/PowerLM-3b",
@@ -7432,16 +12364,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granite",
-    "hf_downloads": 81857,
+    "hf_downloads": 114542,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/PowerLM-3b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "facebook/Perception-LM-3B",
@@ -7458,7 +12384,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "perception_lm",
-    "hf_downloads": 11391,
+    "hf_downloads": 10308,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyankiwi/InternVL3_5-8B-AWQ-8bit",
+    "provider": "cyankiwi",
+    "parameter_count": "3.5B",
+    "parameters_raw": 3536048632,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.6,
+    "min_vram_gb": 3.6,
+    "quantization": "AWQ-8bit",
+    "format": "awq",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internvl_chat",
+    "hf_downloads": 27819,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7480,7 +12426,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 29167,
+    "hf_downloads": 29284,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Chunity/gemma-4-E2B-it-AWQ-4bit",
+    "provider": "chunity",
+    "parameter_count": "3.7B",
+    "parameters_raw": 3658076899,
+    "min_ram_gb": 2.0,
+    "recommended_ram_gb": 3.4,
+    "min_vram_gb": 1.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 12120,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7500,7 +12466,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kanana-1.5-v",
-    "hf_downloads": 218359,
+    "hf_downloads": 252623,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7520,20 +12486,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 38667,
+    "hf_downloads": 151034,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/InternVL2_5-4B-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/InternVL2_5-4B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "5CD-AI/Vintern-3B-R-beta",
@@ -7550,7 +12506,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 35193,
+    "hf_downloads": 43328,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7570,16 +12526,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 22211,
+    "hf_downloads": 29406,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/InternVL2_5-4B-MPO-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Salesforce/blip2-opt-2.7b",
@@ -7596,7 +12546,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "blip-2",
-    "hf_downloads": 480258,
+    "hf_downloads": 551121,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7619,8 +12569,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 3355053,
-    "hf_likes": 640,
+    "hf_downloads": 3701763,
+    "hf_likes": 642,
     "release_date": "2025-01-26",
     "num_hidden_layers": 36,
     "num_attention_heads": 16,
@@ -7656,36 +12606,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 629787,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Nanonets-OCR2-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-VL-3B-Instruct-AWQ",
-    "provider": "Alibaba",
-    "parameter_count": "3.8B",
-    "parameters_raw": 3754622976,
-    "min_ram_gb": 2.1,
-    "recommended_ram_gb": 3.5,
-    "min_vram_gb": 1.9,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 128000,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 92656,
+    "hf_downloads": 425557,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7705,20 +12626,53 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 28796,
+    "hf_downloads": 131502,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Nanonets-OCR-s-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Nanonets-OCR-s-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-VL-3B-Instruct-AWQ",
+    "provider": "Alibaba",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3754622976,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 128000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 128970,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "stanford-oval/churro-3B",
+    "provider": "stanford-oval",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3754622976,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 12096,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "microsoft/Phi-tiny-MoE-instruct",
@@ -7735,7 +12689,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phimoe",
-    "hf_downloads": 679789,
+    "hf_downloads": 688129,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -7772,6 +12726,36 @@
     ]
   },
   {
+    "name": "nvidia/Nemotron-Mini-4B-Instruct",
+    "provider": "nvidia",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3806330880,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.5,
+    "min_vram_gb": 1.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron",
+    "hf_downloads": 22086,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Nemotron-Mini-4B-Instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Nemotron-Mini-4B-Instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
     "name": "microsoft/phi-3-mini-4k-instruct",
     "provider": "Microsoft",
     "parameter_count": "3.8B",
@@ -7786,8 +12770,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "phi3",
-    "hf_downloads": 746649,
-    "hf_likes": 1415,
+    "hf_downloads": 760864,
+    "hf_likes": 1416,
     "release_date": "2024-04-22",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -7819,8 +12803,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "phi3",
-    "hf_downloads": 727640,
-    "hf_likes": 973,
+    "hf_downloads": 708751,
+    "hf_likes": 975,
     "release_date": "2024-08-16",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -7852,20 +12836,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 746649,
+    "hf_downloads": 760864,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Phi-3-mini-4k-instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Phi-3-mini-4k-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "kaitchup/Phi-3-mini-4k-instruct-gptq-4bit",
@@ -7882,7 +12856,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 1174705,
+    "hf_downloads": 1099481,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7902,10 +12876,36 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ristretto",
-    "hf_downloads": 31780,
+    "hf_downloads": 37230,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "openbmb/MiniCPM3-4B",
+    "provider": "openbmb",
+    "parameter_count": "3.8B",
+    "parameters_raw": 3844935680,
+    "min_ram_gb": 2.1,
+    "recommended_ram_gb": 3.6,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minicpm3",
+    "hf_downloads": 27718,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/MiniCPM3-4B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "RedHatAI/gemma-3-12b-it-quantized.w4a16",
@@ -7922,7 +12922,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 25266,
+    "hf_downloads": 28772,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7944,7 +12944,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3_text",
-    "hf_downloads": 36773,
+    "hf_downloads": 36826,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -7964,16 +12964,50 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 223362,
+    "hf_downloads": 232399,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Nanbeige4.1-3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Phi-3-mini-4k-instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.9B",
+    "parameters_raw": 3934684862,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 35955,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Phi-3.5-mini-instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "3.9B",
+    "parameters_raw": 3934684872,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 29879,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Salesforce/blip2-flan-t5-xl",
@@ -7990,7 +13024,87 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "blip-2",
-    "hf_downloads": 56404,
+    "hf_downloads": 43729,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen1.5-4B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "4.0B",
+    "parameters_raw": 3950369280,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14677,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen1.5-4B-Chat-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "microsoft/Phi-3.5-MoE-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "4.0B",
+    "parameters_raw": 3956539392,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phimoe",
+    "hf_downloads": 107782,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 16,
+    "active_experts": 2,
+    "active_parameters": 667666021,
+    "gguf_sources": [
+      {
+        "repo": "bartowski/Phi-3.5-MoE-instruct-GGUF",
+        "provider": "bartowski"
+      },
+      {
+        "repo": "mradermacher/Phi-3.5-MoE-instruct-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8",
+    "provider": "nvidia",
+    "parameter_count": "4.0B",
+    "parameters_raw": 3973556900,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 33671,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8010,7 +13124,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 12170,
+    "hf_downloads": 26060,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8030,7 +13144,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 68248,
+    "hf_downloads": 82586,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8052,7 +13166,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "granite4_vision",
-    "hf_downloads": 133495,
+    "hf_downloads": 169875,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8101,20 +13215,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 9888900,
+    "hf_downloads": 11083271,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-4B-Instruct-2507-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-4B-Instruct-2507-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-4B-Base",
@@ -8133,48 +13237,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 1888692,
+    "hf_downloads": 1966089,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-4B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen3-4B-Thinking-2507",
-    "provider": "Alibaba",
-    "parameter_count": "4.0B",
-    "parameters_raw": 4022468096,
-    "min_ram_gb": 2.2,
-    "recommended_ram_gb": 3.7,
-    "min_vram_gb": 2.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3",
-    "hf_downloads": 893386,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-4B-Thinking-2507-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-4B-Thinking-2507-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-4B-AWQ",
@@ -8193,7 +13259,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 640991,
+    "hf_downloads": 626352,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8213,35 +13279,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 185257,
+    "hf_downloads": 618788,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Rio-3.0-Open-Mini-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "JunHowie/Qwen3-4B-Instruct-2507-GPTQ-Int4",
-    "provider": "junhowie",
+    "name": "Qwen/Qwen3-4B-Thinking-2507",
+    "provider": "Alibaba",
     "parameter_count": "4.0B",
     "parameters_raw": 4022468096,
     "min_ram_gb": 2.2,
     "recommended_ram_gb": 3.7,
     "min_vram_gb": 2.1,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 262144,
-    "use_case": "Instruction following, chat",
+    "use_case": "General purpose",
     "capabilities": [
       "tool_use"
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 75040,
+    "hf_downloads": 471622,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8263,7 +13323,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 48301,
+    "hf_downloads": 51136,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "JunHowie/Qwen3-4B-Instruct-2507-GPTQ-Int4",
+    "provider": "junhowie",
+    "parameter_count": "4.0B",
+    "parameters_raw": 4022468096,
+    "min_ram_gb": 2.2,
+    "recommended_ram_gb": 3.7,
+    "min_vram_gb": 2.1,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 43617,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8283,7 +13365,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 133730,
+    "hf_downloads": 167584,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8303,7 +13385,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 36297,
+    "hf_downloads": 41722,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8326,7 +13408,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 41204,
+    "hf_downloads": 61293,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8349,7 +13431,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 25164,
+    "hf_downloads": 34387,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8369,7 +13451,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis",
-    "hf_downloads": 42879,
+    "hf_downloads": 57137,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8389,7 +13471,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3_v",
-    "hf_downloads": 154671,
+    "hf_downloads": 223911,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8411,7 +13493,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 37972,
+    "hf_downloads": 40221,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8433,7 +13515,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 115902,
+    "hf_downloads": 124489,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8453,7 +13535,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 31580,
+    "hf_downloads": 31231,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "bg-digitalservices/Gemma-4-E2B-it-NVFP4",
+    "provider": "bg-digitalservices",
+    "parameter_count": "4.3B",
+    "parameters_raw": 4293811779,
+    "min_ram_gb": 2.4,
+    "recommended_ram_gb": 4.0,
+    "min_vram_gb": 2.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 15220,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8476,8 +13578,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "gemma3",
-    "hf_downloads": 2130064,
-    "hf_likes": 1314,
+    "hf_downloads": 2235493,
+    "hf_likes": 1320,
     "release_date": "2025-02-20",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -8513,16 +13615,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 202116,
+    "hf_downloads": 269605,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-3-4b-pt-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "google/medgemma-1.5-4b-it",
@@ -8539,17 +13635,53 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 102908,
+    "hf_downloads": 120144,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/Nemotron-3-Content-Safety",
+    "provider": "nvidia",
+    "parameter_count": "4.3B",
+    "parameters_raw": 4300079472,
+    "min_ram_gb": 2.4,
+    "recommended_ram_gb": 4.0,
+    "min_vram_gb": 2.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3",
+    "hf_downloads": 14339,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zai-org/glm-edge-4b-chat",
+    "provider": "zai-org",
+    "parameter_count": "4.3B",
+    "parameters_raw": 4327984128,
+    "min_ram_gb": 2.4,
+    "recommended_ram_gb": 4.0,
+    "min_vram_gb": 2.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm",
+    "hf_downloads": 24535,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "unsloth/medgemma-1.5-4b-it-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/medgemma-1.5-4b-it-GGUF",
+        "repo": "mradermacher/glm-edge-4b-chat-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -8571,13 +13703,35 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 45457,
+    "hf_downloads": 30418,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3Guard-Gen-4B",
+    "provider": "Alibaba",
+    "parameter_count": "4.4B",
+    "parameters_raw": 4411424256,
+    "min_ram_gb": 2.5,
+    "recommended_ram_gb": 4.1,
+    "min_vram_gb": 2.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17195,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "mradermacher/Qwen3-4B-SafeRL-GGUF",
+        "repo": "mradermacher/Qwen3Guard-Gen-4B-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -8599,7 +13753,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 596189,
+    "hf_downloads": 733046,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8621,7 +13775,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 55530,
+    "hf_downloads": 54237,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8644,20 +13798,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 2304311,
+    "hf_downloads": 2347064,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-4B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-4B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-VL-4B-Thinking",
@@ -8677,20 +13821,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 479962,
+    "hf_downloads": 1472471,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-4B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-4B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "huihui-ai/Huihui-Qwen3.5-4B-abliterated",
@@ -8709,16 +13843,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 13127,
+    "hf_downloads": 12573,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-4B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/gemma-4-26B-A4B-it-MLX-4bit",
@@ -8735,7 +13863,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 129130,
+    "hf_downloads": 147835,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -8761,7 +13889,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 31094,
+    "hf_downloads": 31550,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 503765510
+  },
+  {
+    "name": "stelterlab/Qwen3-Coder-30B-A3B-Instruct-AWQ",
+    "provider": "stelterlab",
+    "parameter_count": "4.6B",
+    "parameters_raw": 4605856128,
+    "min_ram_gb": 2.6,
+    "recommended_ram_gb": 4.3,
+    "min_vram_gb": 2.4,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 28256,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -8785,7 +13939,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis",
-    "hf_downloads": 70341,
+    "hf_downloads": 80464,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "arcee-ai/AFM-4.5B-Base",
+    "provider": "arcee-ai",
+    "parameter_count": "4.6B",
+    "parameters_raw": 4619184640,
+    "min_ram_gb": 2.6,
+    "recommended_ram_gb": 4.3,
+    "min_vram_gb": 2.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1310720,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "arcee",
+    "hf_downloads": 21313,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8808,8 +13982,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 3966264,
-    "hf_likes": 503,
+    "hf_downloads": 5193094,
+    "hf_likes": 518,
     "release_date": "2026-02-27",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -8844,13 +14018,19 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 134173,
-    "hf_likes": 64,
+    "hf_downloads": 161928,
+    "hf_likes": 65,
     "release_date": "2026-02-27",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
-    "head_dim": null
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-4B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "QuantTrio/Qwen3.5-4B-AWQ",
@@ -8869,7 +14049,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 42743,
+    "hf_downloads": 40077,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8891,7 +14071,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 15711,
+    "hf_downloads": 10461,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8913,7 +14093,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 39432,
+    "hf_downloads": 19522,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8935,7 +14115,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 46376,
+    "hf_downloads": 48105,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -8955,7 +14135,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 42005,
+    "hf_downloads": 41393,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -8981,7 +14161,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral3",
-    "hf_downloads": 30344,
+    "hf_downloads": 21534,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9001,16 +14181,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qianfan_ocr",
-    "hf_downloads": 363059,
+    "hf_downloads": 424056,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/Qianfan-OCR-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "lmms-lab/LLaVA-OneVision-1.5-4B-Base",
@@ -9029,29 +14203,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 87202,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "cyankiwi/Qwen3.5-4B-AWQ-BF16-INT4",
-    "provider": "cyankiwi",
-    "parameter_count": "4.7B",
-    "parameters_raw": 4743177998,
-    "min_ram_gb": 2.7,
-    "recommended_ram_gb": 4.4,
-    "min_vram_gb": 2.4,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 12612,
+    "hf_downloads": 137946,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9071,10 +14223,36 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "t5",
-    "hf_downloads": 84601,
+    "hf_downloads": 84606,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Qwen3-30B-A3B-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "4.8B",
+    "parameters_raw": 4770822144,
+    "min_ram_gb": 2.7,
+    "recommended_ram_gb": 4.4,
+    "min_vram_gb": 2.4,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 14092,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 521808667
   },
   {
     "name": "cyankiwi/Qwen3.5-4B-AWQ-4bit",
@@ -9093,7 +14271,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 218343,
+    "hf_downloads": 289427,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Chunity/gemma-4-E4B-it-AWQ-4bit",
+    "provider": "chunity",
+    "parameter_count": "4.8B",
+    "parameters_raw": 4805237482,
+    "min_ram_gb": 2.7,
+    "recommended_ram_gb": 4.5,
+    "min_vram_gb": 2.5,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 13224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9113,7 +14311,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "R",
-    "hf_downloads": 92190,
+    "hf_downloads": 124740,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9136,7 +14334,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 75610,
+    "hf_downloads": 83844,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9156,7 +14354,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "apriel",
-    "hf_downloads": 134702,
+    "hf_downloads": 28363,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9176,7 +14374,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hulumed_qwen3",
-    "hf_downloads": 31765,
+    "hf_downloads": 26549,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9198,16 +14396,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 144909,
+    "hf_downloads": 258663,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/translategemma-4b-it-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Infomaniak-AI/vllm-translategemma-4b-it",
@@ -9226,7 +14418,49 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 27600,
+    "hf_downloads": 24339,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Llama-3.1-8B-Instruct-NVFP4",
+    "provider": "redhatai",
+    "parameter_count": "5.0B",
+    "parameters_raw": 4976808384,
+    "min_ram_gb": 2.8,
+    "recommended_ram_gb": 4.6,
+    "min_vram_gb": 2.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 19265,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "allenai/Olmo-Hybrid-7B",
+    "provider": "allenai",
+    "parameter_count": "5.0B",
+    "parameters_raw": 4978114560,
+    "min_ram_gb": 2.8,
+    "recommended_ram_gb": 4.6,
+    "min_vram_gb": 2.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmo_hybrid",
+    "hf_downloads": 33527,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9249,7 +14483,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 53163,
+    "hf_downloads": 71143,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "dealignai/Qwen3.6-27B-JANG_4M-CRACK",
+    "provider": "dealignai",
+    "parameter_count": "5.0B",
+    "parameters_raw": 5034102000,
+    "min_ram_gb": 2.8,
+    "recommended_ram_gb": 4.7,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 10181,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9269,7 +14525,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 197630,
+    "hf_downloads": 109778,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9293,7 +14549,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 29302,
+    "hf_downloads": 28703,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9301,6 +14557,28 @@
     "num_experts": 128,
     "active_experts": 6,
     "active_parameters": 477744593
+  },
+  {
+    "name": "lmstudio-community/Qwen3-32B-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5119652864,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 17790,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/Qwen2.5-Coder-32B-Instruct-MLX-4bit",
@@ -9319,7 +14597,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 70143,
+    "hf_downloads": 71387,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9339,7 +14617,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35908,
+    "hf_downloads": 39299,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9362,8 +14640,8 @@
     ],
     "pipeline_tag": "any-to-any",
     "architecture": "gemma4",
-    "hf_downloads": 2717607,
-    "hf_likes": 542,
+    "hf_downloads": 3384168,
+    "hf_likes": 574,
     "release_date": "2026-03-02",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -9385,6 +14663,128 @@
     ]
   },
   {
+    "name": "deepseek-ai/deepseek-llm-7b-chat",
+    "provider": "DeepSeek",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5138022400,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 53218,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/deepseek-math-7b-instruct",
+    "provider": "DeepSeek",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5138022400,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 41162,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/deepseek-llm-7b-base",
+    "provider": "DeepSeek",
+    "parameter_count": "5.1B",
+    "parameters_raw": 5138022400,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 39319,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "baffo32/decapoda-research-llama-7B-hf",
+    "provider": "baffo32",
+    "parameter_count": "5.2B",
+    "parameters_raw": 5164236800,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 52145,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "wisdomik/Quilt-Llava-v1.5-7b",
+    "provider": "wisdomik",
+    "parameter_count": "5.2B",
+    "parameters_raw": 5164236800,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llava",
+    "hf_downloads": 35041,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "selfrag/selfrag_llama2_7b",
+    "provider": "selfrag",
+    "parameter_count": "5.2B",
+    "parameters_raw": 5164302336,
+    "min_ram_gb": 2.9,
+    "recommended_ram_gb": 4.8,
+    "min_vram_gb": 2.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16417,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "ISTA-DASLab/gemma-3-27b-it-GPTQ-4b-128g",
     "provider": "ista-daslab",
     "parameter_count": "5.2B",
@@ -9399,7 +14799,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 342232,
+    "hf_downloads": 273573,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "baichuan-inc/Baichuan-7B",
+    "provider": "baichuan-inc",
+    "parameter_count": "5.3B",
+    "parameters_raw": 5295308800,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 4.9,
+    "min_vram_gb": 2.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "baichuan",
+    "hf_downloads": 44659,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9419,16 +14839,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 243183,
+    "hf_downloads": 598255,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/chandra-ocr-2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-Coder-30B-A3B-Instruct-AWQ-4bit",
@@ -9447,7 +14861,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 58715,
+    "hf_downloads": 252879,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9473,7 +14887,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 37259,
+    "hf_downloads": 54751,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9481,6 +14895,126 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 580405768
+  },
+  {
+    "name": "kyujinpy/Ko-PlatYi-6B",
+    "provider": "kyujinpy",
+    "parameter_count": "5.4B",
+    "parameters_raw": 5354553344,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.0,
+    "min_vram_gb": 2.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 36419,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
+    "provider": "nvidia",
+    "parameter_count": "5.4B",
+    "parameters_raw": 5367627776,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.0,
+    "min_vram_gb": 2.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 113983,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/NVIDIA-Nemotron-3-Nano-4B",
+    "provider": "unsloth",
+    "parameter_count": "5.4B",
+    "parameters_raw": 5367627776,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.0,
+    "min_vram_gb": 2.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 17399,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "BAAI/AquilaChat2-7B",
+    "provider": "BAAI",
+    "parameter_count": "5.4B",
+    "parameters_raw": 5442797568,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.1,
+    "min_vram_gb": 2.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "aquila",
+    "hf_downloads": 20832,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm-chat-7b",
+    "provider": "internlm",
+    "parameter_count": "5.5B",
+    "parameters_raw": 5455740928,
+    "min_ram_gb": 3.0,
+    "recommended_ram_gb": 5.1,
+    "min_vram_gb": 2.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm",
+    "hf_downloads": 52556,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "baichuan-inc/Baichuan2-7B-Chat",
+    "provider": "baichuan-inc",
+    "parameter_count": "5.5B",
+    "parameters_raw": 5548015616,
+    "min_ram_gb": 3.1,
+    "recommended_ram_gb": 5.2,
+    "min_vram_gb": 2.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "baichuan",
+    "hf_downloads": 63959,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "microsoft/Phi-4-multimodal-instruct",
@@ -9497,13 +15031,35 @@
     "capabilities": [],
     "pipeline_tag": "automatic-speech-recognition",
     "architecture": "phi4mm",
-    "hf_downloads": 375170,
+    "hf_downloads": 410265,
     "hf_likes": 1597,
     "release_date": "2025-02-24",
     "num_hidden_layers": 32,
     "num_attention_heads": 24,
     "num_key_value_heads": 8,
     "head_dim": 128
+  },
+  {
+    "name": "Qwen/Qwen2.5-7B-Instruct-AWQ",
+    "provider": "Alibaba",
+    "parameter_count": "5.8B",
+    "parameters_raw": 5785780224,
+    "min_ram_gb": 3.2,
+    "recommended_ram_gb": 5.4,
+    "min_vram_gb": 3.0,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 1602299,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-VL-30B-A3B-Instruct-AWQ-4bit",
@@ -9523,7 +15079,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 23899,
+    "hf_downloads": 27524,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9547,7 +15103,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 28193,
+    "hf_downloads": 104174,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9567,7 +15123,111 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 13637,
+    "hf_downloads": 14848,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mistralai/Mistral-7B-Instruct-v0.1",
+    "provider": "Mistral AI",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036652032,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 397723,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "BioMistral/BioMistral-7B",
+    "provider": "biomistral",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036652032,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 184555,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Ttimofeyka/MistralRP-Noromaid-NSFW-Mistral-7B-GGUF",
+    "provider": "ttimofeyka",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036652032,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 32401,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "teknium/OpenHermes-2.5-Mistral-7B",
+    "provider": "teknium",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036660224,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 74646,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "openchat/openchat_3.5",
+    "provider": "OpenChat",
+    "parameter_count": "6.0B",
+    "parameters_raw": 6036660224,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.6,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 39997,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9587,7 +15247,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 24454,
+    "hf_downloads": 19094,
     "hf_likes": 70,
     "release_date": "2023-11-22",
     "num_hidden_layers": 32,
@@ -9600,6 +15260,30 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "arcee-ai/Trinity-Nano-Preview",
+    "provider": "arcee-ai",
+    "parameter_count": "6.1B",
+    "parameters_raw": 6120003328,
+    "min_ram_gb": 3.4,
+    "recommended_ram_gb": 5.7,
+    "min_vram_gb": 3.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "afmoe",
+    "hf_downloads": 19900,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 669375358
   },
   {
     "name": "lmstudio-community/gemma-4-26B-A4B-it-MLX-6bit",
@@ -9616,7 +15300,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 111097,
+    "hf_downloads": 115209,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -9640,7 +15324,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 36168,
+    "hf_downloads": 46228,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9662,7 +15346,299 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 119168,
+    "hf_downloads": 320204,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zhiqing/Huihui-Qwen3.6-27B-abliterated-AWQ",
+    "provider": "zhiqing",
+    "parameter_count": "6.3B",
+    "parameters_raw": 6284446960,
+    "min_ram_gb": 3.5,
+    "recommended_ram_gb": 5.9,
+    "min_vram_gb": 3.2,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 15312,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-chat-7b",
+    "provider": "internlm",
+    "parameter_count": "6.3B",
+    "parameters_raw": 6284640256,
+    "min_ram_gb": 3.5,
+    "recommended_ram_gb": 5.9,
+    "min_vram_gb": 3.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 54555,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-7b",
+    "provider": "internlm",
+    "parameter_count": "6.3B",
+    "parameters_raw": 6284640256,
+    "min_ram_gb": 3.5,
+    "recommended_ram_gb": 5.9,
+    "min_vram_gb": 3.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 25804,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-base-7b",
+    "provider": "internlm",
+    "parameter_count": "6.3B",
+    "parameters_raw": 6284640256,
+    "min_ram_gb": 3.5,
+    "recommended_ram_gb": 5.9,
+    "min_vram_gb": 3.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 20075,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tencent/Hunyuan-7B-Instruct",
+    "provider": "tencent",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430552064,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "hunyuan_v1_dense",
+    "hf_downloads": 16135,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+    "provider": "DeepSeek",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 1891196,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4",
+    "provider": "hugging-quants",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 382229,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 53923,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "NousResearch/Meta-Llama-3-8B-Instruct",
+    "provider": "NousResearch",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 48446,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "modularai/Llama-3.1-8B-Instruct-GGUF",
+    "provider": "modularai",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 27617,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "casperhansen/llama-3-8b-instruct-awq",
+    "provider": "casperhansen",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 24129,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.1-8B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430916608,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15678,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "S4nfs/Neeto-1.0-8b",
+    "provider": "s4nfs",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6430920704,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14921,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "dealignai/Gemma-4-31B-JANG_4M-Uncensored",
+    "provider": "dealignai",
+    "parameter_count": "6.4B",
+    "parameters_raw": 6433044332,
+    "min_ram_gb": 3.6,
+    "recommended_ram_gb": 6.0,
+    "min_vram_gb": 3.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 19283,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9682,7 +15658,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 188142,
+    "hf_downloads": 182625,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9704,7 +15680,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 33063,
+    "hf_downloads": 29478,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9724,7 +15700,137 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 16420,
+    "hf_downloads": 13723,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "facebook/opt-6.7b",
+    "provider": "facebook",
+    "parameter_count": "6.6B",
+    "parameters_raw": 6648365056,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 38687,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-8B",
+    "provider": "unsloth",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 96281,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-8B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 60797,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 51987,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-8B-Base",
+    "provider": "unsloth",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 26517,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3-8B-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6662127616,
+    "min_ram_gb": 3.7,
+    "recommended_ram_gb": 6.2,
+    "min_vram_gb": 3.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 15258,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9771,7 +15877,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 35217,
+    "hf_downloads": 36841,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "kifai/GECKO-7B",
+    "provider": "kifai",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6738415616,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.3,
+    "min_vram_gb": 3.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14746,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -9791,16 +15917,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1937898,
+    "hf_downloads": 1519527,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-2-7b-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "huggyllama/llama-7b",
@@ -9817,16 +15937,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 217705,
+    "hf_downloads": 192844,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/llama-7b-GGUF",
-        "provider": "TheBloke"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "NousResearch/Llama-2-7b-hf",
@@ -9843,16 +15957,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 99323,
+    "hf_downloads": 114122,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-2-7b-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "NousResearch/Llama-2-7b-chat-hf",
@@ -9869,16 +15977,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 33437,
+    "hf_downloads": 32351,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-2-7b-chat-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "meta-llama/CodeLlama-7b-Instruct-hf",
@@ -9895,8 +15997,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 2709,
-    "hf_likes": 59,
+    "hf_downloads": 2156,
+    "hf_likes": 60,
     "release_date": "2024-03-13",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -9924,16 +16026,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 134709,
+    "hf_downloads": 203298,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-7b-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "codellama/CodeLlama-7b-Instruct-hf",
@@ -9950,16 +16046,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 108702,
+    "hf_downloads": 45380,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/CodeLlama-7b-Instruct-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "defog/sqlcoder-7b-2",
@@ -9976,16 +16066,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 34346,
+    "hf_downloads": 27994,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/sqlcoder-7b-2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/Llama-2-7B-Chat-GPTQ",
+    "provider": "thebloke",
+    "parameter_count": "6.7B",
+    "parameters_raw": 6739777536,
+    "min_ram_gb": 3.8,
+    "recommended_ram_gb": 6.3,
+    "min_vram_gb": 3.5,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 22028,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "deepseek-ai/deepseek-coder-6.7b-instruct",
@@ -10002,20 +16106,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 214722,
+    "hf_downloads": 237005,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/deepseek-coder-6.7b-instruct-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/deepseek-coder-6.7b-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "deepseek-ai/deepseek-coder-6.7b-base",
@@ -10032,20 +16126,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 33266,
+    "hf_downloads": 41121,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/deepseek-coder-6.7b-base-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/deepseek-coder-6.7b-base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "deepseek-ai/deepseek-coder-7b-instruct-v1.5",
@@ -10062,16 +16146,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 41756,
+    "hf_downloads": 108133,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/deepseek-coder-7b-instruct-v1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/OLMoE-1B-7B-0125-Instruct",
@@ -10088,20 +16166,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmoe",
-    "hf_downloads": 79719,
+    "hf_downloads": 91071,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 8,
-    "active_parameters": 1167608556,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/OLMoE-1B-7B-0125-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 1167608556
   },
   {
     "name": "allenai/OLMoE-1B-7B-0924-Instruct",
@@ -10118,24 +16190,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmoe",
-    "hf_downloads": 35782,
+    "hf_downloads": 37916,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 8,
-    "active_parameters": 1167608556,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/OLMoE-1B-7B-0924-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/OLMoE-1B-7B-0924-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 1167608556
+  },
+  {
+    "name": "allenai/OLMoE-1B-7B-0125",
+    "provider": "allenai",
+    "parameter_count": "6.9B",
+    "parameters_raw": 6919161856,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.4,
+    "min_vram_gb": 3.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmoe",
+    "hf_downloads": 18068,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 8,
+    "active_parameters": 1167608556
   },
   {
     "name": "ibm-granite/granite-4.0-h-tiny",
@@ -10152,7 +16238,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "granitemoehybrid",
-    "hf_downloads": 88464,
+    "hf_downloads": 75159,
     "hf_likes": 201,
     "release_date": "2025-09-16",
     "num_hidden_layers": 40,
@@ -10175,6 +16261,46 @@
     ]
   },
   {
+    "name": "unsloth/llama-2-7b-chat-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "6.9B",
+    "parameters_raw": 6941323894,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14024,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "farbodtavakkoli/OTel-LLM-8.3B-IT",
+    "provider": "farbodtavakkoli",
+    "parameter_count": "7.0B",
+    "parameters_raw": 6967787520,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 809696,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "EleutherAI/pythia-6.9b",
     "provider": "eleutherai",
     "parameter_count": "7.0B",
@@ -10189,16 +16315,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_neox",
-    "hf_downloads": 138579,
+    "hf_downloads": 116108,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/pythia-6.9b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "openchat/openchat-3.5-0106",
@@ -10245,6 +16365,26 @@
     "release_date": "2025-05-01"
   },
   {
+    "name": "humain-ai/ALLaM-7B-Instruct-preview",
+    "provider": "humain-ai",
+    "parameter_count": "7.0B",
+    "parameters_raw": 7000559616,
+    "min_ram_gb": 3.9,
+    "recommended_ram_gb": 6.5,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15787,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "microsoft/Orca-2-7b",
     "provider": "Microsoft",
     "parameter_count": "7.0B",
@@ -10286,16 +16426,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "chameleon",
-    "hf_downloads": 117790,
+    "hf_downloads": 152505,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/chameleon-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "liuhaotian/llava-v1.6-vicuna-7b",
@@ -10314,7 +16448,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 30136,
+    "hf_downloads": 32654,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10334,7 +16468,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 107537,
+    "hf_downloads": 120141,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10356,7 +16490,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 2648883,
+    "hf_downloads": 3047197,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10378,7 +16512,67 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 43342,
+    "hf_downloads": 45213,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-3.0-8b-instruct",
+    "provider": "ibm-granite",
+    "parameter_count": "7.1B",
+    "parameters_raw": 7079997440,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.6,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granite",
+    "hf_downloads": 37050,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-guardian-3.3-8b",
+    "provider": "ibm-granite",
+    "parameter_count": "7.1B",
+    "parameters_raw": 7080013824,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.6,
+    "min_vram_gb": 3.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granite",
+    "hf_downloads": 14069,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RekaAI/reka-edge-2603",
+    "provider": "rekaai",
+    "parameter_count": "7.1B",
+    "parameters_raw": 7128509568,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.6,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "yasa2",
+    "hf_downloads": 11536,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10398,13 +16592,58 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "starcoder2",
-    "hf_downloads": 15700,
+    "hf_downloads": 14467,
     "hf_likes": 215,
     "release_date": "2024-02-20",
     "num_hidden_layers": 32,
     "num_attention_heads": 36,
     "num_key_value_heads": 4,
     "head_dim": 128
+  },
+  {
+    "name": "shoumenchougou/RWKV7-G1f-7.2B-GGUF",
+    "provider": "RWKV",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7200000000,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "rwkv",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
+  },
+  {
+    "name": "Chunity/Qwen3.6-35B-A3B-AutoRound-AWQ-4bit",
+    "provider": "chunity",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7204574576,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 13329,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 574114528
   },
   {
     "name": "tiiuae/falcon-7b-instruct",
@@ -10421,7 +16660,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "falcon",
-    "hf_downloads": 53333,
+    "hf_downloads": 52538,
     "hf_likes": 1032,
     "release_date": "2023-04-25",
     "num_hidden_layers": 32,
@@ -10450,16 +16689,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "falcon",
-    "hf_downloads": 220831,
+    "hf_downloads": 283814,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/falcon-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "HuggingFaceH4/zephyr-7b-beta",
@@ -10476,8 +16709,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "mistral",
-    "hf_downloads": 119699,
-    "hf_likes": 1843,
+    "hf_downloads": 145707,
+    "hf_likes": 1842,
     "release_date": "2023-10-26",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -10511,20 +16744,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 2067579,
+    "hf_downloads": 2585420,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Mistral-7B-Instruct-v0.2-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Mistral-7B-Instruct-v0.2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "mistralai/Mistral-7B-v0.1",
@@ -10541,20 +16764,32 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 992414,
+    "hf_downloads": 1041293,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/Mistral-7B-v0.1-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/Mistral-7B-v0.1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/Mistral-7B-Instruct-v0.2-AWQ",
+    "provider": "thebloke",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 166342,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "SanjiWatsuki/Kunoichi-DPO-v2-7B",
@@ -10571,16 +16806,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 120104,
+    "hf_downloads": 134208,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Kunoichi-DPO-v2-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "parasail-ai/GritLM-7B-vllm",
@@ -10597,7 +16826,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 48217,
+    "hf_downloads": 57825,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10617,16 +16846,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 44578,
+    "hf_downloads": 42317,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/prometheus-7b-v2.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "mlabonne/NeuralMonarch-7B",
@@ -10643,16 +16866,134 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 29091,
+    "hf_downloads": 29874,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/NeuralMonarch-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "GritLM/GritLM-7B",
+    "provider": "gritlm",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 21029,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lex-hue/Delexa-7b",
+    "provider": "lex-hue",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 15711,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "pucpr-br/Clinical-BR-Mistral-7B-v0.2",
+    "provider": "pucpr-br",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 15418,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlabonne/AlphaMonarch-7B",
+    "provider": "mlabonne",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241732096,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 13498,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/OpenHermes-2.5-Mistral-7B-AWQ",
+    "provider": "thebloke",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7241748480,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 18140,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TheBloke/Mistral-7B-Instruct-v0.2-GPTQ",
+    "provider": "thebloke",
+    "parameter_count": "7.2B",
+    "parameters_raw": 7243108352,
+    "min_ram_gb": 4.0,
+    "recommended_ram_gb": 6.7,
+    "min_vram_gb": 3.7,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 88650,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "mistralai/Mistral-7B-Instruct-v0.3",
@@ -10671,8 +17012,8 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 3103899,
-    "hf_likes": 2541,
+    "hf_downloads": 3599033,
+    "hf_likes": 2557,
     "release_date": "2024-05-22",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -10704,7 +17045,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 75507,
+    "hf_downloads": 70202,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10726,7 +17067,67 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 106057,
+    "hf_downloads": 129182,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/CodeQwen1.5-7B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "7.3B",
+    "parameters_raw": 7250284544,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 23801,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "skt/A.X-4.0-Light",
+    "provider": "skt",
+    "parameter_count": "7.3B",
+    "parameters_raw": 7259624960,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 13962,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tiiuae/falcon-mamba-7b-instruct",
+    "provider": "TII",
+    "parameter_count": "7.3B",
+    "parameters_raw": 7272665088,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.8,
+    "min_vram_gb": 3.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "falcon_mamba",
+    "hf_downloads": 16718,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10746,16 +17147,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 121152,
+    "hf_downloads": 192664,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Olmo-3-1025-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/Olmo-3-7B-Instruct-SFT",
@@ -10772,16 +17167,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 81799,
+    "hf_downloads": 82888,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Olmo-3-7B-Instruct-SFT-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/OLMo-2-1124-7B-Instruct",
@@ -10798,20 +17187,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo2",
-    "hf_downloads": 27977,
+    "hf_downloads": 33598,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/OLMo-2-1124-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/OLMo-2-1124-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Zyphra/Zamba2-7B-Instruct",
+    "provider": "zyphra",
+    "parameter_count": "7.4B",
+    "parameters_raw": 7356749648,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "zamba2",
+    "hf_downloads": 21587,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LanguageBind/Video-LLaVA-7B-hf",
@@ -10830,7 +17229,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "video_llava",
-    "hf_downloads": 13391,
+    "hf_downloads": 14563,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "microsoft/Phi-3-small-8k-instruct",
+    "provider": "Microsoft",
+    "parameter_count": "7.4B",
+    "parameters_raw": 7392274432,
+    "min_ram_gb": 4.1,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "phi3small",
+    "hf_downloads": 17456,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10850,7 +17269,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 17529,
+    "hf_downloads": 13800,
     "hf_likes": 79,
     "release_date": "2024-11-29",
     "num_hidden_layers": 28,
@@ -10869,6 +17288,130 @@
     ]
   },
   {
+    "name": "unsloth/mistral-7b-instruct-v0.2-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7460400036,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 13465,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/mistral-7b-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7460400452,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 6.9,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 31116,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/mistral-7b-instruct-v0.3-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7466691910,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 7.0,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 51294,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/mistral-7b-v0.3-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7466691914,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 7.0,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 396946,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/Minitron-8B-Base",
+    "provider": "nvidia",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7491026944,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 7.0,
+    "min_vram_gb": 3.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron",
+    "hf_downloads": 21315,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "LGAI-EXAONE/EXAONE-4.5-33B-AWQ",
+    "provider": "lgai-exaone",
+    "parameter_count": "7.5B",
+    "parameters_raw": 7507208320,
+    "min_ram_gb": 4.2,
+    "recommended_ram_gb": 7.0,
+    "min_vram_gb": 3.8,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "exaone4_5",
+    "hf_downloads": 14700,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "openvla/openvla-7b-finetuned-libero-object",
     "provider": "openvla",
     "parameter_count": "7.5B",
@@ -10883,7 +17426,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "openvla",
-    "hf_downloads": 65732,
+    "hf_downloads": 66477,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10903,7 +17446,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "openvla",
-    "hf_downloads": 12540,
+    "hf_downloads": 11976,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -10925,16 +17468,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_mistral",
-    "hf_downloads": 14427,
+    "hf_downloads": 16768,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llava-med-v1.5-mistral-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "liuhaotian/llava-v1.6-mistral-7b",
@@ -10953,35 +17490,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_mistral",
-    "hf_downloads": 34189,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llava-v1.6-mistral-7b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "llava-hf/bakLlava-v1-hf",
-    "provider": "llava-hf",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7566743552,
-    "min_ram_gb": 4.2,
-    "recommended_ram_gb": 7.0,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose",
-    "capabilities": [
-      "vision"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "llava",
-    "hf_downloads": 10841,
+    "hf_downloads": 37803,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11003,7 +17512,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 627279,
+    "hf_downloads": 610871,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11025,8 +17534,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 12582644,
-    "hf_likes": 1245,
+    "hf_downloads": 14206853,
+    "hf_likes": 1261,
     "release_date": "2024-09-16",
     "num_hidden_layers": 28,
     "num_attention_heads": 28,
@@ -11060,8 +17569,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 2086890,
-    "hf_likes": 700,
+    "hf_downloads": 2255359,
+    "hf_likes": 704,
     "release_date": "2024-09-17",
     "num_hidden_layers": 28,
     "num_attention_heads": 28,
@@ -11097,8 +17606,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 573416,
-    "hf_likes": 827,
+    "hf_downloads": 583643,
+    "hf_likes": 830,
     "release_date": "2025-01-20",
     "num_hidden_layers": 28,
     "num_attention_heads": 28,
@@ -11120,34 +17629,6 @@
     ]
   },
   {
-    "name": "Qwen/Qwen2.5-Coder-7B",
-    "provider": "Alibaba",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Code generation and completion",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 1654696,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
     "name": "Qwen/Qwen2.5-7B",
     "provider": "Alibaba",
     "parameter_count": "7.6B",
@@ -11164,27 +17645,21 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1651354,
+    "hf_downloads": 1926266,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "Qwen/Qwen2.5-Coder-7B-Instruct-GPTQ-Int4",
+    "name": "Qwen/Qwen2.5-Coder-7B",
     "provider": "Alibaba",
     "parameter_count": "7.6B",
     "parameters_raw": 7615616512,
     "min_ram_gb": 4.3,
     "recommended_ram_gb": 7.1,
     "min_vram_gb": 3.9,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 32768,
     "use_case": "Code generation and completion",
     "capabilities": [
@@ -11192,7 +17667,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 842230,
+    "hf_downloads": 1804792,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11212,20 +17687,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 569047,
+    "hf_downloads": 664586,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-Math-7B",
@@ -11244,16 +17709,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 432991,
+    "hf_downloads": 625591,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-Math-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-7B-Instruct-GPTQ-Int4",
+    "provider": "Alibaba",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 588928,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-Coder-7B-Instruct-AWQ",
@@ -11272,7 +17753,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 323191,
+    "hf_downloads": 331991,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-7B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 299805,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11292,35 +17795,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "Dream",
-    "hf_downloads": 150426,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Dream-v0-Instruct-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
-    "provider": "Alibaba",
-    "parameter_count": "7.6B",
-    "parameters_raw": 7615616512,
-    "min_ram_gb": 4.3,
-    "recommended_ram_gb": 7.1,
-    "min_vram_gb": 3.9,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 77158,
+    "hf_downloads": 169291,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11340,20 +17815,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 67131,
+    "hf_downloads": 72854,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "XCurOS/XCurOS-0.1-8B-Instruct",
-    "provider": "xcuros",
+    "name": "unsloth/Qwen2.5-7B",
+    "provider": "unsloth",
     "parameter_count": "7.6B",
     "parameters_raw": 7615616512,
     "min_ram_gb": 4.3,
@@ -11361,12 +17830,14 @@
     "min_vram_gb": 3.9,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 51017,
+    "hf_downloads": 68389,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11388,20 +17859,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 42434,
+    "hf_downloads": 66019,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-Math-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Math-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "XCurOS/XCurOS-0.1-8B-Instruct",
+    "provider": "xcuros",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 53507,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Dream-org/Dream-v0-Base-7B",
@@ -11418,16 +17899,32 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "Dream",
-    "hf_downloads": 41884,
+    "hf_downloads": 52572,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Dream-v0-Base-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-7B-Instruct-GPTQ-Int4",
+    "provider": "Alibaba",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 47871,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-7B-Instruct-1M",
@@ -11446,20 +17943,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 30960,
+    "hf_downloads": 36221,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-7B-Instruct-1M-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-7B-Instruct-1M-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "DeepHat/DeepHat-V1-7B",
+    "provider": "deephat",
+    "parameter_count": "7.6B",
+    "parameters_raw": 7615616512,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.1,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 17275,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "microsoft/Phi-mini-MoE-instruct",
@@ -11476,7 +17983,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phimoe",
-    "hf_downloads": 133227,
+    "hf_downloads": 157536,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -11500,7 +18007,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 137613,
+    "hf_downloads": 156068,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -11508,6 +18015,28 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 838664239
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD",
+    "provider": "nvidia",
+    "parameter_count": "7.7B",
+    "parameters_raw": 7699118592,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.2,
+    "min_vram_gb": 3.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "NemotronH_Nano_VL_V2",
+    "hf_downloads": 26042,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen1.5-7B",
@@ -11524,16 +18053,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 89588,
+    "hf_downloads": 84128,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen1.5-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen-7B-Chat",
@@ -11550,16 +18073,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen",
-    "hf_downloads": 81727,
+    "hf_downloads": 66923,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen-7B-Chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen-7B",
@@ -11576,16 +18093,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen",
-    "hf_downloads": 47134,
+    "hf_downloads": 20129,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen1.5-7B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "7.7B",
+    "parameters_raw": 7721324544,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.2,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 15239,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "internlm/internlm2_5-7b-chat",
@@ -11602,20 +18133,50 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internlm2",
-    "hf_downloads": 50406,
+    "hf_downloads": 63009,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/internlm2_5-7b-chat-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/internlm2_5-7b-chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "chujiezheng/internlm2-chat-7b-ExPO",
+    "provider": "chujiezheng",
+    "parameter_count": "7.7B",
+    "parameters_raw": 7737708544,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.2,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 16277,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TurbulenceDeterministe/Carnice-9b-W8A16-AWQ",
+    "provider": "turbulencedeterministe",
+    "parameter_count": "7.7B",
+    "parameters_raw": 7742552560,
+    "min_ram_gb": 8.7,
+    "recommended_ram_gb": 14.4,
+    "min_vram_gb": 7.9,
+    "quantization": "AWQ-8bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 22789,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Salesforce/blip2-opt-6.7b",
@@ -11632,7 +18193,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "blip-2",
-    "hf_downloads": 47282,
+    "hf_downloads": 62360,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11652,7 +18213,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "molmo2",
-    "hf_downloads": 76108,
+    "hf_downloads": 102694,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11672,7 +18233,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 86237,
+    "hf_downloads": 153757,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm3-8b-instruct",
+    "provider": "internlm",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7774142464,
+    "min_ram_gb": 4.3,
+    "recommended_ram_gb": 7.2,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 196608,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm3",
+    "hf_downloads": 37290,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11692,7 +18273,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "moshi",
-    "hf_downloads": 101654,
+    "hf_downloads": 105227,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-7B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7786310038,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 141211,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11712,16 +18315,100 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone",
-    "hf_downloads": 286142,
+    "hf_downloads": 295023,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-7B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7820050908,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 195330,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-Coder-7B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7820050928,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 169571,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-7B-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7820050938,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 13364,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zai-org/GLM-4.5-Air-FP8",
+    "provider": "zai-org",
+    "parameter_count": "7.8B",
+    "parameters_raw": 7831814144,
+    "min_ram_gb": 4.4,
+    "recommended_ram_gb": 7.3,
+    "min_vram_gb": 4.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 29834,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/EXAONE-Deep-7.8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 856604667
   },
   {
     "name": "XiaomiMiMo/MiMo-7B-Base",
@@ -11738,7 +18425,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mimo",
-    "hf_downloads": 92320,
+    "hf_downloads": 93775,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11758,7 +18445,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3n",
-    "hf_downloads": 317754,
+    "hf_downloads": 208415,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11778,7 +18465,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "instructblip",
-    "hf_downloads": 13159,
+    "hf_downloads": 12867,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11798,7 +18485,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl",
-    "hf_downloads": 22573,
+    "hf_downloads": 28192,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11818,24 +18505,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 20205,
+    "hf_downloads": 22169,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/InternVL3-8B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/InternVL3-8B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/InternVL3-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "lingshu-medical-mllm/Lingshu-I-8B",
@@ -11852,7 +18525,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl",
-    "hf_downloads": 14737,
+    "hf_downloads": 14185,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11872,7 +18545,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 283246,
+    "hf_downloads": 290857,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -11892,16 +18565,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 134773,
+    "hf_downloads": 190989,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-E4B-it-OBLITERATED-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "google/gemma-4-E4B-it",
@@ -11921,8 +18588,8 @@
     ],
     "pipeline_tag": "any-to-any",
     "architecture": "gemma4",
-    "hf_downloads": 4040361,
-    "hf_likes": 856,
+    "hf_downloads": 5455888,
+    "hf_likes": 922,
     "release_date": "2026-03-02",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -11975,6 +18642,26 @@
     ]
   },
   {
+    "name": "GSAI-ML/LLaDA-1.5",
+    "provider": "gsai-ml",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8015581184,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llada",
+    "hf_downloads": 25340,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "allenai/Molmo-7B-D-0924",
     "provider": "allenai",
     "parameter_count": "8.0B",
@@ -11989,7 +18676,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "molmo",
-    "hf_downloads": 38879,
+    "hf_downloads": 39541,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12011,20 +18698,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "cohere2",
-    "hf_downloads": 26912,
+    "hf_downloads": 29117,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/c4ai-command-r7b-12-2024-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/c4ai-command-r7b-12-2024-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "CohereLabs/aya-expanse-8b",
+    "provider": "coherelabs",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8028033024,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "cohere",
+    "hf_downloads": 21937,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "meta-llama/Llama-3.1-8B",
@@ -12041,8 +18738,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 1457060,
-    "hf_likes": 2173,
+    "hf_downloads": 1546453,
+    "hf_likes": 2180,
     "release_date": "2024-07-14",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -12066,8 +18763,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 9335798,
-    "hf_likes": 5767,
+    "hf_downloads": 9683014,
+    "hf_likes": 5792,
     "release_date": "2024-07-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -12122,16 +18819,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 3269447,
+    "hf_downloads": 3357934,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Meta-Llama-3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "meta-llama/Meta-Llama-3-8B-Instruct",
@@ -12150,20 +18841,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 1460299,
+    "hf_downloads": 1665386,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Meta-Llama-3-8B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Meta-Llama-3-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Llama-3.1-8B-Instruct-FP8",
@@ -12182,7 +18863,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 783156,
+    "hf_downloads": 739804,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.1-8B-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 715273,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12202,20 +18905,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 386138,
+    "hf_downloads": 403856,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/saiga_llama3_8b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "NousResearch/Meta-Llama-3.1-8B-Instruct",
-    "provider": "NousResearch",
+    "name": "unsloth/Meta-Llama-3.1-8B-Instruct",
+    "provider": "unsloth",
     "parameter_count": "8.0B",
     "parameters_raw": 8030261248,
     "min_ram_gb": 4.5,
@@ -12230,46 +18927,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 196722,
+    "hf_downloads": 281773,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Meta-Llama-3.1-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "meta-llama/Llama-Guard-3-8B",
-    "provider": "Meta",
-    "parameter_count": "8.0B",
-    "parameters_raw": 8030261248,
-    "min_ram_gb": 4.5,
-    "recommended_ram_gb": 7.5,
-    "min_vram_gb": 4.1,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "llama",
-    "hf_downloads": 149672,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-Guard-3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "NousResearch/Hermes-3-Llama-3.1-8B",
@@ -12288,24 +18949,34 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 149032,
+    "hf_downloads": 189407,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Hermes-3-Llama-3.1-8B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Hermes-3-Llama-3.1-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "DeSTA-ntu/Llama-3.1-8B-Instruct",
-    "provider": "desta-ntu",
+    "name": "meta-llama/Llama-Guard-3-8B",
+    "provider": "Meta",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 154354,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "NousResearch/Meta-Llama-3.1-8B-Instruct",
+    "provider": "NousResearch",
     "parameter_count": "8.0B",
     "parameters_raw": 8030261248,
     "min_ram_gb": 4.5,
@@ -12320,16 +18991,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 77418,
+    "hf_downloads": 142895,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3.1-8B-Instruct-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "MaziyarPanahi/Meta-Llama-3-8B-Instruct-GPTQ",
@@ -12348,7 +19013,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 62126,
+    "hf_downloads": 82890,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "DeSTA-ntu/Llama-3.1-8B-Instruct",
+    "provider": "desta-ntu",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 78120,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12368,16 +19055,32 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 38863,
+    "hf_downloads": 68223,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-3.1-Nemotron-Safety-Guard-8B-v3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "solidrust/Meta-Llama-3.1-8B-Instruct-abliterated-AWQ",
+    "provider": "solidrust",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 54085,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "NousResearch/Meta-Llama-3-8B",
@@ -12394,16 +19097,116 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 34566,
+    "hf_downloads": 44869,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Meta-Llama-3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "qqlabs/llama3_1_relevance_dev",
+    "provider": "qqlabs",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 26278,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "solidrust/Hermes-3-Llama-3.1-8B-AWQ",
+    "provider": "solidrust",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 24028,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Meta-Llama-3-8B-Instruct-FP8-KV",
+    "provider": "redhatai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 23932,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/llama-3-8b-Instruct",
+    "provider": "unsloth",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21165,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Meta-Llama-3.1-8B",
+    "provider": "unsloth",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 20928,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "nvidia/Llama-3.1-Nemotron-Nano-8B-v1",
@@ -12420,20 +19223,130 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 33308,
+    "hf_downloads": 16930,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3.1-Nemotron-Nano-8B-v1-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Llama-3.1-Nemotron-Nano-8B-v1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "FlagAlpha/Llama3-Chinese-8B-Instruct",
+    "provider": "flagalpha",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16289,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "migtissera/Tess-2.0-Llama-3-8B",
+    "provider": "migtissera",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16182,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlabonne/NeuralDaredevil-8B-abliterated",
+    "provider": "mlabonne",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15462,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Danielbrdz/Barcenas-Llama3-8b-ORPO",
+    "provider": "danielbrdz",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13549,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "uygarkurt/llama-3-merged-linear",
+    "provider": "uygarkurt",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13484,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "DeepMount00/Llama-3-8b-Ita",
+    "provider": "deepmount00",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261248,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13354,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8",
@@ -12452,7 +19365,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 408871,
+    "hf_downloads": 477426,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12472,7 +19385,67 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 221149,
+    "hf_downloads": 225059,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/Meta-Llama-3-8B-FP8-compressed-tensors-test",
+    "provider": "nm-testing",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030261696,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14132,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "allenai/Llama-3.1-Tulu-3-8B-SFT",
+    "provider": "allenai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030326784,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 24958,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "allenai/Llama-3.1-Tulu-3.1-8B",
+    "provider": "allenai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030326784,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15470,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12494,7 +19467,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 152434,
+    "hf_downloads": 140314,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12516,20 +19489,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 222370,
+    "hf_downloads": 34905,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Hermes-2-Pro-Llama-3-8B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Hermes-2-Pro-Llama-3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "nm-testing/Meta-Llama-3-8B-Instruct-nonuniform-test",
+    "provider": "nm-testing",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8030568538,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21808,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "llava-hf/llava-onevision-qwen2-7b-ov-hf",
@@ -12548,7 +19533,49 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_onevision",
-    "hf_downloads": 60557,
+    "hf_downloads": 106871,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "fdtn-ai/Foundation-Sec-8B",
+    "provider": "fdtn-ai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8031309824,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 15826,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "pearl-ai/Llama-3.1-8B-Instruct-pearl",
+    "provider": "pearl-ai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8031547392,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 50891,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12570,7 +19597,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 51346,
+    "hf_downloads": 62130,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12592,7 +19619,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 34547,
+    "hf_downloads": 38748,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12614,7 +19641,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 25134,
+    "hf_downloads": 21342,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8",
+    "provider": "redhatai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8031637504,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 19937,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "FriendliAI/Meta-Llama-3.1-8B-Instruct-int8",
+    "provider": "friendliai",
+    "parameter_count": "8.0B",
+    "parameters_raw": 8031637504,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14357,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12634,10 +19705,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hulumed_qwen2",
-    "hf_downloads": 16452,
+    "hf_downloads": 15838,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "upstage/Solar-Open-100B",
+    "provider": "Upstage",
+    "parameter_count": "8.1B",
+    "parameters_raw": 8053063680,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "solar_open",
+    "hf_downloads": 236957,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 880803840
   },
   {
     "name": "swiss-ai/Apertus-8B-Instruct-2509",
@@ -12654,20 +19749,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "apertus",
-    "hf_downloads": 205379,
+    "hf_downloads": 181872,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Apertus-8B-Instruct-2509-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Apertus-8B-Instruct-2509-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "swiss-ai/Apertus-8B-2509",
@@ -12684,16 +19769,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "apertus",
-    "hf_downloads": 27610,
+    "hf_downloads": 30838,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Apertus-8B-2509-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-8b-code-instruct-128k",
+    "provider": "ibm-granite",
+    "parameter_count": "8.1B",
+    "parameters_raw": 8054910976,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14500,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "nvidia/Eagle2.5-8B",
@@ -12710,7 +19809,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "eagle_2_5_vl",
-    "hf_downloads": 69432,
+    "hf_downloads": 86031,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12730,7 +19829,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 479094,
+    "hf_downloads": 481225,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12750,7 +19849,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 300602,
+    "hf_downloads": 311890,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "inceptionai/Jais-2-8B-Chat",
+    "provider": "inceptionai",
+    "parameter_count": "8.1B",
+    "parameters_raw": 8090401280,
+    "min_ram_gb": 4.5,
+    "recommended_ram_gb": 7.5,
+    "min_vram_gb": 4.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "jais2",
+    "hf_downloads": 16379,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12770,16 +19889,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 134456,
+    "hf_downloads": 119195,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/MiniCPM-V-2_6-GGUF",
-        "provider": "bartowski"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Nemotron-H-8B-Base-8K",
@@ -12796,7 +19909,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 53188,
+    "hf_downloads": 51184,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12816,20 +19929,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "granite",
-    "hf_downloads": 421370,
+    "hf_downloads": 75870,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/granite-3.3-8b-instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/granite-3.3-8b-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "openbmb/MiniCPM4.1-8B",
@@ -12846,16 +19949,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpm",
-    "hf_downloads": 32266,
+    "hf_downloads": 58999,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/MiniCPM4.1-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "openbmb/MiniCPM4-8B",
+    "provider": "openbmb",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8185253888,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minicpm",
+    "hf_downloads": 16536,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-8B",
@@ -12874,8 +19991,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3",
-    "hf_downloads": 9024066,
-    "hf_likes": 1067,
+    "hf_downloads": 10813873,
+    "hf_likes": 1073,
     "release_date": "2025-04-27",
     "num_hidden_layers": 36,
     "num_attention_heads": 32,
@@ -12913,7 +20030,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 1106454,
+    "hf_downloads": 1435479,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -12935,16 +20052,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 474822,
+    "hf_downloads": 573569,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-8B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
@@ -12963,20 +20074,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 260565,
+    "hf_downloads": 258291,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-0528-Qwen3-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3Guard-Gen-8B",
@@ -12995,16 +20096,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 191646,
+    "hf_downloads": 111035,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3Guard-Gen-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Qwen3-8B-FP8",
@@ -13023,7 +20118,47 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 37108,
+    "hf_downloads": 19438,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "JetLM/SDAR-8B-Chat",
+    "provider": "jetlm",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8190735360,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "sdar",
+    "hf_downloads": 14569,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hkust-nlp/WebExplorer-8B",
+    "provider": "hkust-nlp",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8190735360,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 23481,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13045,7 +20180,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 185789,
+    "hf_downloads": 226410,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13067,7 +20202,219 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 33304,
+    "hf_downloads": 35052,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Qwen3-8B-FP8-dynamic",
+    "provider": "redhatai",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8192136192,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.6,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 30065,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-Distill-Llama-8B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8243411700,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 18253,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Meta-Llama-3.1-8B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8243411714,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 61501,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.1-8B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8243411714,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 33310,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/meta-Llama-3.1-8B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8243411722,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 25808,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929342,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 428533,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.1-8B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929342,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 25365,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Meta-Llama-3.1-8B-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929356,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 33050,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/llama-3-8b-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929382,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 80536,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/llama-3-8b-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "8.2B",
+    "parameters_raw": 8248929386,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 81051,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13089,24 +20436,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 2054600,
+    "hf_downloads": 3258098,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2-VL-7B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "ggml-org/Qwen2-VL-7B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2-VL-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2-VL-7B-Instruct-AWQ",
@@ -13125,7 +20458,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 1662721,
+    "hf_downloads": 1708456,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13147,16 +20480,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 43410,
+    "hf_downloads": 35219,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2-VL-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2-VL-7B-Instruct-GPTQ-Int4",
@@ -13175,27 +20502,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 37527,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "MBZUAI/AIN",
-    "provider": "mbzuai",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8291375616,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.7,
-    "min_vram_gb": 4.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_vl",
-    "hf_downloads": 16222,
+    "hf_downloads": 11796,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13218,8 +20525,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 8847645,
-    "hf_likes": 1512,
+    "hf_downloads": 8902443,
+    "hf_likes": 1519,
     "release_date": "2025-01-26",
     "num_hidden_layers": 28,
     "num_attention_heads": 28,
@@ -13236,32 +20543,6 @@
       },
       {
         "repo": "mradermacher/Qwen2.5-VL-7B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "reducto/RolmOCR",
-    "provider": "reducto",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8292166656,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.7,
-    "min_vram_gb": 4.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 304708,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/RolmOCR-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -13284,7 +20565,47 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 241779,
+    "hf_downloads": 341659,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "reducto/RolmOCR",
+    "provider": "reducto",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8292166656,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 312983,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "numind/NuExtract-2.0-8B-GPTQ",
+    "provider": "numind",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8292166656,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 172124,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13304,33 +20625,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 156760,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/olmOCR-2-7B-1025-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "numind/NuExtract-2.0-8B-GPTQ",
-    "provider": "numind",
-    "parameter_count": "8.3B",
-    "parameters_raw": 8292166656,
-    "min_ram_gb": 4.6,
-    "recommended_ram_gb": 7.7,
-    "min_vram_gb": 4.2,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
-    "context_length": 128000,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2_5_vl",
-    "hf_downloads": 64989,
+    "hf_downloads": 68739,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13350,16 +20645,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 18743,
+    "hf_downloads": 19470,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/UI-TARS-1.5-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/olmOCR-7B-0825",
@@ -13376,20 +20665,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 16866,
+    "hf_downloads": 17425,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/olmOCR-7B-0825-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "OctoMed/OctoMed-7B",
-    "provider": "octomed",
+    "name": "Singh8898/DiegoCropper",
+    "provider": "singh8898",
     "parameter_count": "8.3B",
     "parameters_raw": 8292166656,
     "min_ram_gb": 4.6,
@@ -13402,16 +20685,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 15778,
+    "hf_downloads": 12113,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/OctoMed-7B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "numind/NuExtract-2.0-8B",
+    "provider": "numind",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8292166656,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.7,
+    "min_vram_gb": 4.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 128000,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2_5_vl",
+    "hf_downloads": 10735,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "xlangai/OpenCUA-7B",
@@ -13428,7 +20725,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "opencua",
-    "hf_downloads": 153947,
+    "hf_downloads": 145002,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13448,27 +20745,49 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 259229,
+    "hf_downloads": 277163,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "openbmb/MiniCPM-V-2_6-int4",
-    "provider": "openbmb",
+    "name": "RedHatAI/Qwen3-8B-quantized.w4a16",
+    "provider": "redhatai",
     "parameter_count": "8.3B",
-    "parameters_raw": 8315441823,
+    "parameters_raw": 8299263480,
     "min_ram_gb": 4.6,
     "recommended_ram_gb": 7.7,
     "min_vram_gb": 4.3,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Lightweight, edge deployment",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 23620,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "adept/persimmon-8b-chat",
+    "provider": "adept",
+    "parameter_count": "8.3B",
+    "parameters_raw": 8321499136,
+    "min_ram_gb": 4.6,
+    "recommended_ram_gb": 7.8,
+    "min_vram_gb": 4.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "Instruction following, chat",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "minicpmv",
-    "hf_downloads": 18804,
+    "architecture": "persimmon",
+    "hf_downloads": 15076,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13488,8 +20807,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2_moe",
-    "hf_downloads": 111280,
-    "hf_likes": 351,
+    "hf_downloads": 112372,
+    "hf_likes": 352,
     "release_date": "2025-10-07",
     "num_hidden_layers": 24,
     "num_attention_heads": 32,
@@ -13523,7 +20842,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 22591,
+    "hf_downloads": 18801,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13545,7 +20864,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 36198,
+    "hf_downloads": 35287,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13565,7 +20884,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen",
-    "hf_downloads": 44796,
+    "hf_downloads": 63224,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13585,7 +20904,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "idefics2",
-    "hf_downloads": 105584,
+    "hf_downloads": 106490,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13607,20 +20926,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 47616,
+    "hf_downloads": 32660,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Mistral-NeMo-Minitron-8B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Mistral-NeMo-Minitron-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "KonstantinosKK/lavida-llada-v1.0-instruct-hf-transformers",
@@ -13637,7 +20946,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llava_llada",
-    "hf_downloads": 17489,
+    "hf_downloads": 13166,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13659,16 +20968,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 84252,
+    "hf_downloads": 89420,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llama-joycaption-beta-one-hf-llava-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "TIGER-Lab/Mantis-8B-siglip-llama3",
@@ -13685,7 +20988,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 56653,
+    "hf_downloads": 74442,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13707,27 +21010,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 14637,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "OpenGVLab/InternVL3_5-8B-HF",
-    "provider": "opengvlab",
-    "parameter_count": "8.5B",
-    "parameters_raw": 8528318464,
-    "min_ram_gb": 4.8,
-    "recommended_ram_gb": 7.9,
-    "min_vram_gb": 4.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "internvl",
-    "hf_downloads": 48763,
+    "hf_downloads": 132276,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13747,16 +21030,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 41399,
+    "hf_downloads": 165709,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/InternVL3_5-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "OpenGVLab/InternVL3_5-8B-HF",
+    "provider": "opengvlab",
+    "parameter_count": "8.5B",
+    "parameters_raw": 8528318464,
+    "min_ram_gb": 4.8,
+    "recommended_ram_gb": 7.9,
+    "min_vram_gb": 4.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internvl",
+    "hf_downloads": 48151,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "openbmb/MiniCPM-Llama3-V-2_5",
@@ -13773,7 +21070,71 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 39339,
+    "hf_downloads": 25511,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "google/gemma-1.1-7b-it",
+    "provider": "Google",
+    "parameter_count": "8.5B",
+    "parameters_raw": 8537680896,
+    "min_ram_gb": 4.8,
+    "recommended_ram_gb": 8.0,
+    "min_vram_gb": 4.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma",
+    "hf_downloads": 14721,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen-VL",
+    "provider": "Alibaba",
+    "parameter_count": "8.5B",
+    "parameters_raw": 8541175808,
+    "min_ram_gb": 4.8,
+    "recommended_ram_gb": 8.0,
+    "min_vram_gb": 4.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen",
+    "hf_downloads": 90484,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen-VL-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "8.5B",
+    "parameters_raw": 8541175808,
+    "min_ram_gb": 4.8,
+    "recommended_ram_gb": 8.0,
+    "min_vram_gb": 4.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen",
+    "hf_downloads": 74574,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13793,7 +21154,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 272528,
+    "hf_downloads": 276702,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13813,7 +21174,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 49275,
+    "hf_downloads": 49874,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13835,7 +21196,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "aya_vision",
-    "hf_downloads": 108072,
+    "hf_downloads": 129802,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13855,7 +21216,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "molmo2",
-    "hf_downloads": 543123,
+    "hf_downloads": 580858,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13875,7 +21236,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "Bee",
-    "hf_downloads": 91543,
+    "hf_downloads": 124069,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13895,7 +21256,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 127083,
+    "hf_downloads": 141948,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13915,7 +21276,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minicpmv",
-    "hf_downloads": 30739,
+    "hf_downloads": 41348,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13935,7 +21296,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "emu3",
-    "hf_downloads": 51291,
+    "hf_downloads": 58658,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -13958,20 +21319,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 3937427,
+    "hf_downloads": 5028618,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-8B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-8B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-VL-8B-Thinking",
@@ -13991,20 +21342,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 471775,
+    "hf_downloads": 797018,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-8B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-8B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Cosmos-Reason2-8B",
@@ -14021,16 +21362,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 175437,
+    "hf_downloads": 225634,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Cosmos-Reason2-8B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "datalab-to/chandra",
@@ -14047,7 +21382,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 101639,
+    "hf_downloads": 103682,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14067,16 +21402,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 86533,
+    "hf_downloads": 91675,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/XCurOS-1.2-8B-VLBF16-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "thelamapi/next-ocr",
@@ -14093,16 +21422,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 12077,
+    "hf_downloads": 11175,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/next-ocr-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-VL-8B-Instruct-FP8",
@@ -14122,7 +21445,110 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 453977,
+    "hf_downloads": 576836,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-VL-8B-Thinking-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "8.8B",
+    "parameters_raw": 8767547632,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_vl",
+    "hf_downloads": 42315,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-granite/granite-4.1-8b",
+    "provider": "ibm-granite",
+    "parameter_count": "8.8B",
+    "parameters_raw": 8791592960,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "granite",
+    "hf_downloads": 21803,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "01-ai/Yi-1.5-9B-Chat",
+    "provider": "01.ai",
+    "parameter_count": "8.8B",
+    "parameters_raw": 8829407232,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21677,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "01-ai/Yi-1.5-9B",
+    "provider": "01.ai",
+    "parameter_count": "8.8B",
+    "parameters_raw": 8829407232,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14528,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "tiiuae/falcon-mamba-7b",
+    "provider": "TII",
+    "parameter_count": "8.9B",
+    "parameters_raw": 8856272896,
+    "min_ram_gb": 4.9,
+    "recommended_ram_gb": 8.2,
+    "min_vram_gb": 4.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "falcon_mamba",
+    "hf_downloads": 72129,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14142,8 +21568,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "nemotron_h",
-    "hf_downloads": 532819,
-    "hf_likes": 489,
+    "hf_downloads": 560506,
+    "hf_likes": 490,
     "release_date": "2025-08-12",
     "num_hidden_layers": 56,
     "num_attention_heads": 40,
@@ -14165,16 +21591,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 185794,
+    "hf_downloads": 141066,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/NVIDIA-Nemotron-Nano-9B-v2-Japanese-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Base",
@@ -14191,7 +21611,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 31139,
+    "hf_downloads": 24080,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14211,7 +21631,69 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 71287,
+    "hf_downloads": 81607,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "AIDC-AI/Ovis2-8B",
+    "provider": "aidc-ai",
+    "parameter_count": "8.9B",
+    "parameters_raw": 8935282678,
+    "min_ram_gb": 5.0,
+    "recommended_ram_gb": 8.3,
+    "min_vram_gb": 4.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ovis",
+    "hf_downloads": 27848,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen3.5-9B-OptiQ-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "9.0B",
+    "parameters_raw": 8953801728,
+    "min_ram_gb": 5.0,
+    "recommended_ram_gb": 8.3,
+    "min_vram_gb": 4.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 142142,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "maxcurrent/Peagle-9b",
+    "provider": "maxcurrent",
+    "parameter_count": "9.0B",
+    "parameters_raw": 8986628096,
+    "min_ram_gb": 5.0,
+    "recommended_ram_gb": 8.4,
+    "min_vram_gb": 4.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 13401,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14233,7 +21715,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 42100,
+    "hf_downloads": 41989,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14253,7 +21735,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 317137,
+    "hf_downloads": 339120,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Qwen3-32B-MLX-8bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "9.2B",
+    "parameters_raw": 9214833664,
+    "min_ram_gb": 5.1,
+    "recommended_ram_gb": 8.6,
+    "min_vram_gb": 4.7,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 16976,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14275,7 +21779,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 65757,
+    "hf_downloads": 66555,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14295,7 +21799,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 35656,
+    "hf_downloads": 39079,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14315,8 +21819,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "gemma2",
-    "hf_downloads": 459638,
-    "hf_likes": 793,
+    "hf_downloads": 521850,
+    "hf_likes": 795,
     "release_date": "2024-06-24",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -14329,6 +21833,72 @@
       },
       {
         "repo": "mradermacher/gemma-2-9b-it-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "unsloth/gemma-2-9b-it",
+    "provider": "unsloth",
+    "parameter_count": "9.2B",
+    "parameters_raw": 9241705984,
+    "min_ram_gb": 5.2,
+    "recommended_ram_gb": 8.6,
+    "min_vram_gb": 4.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma2",
+    "hf_downloads": 32998,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "moondream/moondream3-preview",
+    "provider": "moondream",
+    "parameter_count": "9.3B",
+    "parameters_raw": 9268626928,
+    "min_ram_gb": 5.2,
+    "recommended_ram_gb": 8.6,
+    "min_vram_gb": 4.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "moondream3",
+    "hf_downloads": 29461,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "speakleash/Bielik-11B-v2.3-Instruct",
+    "provider": "speakleash",
+    "parameter_count": "9.4B",
+    "parameters_raw": 9359065088,
+    "min_ram_gb": 5.2,
+    "recommended_ram_gb": 8.7,
+    "min_vram_gb": 4.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 14359,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Bielik-11B-v2.3-Instruct-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -14348,20 +21918,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 27822,
+    "hf_downloads": 24226,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 8,
-    "active_parameters": 1580596576,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/academic-ds-9B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 1580596576
+  },
+  {
+    "name": "zai-org/glm-4-9b-chat-hf",
+    "provider": "zai-org",
+    "parameter_count": "9.4B",
+    "parameters_raw": 9399951360,
+    "min_ram_gb": 5.3,
+    "recommended_ram_gb": 8.8,
+    "min_vram_gb": 4.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm",
+    "hf_downloads": 19901,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "THUDM/glm-4-9b-chat",
@@ -14378,7 +21962,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "chatglm",
-    "hf_downloads": 426483,
+    "hf_downloads": 372499,
     "hf_likes": 706,
     "release_date": "2024-06-04",
     "num_hidden_layers": 40,
@@ -14397,6 +21981,26 @@
     ]
   },
   {
+    "name": "zai-org/GLM-4-9B-0414",
+    "provider": "zai-org",
+    "parameter_count": "9.4B",
+    "parameters_raw": 9400279040,
+    "min_ram_gb": 5.3,
+    "recommended_ram_gb": 8.8,
+    "min_vram_gb": 4.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4",
+    "hf_downloads": 22844,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "adept/fuyu-8b",
     "provider": "adept",
     "parameter_count": "9.4B",
@@ -14411,7 +22015,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "fuyu",
-    "hf_downloads": 80781,
+    "hf_downloads": 92166,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14433,7 +22037,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 20633,
+    "hf_downloads": 28840,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14455,44 +22059,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 16553,
+    "hf_downloads": 14508,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Gliese-Qwen3.5-9B-Abliterated-Caption-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "Momix-44/Qwen3.5-9B-gemini-3.1-opus-4.6-reasoning",
-    "provider": "momix-44",
-    "parameter_count": "9.4B",
-    "parameters_raw": 9409813744,
+    "name": "unsloth/gemma-2-9b-it-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "9.5B",
+    "parameters_raw": 9502508184,
     "min_ram_gb": 5.3,
     "recommended_ram_gb": 8.8,
-    "min_vram_gb": 4.8,
+    "min_vram_gb": 4.9,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 10188,
+    "architecture": "gemma2",
+    "hf_downloads": 31384,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-9B-gemini-3.1-opus-4.6-reasoning-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3.5-9B",
@@ -14512,8 +22102,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 7121429,
-    "hf_likes": 1362,
+    "hf_downloads": 7908981,
+    "hf_likes": 1388,
     "release_date": "2026-02-27",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -14548,13 +22138,51 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 130945,
+    "hf_downloads": 163939,
     "hf_likes": 73,
     "release_date": "2026-02-26",
     "num_hidden_layers": null,
     "num_attention_heads": null,
     "num_key_value_heads": null,
-    "head_dim": null
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-9B-Base-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2",
+    "provider": "jackrong",
+    "parameter_count": "9.7B",
+    "parameters_raw": 9653104368,
+    "min_ram_gb": 5.4,
+    "recommended_ram_gb": 9.0,
+    "min_vram_gb": 4.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 8766,
+    "hf_likes": 165,
+    "release_date": "2026-03-16",
+    "num_hidden_layers": null,
+    "num_attention_heads": null,
+    "num_key_value_heads": null,
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
   },
   {
     "name": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled",
@@ -14573,7 +22201,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 382681,
+    "hf_downloads": 379279,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14593,16 +22221,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 354821,
+    "hf_downloads": 354144,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwopus3.5-9B-v3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "QuantTrio/Qwen3.5-9B-AWQ",
@@ -14621,7 +22243,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 265356,
+    "hf_downloads": 228107,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14643,16 +22265,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 87524,
+    "hf_downloads": 45014,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-9B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "huihui-ai/Huihui-Qwen3.5-9B-Claude-4.6-Opus-abliterated",
@@ -14671,35 +22287,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 45313,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-9B-Claude-4.6-Opus-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Jackrong/Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2",
-    "provider": "jackrong",
-    "parameter_count": "9.7B",
-    "parameters_raw": 9653104368,
-    "min_ram_gb": 5.4,
-    "recommended_ram_gb": 9.0,
-    "min_vram_gb": 4.9,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 15066,
+    "hf_downloads": 31411,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14721,16 +22309,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 10157,
+    "hf_downloads": 12466,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-9B-GLM5.1-Distill-v1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "lovedheart/Qwen3.5-9B-FP8",
@@ -14749,7 +22331,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 283542,
+    "hf_downloads": 270831,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14769,7 +22351,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen",
-    "hf_downloads": 227107,
+    "hf_downloads": 231334,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ibm-ai-platform/Bamba-9B-v1",
+    "provider": "ibm-ai-platform",
+    "parameter_count": "9.8B",
+    "parameters_raw": 9780235392,
+    "min_ram_gb": 5.5,
+    "recommended_ram_gb": 9.1,
+    "min_vram_gb": 5.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "bamba",
+    "hf_downloads": 23909,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14791,7 +22393,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 23430,
+    "hf_downloads": 26774,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14813,10 +22415,34 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 15277,
+    "hf_downloads": 19010,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "Snowflake/snowflake-arctic-instruct",
+    "provider": "snowflake",
+    "parameter_count": "9.9B",
+    "parameters_raw": 9863168000,
+    "min_ram_gb": 5.5,
+    "recommended_ram_gb": 9.2,
+    "min_vram_gb": 5.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "arctic",
+    "hf_downloads": 23546,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 2,
+    "active_parameters": 639564800
   },
   {
     "name": "cyankiwi/Qwen3.5-9B-AWQ-4bit",
@@ -14835,7 +22461,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 251801,
+    "hf_downloads": 343105,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14857,7 +22483,47 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "plamo2vl",
-    "hf_downloads": 10491,
+    "hf_downloads": 10383,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmsys/longchat-13b-16k",
+    "provider": "LMSYS",
+    "parameter_count": "10.0B",
+    "parameters_raw": 10020454400,
+    "min_ram_gb": 5.6,
+    "recommended_ram_gb": 9.3,
+    "min_vram_gb": 5.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16664,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Undi95/ReMM-SLERP-L2-13B",
+    "provider": "undi95",
+    "parameter_count": "10.0B",
+    "parameters_raw": 10020454400,
+    "min_ram_gb": 5.6,
+    "recommended_ram_gb": 9.3,
+    "min_vram_gb": 5.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14887,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14879,7 +22545,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "step_robotics",
-    "hf_downloads": 269013,
+    "hf_downloads": 342363,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -14899,20 +22565,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4v",
-    "hf_downloads": 366504,
+    "hf_downloads": 390582,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.1V-9B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/GLM-4.1V-9B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "zai-org/GLM-4.6V-Flash",
@@ -14929,24 +22585,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4v",
-    "hf_downloads": 40322,
+    "hf_downloads": 43469,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.6V-Flash-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/GLM-4.6V-Flash-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/GLM-4.6V-Flash-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "dengcao/GLM-4.1V-9B-Thinking-AWQ",
@@ -14963,10 +22605,54 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4v",
-    "hf_downloads": 256742,
+    "hf_downloads": 180048,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "CausalLM/14B-DPO-alpha",
+    "provider": "causallm",
+    "parameter_count": "10.6B",
+    "parameters_raw": 10582753280,
+    "min_ram_gb": 5.9,
+    "recommended_ram_gb": 9.9,
+    "min_vram_gb": 5.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 24618,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "varjosoft/gemma-4-26B-A4B-it-TQ3-native",
+    "provider": "varjosoft",
+    "parameter_count": "10.6B",
+    "parameters_raw": 10619634222,
+    "min_ram_gb": 5.9,
+    "recommended_ram_gb": 9.9,
+    "min_vram_gb": 5.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 15028,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1161522487
   },
   {
     "name": "meta-llama/Llama-3.2-11B-Vision",
@@ -14985,7 +22671,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mllama",
-    "hf_downloads": 13070,
+    "hf_downloads": 13481,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15008,8 +22694,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "mllama",
-    "hf_downloads": 109463,
-    "hf_likes": 1587,
+    "hf_downloads": 156636,
+    "hf_likes": 1588,
     "release_date": "2024-09-18",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -15034,7 +22720,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mllama",
-    "hf_downloads": 30527,
+    "hf_downloads": 30475,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15054,7 +22740,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 63398,
+    "hf_downloads": 63642,
     "hf_likes": 652,
     "release_date": "2023-12-12",
     "num_hidden_layers": 48,
@@ -15087,20 +22773,90 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 29189,
+    "hf_downloads": 29551,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "TheBloke/SOLAR-10.7B-v1.0-GGUF",
-        "provider": "TheBloke"
-      },
-      {
-        "repo": "mradermacher/SOLAR-10.7B-v1.0-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "jeonsworld/CarbonVillain-en-10.7B-v4",
+    "provider": "jeonsworld",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13566,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "kekmodel/StopCarbon-10.7B-v5",
+    "provider": "kekmodel",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13531,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "invalid-coder/Sakura-SOLAR-Instruct-CarbonVillain-en-10.7B-v2-slerp",
+    "provider": "invalid-coder",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 13516,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "vicgalle/CarbonBeagle-11B-truthy",
+    "provider": "vicgalle",
+    "parameter_count": "10.7B",
+    "parameters_raw": 10731524096,
+    "min_ram_gb": 6.0,
+    "recommended_ram_gb": 10.0,
+    "min_vram_gb": 5.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 13437,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "naver-hyperclovax/HyperCLOVAX-SEED-Omni-8B",
@@ -15117,7 +22873,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "vlm",
-    "hf_downloads": 297851,
+    "hf_downloads": 260475,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "OrionStarAI/Orion-14B-Chat",
+    "provider": "orionstarai",
+    "parameter_count": "10.9B",
+    "parameters_raw": 10918952960,
+    "min_ram_gb": 6.1,
+    "recommended_ram_gb": 10.2,
+    "min_vram_gb": 5.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "orion",
+    "hf_downloads": 21615,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15137,10 +22913,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 238608,
+    "hf_downloads": 126797,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "allenai/Flex-reddit-2x7B-1T",
+    "provider": "allenai",
+    "parameter_count": "11.6B",
+    "parameters_raw": 11627401216,
+    "min_ram_gb": 6.5,
+    "recommended_ram_gb": 10.8,
+    "min_vram_gb": 6.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "flex_olmo",
+    "hf_downloads": 14461,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 2,
+    "active_experts": 2,
+    "active_parameters": 11627401216
   },
   {
     "name": "Intel/Qwen3-Coder-Next-int4-AutoRound",
@@ -15159,7 +22959,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 70604,
+    "hf_downloads": 72209,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15167,6 +22967,26 @@
     "num_experts": 512,
     "active_experts": 10,
     "active_parameters": 810590063
+  },
+  {
+    "name": "EleutherAI/pythia-12b",
+    "provider": "eleutherai",
+    "parameter_count": "12.0B",
+    "parameters_raw": 11997067840,
+    "min_ram_gb": 6.7,
+    "recommended_ram_gb": 11.2,
+    "min_vram_gb": 6.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 20123,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "google/gemma-3-12b-it",
@@ -15218,7 +23038,95 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 29560,
+    "hf_downloads": 88649,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-14B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "12.1B",
+    "parameters_raw": 12102533120,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.3,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 179635,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-14B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "12.1B",
+    "parameters_raw": 12102533120,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.3,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 162348,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TeichAI/Qwen3-14B-Claude-4.5-Opus-High-Reasoning-Distill-GGUF",
+    "provider": "teichai",
+    "parameter_count": "12.1B",
+    "parameters_raw": 12102533120,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.3,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 46132,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-14B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "12.1B",
+    "parameters_raw": 12102533120,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.3,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 37409,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15240,7 +23148,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 140150,
+    "hf_downloads": 209562,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15260,42 +23168,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 43033,
+    "hf_downloads": 45100,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-3-12b-it-qat-q4_0-unquantized-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "google/gemma-3-12b-pt",
-    "provider": "Google",
-    "parameter_count": "12.2B",
-    "parameters_raw": 12187325040,
-    "min_ram_gb": 6.8,
-    "recommended_ram_gb": 11.4,
-    "min_vram_gb": 6.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma3",
-    "hf_downloads": 17746,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-3-12b-pt-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "gaunernst/gemma-3-12b-it-int4-awq",
@@ -15312,7 +23188,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 16212,
+    "hf_downloads": 37067,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "google/gemma-3-12b-pt",
+    "provider": "Google",
+    "parameter_count": "12.2B",
+    "parameters_raw": 12187325040,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.4,
+    "min_vram_gb": 6.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3",
+    "hf_downloads": 18586,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15349,6 +23245,70 @@
     ]
   },
   {
+    "name": "inflatebot/MN-12B-Mag-Mell-R1",
+    "provider": "inflatebot",
+    "parameter_count": "12.2B",
+    "parameters_raw": 12247782400,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.4,
+    "min_vram_gb": 6.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1024000,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 26453,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "casperhansen/mistral-nemo-instruct-2407-awq",
+    "provider": "casperhansen",
+    "parameter_count": "12.2B",
+    "parameters_raw": 12247782400,
+    "min_ram_gb": 6.8,
+    "recommended_ram_gb": 11.4,
+    "min_vram_gb": 6.3,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1024000,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 14262,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mlx-community/Qwen2.5-14B-Instruct-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "12.6B",
+    "parameters_raw": 12606504960,
+    "min_ram_gb": 7.0,
+    "recommended_ram_gb": 11.7,
+    "min_vram_gb": 6.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 70516,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "mistral-experimental/pixtral-12b",
     "provider": "mistral-experimental",
     "parameter_count": "12.7B",
@@ -15365,20 +23325,74 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 119129,
+    "hf_downloads": 125830,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "facebook/opt-13b",
+    "provider": "facebook",
+    "parameter_count": "12.8B",
+    "parameters_raw": 12840304640,
+    "min_ram_gb": 7.2,
+    "recommended_ram_gb": 12.0,
+    "min_vram_gb": 6.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 16940,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "mixtao/MixTAO-7Bx2-MoE-v8.1",
+    "provider": "mixtao",
+    "parameter_count": "12.9B",
+    "parameters_raw": 12879138816,
+    "min_ram_gb": 7.2,
+    "recommended_ram_gb": 12.0,
+    "min_vram_gb": 6.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 20288,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/pixtral-12b-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/pixtral-12b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 2,
+    "active_experts": 2,
+    "active_parameters": 12879138816
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-Nano-9B-v2-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "13.0B",
+    "parameters_raw": 12950568960,
+    "min_ram_gb": 7.2,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 15890,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "microsoft/Orca-2-13b",
@@ -15476,16 +23490,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 128187,
+    "hf_downloads": 151010,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/HarmBench-Llama-2-13b-cls-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "meta-llama/CodeLlama-13b-Instruct-hf",
@@ -15502,7 +23510,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 2798,
+    "hf_downloads": 2866,
     "hf_likes": 28,
     "release_date": "2024-03-13",
     "num_hidden_layers": null,
@@ -15515,6 +23523,26 @@
         "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "TheBloke/NexusRaven-V2-13B-AWQ",
+    "provider": "thebloke",
+    "parameter_count": "13.0B",
+    "parameters_raw": 13016110080,
+    "min_ram_gb": 7.3,
+    "recommended_ram_gb": 12.1,
+    "min_vram_gb": 6.7,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 16384,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21246,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8",
@@ -15533,7 +23561,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 642169,
+    "hf_downloads": 493102,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15555,10 +23583,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 218255,
+    "hf_downloads": 275296,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "DavidAU/gemma-3-12b-it-vl-GLM-4.7-Flash-INSTRUCT-Thinking-Hybrid-Heretic-Uncensored",
+    "provider": "davidau",
+    "parameter_count": "13.2B",
+    "parameters_raw": 13194203760,
+    "min_ram_gb": 7.4,
+    "recommended_ram_gb": 12.3,
+    "min_vram_gb": 6.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3",
+    "hf_downloads": 16446,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "shoumenchougou/RWKV7-G1f-13.3B-GGUF",
+    "provider": "RWKV",
+    "parameter_count": "13.3B",
+    "parameters_raw": 13300000000,
+    "min_ram_gb": 7.4,
+    "recommended_ram_gb": 12.4,
+    "min_vram_gb": 6.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose text generation",
+    "capabilities": [],
+    "pipeline_tag": "text-generation",
+    "architecture": "rwkv",
+    "hf_downloads": 0,
+    "hf_likes": 0,
+    "release_date": null
   },
   {
     "name": "llava-hf/llava-1.5-13b-hf",
@@ -15577,16 +23646,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 11441,
+    "hf_downloads": 11662,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/llava-1.5-13b-hf-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "llava-hf/llava-v1.6-vicuna-13b-hf",
@@ -15605,7 +23668,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 29356,
+    "hf_downloads": 35915,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "allenai/OLMo-2-1124-13B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "13.7B",
+    "parameters_raw": 13716198400,
+    "min_ram_gb": 7.7,
+    "recommended_ram_gb": 12.8,
+    "min_vram_gb": 7.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmo2",
+    "hf_downloads": 19733,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15625,20 +23708,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "phi3",
-    "hf_downloads": 56332,
+    "hf_downloads": 55441,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Phi-3-medium-4k-instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Phi-3-medium-4k-instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "microsoft/phi-4",
@@ -15716,6 +23789,46 @@
     ]
   },
   {
+    "name": "Qwen/Qwen1.5-14B-Chat",
+    "provider": "Alibaba",
+    "parameter_count": "14.2B",
+    "parameters_raw": 14167290880,
+    "min_ram_gb": 7.9,
+    "recommended_ram_gb": 13.2,
+    "min_vram_gb": 7.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 17892,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen1.5-14B",
+    "provider": "Alibaba",
+    "parameter_count": "14.2B",
+    "parameters_raw": 14167290880,
+    "min_ram_gb": 7.9,
+    "recommended_ram_gb": 13.2,
+    "min_vram_gb": 7.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14030,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "RedHatAI/Mistral-Small-3.2-24B-Instruct-2506-NVFP4",
     "provider": "redhatai",
     "parameter_count": "14.3B",
@@ -15732,7 +23845,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral3",
-    "hf_downloads": 49707,
+    "hf_downloads": 44963,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15752,7 +23865,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_moe",
-    "hf_downloads": 150264,
+    "hf_downloads": 166813,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15760,6 +23873,30 @@
     "num_experts": 60,
     "active_experts": 4,
     "active_parameters": 1622455541
+  },
+  {
+    "name": "nvidia/Gemma-4-26B-A4B-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "14.4B",
+    "parameters_raw": 14386941232,
+    "min_ram_gb": 8.0,
+    "recommended_ram_gb": 13.4,
+    "min_vram_gb": 7.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 98843,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1573571693
   },
   {
     "name": "cyankiwi/Qwen3-Coder-Next-AWQ-4bit",
@@ -15778,7 +23915,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 112730,
+    "hf_downloads": 114534,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15804,7 +23941,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 41839,
+    "hf_downloads": 40550,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15812,6 +23949,26 @@
     "num_experts": 512,
     "active_experts": 10,
     "active_parameters": 990253467
+  },
+  {
+    "name": "unsloth/phi-4",
+    "provider": "unsloth",
+    "parameter_count": "14.7B",
+    "parameters_raw": 14659507200,
+    "min_ram_gb": 8.2,
+    "recommended_ram_gb": 13.7,
+    "min_vram_gb": 7.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16384,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 26050,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3-Next-80B-A3B-Instruct-AWQ-4bit",
@@ -15830,7 +23987,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 211029,
+    "hf_downloads": 309830,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15856,7 +24013,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 122992,
+    "hf_downloads": 125557,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -15880,7 +24037,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hyperclovax",
-    "hf_downloads": 548545,
+    "hf_downloads": 337324,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15900,7 +24057,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "hyperclovax",
-    "hf_downloads": 35894,
+    "hf_downloads": 39886,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15922,29 +24079,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 732814,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "OpenPipe/Qwen3-14B-Instruct",
-    "provider": "openpipe",
-    "parameter_count": "14.8B",
-    "parameters_raw": 14768307200,
-    "min_ram_gb": 8.3,
-    "recommended_ram_gb": 13.8,
-    "min_vram_gb": 7.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 40960,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3",
-    "hf_downloads": 162308,
+    "hf_downloads": 903811,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15966,7 +24101,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 125796,
+    "hf_downloads": 125813,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "OpenPipe/Qwen3-14B-Instruct",
+    "provider": "openpipe",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14768307200,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 125288,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "JunHowie/Qwen3-14B-GPTQ-Int4",
+    "provider": "junhowie",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14768307200,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 78307,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -15988,16 +24167,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 61669,
+    "hf_downloads": 69069,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-14B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "TeichAI/Qwen3-14B-Claude-4.5-Opus-High-Reasoning-Distill",
+    "provider": "teichai",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14768307200,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 21576,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-14B-Instruct",
@@ -16074,7 +24269,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 951167,
+    "hf_downloads": 1141729,
     "hf_likes": 151,
     "release_date": "2024-11-06",
     "num_hidden_layers": 48,
@@ -16113,7 +24308,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1904475,
+    "hf_downloads": 1941920,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16135,7 +24330,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 621436,
+    "hf_downloads": 1050140,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16155,24 +24350,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 462743,
+    "hf_downloads": 433379,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-14B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-14B-Instruct-GPTQ-Int4",
@@ -16191,7 +24372,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 158402,
+    "hf_downloads": 184610,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16213,16 +24394,78 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 121026,
+    "hf_downloads": 144761,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-14B-Instruct-GPTQ-Int8",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770033664,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.5,
+    "min_vram_gb": 15.1,
+    "quantization": "GPTQ-Int8",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 32755,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-Coder-14B",
+    "provider": "Alibaba",
+    "parameter_count": "14.8B",
+    "parameters_raw": 14770033664,
+    "min_ram_gb": 8.3,
+    "recommended_ram_gb": 13.8,
+    "min_vram_gb": 7.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 24573,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "prithivMLmods/gemma-4-26B-A4B-it-MXFP4A16",
+    "provider": "prithivmlmods",
+    "parameter_count": "15.1B",
+    "parameters_raw": 15067525710,
+    "min_ram_gb": 8.4,
+    "recommended_ram_gb": 14.0,
+    "min_vram_gb": 7.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 10932,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-14B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1648010621
   },
   {
     "name": "bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4",
@@ -16239,7 +24482,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 300831,
+    "hf_downloads": 385977,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16265,7 +24508,73 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "phi4-siglip",
-    "hf_downloads": 135315,
+    "hf_downloads": 159013,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-14B-Instruct-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "15.2B",
+    "parameters_raw": 15155350546,
+    "min_ram_gb": 8.5,
+    "recommended_ram_gb": 14.1,
+    "min_vram_gb": 7.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 33330,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-Coder-14B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "15.2B",
+    "parameters_raw": 15183924206,
+    "min_ram_gb": 8.5,
+    "recommended_ram_gb": 14.1,
+    "min_vram_gb": 7.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 19634,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-14B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "15.2B",
+    "parameters_raw": 15183924272,
+    "min_ram_gb": 8.5,
+    "recommended_ram_gb": 14.1,
+    "min_vram_gb": 7.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 28548,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16310,7 +24619,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 267972,
+    "hf_downloads": 195504,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16357,8 +24666,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v2",
-    "hf_downloads": 965737,
-    "hf_likes": 589,
+    "hf_downloads": 1086169,
+    "hf_likes": 593,
     "release_date": "2024-06-14",
     "num_hidden_layers": 27,
     "num_attention_heads": 16,
@@ -16394,50 +24703,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 868178,
+    "hf_downloads": 903474,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2184182961,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/DeepSeek-V2-Lite-Chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "deepseek-ai/DeepSeek-V2-Lite",
-    "provider": "DeepSeek",
-    "parameter_count": "15.7B",
-    "parameters_raw": 15706484224,
-    "min_ram_gb": 8.8,
-    "recommended_ram_gb": 14.6,
-    "min_vram_gb": 8.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 6553600,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "deepseek_v2",
-    "hf_downloads": 369076,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 2184182961,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/DeepSeek-V2-Lite-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2184182961
   },
   {
     "name": "TechxGenus/DeepSeek-Coder-V2-Lite-Instruct-AWQ",
@@ -16454,7 +24727,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 318177,
+    "hf_downloads": 539289,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2184182961
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V2-Lite",
+    "provider": "DeepSeek",
+    "parameter_count": "15.7B",
+    "parameters_raw": 15706484224,
+    "min_ram_gb": 8.8,
+    "recommended_ram_gb": 14.6,
+    "min_vram_gb": 8.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v2",
+    "hf_downloads": 425194,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16478,7 +24775,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 98087,
+    "hf_downloads": 116489,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16488,28 +24785,24 @@
     "active_parameters": 2184182961
   },
   {
-    "name": "moonshotai/Moonlight-16B-A3B",
-    "provider": "moonshotai",
-    "parameter_count": "16.0B",
-    "parameters_raw": 15960111936,
-    "min_ram_gb": 8.9,
-    "recommended_ram_gb": 14.9,
-    "min_vram_gb": 8.2,
+    "name": "bigcode/starcoder",
+    "provider": "BigCode",
+    "parameter_count": "15.8B",
+    "parameters_raw": 15819446272,
+    "min_ram_gb": 8.8,
+    "recommended_ram_gb": 14.7,
+    "min_vram_gb": 8.1,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose",
+    "context_length": 4096,
+    "use_case": "Code generation and completion",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "deepseek_v3",
-    "hf_downloads": 63054,
+    "architecture": "gpt_bigcode",
+    "hf_downloads": 14709,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 64,
-    "active_experts": 6,
-    "active_parameters": 2219453062
+    "_discovered": true
   },
   {
     "name": "moonshotai/Moonlight-16B-A3B-Instruct",
@@ -16526,7 +24819,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 61342,
+    "hf_downloads": 56225,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2219453062
+  },
+  {
+    "name": "moonshotai/Moonlight-16B-A3B",
+    "provider": "moonshotai",
+    "parameter_count": "16.0B",
+    "parameters_raw": 15960111936,
+    "min_ram_gb": 8.9,
+    "recommended_ram_gb": 14.9,
+    "min_vram_gb": 8.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 54837,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16550,7 +24867,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_vl_v2",
-    "hf_downloads": 15362,
+    "hf_downloads": 16027,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16570,7 +24887,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llada2_moe",
-    "hf_downloads": 97464,
+    "hf_downloads": 119345,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 1295371577
+  },
+  {
+    "name": "inclusionAI/Ling-mini-2.0",
+    "provider": "inclusionai",
+    "parameter_count": "16.3B",
+    "parameters_raw": 16255643392,
+    "min_ram_gb": 9.1,
+    "recommended_ram_gb": 15.1,
+    "min_vram_gb": 8.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "bailing_moe",
+    "hf_downloads": 22637,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16594,7 +24935,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 32067,
+    "hf_downloads": 29393,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16618,20 +24959,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek",
-    "hf_downloads": 31198,
+    "hf_downloads": 34084,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2277249690,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/deepseek-moe-16b-base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2277249690
   },
   {
     "name": "deepseek-ai/deepseek-moe-16b-chat",
@@ -16648,20 +24983,66 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek",
-    "hf_downloads": 26692,
+    "hf_downloads": 25747,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2277249690,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/deepseek-moe-16b-chat-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2277249690
+  },
+  {
+    "name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+    "provider": "Alibaba",
+    "parameter_count": "16.4B",
+    "parameters_raw": 16392912896,
+    "min_ram_gb": 9.2,
+    "recommended_ram_gb": 15.3,
+    "min_vram_gb": 8.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 142008,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1792974844
+  },
+  {
+    "name": "Qwen/Qwen3-235B-A22B-Thinking-2507",
+    "provider": "Alibaba",
+    "parameter_count": "16.4B",
+    "parameters_raw": 16392912896,
+    "min_ram_gb": 9.2,
+    "recommended_ram_gb": 15.3,
+    "min_vram_gb": 8.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 37143,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1792974844
   },
   {
     "name": "moonshotai/Kimi-VL-A3B-Instruct",
@@ -16680,20 +25061,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "kimi_vl",
-    "hf_downloads": 244263,
+    "hf_downloads": 254749,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2281689908,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Kimi-VL-A3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2281689908
   },
   {
     "name": "moonshotai/Kimi-VL-A3B-Thinking",
@@ -16712,7 +25087,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "kimi_vl",
-    "hf_downloads": 94032,
+    "hf_downloads": 108715,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16720,6 +25095,32 @@
     "num_experts": 64,
     "active_experts": 6,
     "active_parameters": 2281689908
+  },
+  {
+    "name": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "16.5B",
+    "parameters_raw": 16536305663,
+    "min_ram_gb": 9.2,
+    "recommended_ram_gb": 15.4,
+    "min_vram_gb": 8.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 119783,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 1612289795
   },
   {
     "name": "sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP",
@@ -16738,7 +25139,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 30787,
+    "hf_downloads": 210715,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "osoleve/Qwen3.5-27B-Text-NVFP4-MTP",
+    "provider": "osoleve",
+    "parameter_count": "16.7B",
+    "parameters_raw": 16667329536,
+    "min_ram_gb": 9.3,
+    "recommended_ram_gb": 15.5,
+    "min_vram_gb": 8.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 18391,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Abiray/Qwen3.6-27B-NVFP4",
+    "provider": "abiray",
+    "parameter_count": "16.7B",
+    "parameters_raw": 16703361232,
+    "min_ram_gb": 9.3,
+    "recommended_ram_gb": 15.6,
+    "min_vram_gb": 8.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 17711,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16760,7 +25205,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 103179,
+    "hf_downloads": 63560,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16782,7 +25227,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 15726,
+    "hf_downloads": 15237,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16802,7 +25247,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "bailing_moe",
-    "hf_downloads": 487,
+    "hf_downloads": 353,
     "hf_likes": 79,
     "release_date": "2025-02-28",
     "num_hidden_layers": 28,
@@ -16835,20 +25280,82 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bailing_moe",
-    "hf_downloads": 25681,
+    "hf_downloads": 30477,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 6,
-    "active_parameters": 2336524543,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Ling-lite-1.5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2336524543
+  },
+  {
+    "name": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-Multimodal-NVFP4-MTP-XS",
+    "provider": "aeon-7",
+    "parameter_count": "17.1B",
+    "parameters_raw": 17128059632,
+    "min_ram_gb": 9.6,
+    "recommended_ram_gb": 16.0,
+    "min_vram_gb": 8.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 15337,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "sakamakismile/Huihui-Qwen3.6-27B-abliterated-NVFP4-MTP",
+    "provider": "sakamakismile",
+    "parameter_count": "17.1B",
+    "parameters_raw": 17128059632,
+    "min_ram_gb": 9.6,
+    "recommended_ram_gb": 16.0,
+    "min_vram_gb": 8.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 28230,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "bharatgenai/Param2-17B-A2.4B-Thinking",
+    "provider": "bharatgenai",
+    "parameter_count": "17.2B",
+    "parameters_raw": 17151140480,
+    "min_ram_gb": 9.6,
+    "recommended_ram_gb": 16.0,
+    "min_vram_gb": 8.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "param2moe",
+    "hf_downloads": 24664,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 6,
+    "active_parameters": 2385080470
   },
   {
     "name": "nvidia/Qwen3-32B-NVFP4",
@@ -16867,7 +25374,73 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 131941,
+    "hf_downloads": 76408,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Qwen3-30B-A3B-NVFP4",
+    "provider": "redhatai",
+    "parameter_count": "17.5B",
+    "parameters_raw": 17452222848,
+    "min_ram_gb": 9.8,
+    "recommended_ram_gb": 16.3,
+    "min_vram_gb": 8.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 23012,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 1908836870
+  },
+  {
+    "name": "internlm/internlm2-20b",
+    "provider": "internlm",
+    "parameter_count": "17.5B",
+    "parameters_raw": 17480024064,
+    "min_ram_gb": 9.8,
+    "recommended_ram_gb": 16.3,
+    "min_vram_gb": 9.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 20141,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-base-20b",
+    "provider": "internlm",
+    "parameter_count": "17.5B",
+    "parameters_raw": 17480024064,
+    "min_ram_gb": 9.8,
+    "recommended_ram_gb": 16.3,
+    "min_vram_gb": 9.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 16666,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16889,7 +25462,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 21831,
+    "hf_downloads": 39925,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -16909,7 +25482,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 342930,
+    "hf_downloads": 359806,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -16917,6 +25490,50 @@
     "num_experts": 128,
     "active_experts": 6,
     "active_parameters": 1724039438
+  },
+  {
+    "name": "upstage/solar-pro-preview-instruct",
+    "provider": "Upstage",
+    "parameter_count": "18.6B",
+    "parameters_raw": 18619432960,
+    "min_ram_gb": 10.4,
+    "recommended_ram_gb": 17.3,
+    "min_vram_gb": 9.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "solar",
+    "hf_downloads": 29287,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyankiwi/GLM-4.5-Air-AWQ-4bit",
+    "provider": "cyankiwi",
+    "parameter_count": "18.6B",
+    "parameters_raw": 18626406504,
+    "min_ram_gb": 10.4,
+    "recommended_ram_gb": 17.3,
+    "min_vram_gb": 9.5,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 15938,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 2037263205
   },
   {
     "name": "RedHatAI/Qwen3-32B-NVFP4",
@@ -16935,34 +25552,72 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 48780,
+    "hf_downloads": 66222,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16",
-    "provider": "redhatai",
-    "parameter_count": "19.6B",
-    "parameters_raw": 19601967392,
-    "min_ram_gb": 11.0,
-    "recommended_ram_gb": 18.3,
-    "min_vram_gb": 10.0,
+    "name": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-NVFP4",
+    "provider": "aeon-7",
+    "parameter_count": "19.1B",
+    "parameters_raw": 19135893232,
+    "min_ram_gb": 10.7,
+    "recommended_ram_gb": 17.8,
+    "min_vram_gb": 9.8,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 167772160,
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 25376,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "internlm/internlm2-chat-20b",
+    "provider": "internlm",
+    "parameter_count": "19.9B",
+    "parameters_raw": 19861149696,
+    "min_ram_gb": 11.1,
+    "recommended_ram_gb": 18.5,
+    "min_vram_gb": 10.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
     "use_case": "Instruction following, chat",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "llama4",
-    "hf_downloads": 25023,
+    "architecture": "internlm2",
+    "hf_downloads": 20986,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 16,
-    "active_experts": 1,
-    "active_parameters": 2143965182
+    "_discovered": true
+  },
+  {
+    "name": "chujiezheng/internlm2-chat-20b-ExPO",
+    "provider": "chujiezheng",
+    "parameter_count": "19.9B",
+    "parameters_raw": 19861149696,
+    "min_ram_gb": 11.1,
+    "recommended_ram_gb": 18.5,
+    "min_vram_gb": 10.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "internlm2",
+    "hf_downloads": 16210,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "RedHatAI/gemma-4-31B-it-NVFP4",
@@ -16979,7 +25634,71 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 79892,
+    "hf_downloads": 174857,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "MaziyarPanahi/Mixtral-8x22B-v0.1-GGUF",
+    "provider": "maziyarpanahi",
+    "parameter_count": "19.9B",
+    "parameters_raw": 19926614015,
+    "min_ram_gb": 11.1,
+    "recommended_ram_gb": 18.6,
+    "min_vram_gb": 10.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 69149,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 5728901528
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-Nano-12B-v2",
+    "provider": "nvidia",
+    "parameter_count": "20.2B",
+    "parameters_raw": 20174602240,
+    "min_ram_gb": 11.3,
+    "recommended_ram_gb": 18.8,
+    "min_vram_gb": 10.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 14379,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "EleutherAI/gpt-neox-20b",
+    "provider": "eleutherai",
+    "parameter_count": "20.2B",
+    "parameters_raw": 20241186816,
+    "min_ram_gb": 11.3,
+    "recommended_ram_gb": 18.9,
+    "min_vram_gb": 10.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_neox",
+    "hf_downloads": 269895,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17001,7 +25720,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 47596,
+    "hf_downloads": 63459,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17021,10 +25740,58 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 1851495,
+    "hf_downloads": 2227074,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "mlx-community/gpt-oss-20b-MXFP4-Q8",
+    "provider": "mlx-community",
+    "parameter_count": "20.9B",
+    "parameters_raw": 20914755648,
+    "min_ram_gb": 11.7,
+    "recommended_ram_gb": 19.5,
+    "min_vram_gb": 10.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 570903,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3529365014
+  },
+  {
+    "name": "unsloth/gpt-oss-20b-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "20.9B",
+    "parameters_raw": 20914757184,
+    "min_ram_gb": 11.7,
+    "recommended_ram_gb": 19.5,
+    "min_vram_gb": 10.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 200252,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3529365271
   },
   {
     "name": "ArliAI/gpt-oss-20b-Derestricted",
@@ -17041,20 +25808,62 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 50651,
+    "hf_downloads": 141378,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 32,
     "active_experts": 4,
-    "active_parameters": 3529365271,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gpt-oss-20b-Derestricted-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3529365271
+  },
+  {
+    "name": "unsloth/gpt-oss-20b-BF16",
+    "provider": "unsloth",
+    "parameter_count": "20.9B",
+    "parameters_raw": 20914757184,
+    "min_ram_gb": 11.7,
+    "recommended_ram_gb": 19.5,
+    "min_vram_gb": 10.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 70955,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3529365271
+  },
+  {
+    "name": "unsloth/gpt-oss-20b-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "20.9B",
+    "parameters_raw": 20914757184,
+    "min_ram_gb": 11.7,
+    "recommended_ram_gb": 19.5,
+    "min_vram_gb": 10.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 31497,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3529365271
   },
   {
     "name": "shieldstar/Qwen3.5-122B-A10B-int4-AutoRound-EC",
@@ -17073,7 +25882,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 182229,
+    "hf_downloads": 183458,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17081,6 +25890,32 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 1678276637
+  },
+  {
+    "name": "rdtand/Qwen3.6-35B-A3B-PrismaQuant-4.75bit-vllm",
+    "provider": "rdtand",
+    "parameter_count": "21.1B",
+    "parameters_raw": 21124964170,
+    "min_ram_gb": 11.8,
+    "recommended_ram_gb": 19.7,
+    "min_vram_gb": 10.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 33686,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 1683395576
   },
   {
     "name": "openai/gpt-oss-20b",
@@ -17097,28 +25932,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 6507411,
+    "hf_downloads": 7160610,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 32,
     "active_experts": 4,
-    "active_parameters": 3630142231,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gpt-oss-20b-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gpt-oss-20b-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gpt-oss-20b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3630142231
   },
   {
     "name": "RedHatAI/gpt-oss-20b",
@@ -17135,28 +25956,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 26380,
+    "hf_downloads": 39534,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 32,
     "active_experts": 4,
-    "active_parameters": 3630142231,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gpt-oss-20b-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gpt-oss-20b-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/gpt-oss-20b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3630142231
+  },
+  {
+    "name": "unsloth/gpt-oss-20b",
+    "provider": "unsloth",
+    "parameter_count": "21.5B",
+    "parameters_raw": 21511953984,
+    "min_ram_gb": 12.0,
+    "recommended_ram_gb": 20.0,
+    "min_vram_gb": 11.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 26861,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 4,
+    "active_parameters": 3630142231
   },
   {
     "name": "lmstudio-community/ERNIE-4.5-21B-A3B-MLX-4bit",
@@ -17173,7 +26004,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ernie4_5_moe",
-    "hf_downloads": 31407,
+    "hf_downloads": 32196,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17193,7 +26024,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ernie4_5_moe",
-    "hf_downloads": 31049,
+    "hf_downloads": 31843,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17213,10 +26044,148 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ernie4_5_moe",
-    "hf_downloads": 31012,
+    "hf_downloads": 31823,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "baidu/ERNIE-4.5-21B-A3B-Thinking",
+    "provider": "baidu",
+    "parameter_count": "21.8B",
+    "parameters_raw": 21825437888,
+    "min_ram_gb": 12.2,
+    "recommended_ram_gb": 20.3,
+    "min_vram_gb": 11.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "ernie4_5_moe",
+    "hf_downloads": 37511,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "zai-org/GLM-4.7-FP8",
+    "provider": "zai-org",
+    "parameter_count": "22.0B",
+    "parameters_raw": 21999124480,
+    "min_ram_gb": 12.3,
+    "recommended_ram_gb": 20.5,
+    "min_vram_gb": 11.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 309329,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 2144914632
+  },
+  {
+    "name": "zai-org/GLM-4.6-FP8",
+    "provider": "zai-org",
+    "parameter_count": "22.0B",
+    "parameters_raw": 21999124480,
+    "min_ram_gb": 12.3,
+    "recommended_ram_gb": 20.5,
+    "min_vram_gb": 11.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 14180,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 2144914632
+  },
+  {
+    "name": "mconcat/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-NVFP4",
+    "provider": "mconcat",
+    "parameter_count": "22.1B",
+    "parameters_raw": 22146895376,
+    "min_ram_gb": 12.4,
+    "recommended_ram_gb": 20.6,
+    "min_vram_gb": 11.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 14303,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "MiniMaxAI/MiniMax-M1-40k",
+    "provider": "minimaxai",
+    "parameter_count": "22.4B",
+    "parameters_raw": 22368485376,
+    "min_ram_gb": 12.5,
+    "recommended_ram_gb": 20.8,
+    "min_vram_gb": 11.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 10240000,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minimax_m1",
+    "hf_downloads": 38223,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 2,
+    "active_parameters": 2446553086
+  },
+  {
+    "name": "MiniMaxAI/MiniMax-Text-01-hf",
+    "provider": "minimaxai",
+    "parameter_count": "22.4B",
+    "parameters_raw": 22368485376,
+    "min_ram_gb": 12.5,
+    "recommended_ram_gb": 20.8,
+    "min_vram_gb": 11.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 10240000,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minimax",
+    "hf_downloads": 25029,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 32,
+    "active_experts": 2,
+    "active_parameters": 2446553086
   },
   {
     "name": "cyankiwi/MiniMax-M2.5-REAP-139B-A10B-AWQ-4bit",
@@ -17233,7 +26202,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 97045,
+    "hf_downloads": 124334,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17241,40 +26210,6 @@
     "num_experts": 154,
     "active_experts": 8,
     "active_parameters": 2265661607
-  },
-  {
-    "name": "cerebras/GLM-4.7-Flash-REAP-23B-A3B",
-    "provider": "cerebras",
-    "parameter_count": "23.0B",
-    "parameters_raw": 22996118432,
-    "min_ram_gb": 12.9,
-    "recommended_ram_gb": 21.4,
-    "min_vram_gb": 11.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 202752,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "glm4_moe_lite",
-    "hf_downloads": 81075,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 48,
-    "active_experts": 4,
-    "active_parameters": 2970331961,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/GLM-4.7-Flash-REAP-23B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "stelterlab/Mistral-Small-24B-Instruct-2501-AWQ",
@@ -17293,21 +26228,101 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 435636,
+    "hf_downloads": 389647,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
   },
   {
-    "name": "gghfez/Mistral-Small-3.2-24B-Instruct-hf-AWQ",
-    "provider": "gghfez",
+    "name": "lmstudio-community/Devstral-Small-2507-MLX-8bit",
+    "provider": "lmstudio-community",
     "parameter_count": "23.6B",
     "parameters_raw": 23572403200,
     "min_ram_gb": 13.2,
     "recommended_ram_gb": 22.0,
     "min_vram_gb": 12.1,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 22819,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Devstral-Small-2507-MLX-4bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23572403200,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 21539,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Devstral-Small-2507-MLX-6bit",
+    "provider": "lmstudio-community",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23572403200,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 21322,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "lmstudio-community/Devstral-Small-2507-MLX-bf16",
+    "provider": "lmstudio-community",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23572403200,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 131072,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 21229,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Mistral-Small-24B-Instruct-2501-quantized.w8a8",
+    "provider": "redhatai",
+    "parameter_count": "23.6B",
+    "parameters_raw": 23575680000,
+    "min_ram_gb": 13.2,
+    "recommended_ram_gb": 22.0,
+    "min_vram_gb": 12.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 32768,
     "use_case": "Instruction following, chat",
     "capabilities": [
@@ -17315,7 +26330,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mistral",
-    "hf_downloads": 44237,
+    "hf_downloads": 18831,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17335,7 +26350,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_moe",
-    "hf_downloads": 423232,
+    "hf_downloads": 395200,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17359,7 +26374,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_moe",
-    "hf_downloads": 419532,
+    "hf_downloads": 391582,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17383,7 +26398,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_moe",
-    "hf_downloads": 418897,
+    "hf_downloads": 391147,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17407,7 +26422,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "lfm2_moe",
-    "hf_downloads": 418568,
+    "hf_downloads": 390790,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17431,8 +26446,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "lfm2_moe",
-    "hf_downloads": 32082,
-    "hf_likes": 315,
+    "hf_downloads": 24892,
+    "hf_likes": 322,
     "release_date": "2026-02-24",
     "num_hidden_layers": 40,
     "num_attention_heads": 32,
@@ -17495,16 +26510,118 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "mistral3",
-    "hf_downloads": 85062,
+    "hf_downloads": 16621,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Dolphin-Mistral-24B-Venice-Edition-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Mistral-Small-24B-Instruct-2501-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24252853524,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "mistral",
+    "hf_downloads": 25098,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3-32B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24266014720,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 285524,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "microsoft/FrogBoss-32B-2510",
+    "provider": "Microsoft",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24266014720,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 76121,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-32B-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24266014720,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 38384,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen3-32B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "24.3B",
+    "parameters_raw": 24266014720,
+    "min_ram_gb": 13.6,
+    "recommended_ram_gb": 22.6,
+    "min_vram_gb": 12.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3",
+    "hf_downloads": 16189,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "cyankiwi/Qwen3.5-122B-A10B-AWQ-4bit",
@@ -17523,7 +26640,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 85342,
+    "hf_downloads": 82274,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17547,7 +26664,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 26626,
+    "hf_downloads": 32662,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17571,7 +26688,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "aria",
-    "hf_downloads": 88854,
+    "hf_downloads": 91858,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17591,10 +26708,114 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "aria",
-    "hf_downloads": 73139,
+    "hf_downloads": 87834,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "allenai/Olmo-3.1-32B-Instruct",
+    "provider": "allenai",
+    "parameter_count": "25.3B",
+    "parameters_raw": 25343703040,
+    "min_ram_gb": 14.2,
+    "recommended_ram_gb": 23.6,
+    "min_vram_gb": 13.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "olmo3",
+    "hf_downloads": 25310,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepcogito/cogito-v1-preview-qwen-32B",
+    "provider": "deepcogito",
+    "parameter_count": "25.6B",
+    "parameters_raw": 25606804480,
+    "min_ram_gb": 14.3,
+    "recommended_ram_gb": 23.8,
+    "min_vram_gb": 13.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 53524,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Valdemardi/DeepSeek-R1-Distill-Qwen-32B-AWQ",
+    "provider": "valdemardi",
+    "parameter_count": "25.6B",
+    "parameters_raw": 25608847360,
+    "min_ram_gb": 14.3,
+    "recommended_ram_gb": 23.9,
+    "min_vram_gb": 13.1,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14777,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ByteDance-Seed/Seed-OSS-36B-Instruct",
+    "provider": "bytedance-seed",
+    "parameter_count": "25.6B",
+    "parameters_raw": 25624576000,
+    "min_ram_gb": 14.3,
+    "recommended_ram_gb": 23.9,
+    "min_vram_gb": 13.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 524288,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "seed_oss",
+    "hf_downloads": 23427,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "TrevorJS/gemma-4-26B-A4B-it-uncensored",
+    "provider": "trevorjs",
+    "parameter_count": "25.8B",
+    "parameters_raw": 25805933872,
+    "min_ram_gb": 14.4,
+    "recommended_ram_gb": 24.0,
+    "min_vram_gb": 13.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 82769,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 2822524013
   },
   {
     "name": "coder3101/gemma-4-26B-A4B-it-heretic",
@@ -17611,20 +26832,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 57906,
+    "hf_downloads": 56089,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 2822524013,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-26B-A4B-it-heretic-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2822524013
   },
   {
     "name": "jenerallee78/gemma-4-26B-A4B-it-ara-abliterated",
@@ -17641,7 +26856,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 22318,
+    "hf_downloads": 24470,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17649,6 +26864,30 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 2822524013
+  },
+  {
+    "name": "Jiunsong/supergemma4-26b-abliterated-multimodal",
+    "provider": "jiunsong",
+    "parameter_count": "25.8B",
+    "parameters_raw": 25805936206,
+    "min_ram_gb": 14.4,
+    "recommended_ram_gb": 24.0,
+    "min_vram_gb": 13.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 13983,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 2822524266
   },
   {
     "name": "LargitData/gemma-4-26b-a4b-it-fp8",
@@ -17665,7 +26904,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 32183,
+    "hf_downloads": 35522,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17689,7 +26928,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 11391,
+    "hf_downloads": 13805,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17716,8 +26955,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "gemma4",
-    "hf_downloads": 5053655,
-    "hf_likes": 841,
+    "hf_downloads": 6654508,
+    "hf_likes": 885,
     "release_date": "2026-03-11",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -17757,44 +26996,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 226839,
+    "hf_downloads": 243518,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 2903264368,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-26B-A4B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
-    "provider": "cyankiwi",
-    "parameter_count": "26.6B",
-    "parameters_raw": 26554316366,
-    "min_ram_gb": 14.8,
-    "recommended_ram_gb": 24.7,
-    "min_vram_gb": 13.6,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 1059059,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 128,
-    "active_experts": 8,
-    "active_parameters": 2904378346
+    "active_parameters": 2903264368
   },
   {
     "name": "cyankiwi/gemma-4-26B-A4B-it-AWQ-8bit",
@@ -17811,7 +27020,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 36161,
+    "hf_downloads": 45108,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -17819,6 +27028,72 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 2904378346
+  },
+  {
+    "name": "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
+    "provider": "cyankiwi",
+    "parameter_count": "26.6B",
+    "parameters_raw": 26554339636,
+    "min_ram_gb": 14.8,
+    "recommended_ram_gb": 24.7,
+    "min_vram_gb": 13.6,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 1903463,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 2904380893
+  },
+  {
+    "name": "Jackrong/MLX-Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2-4bit",
+    "provider": "jackrong",
+    "parameter_count": "26.9B",
+    "parameters_raw": 26895993856,
+    "min_ram_gb": 15.0,
+    "recommended_ram_gb": 25.0,
+    "min_vram_gb": 13.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 16206,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Jackrong/Qwopus3.5-27B-v3-FP8-vllm-ready",
+    "provider": "jackrong",
+    "parameter_count": "26.9B",
+    "parameters_raw": 26899902464,
+    "min_ram_gb": 15.0,
+    "recommended_ram_gb": 25.1,
+    "min_vram_gb": 13.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_text",
+    "hf_downloads": 14301,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "google/gemma-2-27b-it",
@@ -17835,7 +27110,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "gemma2",
-    "hf_downloads": 44572,
+    "hf_downloads": 48420,
     "hf_likes": 565,
     "release_date": "2024-06-24",
     "num_hidden_layers": null,
@@ -17854,30 +27129,24 @@
     ]
   },
   {
-    "name": "Jackrong/Qwopus3.5-27B-v3",
-    "provider": "jackrong",
-    "parameter_count": "27.4B",
-    "parameters_raw": 27356728560,
-    "min_ram_gb": 15.3,
-    "recommended_ram_gb": 25.5,
-    "min_vram_gb": 14.0,
+    "name": "unsloth/gemma-2-27b-it",
+    "provider": "unsloth",
+    "parameter_count": "27.2B",
+    "parameters_raw": 27227128320,
+    "min_ram_gb": 15.2,
+    "recommended_ram_gb": 25.4,
+    "min_vram_gb": 13.9,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 262144,
+    "context_length": 8192,
     "use_case": "General purpose",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 36226,
+    "architecture": "gemma2",
+    "hf_downloads": 22628,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwopus3.5-27B-v3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "groxaxo/Qwen3.6-27B-GPTQ-Pro-4bit",
@@ -17896,7 +27165,49 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 26547,
+    "hf_downloads": 76493,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "llmfan46/Qwen3.6-27B-uncensored-heretic-v2",
+    "provider": "llmfan46",
+    "parameter_count": "27.4B",
+    "parameters_raw": 27356728560,
+    "min_ram_gb": 15.3,
+    "recommended_ram_gb": 25.5,
+    "min_vram_gb": 14.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 58850,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Jackrong/Qwopus3.5-27B-v3",
+    "provider": "jackrong",
+    "parameter_count": "27.4B",
+    "parameters_raw": 27356728560,
+    "min_ram_gb": 15.3,
+    "recommended_ram_gb": 25.5,
+    "min_vram_gb": 14.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 27138,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17916,29 +27227,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 24281,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
-  },
-  {
-    "name": "HarleyWang/Qwen3.5-27B-Claude-Opus-4.6-High-Reasoning",
-    "provider": "harleywang",
-    "parameter_count": "27.4B",
-    "parameters_raw": 27356728560,
-    "min_ram_gb": 15.3,
-    "recommended_ram_gb": 25.5,
-    "min_vram_gb": 14.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 24231,
+    "hf_downloads": 20228,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17960,7 +27249,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 59882,
+    "hf_downloads": 39710,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -17983,8 +27272,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "gemma3",
-    "hf_downloads": 510045,
-    "hf_likes": 1958,
+    "hf_downloads": 603039,
+    "hf_likes": 1964,
     "release_date": "2025-03-01",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -18020,7 +27309,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma3",
-    "hf_downloads": 63527,
+    "hf_downloads": 62381,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18042,7 +27331,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 18587,
+    "hf_downloads": 18011,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18065,8 +27354,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 3266173,
-    "hf_likes": 962,
+    "hf_downloads": 3295812,
+    "hf_likes": 967,
     "release_date": "2026-02-24",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -18079,6 +27368,38 @@
       },
       {
         "repo": "mradermacher/Qwen3.5-27B-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
+    "name": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
+    "provider": "jackrong",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "image-text-to-text",
+    "architecture": "qwen3_5",
+    "hf_downloads": 280937,
+    "hf_likes": 2818,
+    "release_date": "2026-02-27",
+    "num_hidden_layers": null,
+    "num_attention_heads": null,
+    "num_key_value_heads": null,
+    "head_dim": null,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
         "provider": "mradermacher"
       }
     ]
@@ -18101,8 +27422,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5",
-    "hf_downloads": 508728,
-    "hf_likes": 975,
+    "hf_downloads": 1613364,
+    "hf_likes": 1135,
     "release_date": "2026-04-21",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -18116,8 +27437,34 @@
       {
         "repo": "ggml-org/Qwen3.6-27B-GGUF",
         "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3.6-27B-GGUF",
+        "provider": "mradermacher"
       }
     ]
+  },
+  {
+    "name": "raydelossantos/Qwen3.6-27B-GPTQ-Int4",
+    "provider": "raydelossantos",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 17477,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2",
@@ -18136,38 +27483,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 609855,
+    "hf_downloads": 657976,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
-  },
-  {
-    "name": "Jackrong/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled",
-    "provider": "jackrong",
-    "parameter_count": "27.8B",
-    "parameters_raw": 27781427952,
-    "min_ram_gb": 15.5,
-    "recommended_ram_gb": 25.9,
-    "min_vram_gb": 14.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 469629,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "Qwen/Qwen3.5-27B-GPTQ-Int4",
@@ -18186,7 +27505,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 372476,
+    "hf_downloads": 422976,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18208,7 +27527,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 342820,
+    "hf_downloads": 332309,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18230,35 +27549,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 208145,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-27B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "QuantTrio/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2-AWQ",
-    "provider": "quanttrio",
-    "parameter_count": "27.8B",
-    "parameters_raw": 27781427952,
-    "min_ram_gb": 15.5,
-    "recommended_ram_gb": 25.9,
-    "min_vram_gb": 14.2,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5",
-    "hf_downloads": 93796,
+    "hf_downloads": 238154,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18280,7 +27571,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 32081,
+    "hf_downloads": 170406,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "QuantTrio/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-v2-AWQ",
+    "provider": "quanttrio",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 116412,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18302,22 +27615,38 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 16487,
+    "hf_downloads": 21020,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-27B-Claude-4.6-Opus-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "Qwen/Qwen3.5-27B-FP8",
-    "provider": "Alibaba",
+    "name": "TheCluster/Qwen3.6-27B-Heretic-MLX-bf16",
+    "provider": "thecluster",
     "parameter_count": "27.8B",
-    "parameters_raw": 27782935472,
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 18848,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
+    "provider": "huihui-ai",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
     "min_ram_gb": 15.5,
     "recommended_ram_gb": 25.9,
     "min_vram_gb": 14.2,
@@ -18330,7 +27659,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 1266239,
+    "hf_downloads": 18461,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "QuantTrio/Qwen3.6-27B-AWQ-6Bit",
+    "provider": "quanttrio",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27781427952,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 10760,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18352,7 +27703,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 745458,
+    "hf_downloads": 2294833,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen3.5-27B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "27.8B",
+    "parameters_raw": 27782935472,
+    "min_ram_gb": 15.5,
+    "recommended_ram_gb": 25.9,
+    "min_vram_gb": 14.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5",
+    "hf_downloads": 1544344,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18374,7 +27747,27 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 28661,
+    "hf_downloads": 21751,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "ig1/medgemma-27b-text-it-FP8-Dynamic",
+    "provider": "ig1",
+    "parameter_count": "28.4B",
+    "parameters_raw": 28422129408,
+    "min_ram_gb": 15.9,
+    "recommended_ram_gb": 26.5,
+    "min_vram_gb": 14.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma3_text",
+    "hf_downloads": 36621,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18396,7 +27789,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 118392,
+    "hf_downloads": 242269,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18418,7 +27811,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 13925,
+    "hf_downloads": 13505,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18440,7 +27833,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 31977,
+    "hf_downloads": 139355,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18462,7 +27855,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 196379,
+    "hf_downloads": 753773,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -18484,10 +27877,154 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "ernie4_5_moe_vl",
-    "hf_downloads": 94903,
+    "hf_downloads": 128239,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3.2-Exp",
+    "provider": "DeepSeek",
+    "parameter_count": "29.6B",
+    "parameters_raw": 29582163968,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.6,
+    "min_vram_gb": 15.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v32",
+    "hf_downloads": 194549,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2357328686
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3.1",
+    "provider": "DeepSeek",
+    "parameter_count": "29.6B",
+    "parameters_raw": 29582163968,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.6,
+    "min_vram_gb": 15.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 180081,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2357328686
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "29.6B",
+    "parameters_raw": 29582163968,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.6,
+    "min_vram_gb": 15.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 75494,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2357328686
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-0528-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "29.6B",
+    "parameters_raw": 29582163968,
+    "min_ram_gb": 16.5,
+    "recommended_ram_gb": 27.6,
+    "min_vram_gb": 15.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 16102,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2357328686
+  },
+  {
+    "name": "unsloth/Kimi-K2-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "29.8B",
+    "parameters_raw": 29829890048,
+    "min_ram_gb": 16.7,
+    "recommended_ram_gb": 27.8,
+    "min_vram_gb": 15.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 30020,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 384,
+    "active_experts": 8,
+    "active_parameters": 2081877742
+  },
+  {
+    "name": "nvidia/Kimi-K2-Thinking-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "29.8B",
+    "parameters_raw": 29829890048,
+    "min_ram_gb": 16.7,
+    "recommended_ram_gb": 27.8,
+    "min_vram_gb": 15.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 27129,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 384,
+    "active_experts": 8,
+    "active_parameters": 2081877742
   },
   {
     "name": "lmstudio-community/GLM-4.7-Flash-MLX-8bit",
@@ -18504,7 +28041,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 347909,
+    "hf_downloads": 327748,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18528,7 +28065,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 325580,
+    "hf_downloads": 304843,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18536,6 +28073,26 @@
     "num_experts": 64,
     "active_experts": 4,
     "active_parameters": 3275058708
+  },
+  {
+    "name": "facebook/opt-30b",
+    "provider": "facebook",
+    "parameter_count": "30.0B",
+    "parameters_raw": 29955358720,
+    "min_ram_gb": 16.7,
+    "recommended_ram_gb": 27.9,
+    "min_vram_gb": 15.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 2048,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "opt",
+    "hf_downloads": 17443,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
@@ -18554,24 +28111,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 2601330,
+    "hf_downloads": 2745230,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "bineric/lynx-instruct-30b",
@@ -18588,20 +28135,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 360455,
+    "hf_downloads": 524626,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/lynx-instruct-30b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ",
@@ -18620,7 +28161,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 356052,
+    "hf_downloads": 508638,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18646,7 +28187,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 250360,
+    "hf_downloads": 219857,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18672,7 +28213,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 220152,
+    "hf_downloads": 215672,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18698,7 +28239,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 209765,
+    "hf_downloads": 206157,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18724,7 +28265,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 199024,
+    "hf_downloads": 194690,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18750,7 +28291,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 196351,
+    "hf_downloads": 191139,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18776,24 +28317,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 126824,
+    "hf_downloads": 137036,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-30B-A3B-Thinking-2507-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-30B-A3B-Thinking-2507-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "Alibaba-NLP/Tongyi-DeepResearch-30B-A3B",
@@ -18810,20 +28341,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 94346,
+    "hf_downloads": 106571,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Tongyi-DeepResearch-30B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "Qwen/Qwen3-30B-A3B-Base",
@@ -18842,20 +28367,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 57001,
+    "hf_downloads": 75353,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3339450907,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3-30B-A3B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3339450907
   },
   {
     "name": "lmstudio-community/Qwen3-30B-A3B-Instruct-2507-MLX-4bit",
@@ -18874,7 +28393,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 32533,
+    "hf_downloads": 32280,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18900,7 +28419,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 31569,
+    "hf_downloads": 31051,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18926,7 +28445,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 30344,
+    "hf_downloads": 29861,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18952,7 +28471,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 27112,
+    "hf_downloads": 25687,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 3339450907
+  },
+  {
+    "name": "QuixiAI/Qwen3-30B-A3B-AWQ",
+    "provider": "quixiai",
+    "parameter_count": "30.5B",
+    "parameters_raw": 30532122624,
+    "min_ram_gb": 17.1,
+    "recommended_ram_gb": 28.4,
+    "min_vram_gb": 15.6,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 16126,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -18978,7 +28523,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 390124,
+    "hf_downloads": 510981,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19004,7 +28549,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 287471,
+    "hf_downloads": 276673,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19030,7 +28575,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 40822,
+    "hf_downloads": 58871,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 3341896987
+  },
+  {
+    "name": "nytopop/Qwen3-30B-A3B.w8a8",
+    "provider": "nytopop",
+    "parameter_count": "30.6B",
+    "parameters_raw": 30554486784,
+    "min_ram_gb": 17.1,
+    "recommended_ram_gb": 28.5,
+    "min_vram_gb": 15.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 40960,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 20285,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19054,16 +28625,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 94880,
+    "hf_downloads": 77830,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/InternVL3_5-30B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "QuantTrio/Qwen3-VL-30B-A3B-Instruct-AWQ",
@@ -19083,7 +28648,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 658955,
+    "hf_downloads": 705645,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19110,24 +28675,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 52455,
+    "hf_downloads": 43605,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 3398363717,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-30B-A3B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-30B-A3B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3398363717
   },
   {
     "name": "browser-use/bu-30b-a3b-preview",
@@ -19144,7 +28699,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 11540,
+    "hf_downloads": 11806,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19168,28 +28723,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 658187,
+    "hf_downloads": 623077,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 64,
     "active_experts": 4,
-    "active_parameters": 3414850312,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.7-Flash-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/GLM-4.7-Flash-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/GLM-4.7-Flash-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 3414850312
+  },
+  {
+    "name": "unsloth/GLM-4.7-Flash",
+    "provider": "unsloth",
+    "parameter_count": "31.2B",
+    "parameters_raw": 31221488576,
+    "min_ram_gb": 17.4,
+    "recommended_ram_gb": 29.1,
+    "min_vram_gb": 16.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe_lite",
+    "hf_downloads": 546627,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 64,
+    "active_experts": 4,
+    "active_parameters": 3414850312
   },
   {
     "name": "QuantTrio/GLM-4.7-Flash-AWQ",
@@ -19206,7 +28771,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 100374,
+    "hf_downloads": 49514,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19230,16 +28795,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 90777,
+    "hf_downloads": 92878,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Gemma-4-31B-Cognitive-Unshackled-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Momix-44/gemma-4-31B-it-heretic-v2",
@@ -19256,42 +28815,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 40364,
+    "hf_downloads": 27066,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-it-heretic-v2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "coder3101/gemma-4-31B-it-heretic",
-    "provider": "coder3101",
-    "parameter_count": "31.3B",
-    "parameters_raw": 31273086512,
-    "min_ram_gb": 17.5,
-    "recommended_ram_gb": 29.1,
-    "min_vram_gb": 16.0,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Code generation and completion",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 18382,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-it-heretic-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "DavidAU/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking",
@@ -19308,16 +28835,30 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 16468,
+    "hf_downloads": 18000,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "llmfan46/gemma-4-31B-it-uncensored-heretic",
+    "provider": "llmfan46",
+    "parameter_count": "31.3B",
+    "parameters_raw": 31273086512,
+    "min_ram_gb": 17.5,
+    "recommended_ram_gb": 29.1,
+    "min_vram_gb": 16.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 12697,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "DavidAU/gemma-4-31B-it-Mystery-Fine-Tune-HERETIC-UNCENSORED-Thinking",
@@ -19334,16 +28875,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 10653,
+    "hf_downloads": 10788,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-it-Mystery-Fine-Tune-HERETIC-UNCENSORED-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "QuantTrio/gemma-4-31B-it-AWQ",
@@ -19360,7 +28895,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 264023,
+    "hf_downloads": 567528,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19380,7 +28915,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 14464,
+    "hf_downloads": 16251,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19400,7 +28935,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 183922,
+    "hf_downloads": 237634,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19420,7 +28955,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "ovis2_6_moe",
-    "hf_downloads": 34453,
+    "hf_downloads": 21804,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19444,7 +28979,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 114989,
+    "hf_downloads": 105525,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19468,7 +29003,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 105938,
+    "hf_downloads": 96337,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19492,7 +29027,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 104893,
+    "hf_downloads": 95068,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19516,7 +29051,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 104615,
+    "hf_downloads": 94930,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19540,8 +29075,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "nemotron_h",
-    "hf_downloads": 1410603,
-    "hf_likes": 722,
+    "hf_downloads": 1312088,
+    "hf_likes": 727,
     "release_date": "2025-12-04",
     "num_hidden_layers": 52,
     "num_attention_heads": 32,
@@ -19573,20 +29108,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 244227,
+    "hf_downloads": 148164,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 6,
-    "active_parameters": 2985101885,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Nemotron-Cascade-2-30B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2985101885
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16",
@@ -19603,7 +29132,55 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 77298,
+    "hf_downloads": 59619,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 6,
+    "active_parameters": 2985101885
+  },
+  {
+    "name": "chankhavu/Nemotron-Cascade-2-30B-A3B-FP8",
+    "provider": "chankhavu",
+    "parameter_count": "31.6B",
+    "parameters_raw": 31577937344,
+    "min_ram_gb": 17.6,
+    "recommended_ram_gb": 29.4,
+    "min_vram_gb": 16.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 14996,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 6,
+    "active_parameters": 2985101885
+  },
+  {
+    "name": "unsloth/Nemotron-3-Nano-30B-A3B",
+    "provider": "unsloth",
+    "parameter_count": "31.6B",
+    "parameters_raw": 31577937344,
+    "min_ram_gb": 17.6,
+    "recommended_ram_gb": 29.4,
+    "min_vram_gb": 16.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 13919,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19627,7 +29204,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 786011,
+    "hf_downloads": 813276,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19635,6 +29212,26 @@
     "num_experts": 128,
     "active_experts": 6,
     "active_parameters": 2985102726
+  },
+  {
+    "name": "ebircak/gemma-4-31B-it-4bit-W4A16-GPTQ",
+    "provider": "ebircak",
+    "parameter_count": "31.7B",
+    "parameters_raw": 31730694816,
+    "min_ram_gb": 17.7,
+    "recommended_ram_gb": 29.6,
+    "min_vram_gb": 16.3,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 21241,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "LGAI-EXAONE/EXAONE-3.5-32B-Instruct",
@@ -19651,20 +29248,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone",
-    "hf_downloads": 66743,
+    "hf_downloads": 61870,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/EXAONE-3.5-32B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/EXAONE-3.5-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "LGAI-EXAONE/EXAONE-3.5-32B-Instruct-AWQ",
@@ -19681,7 +29268,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone",
-    "hf_downloads": 33583,
+    "hf_downloads": 33419,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19701,8 +29288,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "exaone4",
-    "hf_downloads": 26344,
-    "hf_likes": 282,
+    "hf_downloads": 27237,
+    "hf_likes": 281,
     "release_date": "2025-07-11",
     "num_hidden_layers": 64,
     "num_attention_heads": 40,
@@ -19730,7 +29317,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone4",
-    "hf_downloads": 114011,
+    "hf_downloads": 114892,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19750,7 +29337,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone4",
-    "hf_downloads": 28076,
+    "hf_downloads": 14290,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19770,7 +29357,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe_lite",
-    "hf_downloads": 636610,
+    "hf_downloads": 802857,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19794,7 +29381,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "sarvam_moe",
-    "hf_downloads": 41041,
+    "hf_downloads": 46887,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -19802,26 +29389,6 @@
     "num_experts": 128,
     "active_experts": 6,
     "active_parameters": 3039430224
-  },
-  {
-    "name": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
-    "provider": "cyankiwi",
-    "parameter_count": "32.2B",
-    "parameters_raw": 32188299936,
-    "min_ram_gb": 18.0,
-    "recommended_ram_gb": 30.0,
-    "min_vram_gb": 16.5,
-    "quantization": "AWQ-4bit",
-    "format": "awq",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "gemma4",
-    "hf_downloads": 938786,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true
   },
   {
     "name": "cyankiwi/gemma-4-31B-it-AWQ-8bit",
@@ -19838,7 +29405,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 45128,
+    "hf_downloads": 71856,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19858,16 +29425,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "olmo3",
-    "hf_downloads": 47975,
+    "hf_downloads": 44252,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Olmo-3-1125-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "allenai/OLMo-2-0325-32B-Instruct",
@@ -19884,7 +29445,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "olmo2",
-    "hf_downloads": 7146,
+    "hf_downloads": 6361,
     "hf_likes": 148,
     "release_date": "2025-03-12",
     "num_hidden_layers": 64,
@@ -19944,7 +29505,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 402414,
+    "hf_downloads": 539031,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -19967,8 +29528,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "gemma4",
-    "hf_downloads": 6558301,
-    "hf_likes": 2421,
+    "hf_downloads": 8403901,
+    "hf_likes": 2530,
     "release_date": "2026-03-11",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -19990,6 +29551,26 @@
     ]
   },
   {
+    "name": "TrevorJS/gemma-4-31B-it-uncensored",
+    "provider": "trevorjs",
+    "parameter_count": "32.7B",
+    "parameters_raw": 32682372656,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.4,
+    "min_vram_gb": 16.7,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 15746,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "google/gemma-4-31B",
     "provider": "Google",
     "parameter_count": "32.7B",
@@ -20004,16 +29585,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 437603,
+    "hf_downloads": 475351,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/gemma-4-31B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "prithivMLmods/gemma-4-31B-it-FP8",
@@ -20030,7 +29605,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gemma4",
-    "hf_downloads": 29611,
+    "hf_downloads": 26658,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20050,7 +29625,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 42537,
+    "hf_downloads": 42637,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20072,7 +29647,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 630332,
+    "hf_downloads": 780086,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20094,7 +29669,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3",
-    "hf_downloads": 28481,
+    "hf_downloads": 28919,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20116,8 +29691,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 1291147,
-    "hf_likes": 2012,
+    "hf_downloads": 1237772,
+    "hf_likes": 2016,
     "release_date": "2024-11-06",
     "num_hidden_layers": 64,
     "num_attention_heads": 40,
@@ -20153,8 +29728,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 1121586,
-    "hf_likes": 1552,
+    "hf_downloads": 976959,
+    "hf_likes": 1555,
     "release_date": "2025-01-20",
     "num_hidden_layers": 64,
     "num_attention_heads": 40,
@@ -20192,7 +29767,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 1296279,
+    "hf_downloads": 1556968,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20214,7 +29789,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 902951,
+    "hf_downloads": 1132175,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20236,7 +29811,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 526107,
+    "hf_downloads": 545966,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20258,16 +29833,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 159298,
+    "hf_downloads": 147868,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "huihui-ai/DeepSeek-R1-Distill-Qwen-32B-abliterated",
@@ -20284,39 +29853,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 123091,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/DeepSeek-R1-Distill-Qwen-32B-abliterated-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/DeepSeek-R1-Distill-Qwen-32B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2.5-32B-Instruct-GPTQ-Int8",
-    "provider": "Alibaba",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 36.6,
-    "recommended_ram_gb": 61.0,
-    "min_vram_gb": 33.6,
-    "quantization": "GPTQ-Int8",
-    "format": "gptq",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 113897,
+    "hf_downloads": 145382,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20336,7 +29873,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 88692,
+    "hf_downloads": 120292,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-32B-Instruct-GPTQ-Int8",
+    "provider": "Alibaba",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 36.6,
+    "recommended_ram_gb": 61.0,
+    "min_vram_gb": 33.6,
+    "quantization": "GPTQ-Int8",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 118189,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20356,50 +29915,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 66135,
+    "hf_downloads": 65418,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/QwQ-32B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/QwQ-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "nvidia/OpenReasoning-Nemotron-32B",
-    "provider": "nvidia",
-    "parameter_count": "32.8B",
-    "parameters_raw": 32763876352,
-    "min_ram_gb": 18.3,
-    "recommended_ram_gb": 30.5,
-    "min_vram_gb": 16.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 131072,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 55235,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/OpenReasoning-Nemotron-32B-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/OpenReasoning-Nemotron-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-Coder-32B",
@@ -20418,39 +29937,69 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 37826,
+    "hf_downloads": 39820,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2.5-Coder-32B-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-Coder-32B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "RedHatAI/Qwen3-32B-FP8-dynamic",
-    "provider": "redhatai",
+    "name": "unsloth/Qwen2.5-32B-Instruct",
+    "provider": "unsloth",
     "parameter_count": "32.8B",
-    "parameters_raw": 32766710784,
+    "parameters_raw": 32763876352,
     "min_ram_gb": 18.3,
     "recommended_ram_gb": 30.5,
     "min_vram_gb": 16.8,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 40960,
-    "use_case": "General purpose",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
     "capabilities": [
       "tool_use"
     ],
     "pipeline_tag": "unknown",
-    "architecture": "qwen3",
-    "hf_downloads": 67182,
+    "architecture": "qwen2",
+    "hf_downloads": 16175,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/OpenReasoning-Nemotron-32B",
+    "provider": "nvidia",
+    "parameter_count": "32.8B",
+    "parameters_raw": 32763876352,
+    "min_ram_gb": 18.3,
+    "recommended_ram_gb": 30.5,
+    "min_vram_gb": 16.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 14942,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "cyankiwi/gemma-4-31B-it-AWQ-4bit",
+    "provider": "cyankiwi",
+    "parameter_count": "33.1B",
+    "parameters_raw": 33103510176,
+    "min_ram_gb": 18.5,
+    "recommended_ram_gb": 30.8,
+    "min_vram_gb": 17.0,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gemma4",
+    "hf_downloads": 1400255,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20470,7 +30019,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "vlm",
-    "hf_downloads": 74723,
+    "hf_downloads": 88118,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20493,20 +30042,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 1519467,
+    "hf_downloads": 1159400,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-32B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen3-VL-32B-Thinking",
@@ -20526,20 +30065,57 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl",
-    "hf_downloads": 76808,
+    "hf_downloads": 85296,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "huihui-ai/Huihui-Qwen3-VL-32B-Instruct-abliterated",
+    "provider": "huihui-ai",
+    "parameter_count": "33.4B",
+    "parameters_raw": 33357390064,
+    "min_ram_gb": 18.6,
+    "recommended_ram_gb": 31.1,
+    "min_vram_gb": 17.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "vision",
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_vl",
+    "hf_downloads": 69460,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "poolside/Laguna-XS.2",
+    "provider": "poolside",
+    "parameter_count": "33.4B",
+    "parameters_raw": 33442617088,
+    "min_ram_gb": 18.7,
+    "recommended_ram_gb": 31.1,
+    "min_vram_gb": 17.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "laguna",
+    "hf_downloads": 14457,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-32B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-32B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2664958542
   },
   {
     "name": "Qwen/Qwen2.5-VL-32B-Instruct-AWQ",
@@ -20559,7 +30135,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 149003,
+    "hf_downloads": 140434,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20582,24 +30158,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 101303,
+    "hf_downloads": 107521,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen2.5-VL-32B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen2.5-VL-32B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-32B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "karakuri-ai/karakuri-vl-32b-thinking-2507-exp",
@@ -20618,16 +30180,32 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 14988,
+    "hf_downloads": 22283,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/karakuri-vl-32b-thinking-2507-exp-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Qwen2.5-32B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "33.7B",
+    "parameters_raw": 33741233162,
+    "min_ram_gb": 18.9,
+    "recommended_ram_gb": 31.4,
+    "min_vram_gb": 17.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 22315,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "meta-llama/CodeLlama-34b-Instruct-hf",
@@ -20646,7 +30224,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 729,
+    "hf_downloads": 607,
     "hf_likes": 19,
     "release_date": "2024-03-14",
     "num_hidden_layers": null,
@@ -20675,7 +30253,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone4_5",
-    "hf_downloads": 62332,
+    "hf_downloads": 964972,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20695,7 +30273,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone4_5",
-    "hf_downloads": 23283,
+    "hf_downloads": 24153,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20742,20 +30320,102 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 4510689,
+    "hf_downloads": 4716266,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "01-ai/Yi-1.5-34B-Chat",
+    "provider": "01.ai",
+    "parameter_count": "34.4B",
+    "parameters_raw": 34388917248,
+    "min_ram_gb": 19.2,
+    "recommended_ram_gb": 32.0,
+    "min_vram_gb": 17.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16613,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "altomek/YiSM-34B-0rn",
+    "provider": "altomek",
+    "parameter_count": "34.4B",
+    "parameters_raw": 34388917248,
+    "min_ram_gb": 19.2,
+    "recommended_ram_gb": 32.0,
+    "min_vram_gb": 17.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16252,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Youssofal/Qwen3.6-35B-A3B-Abliterated-Heretic-MLX-4bit",
+    "provider": "youssofal",
+    "parameter_count": "34.7B",
+    "parameters_raw": 34660608768,
+    "min_ram_gb": 19.4,
+    "recommended_ram_gb": 32.3,
+    "min_vram_gb": 17.8,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 18891,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/dolphin-2.9.1-yi-1.5-34b-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/dolphin-2.9.1-yi-1.5-34b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2762017254
+  },
+  {
+    "name": "mlx-community/Qwen3.6-35B-A3B-4bit-DWQ",
+    "provider": "mlx-community",
+    "parameter_count": "34.7B",
+    "parameters_raw": 34660608768,
+    "min_ram_gb": 19.4,
+    "recommended_ram_gb": 32.3,
+    "min_vram_gb": 17.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 16997,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2762017254
   },
   {
     "name": "liuhaotian/llava-v1.6-34b",
@@ -20774,7 +30434,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava",
-    "hf_downloads": 24925,
+    "hf_downloads": 18834,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20796,7 +30456,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llava_next",
-    "hf_downloads": 20696,
+    "hf_downloads": 14485,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20829,6 +30489,30 @@
     ]
   },
   {
+    "name": "Hcompany/Holo3-35B-A3B",
+    "provider": "hcompany",
+    "parameter_count": "35.1B",
+    "parameters_raw": 35107181936,
+    "min_ram_gb": 19.6,
+    "recommended_ram_gb": 32.7,
+    "min_vram_gb": 18.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 73953,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2797603552
+  },
+  {
     "name": "llmfan46/Qwen3.5-35B-A3B-uncensored-heretic",
     "provider": "llmfan46",
     "parameter_count": "35.1B",
@@ -20845,7 +30529,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 35652,
+    "hf_downloads": 56139,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -20855,8 +30539,8 @@
     "active_parameters": 2797603552
   },
   {
-    "name": "Hcompany/Holo3-35B-A3B",
-    "provider": "hcompany",
+    "name": "llmfan46/Qwen3.6-35B-A3B-uncensored-heretic",
+    "provider": "llmfan46",
     "parameter_count": "35.1B",
     "parameters_raw": 35107181936,
     "min_ram_gb": 19.6,
@@ -20866,23 +30550,19 @@
     "format": "gguf",
     "context_length": 262144,
     "use_case": "General purpose",
-    "capabilities": [],
+    "capabilities": [
+      "tool_use"
+    ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 12560,
+    "hf_downloads": 45960,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 2797603552,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Holo3-35B-A3B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2797603552
   },
   {
     "name": "prithivMLmods/Qwen3.6-35B-A3B-FP8",
@@ -20901,7 +30581,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 16264,
+    "hf_downloads": 16386,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -20927,7 +30607,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "cohere",
-    "hf_downloads": 146021,
+    "hf_downloads": 161102,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -20950,8 +30630,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 3634694,
-    "hf_likes": 1408,
+    "hf_downloads": 3564034,
+    "hf_likes": 1418,
     "release_date": "2026-02-24",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -20977,6 +30657,41 @@
     ]
   },
   {
+    "name": "Jackrong/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
+    "provider": "jackrong",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "text-generation",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 26567,
+    "hf_likes": 128,
+    "release_date": "2026-03-07",
+    "num_hidden_layers": null,
+    "num_attention_heads": null,
+    "num_key_value_heads": null,
+    "head_dim": null,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2864910871,
+    "gguf_sources": [
+      {
+        "repo": "mradermacher/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
+        "provider": "mradermacher"
+      }
+    ]
+  },
+  {
     "name": "Qwen/Qwen3.6-35B-A3B",
     "provider": "Alibaba",
     "parameter_count": "36.0B",
@@ -20994,8 +30709,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 1510129,
-    "hf_likes": 1493,
+    "hf_downloads": 3030186,
+    "hf_likes": 1632,
     "release_date": "2026-04-15",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -21013,6 +30728,10 @@
       {
         "repo": "ggml-org/Qwen3.6-35B-A3B-GGUF",
         "provider": "ggml-org"
+      },
+      {
+        "repo": "mradermacher/Qwen3.6-35B-A3B-GGUF",
+        "provider": "mradermacher"
       }
     ]
   },
@@ -21033,52 +30752,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 91137,
+    "hf_downloads": 173593,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-Distilled-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Jackrong/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled",
-    "provider": "jackrong",
-    "parameter_count": "36.0B",
-    "parameters_raw": 35951822704,
-    "min_ram_gb": 20.1,
-    "recommended_ram_gb": 33.5,
-    "min_vram_gb": 18.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "Advanced reasoning, chain-of-thought",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 48167,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2864910871
   },
   {
     "name": "Qwen/Qwen3.5-35B-A3B-GPTQ-Int4",
@@ -21097,7 +30778,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 713914,
+    "hf_downloads": 1036077,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21123,7 +30804,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 391699,
+    "hf_downloads": 365296,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21131,38 +30812,6 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 2864910871
-  },
-  {
-    "name": "huihui-ai/Huihui-Qwen3.5-35B-A3B-Claude-4.6-Opus-abliterated",
-    "provider": "huihui-ai",
-    "parameter_count": "36.0B",
-    "parameters_raw": 35951822704,
-    "min_ram_gb": 20.1,
-    "recommended_ram_gb": 33.5,
-    "min_vram_gb": 18.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 161964,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-35B-A3B-Claude-4.6-Opus-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
   },
   {
     "name": "QuantTrio/Qwen3.6-35B-A3B-AWQ",
@@ -21181,7 +30830,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 141805,
+    "hf_downloads": 317512,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2864910871
+  },
+  {
+    "name": "palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4",
+    "provider": "palmfuture",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 82083,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21207,31 +30882,25 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 59699,
+    "hf_downloads": 58594,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-35B-A3B-Base-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2864910871
   },
   {
-    "name": "palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4",
-    "provider": "palmfuture",
+    "name": "huihui-ai/Huihui-Qwen3.5-35B-A3B-Claude-4.6-Opus-abliterated",
+    "provider": "huihui-ai",
     "parameter_count": "36.0B",
     "parameters_raw": 35951822704,
     "min_ram_gb": 20.1,
     "recommended_ram_gb": 33.5,
     "min_vram_gb": 18.4,
-    "quantization": "GPTQ-Int4",
-    "format": "gptq",
+    "quantization": "Q4_K_M",
+    "format": "gguf",
     "context_length": 262144,
     "use_case": "General purpose",
     "capabilities": [
@@ -21239,7 +30908,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 46439,
+    "hf_downloads": 46185,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21265,20 +30934,64 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 25356,
+    "hf_downloads": 23252,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 2864910871,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Huihui-Qwen3.5-35B-A3B-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 2864910871
+  },
+  {
+    "name": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
+    "provider": "huihui-ai",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 16826,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2864910871
+  },
+  {
+    "name": "voicing-ai/Voicing-Agent-V3-35B-A3B",
+    "provider": "voicing-ai",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35951822704,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 14817,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2864910871
   },
   {
     "name": "codgician/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GPTQ-int4",
@@ -21297,7 +31010,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 601217,
+    "hf_downloads": 575670,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21305,32 +31018,6 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 2864910875
-  },
-  {
-    "name": "Qwen/Qwen3.5-35B-A3B-FP8",
-    "provider": "Alibaba",
-    "parameter_count": "36.0B",
-    "parameters_raw": 35953925552,
-    "min_ram_gb": 20.1,
-    "recommended_ram_gb": 33.5,
-    "min_vram_gb": 18.4,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 262144,
-    "use_case": "General purpose",
-    "capabilities": [
-      "tool_use"
-    ],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen3_5_moe",
-    "hf_downloads": 1510313,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 2865078437
   },
   {
     "name": "Qwen/Qwen3.6-35B-A3B-FP8",
@@ -21349,7 +31036,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 1474432,
+    "hf_downloads": 2769535,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 2865078437
+  },
+  {
+    "name": "Qwen/Qwen3.5-35B-A3B-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "36.0B",
+    "parameters_raw": 35953925552,
+    "min_ram_gb": 20.1,
+    "recommended_ram_gb": 33.5,
+    "min_vram_gb": 18.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 1604810,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21373,7 +31086,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "seed_oss",
-    "hf_downloads": 47473,
+    "hf_downloads": 47547,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21393,7 +31106,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "seed_oss",
-    "hf_downloads": 46442,
+    "hf_downloads": 46173,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21413,7 +31126,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "seed_oss",
-    "hf_downloads": 46092,
+    "hf_downloads": 45887,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21433,10 +31146,34 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "seed_oss",
-    "hf_downloads": 46023,
+    "hf_downloads": 45792,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
+  },
+  {
+    "name": "hpcai-tech/grok-1",
+    "provider": "hpcai-tech",
+    "parameter_count": "36.2B",
+    "parameters_raw": 36238786560,
+    "min_ram_gb": 20.2,
+    "recommended_ram_gb": 33.8,
+    "min_vram_gb": 18.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 8192,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "unknown",
+    "hf_downloads": 29957,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 10418651136
   },
   {
     "name": "cyankiwi/MiniMax-M2.7-AWQ-4bit",
@@ -21453,7 +31190,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 141601,
+    "hf_downloads": 211588,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21479,7 +31216,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 486077,
+    "hf_downloads": 567876,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21505,7 +31242,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 214999,
+    "hf_downloads": 361181,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21529,16 +31266,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "internvl_chat",
-    "hf_downloads": 109282,
+    "hf_downloads": 114854,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/InternVL3-38B-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Skywork/Skywork-R1V-38B",
@@ -21555,7 +31286,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "skywork_chat",
-    "hf_downloads": 77175,
+    "hf_downloads": 91858,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21577,16 +31308,74 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5",
-    "hf_downloads": 12900,
+    "hf_downloads": 13806,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "IQuestLab/IQuest-Coder-V1-40B-Instruct",
+    "provider": "iquestlab",
+    "parameter_count": "39.8B",
+    "parameters_raw": 39794283520,
+    "min_ram_gb": 22.2,
+    "recommended_ram_gb": 37.1,
+    "min_vram_gb": 20.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "iquestcoder",
+    "hf_downloads": 20590,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "IQuestLab/IQuest-Coder-V1-40B-Loop-Instruct",
+    "provider": "iquestlab",
+    "parameter_count": "39.8B",
+    "parameters_raw": 39794696320,
+    "min_ram_gb": 22.2,
+    "recommended_ram_gb": 37.1,
+    "min_vram_gb": 20.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 131072,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "iquestloopcoder",
+    "hf_downloads": 20954,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Intel/DeepSeek-V4-Flash-W4A16-AutoRound",
+    "provider": "intel",
+    "parameter_count": "39.9B",
+    "parameters_raw": 39916293330,
+    "min_ram_gb": 22.3,
+    "recommended_ram_gb": 37.2,
+    "min_vram_gb": 20.4,
+    "quantization": "AutoRound-4bit",
+    "format": "autoround",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v4",
+    "hf_downloads": 23712,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 6,
+    "active_parameters": 2884575880
   },
   {
     "name": "tiiuae/falcon-40b-instruct",
@@ -21612,6 +31401,26 @@
     ]
   },
   {
+    "name": "tiiuae/falcon-40b",
+    "provider": "TII",
+    "parameter_count": "41.8B",
+    "parameters_raw": 41835970560,
+    "min_ram_gb": 23.4,
+    "recommended_ram_gb": 39.0,
+    "min_vram_gb": 21.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "falcon",
+    "hf_downloads": 22899,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
     "name": "mistralai/Mixtral-8x7B-Instruct-v0.1",
     "provider": "Mistral AI",
     "parameter_count": "46.7B",
@@ -21628,8 +31437,8 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mixtral",
-    "hf_downloads": 655515,
-    "hf_likes": 4673,
+    "hf_downloads": 687434,
+    "hf_likes": 4675,
     "release_date": "2023-12-10",
     "num_hidden_layers": 32,
     "num_attention_heads": 32,
@@ -21651,6 +31460,54 @@
     ]
   },
   {
+    "name": "RedHatAI/Mixtral-8x7B-Instruct-v0.1",
+    "provider": "redhatai",
+    "parameter_count": "46.7B",
+    "parameters_raw": 46702792704,
+    "min_ram_gb": 26.1,
+    "recommended_ram_gb": 43.5,
+    "min_vram_gb": 23.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 18596,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 13427052901
+  },
+  {
+    "name": "hugging-quants/Mixtral-8x7B-Instruct-v0.1-AWQ-INT4",
+    "provider": "hugging-quants",
+    "parameter_count": "46.7B",
+    "parameters_raw": 46702792704,
+    "min_ram_gb": 26.1,
+    "recommended_ram_gb": 43.5,
+    "min_vram_gb": 23.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 14778,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 13427052901
+  },
+  {
     "name": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
     "provider": "NousResearch",
     "parameter_count": "46.7B",
@@ -21667,7 +31524,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "mixtral",
-    "hf_downloads": 8725,
+    "hf_downloads": 8989,
     "hf_likes": 453,
     "release_date": "2024-01-11",
     "num_hidden_layers": 32,
@@ -21704,16 +31561,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kimi_linear",
-    "hf_downloads": 59205,
+    "hf_downloads": 59426,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Kimi-Linear-48B-A3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "nvidia/Llama-3_3-Nemotron-Super-49B-v1_5-FP8",
@@ -21730,7 +31581,27 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron-nas",
-    "hf_downloads": 53653,
+    "hf_downloads": 60118,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
+    "provider": "nvidia",
+    "parameter_count": "49.9B",
+    "parameters_raw": 49867145216,
+    "min_ram_gb": 27.9,
+    "recommended_ram_gb": 46.4,
+    "min_vram_gb": 25.5,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron-nas",
+    "hf_downloads": 38620,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -21750,74 +31621,158 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron-nas",
-    "hf_downloads": 51622,
+    "hf_downloads": 33234,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3_3-Nemotron-Super-49B-v1_5-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Llama-3_3-Nemotron-Super-49B-v1_5-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "nvidia/Llama-3_3-Nemotron-Super-49B-v1",
-    "provider": "nvidia",
-    "parameter_count": "49.9B",
-    "parameters_raw": 49867145216,
-    "min_ram_gb": 27.9,
-    "recommended_ram_gb": 46.4,
-    "min_vram_gb": 25.5,
+    "name": "ai21labs/AI21-Jamba-Mini-1.5",
+    "provider": "ai21labs",
+    "parameter_count": "51.6B",
+    "parameters_raw": 51570323328,
+    "min_ram_gb": 28.8,
+    "recommended_ram_gb": 48.0,
+    "min_vram_gb": 26.4,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 1048576,
-    "use_case": "General purpose",
+    "context_length": 4096,
+    "use_case": "Lightweight, edge deployment",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "nemotron-nas",
-    "hf_downloads": 35559,
+    "architecture": "jamba",
+    "hf_downloads": 19960,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Llama-3_3-Nemotron-Super-49B-v1-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Llama-3_3-Nemotron-Super-49B-v1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "aoxo/sarvam-105b-uncensored",
-    "provider": "aoxo",
-    "parameter_count": "55.7B",
-    "parameters_raw": 55732545631,
-    "min_ram_gb": 31.1,
-    "recommended_ram_gb": 51.9,
-    "min_vram_gb": 28.5,
+    "name": "Qwen/Qwen2-57B-A14B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "57.4B",
+    "parameters_raw": 57408658944,
+    "min_ram_gb": 32.1,
+    "recommended_ram_gb": 53.5,
+    "min_vram_gb": 29.4,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 5242880,
-    "use_case": "General purpose",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
     "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "sarvam_mla",
-    "hf_downloads": 69601,
+    "architecture": "qwen2_moe",
+    "hf_downloads": 17313,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
-    "num_experts": 128,
+    "num_experts": 64,
     "active_experts": 8,
-    "active_parameters": 6095747177
+    "active_parameters": 9687711195
+  },
+  {
+    "name": "unsloth/Llama-3.3-70B-Instruct-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "60.1B",
+    "parameters_raw": 60106473472,
+    "min_ram_gb": 33.6,
+    "recommended_ram_gb": 56.0,
+    "min_vram_gb": 30.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 213668,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4",
+    "provider": "hugging-quants",
+    "parameter_count": "60.1B",
+    "parameters_raw": 60106473472,
+    "min_ram_gb": 33.6,
+    "recommended_ram_gb": 56.0,
+    "min_vram_gb": 30.8,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 211997,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+    "provider": "DeepSeek",
+    "parameter_count": "60.1B",
+    "parameters_raw": 60106473472,
+    "min_ram_gb": 33.6,
+    "recommended_ram_gb": 56.0,
+    "min_vram_gb": 30.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 132683,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/DeepSeek-R1-Distill-Llama-70B-GGUF",
+    "provider": "unsloth",
+    "parameter_count": "60.1B",
+    "parameters_raw": 60106473472,
+    "min_ram_gb": 33.6,
+    "recommended_ram_gb": 56.0,
+    "min_vram_gb": 30.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Advanced reasoning, chain-of-thought",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 14693,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "deepseek-ai/deepseek-llm-67b-base",
+    "provider": "DeepSeek",
+    "parameter_count": "60.6B",
+    "parameters_raw": 60607692800,
+    "min_ram_gb": 33.9,
+    "recommended_ram_gb": 56.4,
+    "min_vram_gb": 31.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16754,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "lmstudio-community/Qwen3.5-397B-A17B-MLX-4bit",
@@ -21836,7 +31791,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 14364,
+    "hf_downloads": 12733,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21862,7 +31817,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 209536,
+    "hf_downloads": 197082,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21886,7 +31841,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 877172,
+    "hf_downloads": 897144,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -21894,6 +31849,26 @@
     "num_experts": 512,
     "active_experts": 22,
     "active_parameters": 6105718484
+  },
+  {
+    "name": "petals-team/StableBeluga2",
+    "provider": "petals-team",
+    "parameter_count": "69.0B",
+    "parameters_raw": 68976648192,
+    "min_ram_gb": 38.5,
+    "recommended_ram_gb": 64.2,
+    "min_vram_gb": 35.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 21354,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "meta-llama/Llama-3.1-70B-Instruct",
@@ -21912,7 +31887,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 695826,
+    "hf_downloads": 729268,
     "hf_likes": 910,
     "release_date": "2024-07-16",
     "num_hidden_layers": null,
@@ -21937,8 +31912,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 620405,
-    "hf_likes": 2742,
+    "hf_downloads": 778123,
+    "hf_likes": 2751,
     "release_date": "2024-11-26",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -21974,16 +31949,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 669010,
+    "hf_downloads": 698141,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/L3.3-GeneticLemonade-Final-v2-70B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "kosbu/Llama-3.3-70B-Instruct-AWQ",
@@ -22002,7 +31971,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 487633,
+    "hf_downloads": 516755,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22024,7 +31993,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 360886,
+    "hf_downloads": 408815,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22046,7 +32015,49 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 156926,
+    "hf_downloads": 172782,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w4a16",
+    "provider": "redhatai",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 144258,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "meta-llama/Llama-3.1-70B",
+    "provider": "Meta",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4096,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 133962,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22066,19 +32077,13 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 144741,
+    "hf_downloads": 116526,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Meta-Llama-3-70B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "meta-llama/Llama-3.1-70B",
+    "name": "meta-llama/Meta-Llama-3-70B-Instruct",
     "provider": "Meta",
     "parameter_count": "70.6B",
     "parameters_raw": 70553706496,
@@ -22088,11 +32093,13 @@
     "quantization": "Q4_K_M",
     "format": "gguf",
     "context_length": 4096,
-    "use_case": "General purpose",
-    "capabilities": [],
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 129279,
+    "hf_downloads": 78131,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22112,24 +32119,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 50195,
+    "hf_downloads": 50012,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/L3.3-70B-Euryale-v2.3-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/L3.3-70B-Euryale-v2.3-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
-    "name": "meta-llama/Meta-Llama-3-70B-Instruct",
-    "provider": "Meta",
+    "name": "unsloth/Llama-3.3-70B-Instruct",
+    "provider": "unsloth",
     "parameter_count": "70.6B",
     "parameters_raw": 70553706496,
     "min_ram_gb": 39.4,
@@ -22137,27 +32134,39 @@
     "min_vram_gb": 36.1,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 4096,
+    "context_length": 1048576,
     "use_case": "Instruction following, chat",
     "capabilities": [
       "tool_use"
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 44403,
+    "hf_downloads": 30397,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Meta-Llama-3-70B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Meta-Llama-3-70B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "unsloth/Llama-3.3-70B-Instruct-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553706496,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 27985,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "casperhansen/llama-3-70b-instruct-awq",
@@ -22176,7 +32185,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 30174,
+    "hf_downloads": 27638,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8",
+    "provider": "redhatai",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70553707616,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 20543,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22198,7 +32229,51 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 37268,
+    "hf_downloads": 48131,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "NousResearch/Hermes-4-70B-FP8",
+    "provider": "NousResearch",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70560423936,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 46076,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "pearl-ai/Llama-3.3-70B-Instruct-pearl",
+    "provider": "pearl-ai",
+    "parameter_count": "70.6B",
+    "parameters_raw": 70560710656,
+    "min_ram_gb": 39.4,
+    "recommended_ram_gb": 65.7,
+    "min_vram_gb": 36.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 39227,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22220,7 +32295,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 48743,
+    "hf_downloads": 64846,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22246,7 +32321,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 112582,
+    "hf_downloads": 73622,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22254,6 +32329,72 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 5675147164
+  },
+  {
+    "name": "paloalma/Le_Triomphant-ECE-TW3",
+    "provider": "paloalma",
+    "parameter_count": "72.3B",
+    "parameters_raw": 72288575488,
+    "min_ram_gb": 40.4,
+    "recommended_ram_gb": 67.3,
+    "min_vram_gb": 37.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16271,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "paloalma/TW3-JRGL-v2",
+    "provider": "paloalma",
+    "parameter_count": "72.3B",
+    "parameters_raw": 72288575488,
+    "min_ram_gb": 40.4,
+    "recommended_ram_gb": 67.3,
+    "min_vram_gb": 37.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 16253,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "rdtand/Qwen3.5-122B-A10B-PrismaQuant-4.75bit-vllm",
+    "provider": "rdtand",
+    "parameter_count": "72.4B",
+    "parameters_raw": 72399806340,
+    "min_ram_gb": 40.5,
+    "recommended_ram_gb": 67.4,
+    "min_vram_gb": 37.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_5_moe",
+    "hf_downloads": 13565,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 5769359565
   },
   {
     "name": "Qwen/Qwen2.5-72B-Instruct",
@@ -22272,8 +32413,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen2",
-    "hf_downloads": 409864,
-    "hf_likes": 932,
+    "hf_downloads": 437470,
+    "hf_likes": 936,
     "release_date": "2024-09-16",
     "num_hidden_layers": 80,
     "num_attention_heads": 64,
@@ -22307,46 +32448,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 440943,
+    "hf_downloads": 461516,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-72B-Instruct-abliterated-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
-  },
-  {
-    "name": "Qwen/Qwen2-72B-Instruct",
-    "provider": "Alibaba",
-    "parameter_count": "72.7B",
-    "parameters_raw": 72706203648,
-    "min_ram_gb": 40.6,
-    "recommended_ram_gb": 67.7,
-    "min_vram_gb": 37.2,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 32768,
-    "use_case": "Instruction following, chat",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "qwen2",
-    "hf_downloads": 71819,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2-72B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2-72B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-72B",
@@ -22365,16 +32470,30 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 48630,
+    "hf_downloads": 48182,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen2.5-72B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2-72B-Instruct",
+    "provider": "Alibaba",
+    "parameter_count": "72.7B",
+    "parameters_raw": 72706203648,
+    "min_ram_gb": 40.6,
+    "recommended_ram_gb": 67.7,
+    "min_vram_gb": 37.2,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 41766,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2-72B",
@@ -22391,7 +32510,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 29112,
+    "hf_downloads": 32633,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22417,20 +32536,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 26027,
+    "hf_downloads": 23405,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/magnum-v4-72b-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/magnum-v4-72b-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-72B-Instruct-AWQ",
@@ -22449,7 +32558,29 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2",
-    "hf_downloads": 599043,
+    "hf_downloads": 761719,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "Qwen/Qwen2.5-72B-Instruct-GPTQ-Int4",
+    "provider": "Alibaba",
+    "parameter_count": "73.0B",
+    "parameters_raw": 72957861888,
+    "min_ram_gb": 40.8,
+    "recommended_ram_gb": 67.9,
+    "min_vram_gb": 37.4,
+    "quantization": "GPTQ-Int4",
+    "format": "gptq",
+    "context_length": 32768,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen2",
+    "hf_downloads": 18041,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22471,20 +32602,10 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_vl",
-    "hf_downloads": 29643,
+    "hf_downloads": 27207,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/Qwen2-VL-72B-Instruct-GGUF",
-        "provider": "bartowski"
-      },
-      {
-        "repo": "mradermacher/Qwen2-VL-72B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "Qwen/Qwen2.5-VL-72B-Instruct",
@@ -22504,22 +32625,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 103994,
+    "hf_downloads": 125258,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "gguf_sources": [
       {
-        "repo": "unsloth/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
         "repo": "ggml-org/Qwen2.5-VL-72B-Instruct-GGUF",
         "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen2.5-VL-72B-Instruct-GGUF",
-        "provider": "mradermacher"
       }
     ]
   },
@@ -22541,7 +32654,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen2_5_vl",
-    "hf_downloads": 176125,
+    "hf_downloads": 107351,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -22563,7 +32676,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 427782,
+    "hf_downloads": 446552,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22589,7 +32702,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 26835,
+    "hf_downloads": 26056,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22615,7 +32728,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 25936,
+    "hf_downloads": 24992,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22641,7 +32754,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 25608,
+    "hf_downloads": 24683,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22667,7 +32780,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 25470,
+    "hf_downloads": 24515,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22693,8 +32806,8 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3_next",
-    "hf_downloads": 767994,
-    "hf_likes": 1332,
+    "hf_downloads": 1049903,
+    "hf_likes": 1347,
     "release_date": "2026-01-30",
     "num_hidden_layers": 48,
     "num_attention_heads": 16,
@@ -22716,6 +32829,32 @@
     ]
   },
   {
+    "name": "unsloth/Qwen3-Coder-Next",
+    "provider": "unsloth",
+    "parameter_count": "79.7B",
+    "parameters_raw": 79674391296,
+    "min_ram_gb": 44.5,
+    "recommended_ram_gb": 74.2,
+    "min_vram_gb": 40.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 18715,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 5462052994
+  },
+  {
     "name": "Qwen/Qwen3-Coder-Next-FP8",
     "provider": "Alibaba",
     "parameter_count": "79.7B",
@@ -22732,7 +32871,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 469327,
+    "hf_downloads": 283372,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22740,6 +32879,32 @@
     "num_experts": 512,
     "active_experts": 10,
     "active_parameters": 5462383530
+  },
+  {
+    "name": "unsloth/Qwen3-Coder-Next-FP8-Dynamic",
+    "provider": "unsloth",
+    "parameter_count": "79.7B",
+    "parameters_raw": 79748584192,
+    "min_ram_gb": 44.6,
+    "recommended_ram_gb": 74.3,
+    "min_vram_gb": 40.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "Code generation and completion",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_next",
+    "hf_downloads": 14589,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 10,
+    "active_parameters": 5467139259
   },
   {
     "name": "Qwen/Qwen3-Next-80B-A3B-Instruct",
@@ -22758,28 +32923,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 271492,
+    "hf_downloads": 275655,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 512,
     "active_experts": 10,
-    "active_parameters": 5575200546,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/Qwen3-Next-80B-A3B-Instruct-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Qwen3-Next-80B-A3B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 5575200546
   },
   {
     "name": "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8",
@@ -22798,7 +32949,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_next",
-    "hf_downloads": 79769,
+    "hf_downloads": 112833,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22808,27 +32959,28 @@
     "active_parameters": 5575537949
   },
   {
-    "name": "meta-llama/Llama-3.2-90B-Vision-Instruct",
-    "provider": "Meta",
-    "parameter_count": "88.6B",
-    "parameters_raw": 88593355323,
-    "min_ram_gb": 49.5,
-    "recommended_ram_gb": 82.5,
-    "min_vram_gb": 45.4,
+    "name": "saricles/MiniMax-M2.7-REAP-172B-A10B-NVFP4-GB10",
+    "provider": "saricles",
+    "parameter_count": "86.9B",
+    "parameters_raw": 86887015424,
+    "min_ram_gb": 48.6,
+    "recommended_ram_gb": 80.9,
+    "min_vram_gb": 44.5,
     "quantization": "Q4_K_M",
     "format": "gguf",
-    "context_length": 4096,
-    "use_case": "Instruction following, chat",
-    "capabilities": [
-      "vision",
-      "tool_use"
-    ],
+    "context_length": 196608,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
     "pipeline_tag": "unknown",
-    "architecture": "mllama",
-    "hf_downloads": 12095,
+    "architecture": "minimax_m2",
+    "hf_downloads": 13940,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 192,
+    "active_experts": 8,
+    "active_parameters": 7783628459
   },
   {
     "name": "inclusionAI/LLaDA2.1-flash",
@@ -22845,7 +32997,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llada2_moe",
-    "hf_downloads": 243292,
+    "hf_downloads": 113212,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22869,7 +33021,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "sarvam_mla",
-    "hf_downloads": 25346,
+    "hf_downloads": 24052,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -22893,24 +33045,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4v_moe",
-    "hf_downloads": 61811,
+    "hf_downloads": 85906,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 11780883304,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/GLM-4.5V-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/GLM-4.5V-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 11780883304
   },
   {
     "name": "jiangchengchengNLP/Llama-4-Scout-17B-16E-Instruct-abliterated-v2",
@@ -22927,20 +33069,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama4",
-    "hf_downloads": 14379,
+    "hf_downloads": 14399,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 16,
     "active_experts": 1,
-    "active_parameters": 11882696167,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Llama-4-Scout-17B-16E-Instruct-abliterated-v2-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 11882696167
   },
   {
     "name": "zai-org/GLM-4.5-Air",
@@ -22957,24 +33093,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe",
-    "hf_downloads": 395143,
+    "hf_downloads": 405604,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 12082527713,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.5-Air-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/GLM-4.5-Air-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 12082527713
   },
   {
     "name": "CohereLabs/command-a-vision-07-2025",
@@ -22993,7 +33119,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "cohere2_vision",
-    "hf_downloads": 61167,
+    "hf_downloads": 79132,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -23015,7 +33141,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 64247,
+    "hf_downloads": 55285,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23039,7 +33165,55 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 70467,
+    "hf_downloads": 92679,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 9271601628
+  },
+  {
+    "name": "nvidia/MiniMax-M2.7-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "116.3B",
+    "parameters_raw": 116349510656,
+    "min_ram_gb": 65.0,
+    "recommended_ram_gb": 108.4,
+    "min_vram_gb": 59.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 196608,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minimax_m2",
+    "hf_downloads": 72120,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 9271601628
+  },
+  {
+    "name": "amd/MiniMax-M2.5-MXFP4",
+    "provider": "amd",
+    "parameter_count": "116.3B",
+    "parameters_raw": 116349510656,
+    "min_ram_gb": 65.0,
+    "recommended_ram_gb": 108.4,
+    "min_vram_gb": 59.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 196608,
+    "use_case": "Lightweight, edge deployment",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "minimax_m2",
+    "hf_downloads": 14308,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23063,7 +33237,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 55021,
+    "hf_downloads": 54135,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23071,6 +33245,54 @@
     "num_experts": 128,
     "active_experts": 4,
     "active_parameters": 9309823238
+  },
+  {
+    "name": "unsloth/gpt-oss-120b-BF16",
+    "provider": "unsloth",
+    "parameter_count": "116.8B",
+    "parameters_raw": 116829156672,
+    "min_ram_gb": 65.3,
+    "recommended_ram_gb": 108.8,
+    "min_vram_gb": 59.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 190914,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 4,
+    "active_parameters": 9309823421
+  },
+  {
+    "name": "unsloth/gpt-oss-120b-unsloth-bnb-4bit",
+    "provider": "unsloth",
+    "parameter_count": "116.8B",
+    "parameters_raw": 116829156672,
+    "min_ram_gb": 65.3,
+    "recommended_ram_gb": 108.8,
+    "min_vram_gb": 59.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "gpt_oss",
+    "hf_downloads": 40731,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 4,
+    "active_parameters": 9309823421
   },
   {
     "name": "openai/gpt-oss-120b",
@@ -23087,24 +33309,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "gpt_oss",
-    "hf_downloads": 3710123,
+    "hf_downloads": 4369404,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 4,
-    "active_parameters": 9595358141,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/gpt-oss-120b-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "ggml-org/gpt-oss-120b-GGUF",
-        "provider": "ggml-org"
-      }
-    ]
+    "active_parameters": 9595358141
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
@@ -23121,20 +33333,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 662337,
+    "hf_downloads": 791172,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 512,
     "active_experts": 22,
-    "active_parameters": 11226390744,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/NVIDIA-Nemotron-3-Super-120B-A12B-BF16-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 11226390744
   },
   {
     "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
@@ -23151,7 +33357,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "nemotron_h",
-    "hf_downloads": 235243,
+    "hf_downloads": 338538,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 512,
+    "active_experts": 22,
+    "active_parameters": 11226390744
+  },
+  {
+    "name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16",
+    "provider": "nvidia",
+    "parameter_count": "123.6B",
+    "parameters_raw": 123611012096,
+    "min_ram_gb": 69.1,
+    "recommended_ram_gb": 115.1,
+    "min_vram_gb": 63.3,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "nemotron_h",
+    "hf_downloads": 23022,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23178,8 +33408,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 1117358,
-    "hf_likes": 530,
+    "hf_downloads": 893368,
+    "hf_likes": 535,
     "release_date": "2026-02-24",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -23217,7 +33447,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 300834,
+    "hf_downloads": 176332,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23243,7 +33473,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 69835,
+    "hf_downloads": 39404,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23269,7 +33499,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 626468,
+    "hf_downloads": 588460,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23295,7 +33525,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "mixtral",
-    "hf_downloads": 29369,
+    "hf_downloads": 30827,
     "hf_likes": 749,
     "release_date": "2024-04-16",
     "num_hidden_layers": 56,
@@ -23306,6 +33536,30 @@
     "num_experts": 8,
     "active_experts": 2,
     "active_parameters": 39100000000
+  },
+  {
+    "name": "Salesforce/xLAM-8x22b-r",
+    "provider": "salesforce",
+    "parameter_count": "140.6B",
+    "parameters_raw": 140630071296,
+    "min_ram_gb": 78.6,
+    "recommended_ram_gb": 131.0,
+    "min_vram_gb": 72.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 65536,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mixtral",
+    "hf_downloads": 22963,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 8,
+    "active_experts": 2,
+    "active_parameters": 40431145496
   },
   {
     "name": "rednote-hilab/dots.llm1.inst",
@@ -23322,7 +33576,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "dots1",
-    "hf_downloads": 12399,
+    "hf_downloads": 14835,
     "hf_likes": 176,
     "release_date": "2025-05-14",
     "num_hidden_layers": 62,
@@ -23355,8 +33609,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v4",
-    "hf_downloads": 96948,
-    "hf_likes": 829,
+    "hf_downloads": 668670,
+    "hf_likes": 953,
     "release_date": "2026-04-22",
     "num_hidden_layers": 43,
     "num_attention_heads": 64,
@@ -23382,8 +33636,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "bloom",
-    "hf_downloads": 6682,
-    "hf_likes": 4998,
+    "hf_downloads": 6510,
+    "hf_likes": 5001,
     "release_date": "2022-05-19",
     "num_hidden_layers": null,
     "num_attention_heads": 112,
@@ -23405,7 +33659,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "falcon",
-    "hf_downloads": 615,
+    "hf_downloads": 97,
     "hf_likes": 547,
     "release_date": "2023-09-04",
     "num_hidden_layers": null,
@@ -23428,20 +33682,10 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "step3p5",
-    "hf_downloads": 225428,
+    "hf_downloads": 227378,
     "hf_likes": 0,
     "release_date": null,
-    "_discovered": true,
-    "gguf_sources": [
-      {
-        "repo": "ggml-org/Step-3.5-Flash-GGUF",
-        "provider": "ggml-org"
-      },
-      {
-        "repo": "mradermacher/Step-3.5-Flash-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "_discovered": true
   },
   {
     "name": "stepfun-ai/Step-3.5-Flash-FP8",
@@ -23458,7 +33702,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "step3p5",
-    "hf_downloads": 217875,
+    "hf_downloads": 152379,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -23480,7 +33724,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 17215,
+    "hf_downloads": 15236,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23504,7 +33748,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 70188,
+    "hf_downloads": 58088,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23528,7 +33772,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 48660,
+    "hf_downloads": 40809,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23552,7 +33796,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 48305,
+    "hf_downloads": 40533,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23576,7 +33820,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 88905,
+    "hf_downloads": 65145,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23600,7 +33844,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 26773,
+    "hf_downloads": 28606,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23624,8 +33868,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "minimax_m2",
-    "hf_downloads": 496055,
-    "hf_likes": 1083,
+    "hf_downloads": 632064,
+    "hf_likes": 1104,
     "release_date": "2026-04-09",
     "num_hidden_layers": 62,
     "num_attention_heads": 48,
@@ -23661,8 +33905,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "minimax_m2",
-    "hf_downloads": 924475,
-    "hf_likes": 1465,
+    "hf_downloads": 959535,
+    "hf_likes": 1471,
     "release_date": "2026-02-12",
     "num_hidden_layers": 62,
     "num_attention_heads": 48,
@@ -23684,6 +33928,30 @@
     ]
   },
   {
+    "name": "List-cloud/List-3.0-Ultra-Coder-Brain",
+    "provider": "list-cloud",
+    "parameter_count": "228.7B",
+    "parameters_raw": 228703644928,
+    "min_ram_gb": 127.8,
+    "recommended_ram_gb": 213.0,
+    "min_vram_gb": 117.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 204800,
+    "use_case": "Code generation and completion",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "list_ultra_coder",
+    "hf_downloads": 279796,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 18224821702
+  },
+  {
     "name": "MiniMaxAI/MiniMax-M2",
     "provider": "minimaxai",
     "parameter_count": "228.7B",
@@ -23698,20 +33966,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 74884,
+    "hf_downloads": 85462,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 18224821702,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/MiniMax-M2-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 18224821702
   },
   {
     "name": "MiniMaxAI/MiniMax-M2.1",
@@ -23728,24 +33990,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "minimax_m2",
-    "hf_downloads": 28863,
+    "hf_downloads": 26439,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 18224821702,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/MiniMax-M2.1-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/MiniMax-M2.1-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 18224821702
   },
   {
     "name": "Qwen/Qwen3-235B-A22B",
@@ -23764,7 +34016,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3_moe",
-    "hf_downloads": 614892,
+    "hf_downloads": 569157,
     "hf_likes": 1091,
     "release_date": "2025-04-27",
     "num_hidden_layers": 94,
@@ -23787,6 +34039,30 @@
     ]
   },
   {
+    "name": "prefeitura-rio/Rio-3.0-Open",
+    "provider": "prefeitura-rio",
+    "parameter_count": "235.1B",
+    "parameters_raw": 235093634560,
+    "min_ram_gb": 131.4,
+    "recommended_ram_gb": 218.9,
+    "min_vram_gb": 120.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 46879,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 25713366280
+  },
+  {
     "name": "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
     "provider": "Alibaba",
     "parameter_count": "235.1B",
@@ -23803,7 +34079,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 313776,
+    "hf_downloads": 413524,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23829,7 +34105,33 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_moe",
-    "hf_downloads": 135071,
+    "hf_downloads": 179775,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 128,
+    "active_experts": 8,
+    "active_parameters": 25714927049
+  },
+  {
+    "name": "Qwen/Qwen3-235B-A22B-Thinking-2507-FP8",
+    "provider": "Alibaba",
+    "parameter_count": "235.1B",
+    "parameters_raw": 235107904512,
+    "min_ram_gb": 131.4,
+    "recommended_ram_gb": 219.0,
+    "min_vram_gb": 120.4,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "qwen3_moe",
+    "hf_downloads": 20496,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23856,24 +34158,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 1268536,
+    "hf_downloads": 1446131,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 25776408752,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-235B-A22B-Instruct-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-235B-A22B-Instruct-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 25776408752
   },
   {
     "name": "Qwen/Qwen3-VL-235B-A22B-Thinking",
@@ -23893,24 +34185,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 165605,
+    "hf_downloads": 42705,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 25776408752,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Qwen3-VL-235B-A22B-Thinking-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/Qwen3-VL-235B-A22B-Thinking-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 25776408752
   },
   {
     "name": "Qwen/Qwen3-VL-235B-A22B-Instruct-FP8",
@@ -23930,7 +34212,7 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_vl_moe",
-    "hf_downloads": 62698,
+    "hf_downloads": 77678,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23954,7 +34236,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 224871,
+    "hf_downloads": 178190,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -23978,20 +34260,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 30511,
+    "hf_downloads": 106907,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 160,
     "active_experts": 6,
-    "active_parameters": 20185360358,
-    "gguf_sources": [
-      {
-        "repo": "bartowski/DeepSeek-Coder-V2-Instruct-GGUF",
-        "provider": "bartowski"
-      }
-    ]
+    "active_parameters": 20185360358
   },
   {
     "name": "RedHatAI/DeepSeek-V2.5-1210-FP8",
@@ -24008,7 +34284,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v2",
-    "hf_downloads": 53387,
+    "hf_downloads": 53575,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24032,20 +34308,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "exaone_moe",
-    "hf_downloads": 46842,
+    "hf_downloads": 52045,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 128,
     "active_experts": 8,
-    "active_parameters": 25932776361,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/K-EXAONE-236B-A23B-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 25932776361
   },
   {
     "name": "internlm/Intern-S1",
@@ -24062,7 +34332,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "interns1",
-    "hf_downloads": 37447,
+    "hf_downloads": 24716,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24070,6 +34340,78 @@
     "num_experts": 128,
     "active_experts": 8,
     "active_parameters": 26327640510
+  },
+  {
+    "name": "mlx-community/deepseek-ai-DeepSeek-V4-Flash-8bit",
+    "provider": "mlx-community",
+    "parameter_count": "284.3B",
+    "parameters_raw": 284299262080,
+    "min_ram_gb": 158.9,
+    "recommended_ram_gb": 264.8,
+    "min_vram_gb": 145.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v4",
+    "hf_downloads": 23968,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 6,
+    "active_parameters": 20545063856
+  },
+  {
+    "name": "mlx-community/DeepSeek-V4-Flash-2bit-DQ",
+    "provider": "mlx-community",
+    "parameter_count": "284.3B",
+    "parameters_raw": 284333146519,
+    "min_ram_gb": 158.9,
+    "recommended_ram_gb": 264.8,
+    "min_vram_gb": 145.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v4",
+    "hf_downloads": 21723,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 6,
+    "active_parameters": 20547512535
+  },
+  {
+    "name": "mlx-community/DeepSeek-V4-Flash-4bit",
+    "provider": "mlx-community",
+    "parameter_count": "284.3B",
+    "parameters_raw": 284333146519,
+    "min_ram_gb": 158.9,
+    "recommended_ram_gb": 264.8,
+    "min_vram_gb": 145.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v4",
+    "hf_downloads": 20080,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 6,
+    "active_parameters": 20547512535
   },
   {
     "name": "deepseek-ai/DeepSeek-V4-Flash-Base",
@@ -24086,8 +34428,8 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v4",
-    "hf_downloads": 3025,
-    "hf_likes": 179,
+    "hf_downloads": 8733,
+    "hf_likes": 191,
     "release_date": "2026-04-22",
     "num_hidden_layers": 43,
     "num_attention_heads": 64,
@@ -24097,6 +34439,30 @@
     "num_experts": 256,
     "active_experts": 6,
     "active_parameters": 13000000000
+  },
+  {
+    "name": "tencent/Hy3-preview",
+    "provider": "tencent",
+    "parameter_count": "298.8B",
+    "parameters_raw": 298786155776,
+    "min_ram_gb": 167.0,
+    "recommended_ram_gb": 278.3,
+    "min_vram_gb": 153.0,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 262144,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "hy_v3",
+    "hf_downloads": 26687,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 192,
+    "active_experts": 8,
+    "active_parameters": 26766259780
   },
   {
     "name": "baidu/ERNIE-4.5-300B-A47B-Paddle",
@@ -24113,7 +34479,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "ernie4_5_moe",
-    "hf_downloads": 368,
+    "hf_downloads": 285,
     "hf_likes": 13,
     "release_date": "2025-06-28",
     "num_hidden_layers": 54,
@@ -24136,8 +34502,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "mimo_v2_flash",
-    "hf_downloads": 88082,
-    "hf_likes": 720,
+    "hf_downloads": 98870,
+    "hf_likes": 726,
     "release_date": "2025-12-16",
     "num_hidden_layers": 48,
     "num_attention_heads": 64,
@@ -24173,7 +34539,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "step3_vl",
-    "hf_downloads": 155267,
+    "hf_downloads": 178988,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -24193,54 +34559,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe",
-    "hf_downloads": 33338,
+    "hf_downloads": 55370,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 160,
     "active_experts": 8,
-    "active_parameters": 34786625132,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.6-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
-    "name": "zai-org/GLM-4.7",
-    "provider": "zai-org",
-    "parameter_count": "358.3B",
-    "parameters_raw": 358337791296,
-    "min_ram_gb": 200.2,
-    "recommended_ram_gb": 333.7,
-    "min_vram_gb": 183.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 202752,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "glm4_moe",
-    "hf_downloads": 89799,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 160,
-    "active_experts": 8,
-    "active_parameters": 34937934644,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.7-GGUF",
-        "provider": "unsloth"
-      },
-      {
-        "repo": "mradermacher/GLM-4.7-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 34786625132
   },
   {
     "name": "zai-org/GLM-4.5",
@@ -24257,20 +34583,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm4_moe",
-    "hf_downloads": 86728,
+    "hf_downloads": 106876,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 160,
     "active_experts": 8,
-    "active_parameters": 34937934644,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-4.5-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 34937934644
+  },
+  {
+    "name": "zai-org/GLM-4.7",
+    "provider": "zai-org",
+    "parameter_count": "358.3B",
+    "parameters_raw": 358337791296,
+    "min_ram_gb": 200.2,
+    "recommended_ram_gb": 333.7,
+    "min_vram_gb": 183.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 202752,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "glm4_moe",
+    "hf_downloads": 96723,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 160,
+    "active_experts": 8,
+    "active_parameters": 34937934644
   },
   {
     "name": "nvidia/DeepSeek-R1-0528-NVFP4-v2",
@@ -24287,7 +34631,31 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 1065696,
+    "hf_downloads": 1413341,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 31367615334
+  },
+  {
+    "name": "nvidia/DeepSeek-V3.1-NVFP4",
+    "provider": "nvidia",
+    "parameter_count": "393.6B",
+    "parameters_raw": 393632819968,
+    "min_ram_gb": 220.0,
+    "recommended_ram_gb": 366.6,
+    "min_vram_gb": 201.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 14668,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24311,7 +34679,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v32",
-    "hf_downloads": 58361,
+    "hf_downloads": 53854,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24335,7 +34703,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 35706,
+    "hf_downloads": 42299,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24359,7 +34727,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "afmoe",
-    "hf_downloads": 26268,
+    "hf_downloads": 24721,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24385,8 +34753,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "llama4",
-    "hf_downloads": 39219,
-    "hf_likes": 479,
+    "hf_downloads": 42748,
+    "hf_likes": 482,
     "release_date": "2025-04-01",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -24422,7 +34790,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama4",
-    "hf_downloads": 105572,
+    "hf_downloads": 114344,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24449,7 +34817,7 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 399291,
+    "hf_downloads": 586112,
     "hf_likes": 1474,
     "release_date": "2026-02-16",
     "num_hidden_layers": null,
@@ -24488,20 +34856,14 @@
     ],
     "pipeline_tag": "unknown",
     "architecture": "qwen3_5_moe",
-    "hf_downloads": 1330618,
+    "hf_downloads": 1208746,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 512,
     "active_experts": 10,
-    "active_parameters": 27656495656,
-    "gguf_sources": [
-      {
-        "repo": "mradermacher/Qwen3.5-397B-A17B-FP8-GGUF",
-        "provider": "mradermacher"
-      }
-    ]
+    "active_parameters": 27656495656
   },
   {
     "name": "meta-llama/Llama-3.1-405B-Instruct",
@@ -24520,7 +34882,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "llama",
-    "hf_downloads": 237182,
+    "hf_downloads": 246348,
     "hf_likes": 595,
     "release_date": "2024-07-16",
     "num_hidden_layers": null,
@@ -24543,7 +34905,29 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "llama",
-    "hf_downloads": 152424,
+    "hf_downloads": 148654,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true
+  },
+  {
+    "name": "nvidia/Llama-3.1-405B-Instruct-FP8",
+    "provider": "nvidia",
+    "parameter_count": "405.9B",
+    "parameters_raw": 405853388800,
+    "min_ram_gb": 226.8,
+    "recommended_ram_gb": 378.0,
+    "min_vram_gb": 207.9,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "Instruction following, chat",
+    "capabilities": [
+      "tool_use"
+    ],
+    "pipeline_tag": "unknown",
+    "architecture": "llama",
+    "hf_downloads": 17950,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -24563,7 +34947,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 156889,
+    "hf_downloads": 105180,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24589,7 +34973,7 @@
     ],
     "pipeline_tag": "text-generation",
     "architecture": "qwen3_moe",
-    "hf_downloads": 40144,
+    "hf_downloads": 41971,
     "hf_likes": 1331,
     "release_date": "2025-07-22",
     "num_hidden_layers": 62,
@@ -24608,6 +34992,30 @@
     ]
   },
   {
+    "name": "skt/A.X-K1",
+    "provider": "skt",
+    "parameter_count": "519.0B",
+    "parameters_raw": 518983059456,
+    "min_ram_gb": 290.0,
+    "recommended_ram_gb": 483.3,
+    "min_vram_gb": 265.8,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 4194304,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "AXK1",
+    "hf_downloads": 21297,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 192,
+    "active_experts": 8,
+    "active_parameters": 46492232404
+  },
+  {
     "name": "meituan-longcat/LongCat-Flash-Chat",
     "provider": "meituan-longcat",
     "parameter_count": "561.9B",
@@ -24622,7 +35030,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "unknown",
-    "hf_downloads": 52697,
+    "hf_downloads": 61388,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true
@@ -24642,7 +35050,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 42779,
+    "hf_downloads": 50894,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24666,8 +35074,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v3",
-    "hf_downloads": 1045642,
-    "hf_likes": 4063,
+    "hf_downloads": 1171264,
+    "hf_likes": 4064,
     "release_date": "2024-12-25",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -24699,8 +35107,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v3",
-    "hf_downloads": 3896658,
-    "hf_likes": 13315,
+    "hf_downloads": 3805992,
+    "hf_likes": 13319,
     "release_date": "2025-01-20",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -24722,36 +35130,6 @@
     ]
   },
   {
-    "name": "deepseek-ai/DeepSeek-V3-0324",
-    "provider": "DeepSeek",
-    "parameter_count": "684.5B",
-    "parameters_raw": 684531386000,
-    "min_ram_gb": 382.5,
-    "recommended_ram_gb": 637.5,
-    "min_vram_gb": 350.6,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 6553600,
-    "use_case": "General purpose",
-    "capabilities": [],
-    "pipeline_tag": "unknown",
-    "architecture": "deepseek_v3",
-    "hf_downloads": 659144,
-    "hf_likes": 0,
-    "release_date": null,
-    "_discovered": true,
-    "is_moe": true,
-    "num_experts": 256,
-    "active_experts": 8,
-    "active_parameters": 54548594820,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-V3-0324-GGUF",
-        "provider": "unsloth"
-      }
-    ]
-  },
-  {
     "name": "deepseek-ai/DeepSeek-R1-0528",
     "provider": "DeepSeek",
     "parameter_count": "684.5B",
@@ -24766,20 +35144,38 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v3",
-    "hf_downloads": 605074,
+    "hf_downloads": 1375563,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 54548594820,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/DeepSeek-R1-0528-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 54548594820
+  },
+  {
+    "name": "deepseek-ai/DeepSeek-V3-0324",
+    "provider": "DeepSeek",
+    "parameter_count": "684.5B",
+    "parameters_raw": 684531386000,
+    "min_ram_gb": 382.5,
+    "recommended_ram_gb": 637.5,
+    "min_vram_gb": 350.6,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v3",
+    "hf_downloads": 633222,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 54548594820
   },
   {
     "name": "deepseek-ai/DeepSeek-V3.2-Speciale",
@@ -24803,6 +35199,30 @@
     "release_date": "2025-12-01"
   },
   {
+    "name": "QuantTrio/DeepSeek-V3.2-AWQ",
+    "provider": "quanttrio",
+    "parameter_count": "685.0B",
+    "parameters_raw": 685011996928,
+    "min_ram_gb": 382.8,
+    "recommended_ram_gb": 638.0,
+    "min_vram_gb": 350.9,
+    "quantization": "AWQ-4bit",
+    "format": "awq",
+    "context_length": 6553600,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "deepseek_v32",
+    "hf_downloads": 200205,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 256,
+    "active_experts": 8,
+    "active_parameters": 54586893502
+  },
+  {
     "name": "deepseek-ai/DeepSeek-V3.2",
     "provider": "DeepSeek",
     "parameter_count": "685.4B",
@@ -24817,8 +35237,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v32",
-    "hf_downloads": 11290376,
-    "hf_likes": 1424,
+    "hf_downloads": 11633275,
+    "hf_likes": 1427,
     "release_date": "2025-12-01",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -24850,8 +35270,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 442542,
-    "hf_likes": 2078,
+    "hf_downloads": 315464,
+    "hf_likes": 2082,
     "release_date": "2026-02-11",
     "num_hidden_layers": 78,
     "num_attention_heads": 64,
@@ -24883,20 +35303,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 256484,
+    "hf_downloads": 295110,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 256,
     "active_experts": 8,
-    "active_parameters": 60073548574,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/GLM-5.1-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 60073548574
   },
   {
     "name": "zai-org/GLM-5-FP8",
@@ -24913,7 +35327,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 1294393,
+    "hf_downloads": 1609767,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24937,7 +35351,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "glm_moe_dsa",
-    "hf_downloads": 648689,
+    "hf_downloads": 877686,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24961,8 +35375,8 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "deepseek_v4",
-    "hf_downloads": 174402,
-    "hf_likes": 3169,
+    "hf_downloads": 786631,
+    "hf_likes": 3602,
     "release_date": "2026-04-22",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -24988,7 +35402,7 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "bailing_hybrid",
-    "hf_downloads": 28915,
+    "hf_downloads": 31310,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
@@ -24996,6 +35410,54 @@
     "num_experts": 256,
     "active_experts": 8,
     "active_parameters": 80681570216
+  },
+  {
+    "name": "XiaomiMiMo/MiMo-V2.5-Pro",
+    "provider": "xiaomimimo",
+    "parameter_count": "1023.2B",
+    "parameters_raw": 1023244718976,
+    "min_ram_gb": 571.8,
+    "recommended_ram_gb": 953.0,
+    "min_vram_gb": 524.1,
+    "quantization": "Q4_K_M",
+    "format": "gguf",
+    "context_length": 1048576,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "mimo_v2",
+    "hf_downloads": 16030,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 384,
+    "active_experts": 8,
+    "active_parameters": 71413954340
+  },
+  {
+    "name": "mlx-community/Kimi-K2.6-mlx-DQ3_K_M-q8",
+    "provider": "mlx-community",
+    "parameter_count": "1026.4B",
+    "parameters_raw": 1026408232448,
+    "min_ram_gb": 573.6,
+    "recommended_ram_gb": 955.9,
+    "min_vram_gb": 525.8,
+    "quantization": "Q4_K_M",
+    "format": "mlx",
+    "context_length": 16777216,
+    "use_case": "General purpose",
+    "capabilities": [],
+    "pipeline_tag": "unknown",
+    "architecture": "kimi_k25",
+    "hf_downloads": 128730,
+    "hf_likes": 0,
+    "release_date": null,
+    "_discovered": true,
+    "is_moe": true,
+    "num_experts": 384,
+    "active_experts": 8,
+    "active_parameters": 71634741222
   },
   {
     "name": "moonshotai/Kimi-K2-Instruct",
@@ -25012,7 +35474,7 @@
     "capabilities": [],
     "pipeline_tag": "text-generation",
     "architecture": "kimi_k2",
-    "hf_downloads": 409282,
+    "hf_downloads": 720892,
     "hf_likes": 2356,
     "release_date": "2025-07-11",
     "num_hidden_layers": 61,
@@ -25045,20 +35507,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kimi_k2",
-    "hf_downloads": 578999,
+    "hf_downloads": 742257,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 384,
     "active_experts": 8,
-    "active_parameters": 71639103404,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2-Instruct-0905-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 71639103404
   },
   {
     "name": "moonshotai/Kimi-K2-Thinking",
@@ -25075,20 +35531,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kimi_k2",
-    "hf_downloads": 109593,
+    "hf_downloads": 156992,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 384,
     "active_experts": 8,
-    "active_parameters": 73847838596,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2-Thinking-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 73847838596
   },
   {
     "name": "moonshotai/Kimi-K2.5",
@@ -25107,8 +35557,8 @@
     ],
     "pipeline_tag": "image-text-to-text",
     "architecture": "kimi_k25",
-    "hf_downloads": 4324014,
-    "hf_likes": 2769,
+    "hf_downloads": 1958899,
+    "hf_likes": 2775,
     "release_date": "2026-01-01",
     "num_hidden_layers": null,
     "num_attention_heads": null,
@@ -25140,20 +35590,14 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "kimi_k25",
-    "hf_downloads": 489001,
+    "hf_downloads": 997278,
     "hf_likes": 0,
     "release_date": null,
     "_discovered": true,
     "is_moe": true,
     "num_experts": 384,
     "active_experts": 8,
-    "active_parameters": 73880719970,
-    "gguf_sources": [
-      {
-        "repo": "unsloth/Kimi-K2.6-GGUF",
-        "provider": "unsloth"
-      }
-    ]
+    "active_parameters": 73880719970
   },
   {
     "name": "deepseek-ai/DeepSeek-V4-Pro-Base",
@@ -25170,8 +35614,8 @@
     "capabilities": [],
     "pipeline_tag": "unknown",
     "architecture": "deepseek_v4",
-    "hf_downloads": 1532,
-    "hf_likes": 234,
+    "hf_downloads": 5033,
+    "hf_likes": 257,
     "release_date": "2026-04-22",
     "num_hidden_layers": 61,
     "num_attention_heads": 128,
@@ -25181,81 +35625,5 @@
     "num_experts": 384,
     "active_experts": 6,
     "active_parameters": 49000000000
-  },
-  {
-    "name": "shoumenchougou/RWKV7-G1f-1.5B-GGUF",
-    "provider": "RWKV",
-    "parameter_count": "1.5B",
-    "parameters_raw": 1500000000,
-    "min_ram_gb": 1.0,
-    "recommended_ram_gb": 2.0,
-    "min_vram_gb": 0.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "rwkv",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
-  },
-  {
-    "name": "shoumenchougou/RWKV7-G1f-2.9B-GGUF",
-    "provider": "RWKV",
-    "parameter_count": "2.9B",
-    "parameters_raw": 2900000000,
-    "min_ram_gb": 1.6,
-    "recommended_ram_gb": 2.7,
-    "min_vram_gb": 1.5,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "rwkv",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
-  },
-  {
-    "name": "shoumenchougou/RWKV7-G1f-7.2B-GGUF",
-    "provider": "RWKV",
-    "parameter_count": "7.2B",
-    "parameters_raw": 7200000000,
-    "min_ram_gb": 4.0,
-    "recommended_ram_gb": 6.7,
-    "min_vram_gb": 3.7,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "rwkv",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
-  },
-  {
-    "name": "shoumenchougou/RWKV7-G1f-13.3B-GGUF",
-    "provider": "RWKV",
-    "parameter_count": "13.3B",
-    "parameters_raw": 13300000000,
-    "min_ram_gb": 7.4,
-    "recommended_ram_gb": 12.4,
-    "min_vram_gb": 6.8,
-    "quantization": "Q4_K_M",
-    "format": "gguf",
-    "context_length": 8192,
-    "use_case": "General purpose text generation",
-    "capabilities": [],
-    "pipeline_tag": "text-generation",
-    "architecture": "rwkv",
-    "hf_downloads": 0,
-    "hf_likes": 0,
-    "release_date": null
   }
 ]

--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -5,10 +5,10 @@ Fetches model metadata and computes RAM/VRAM requirements from parameter counts.
 Outputs a JSON file consumable by llmfit's models.rs.
 
 Usage:
-  python3 scrape_hf_models.py                  # Curated list only
-  python3 scrape_hf_models.py --threads 8      # Curated list with parallel fetches
-  python3 scrape_hf_models.py --discover        # Curated + top trending models
-  python3 scrape_hf_models.py --discover -n 50  # Curated + top 50 trending
+  python3 scrape_hf_models.py                  # Curated + top 1000 by downloads
+  python3 scrape_hf_models.py --threads 8      # Same, with parallel fetches
+  python3 scrape_hf_models.py -n 500           # Curated + top 500 by downloads
+  python3 scrape_hf_models.py --no-discover     # Curated list only
 """
 
 import argparse
@@ -967,99 +967,287 @@ def enrich_gguf_sources(models: list[dict], threads: int = 1) -> int:
 # ---------------------------------------------------------------------------
 
 # Pipeline tags to search for discoverable models
-DISCOVER_PIPELINES = ["text-generation", "text2text-generation", "image-text-to-text"]
+DISCOVER_PIPELINES = [
+    "text-generation",
+    "text2text-generation",
+    "image-text-to-text",
+    "feature-extraction",       # Embedding models (useful for RAG sizing)
+]
 
-# Orgs to skip — these publish many fine-tunes that clutter the list
+# Orgs to skip — test fixtures and legacy mirrors only.
+# Quantization/repack orgs (TheBloke, bartowski, unsloth, etc.) are kept
+# because they provide popular quantised variants users actually run.
 SKIP_ORGS = {
-    "TheBloke",               # GGUF repacks, not original models
-    "unsloth",                # Training framework repacks
-    "mlx-community",          # MLX conversions
-    "bartowski",              # GGUF repacks
-    "mradermacher",           # GGUF repacks
     "trl-internal-testing",   # Test fixtures
-    "openai-community",       # Legacy model mirrors (gpt2 etc.)
-    "distilbert",             # Distilled legacy models
 }
+
+# Sort strategies to query — results are merged and deduplicated.
+# Each strategy surfaces models that the others might miss.
+DISCOVER_SORT_STRATEGIES = [
+    "downloads",        # All-time most downloaded
+    "trendingScore",    # Currently trending (recent velocity)
+    "likes30d",         # Most liked in the last 30 days
+]
+
+
+def _fetch_models_page(url: str) -> tuple[list[dict], str | None]:
+    """Fetch a page of models from the HuggingFace API.
+
+    Returns (models, next_url) where next_url is parsed from the Link header
+    for cursor-based pagination, or None if there are no more pages.
+    """
+    req = urllib.request.Request(url, headers=_auth_headers())
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        # Parse cursor-based pagination from Link header
+        next_url = None
+        link_header = resp.headers.get("Link", "")
+        if 'rel="next"' in link_header:
+            # Format: <url>; rel="next"
+            next_url = link_header.split(">")[0].lstrip("<")
+        models = json.loads(resp.read().decode())
+    return models, next_url
+
+
+def _build_first_page_url(pipeline: str, sort: str, page_size: int) -> str:
+    """Build the initial API URL for a pipeline query."""
+    return (
+        f"{HF_API}?"
+        f"pipeline_tag={pipeline}&"
+        f"sort={sort}&"
+        f"direction=-1&"
+        f"limit={page_size}&"
+        f"expand[]=safetensors&"
+        f"expand[]=config"
+    )
+
+
+def _estimate_params_from_config(config: dict) -> int | None:
+    """Try to estimate parameter count from model config fields.
+
+    This is a fallback for models that don't expose safetensors metadata
+    in the listing API. Uses common config.json fields to estimate.
+    """
+    # Some configs directly state the param count
+    for key in ("num_parameters", "n_params", "total_params"):
+        val = config.get(key)
+        if val and isinstance(val, (int, float)) and val > 1000:
+            return int(val)
+
+    # Estimate from architecture dimensions (rough but useful)
+    hidden = config.get("hidden_size") or config.get("d_model")
+    layers = config.get("num_hidden_layers") or config.get("n_layer")
+    vocab = config.get("vocab_size")
+    intermediate = config.get("intermediate_size") or config.get("d_ff")
+
+    if hidden and layers and vocab:
+        # Rough transformer parameter estimate:
+        # ~12 * L * H^2 (attention + FFN) + V * H (embeddings)
+        ffn_factor = (intermediate / hidden) if intermediate else 4.0
+        params = int(layers * hidden * hidden * (4 + 2 * ffn_factor) + vocab * hidden)
+        if params > 1_000_000:  # sanity check: at least 1M params
+            return params
+
+    return None
+
+
+def _process_listing(
+    m: dict,
+    curated: set[str],
+    seen_ids: set[str],
+    min_downloads: int,
+    stats: dict,
+) -> dict | None:
+    """Check a single model listing against filters.
+
+    Returns the listing with _total_params attached if accepted, else None.
+    Mutates seen_ids and stats as side effects.
+    """
+    repo_id = m.get("id", "")
+    if not repo_id or "/" not in repo_id:
+        return None
+    stats["total_seen"] += 1
+
+    if repo_id in curated:
+        stats["skip_curated"] += 1
+        return None
+
+    if repo_id in seen_ids:
+        stats["skip_duplicate"] += 1
+        return None
+    seen_ids.add(repo_id)
+
+    org = repo_id.split("/")[0]
+    if org in SKIP_ORGS:
+        stats["skip_org"] += 1
+        return None
+
+    downloads = m.get("downloads", 0)
+    if downloads < min_downloads:
+        stats["skip_downloads"] += 1
+        return None
+
+    tags = set(m.get("tags", []))
+    if tags & {"adapter", "merge", "lora", "qlora"}:
+        stats["skip_tags"] += 1
+        return None
+
+    # Try safetensors metadata first
+    safetensors = m.get("safetensors", {})
+    total_params = safetensors.get("total")
+    if not total_params:
+        params_by_dtype = safetensors.get("parameters", {})
+        if params_by_dtype:
+            total_params = max(params_by_dtype.values())
+
+    param_source = "safetensors"
+
+    # Fallback: fetch full config.json and estimate from arch dims.
+    # Cap config fetches to avoid excessive network calls during discovery.
+    config_attempts = stats["params_from_config"] + stats.get("skip_no_params", 0)
+    if not total_params and config_attempts < 500:
+        full_cfg = fetch_config_json(repo_id)
+        if full_cfg:
+            total_params = _estimate_params_from_config(full_cfg)
+        param_source = "config"
+
+    if not total_params:
+        stats["skip_no_params"] += 1
+        return None
+
+    if param_source == "safetensors":
+        stats["params_from_safetensors"] += 1
+    else:
+        stats["params_from_config"] += 1
+
+    m["_total_params"] = total_params
+    stats["accepted"] += 1
+    return m
 
 
 def discover_trending_models(limit: int = 30, min_downloads: int = 10000) -> list[dict]:
-    """Query HuggingFace API for top text-generation models by download count.
+    """Discover popular models from HuggingFace using multiple sort strategies.
 
-    Uses ?expand=safetensors to get parameter counts directly from the listing
-    API, avoiding individual API calls per model (per HF team recommendation).
+    Queries the HF API with three sort strategies (all-time downloads,
+    trending score, and 30-day likes) across all pipeline types, then
+    merges and deduplicates the results. This surfaces both established
+    popular models and newly trending ones.
 
-    Returns a list of dicts with model listing data (including safetensors
-    metadata) for models NOT already in TARGET_MODELS.
+    Uses cursor-based pagination and falls back to estimating params from
+    config.json when safetensors metadata is unavailable.
+
+    Returns a list of dicts with model listing data for models NOT already
+    in TARGET_MODELS.
     """
     curated = set(TARGET_MODELS)
     discovered = []
     seen_ids = set()
 
-    for pipeline in DISCOVER_PIPELINES:
-        # Fetch more than we need since we'll filter heavily
-        fetch_limit = min(limit * 8, 10000)  # HF API max is 10000
-        url = (
-            f"{HF_API}?"
-            f"pipeline_tag={pipeline}&"
-            f"sort=downloads&"
-            f"direction=-1&"
-            f"limit={fetch_limit}&"
-            f"expand[]=safetensors&"
-            f"expand[]=config"
-        )
-        req = urllib.request.Request(url, headers=_auth_headers())
-        try:
-            with urllib.request.urlopen(req, timeout=60) as resp:
-                models = json.loads(resp.read().decode())
-        except Exception as e:
-            print(f"  ⚠ Failed to fetch trending {pipeline} models: {e}",
-                  file=sys.stderr)
-            continue
+    PAGE_SIZE = 1000
 
-        for m in models:
-            repo_id = m.get("id", "")
-            if not repo_id or "/" not in repo_id:
-                continue
+    stats = {
+        "total_seen": 0,
+        "skip_curated": 0,
+        "skip_duplicate": 0,
+        "skip_org": 0,
+        "skip_downloads": 0,
+        "skip_tags": 0,
+        "skip_no_params": 0,
+        "params_from_safetensors": 0,
+        "params_from_config": 0,
+        "accepted": 0,
+    }
 
-            # Skip if already curated or seen
-            if repo_id in curated or repo_id in seen_ids:
-                continue
-            seen_ids.add(repo_id)
+    for sort_strategy in DISCOVER_SORT_STRATEGIES:
+        strategy_accepted = 0
+        # Trending/likes sorts surface newly popular models that may not
+        # have high all-time downloads yet — use a lower floor for them.
+        effective_min = (min_downloads if sort_strategy == "downloads"
+                         else max(1000, min_downloads // 10))
+        # Cap pages for non-download sorts since they aren't ordered by
+        # downloads and would otherwise scan endlessly.
+        max_pages = 50 if sort_strategy == "downloads" else 5
 
-            # Skip known repack / converter orgs
-            org = repo_id.split("/")[0]
-            if org in SKIP_ORGS:
-                continue
+        for pipeline in DISCOVER_PIPELINES:
+            next_url: str | None = _build_first_page_url(
+                pipeline, sort_strategy, PAGE_SIZE
+            )
+            pipeline_accepted = 0
+            hit_floor = False
+            page_num = 0
 
-            # Skip models with too few downloads
-            downloads = m.get("downloads", 0)
-            if downloads < min_downloads:
-                continue
+            while len(discovered) < limit and next_url and page_num < max_pages:
+                page_num += 1
+                try:
+                    models, next_url = _fetch_models_page(next_url)
+                except Exception as e:
+                    print(f"    ⚠ {pipeline} page {page_num}: {e}",
+                          file=sys.stderr)
+                    break
 
-            # Skip GGUF-only repos, adapters, and merges
-            tags = set(m.get("tags", []))
-            if tags & {"gguf", "adapter", "merge", "lora", "qlora"}:
-                continue
+                if not models:
+                    break
 
-            # Check for actual parameter count from expand=safetensors
-            # (replaces old safetensors tag check — many models have data but no tag)
-            safetensors = m.get("safetensors", {})
-            total_params = safetensors.get("total")
-            if not total_params:
-                params_by_dtype = safetensors.get("parameters", {})
-                if params_by_dtype:
-                    total_params = max(params_by_dtype.values())
-            if not total_params:
-                continue  # no param data available
+                below_min_this_page = 0
 
-            # Attach param count for downstream use
-            m["_total_params"] = total_params
-            discovered.append(m)
+                for m in models:
+                    result = _process_listing(
+                        m, curated, seen_ids, effective_min, stats
+                    )
+                    if result is None:
+                        # Track download-floor hits for early stop
+                        downloads = m.get("downloads", 0)
+                        repo_id = m.get("id", "")
+                        if (repo_id and "/" in repo_id
+                                and repo_id not in curated
+                                and downloads < effective_min):
+                            below_min_this_page += 1
+                        continue
+
+                    discovered.append(result)
+                    pipeline_accepted += 1
+                    strategy_accepted += 1
+                    if len(discovered) >= limit:
+                        break
+
+                # For download-sorted queries, stop when most results are
+                # below the threshold. For trending/likes sorts, always
+                # exhaust pages since ordering isn't by downloads.
+                if sort_strategy == "downloads":
+                    if below_min_this_page > len(models) * 0.8:
+                        hit_floor = True
+                        break
+
+                if len(models) < PAGE_SIZE:
+                    break
+
+                time.sleep(0.2)
+
+            suffix = f", hit download floor" if hit_floor else ""
+            if pipeline_accepted > 0 or page_num > 0:
+                print(f"    {pipeline}: +{pipeline_accepted}"
+                      f" (pages: {page_num}{suffix})")
+
             if len(discovered) >= limit:
                 break
 
+        print(f"  sort={sort_strategy} (min_dl={effective_min:,}): "
+              f"+{strategy_accepted} new models")
+
         if len(discovered) >= limit:
             break
+
+    # Print filter statistics
+    print(f"\n  Discovery filter stats:")
+    print(f"    Total listings seen:     {stats['total_seen']:>6}")
+    print(f"    Skipped (curated dupe):  {stats['skip_curated']:>6}")
+    print(f"    Skipped (seen/duplicate):{stats['skip_duplicate']:>6}")
+    print(f"    Skipped (skip org):      {stats['skip_org']:>6}")
+    print(f"    Skipped (low downloads): {stats['skip_downloads']:>6}")
+    print(f"    Skipped (adapter/merge): {stats['skip_tags']:>6}")
+    print(f"    Skipped (no params):     {stats['skip_no_params']:>6}")
+    print(f"    Params from safetensors: {stats['params_from_safetensors']:>6}")
+    print(f"    Params from config est.: {stats['params_from_config']:>6}")
+    print(f"    Accepted:                {stats['accepted']:>6}")
 
     return discovered[:limit]
 
@@ -1123,13 +1311,17 @@ def main():
         description="Scrape LLM model metadata from HuggingFace for llmfit."
     )
     parser.add_argument(
-        "--discover", action="store_true",
-        help="Auto-discover trending text-generation models from HuggingFace "
-             "in addition to the curated TARGET_MODELS list."
+        "--discover", action="store_true", default=True,
+        help="Auto-discover top models by download count from HuggingFace "
+             "in addition to the curated TARGET_MODELS list (default: enabled)."
     )
     parser.add_argument(
-        "-n", "--discover-limit", type=int, default=30,
-        help="Max number of trending models to discover (default: 30). "
+        "--no-discover", action="store_false", dest="discover",
+        help="Disable auto-discovery, only scrape curated TARGET_MODELS list."
+    )
+    parser.add_argument(
+        "-n", "--discover-limit", type=int, default=1000,
+        help="Max number of top-downloaded models to discover (default: 1000). "
              "Duplicates of curated models are skipped automatically."
     )
     parser.add_argument(
@@ -2234,13 +2426,15 @@ def main():
     # Auto-discover trending models if --discover flag is set
     discovered_count = 0
     if args.discover:
-        print(f"\nDiscovering trending models (limit={args.discover_limit}, "
-              f"min_downloads={args.min_downloads})...")
+        print(f"\nDiscovering top models by downloads (limit={args.discover_limit}, "
+              f"min_downloads={args.min_downloads:,})...")
         trending = discover_trending_models(
             limit=args.discover_limit,
             min_downloads=args.min_downloads,
         )
-        print(f"  Found {len(trending)} new models not in curated list\n")
+        already_scraped = sum(1 for l in trending if l["id"] in scraped_names)
+        print(f"\n  Discovery returned {len(trending)} candidates"
+              f" ({already_scraped} already scraped)\n")
 
         candidates = [l for l in trending if l["id"] not in scraped_names]
 
@@ -2273,6 +2467,43 @@ def main():
                         scraped_names.add(repo_id)
                         discovered_count += 1
 
+    # --- Additive merge with existing database ---
+    # The database is additive: models from previous runs are preserved.
+    # Freshly scraped models update existing entries; historical models
+    # that are no longer in the top discovered set are kept as-is.
+    output_paths = ["data/hf_models.json", "llmfit-core/data/hf_models.json"]
+
+    # Build a map of freshly scraped models (name -> model dict)
+    fresh_by_name = {m["name"]: m for m in results}
+
+    # Load existing database and merge
+    existing_count = 0
+    retained_count = 0
+    updated_count = 0
+    for output_path in output_paths:
+        if os.path.exists(output_path):
+            try:
+                with open(output_path) as f:
+                    existing = json.load(f)
+                existing_count = max(existing_count, len(existing))
+                for old_model in existing:
+                    name = old_model.get("name", "")
+                    if name in fresh_by_name:
+                        updated_count += 1
+                    elif name:
+                        # Historical model not in current scrape — keep it
+                        results.append(old_model)
+                        fresh_by_name[name] = old_model
+                        scraped_names.add(name)
+                        retained_count += 1
+            except (json.JSONDecodeError, KeyError):
+                pass
+            break  # Only need to load from one path
+
+    if existing_count:
+        print(f"\nMerged with existing database ({existing_count} models):")
+        print(f"  Updated: {updated_count}, Retained historical: {retained_count}")
+
     # Sort by parameter count
     results.sort(key=lambda m: m["parameters_raw"])
 
@@ -2284,7 +2515,6 @@ def main():
         print(f"  Found GGUF sources for {gguf_enriched} models")
 
     # Write to both locations: repo root (for reference) and llmfit-core (compiled into binary)
-    output_paths = ["data/hf_models.json", "llmfit-core/data/hf_models.json"]
     for output_path in output_paths:
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         with open(output_path, "w") as f:
@@ -2292,7 +2522,8 @@ def main():
 
     print(f"\n✅ Wrote {len(results)} models to {', '.join(output_paths)}")
     print(f"   Curated: {len(TARGET_MODELS)}, Fallbacks: {fallback_count}, "
-          f"Discovered: {discovered_count}, GGUF-sourced: {gguf_enriched}")
+          f"Discovered: {discovered_count}, Retained: {retained_count}, "
+          f"GGUF-sourced: {gguf_enriched}")
 
     # Print summary table
     print(f"\n{'Model':<50} {'Params':>8} {'Min RAM':>8} {'Rec RAM':>8} {'VRAM':>6}")

--- a/scripts/update_models.sh
+++ b/scripts/update_models.sh
@@ -104,7 +104,7 @@ echo
 echo -e "${BLUE}Next steps:${NC}"
 echo "  • Run './target/release/llmfit' to test the updated binary"
 echo "  • Check 'data/hf_models.json' for the updated model list"
-echo "  • Example: ./scripts/update_models.sh --threads 8"
+echo "  • Example: ./scripts/update_models.sh --threads 8 --gguf-sources"
 if [ ! -z "$BACKUP_FILE" ]; then
     echo "  • Delete backup file if satisfied: rm $BACKUP_FILE"
 fi


### PR DESCRIPTION
## Summary
- **Fix broken pagination**: HF API ignores `offset` param — switched to cursor-based pagination via `Link` header, which was causing the scraper to only ever process the first page of results
- **Multi-strategy discovery**: queries 3 sort strategies (`downloads`, `trendingScore`, `likes30d`) across 4 pipeline types, merged and deduplicated — surfaces both established popular models and newly trending ones
- **Additive database**: existing models are retained across runs; fresh scrapes update entries in place but never delete historical models
- **Allow repack/quantization orgs**: removed TheBloke, bartowski, unsloth, mradermacher, mlx-community from skip list since users actually run those quantised variants
- **Config.json param fallback**: estimates params from model config when safetensors metadata is missing (~200 additional models rescued)
- **Discovery on by default**: `--discover` defaults to True with 1000 model limit; `--no-discover` to disable
- **Filter statistics**: every run prints a breakdown of where models were filtered

Result: **1520 models** (up from 1023), including 364 retained historical.

## Test plan
- [x] Verified cursor pagination returns distinct pages (not the same first page repeated)
- [x] Tested discovery with limit=5000 to confirm natural ceiling at ~1692 unique models with 10k min downloads
- [x] Confirmed trending/likes30d strategies surface models not in downloads sort
- [x] Verified additive merge retains historical models from previous database
- [x] Full end-to-end run: `./scripts/update_models.sh --threads 8 --gguf-sources --min-downloads 10000` completed successfully
- [x] Binary rebuilt and verified at 11M