### PR TITLE
fix: MoE offload speed overestimate for Qwen3-Coder-Next

### DIFF
--- a/llmfit-core/data/hf_models.json
+++ b/llmfit-core/data/hf_models.json
@@ -52497,7 +52497,7 @@
     "is_moe": true,
     "num_experts": 512,
     "active_experts": 10,
-    "active_parameters": 3000000000,
+    "active_parameters": 5462052994,
     "gguf_sources": [
       {
         "repo": "unsloth/Qwen3-Coder-Next-GGUF",

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -1082,7 +1082,8 @@ fn estimate_tps(
                     gpu_compute_time,
                     1.0 / total_time
                 );
-                return (1.0 / total_time).max(0.1);
+                let mode_factor = config.run_mode_factors.for_run_mode(run_mode);
+                return ((1.0 / total_time) * mode_factor).max(0.1);
             }
 
             // GPU mode: MoE model fits in VRAM with ALL expert weights loaded.


### PR DESCRIPTION
## Summary
- Fix wrong `active_parameters` (3B → 5.46B) for `Qwen/Qwen3-Coder-Next` in model catalog
- Fix MoeOffload speed path skipping `run_mode_factor` (0.8) — early return predates RunModeFactors system

## Problem
LLMFit estimated **28.3 tok/s** for Qwen3-Coder-Next in MoEOffload mode. Actual measured speed on RX 6900 XT is **10.3 tok/s** — a 2.74x overestimate.

## Root Causes

### 1. Wrong active_parameters in catalog
`Qwen/Qwen3-Coder-Next` had `active_parameters: 3000000000` (3B). Every other variant of the same model (`unsloth/Qwen3-Coder-Next`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, etc.) has `active_parameters: ~5462052994` (5.46B). The GGUF scraping got a wrong value for this one entry.

Impact alone: 28.3 → 15.5 tok/s (still 1.50x overestimate)

### 2. MoeOffload path skips run_mode_factor
The MoeOffload early-return at `fit.rs:1085` was written in commit `e1f3245` (April 19) BEFORE `RunModeFactors` was added in commit `7794a29`. Every other estimation path applies `mode_factor`, but MoeOffload doesn't.

Impact with both fixes: 28.3 → **12.4 tok/s** (1.20x overestimate, within ±30% tolerance)

## Validation
Benchmarks run with `llama-bench` on RX 6900 XT (16GB VRAM, 512 GB/s, DDR4):

| Model | Measured | LLMFit Fixture | Gap |
|-------|----------|---------------|-----|
| OLMoE-1B-7B Q4_K_M | 257.1 tok/s | 258.2 | 0.4% |
| Qwen1.5-MoE Q4_K_M | 130.9 tok/s | 128.7 | 1.7% |
| DeepSeek-V2-Lite Q4_K_M | 123.0 tok/s | 123.8 | 0.6% |
| Qwen3.5-35B Q2_K_XL | 78.4 tok/s | 79.6 | 1.5% |

All GPU-mode MoE models unchanged by this fix. All 358 existing tests pass.

## Test plan
- [x] `cargo test --release` — 358 passed, 0 failed
- [x] GPU-mode MoE estimates unchanged (spot-checked 5 models)
- [x] Qwen3-Coder-Next MoeOffload estimate: 28.3 → 12.4 tok/s (measured: 10.3)
- [x] Debug output: `LLMFIT_DEBUG=1 llmfit recommend` shows correct DDR bandwidth calculation

👾 Generated with [Letta Code](https://letta.com)