### PR TITLE
fix(hardware): fix iGPU filtering on Ryzen 9 9950X with 2 GB iGPU

### DIFF
--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -579,12 +579,12 @@ impl SystemSpecs {
         // Filter out integrated GPUs (iGPUs) that have very little VRAM.
         // rocm-smi reports all GPU agents including iGPUs on APUs like
         // Ryzen 9800X3D, which would otherwise inflate the GPU count.
-        // Discrete GPUs have >= 2 GB VRAM; iGPUs typically show < 1 GB.
+         // Discrete GPUs have > 2 GB VRAM; iGPUs typically show <= 2 GB.
         const IGPU_VRAM_THRESHOLD: u64 = 2 * 1024 * 1024 * 1024; // 2 GB
         let discrete_vram: Vec<u64> = per_gpu_vram_bytes
             .iter()
             .copied()
-            .filter(|&v| v >= IGPU_VRAM_THRESHOLD)
+            .filter(|&v| v > IGPU_VRAM_THRESHOLD)
             .collect();
         let (effective_vram, gpu_count) = if discrete_vram.is_empty() {
             // No discrete GPUs found; use all entries (may be an iGPU-only system)


### PR DESCRIPTION
On systems with an AMD Ryzen 9 9950X (or similar APUs with a Granite Ridge iGPU), rocm-smi reports two GPU agents: the discrete GPU and the integrated GPU. The iGPU filter in detect_amd_gpu_rocm_info() uses a 2 GB VRAM threshold with >= to distinguish discrete GPUs from iGPUs.

The Ryzen 9 9950X's Granite Ridge iGPU has exactly 2 GB of VRAM (2,147,483,648 bytes), so it passes the >= check and is counted as a discrete GPU. This results in llmfit system reporting gpu_count: 2 with both labeled as the discrete GPU's name, even though only one discrete GPU is present.

Change >= to > so that GPUs with exactly 2 GB VRAM (the iGPU boundary) are excluded, while all discrete GPUs which have well over 2 GB are still included. The fallback path for iGPU-only systems (the discrete_vram.is_empty() branch) still handles the case where no discrete GPU is found.

System details:
- CPU: AMD Ryzen 9 9950X 16-Core Processor
- Discrete GPU: AMD Radeon AI PRO R9700 (32 GB VRAM)
- iGPU: AMD Radeon Graphics / Granite Ridge (2 GB VRAM, PCI ID 1002:13C0)
- ROCm SMI version: 4.0.0, ROCm SMI LIB: 7.8.0