### PR TITLE
feat: add MCP server mode and NATS event publishing

### DIFF
--- a/API.md
+++ b/API.md
@@ -224,6 +224,107 @@ curl "http://127.0.0.1:8787/api/v1/models/top?limit=5&min_fit=good&use_case=codi
 curl "http://127.0.0.1:8787/api/v1/models/Mistral?runtime=any"
 ```
 
+---
+
+## MCP Server Mode
+
+llmfit can run as an MCP (Model Context Protocol) server over stdio, making it discoverable by AI agents (Claude, Cursor, etc.).
+
+### Start the MCP server
+
+```sh
+llmfit serve --mcp
+```
+
+Global hardware overrides still apply:
+
+```sh
+llmfit --memory 24G --ram 64G serve --mcp
+```
+
+### MCP client configuration
+
+Add to your MCP client config (e.g. `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "llmfit": {
+      "command": "llmfit",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}
+```
+
+### Available tools
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `get_system_specs` | Node hardware info (RAM, GPU, CPU) | None |
+| `recommend_models` | Top models for this hardware | `limit?`, `use_case?`, `min_fit?`, `runtime?`, `license?`, `sort?` |
+| `search_models` | Free-text model search | `query`, `limit?` |
+| `plan_hardware` | Hardware requirements for a model | `model`, `context?`, `quant?`, `target_tps?` |
+| `get_runtimes` | Installed inference runtimes | None |
+| `get_installed_models` | Models in local runtimes | None |
+
+---
+
+## NATS Event Publishing
+
+When built with the `nats` feature, llmfit can publish hardware and model events to NATS for integration with coordination systems (e.g. Sympozium membrane).
+
+### Build with NATS support
+
+```sh
+cargo build --features nats
+```
+
+### Enable event publishing
+
+```sh
+llmfit serve --send-events --nats-url nats://localhost:4222
+llmfit serve --mcp --send-events  # also works with MCP mode
+```
+
+The `NATS_URL` environment variable is also supported.
+
+### Event subjects
+
+Events are published to `llmfit.{event_type}.{hostname}`:
+
+| Subject | Trigger | Payload |
+|---------|---------|---------|
+| `llmfit.system.{hostname}` | Startup + every 60s | System hardware specs |
+| `llmfit.fit.{hostname}` | After fit analysis | Model fit summary |
+| `llmfit.plan.{hostname}` | After plan estimate | Plan estimate |
+| `llmfit.runtimes.{hostname}` | Startup + on query | Runtime availability |
+| `llmfit.installed.{hostname}` | Startup + on query | Installed models |
+
+### Event envelope
+
+All events are wrapped in a common envelope:
+
+```json
+{
+  "timestamp": "1747058400",
+  "hostname": "worker-1",
+  "event_type": "system",
+  "version": "1",
+  "data": { ... }
+}
+```
+
+### Subscribe to events
+
+```sh
+nats sub 'llmfit.>'                    # all events from all nodes
+nats sub 'llmfit.system.>'             # system specs from all nodes
+nats sub 'llmfit.system.worker-1'      # system specs from specific node
+```
+
+---
+
 ## Versioning notes
 
 Current API prefix is `v1`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31811585c7c5bc2f60f8b80d5a6b0f737115611dac47567d7f7d94562ebb180b"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.10.1",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +292,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -506,14 +559,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -606,6 +672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +766,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -847,6 +928,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,10 +988,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -1075,6 +1199,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1332,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -1301,12 +1453,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1361,6 +1529,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1542,6 +1711,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2365,6 +2535,7 @@ version = "0.9.23"
 dependencies = [
  "arboard",
  "assert_cmd",
+ "async-nats",
  "axum",
  "clap",
  "colored",
@@ -2374,6 +2545,8 @@ dependencies = [
  "http-body-util",
  "llmfit-core",
  "ratatui",
+ "rmcp",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tabled",
@@ -2631,6 +2804,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.6",
+ "signatory",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2841,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2859,6 +3056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,6 +3133,21 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3169,10 +3387,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -3450,6 +3698,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,6 +3745,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -3714,6 +3979,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,6 +4054,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3798,6 +4110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,7 +4126,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -3830,8 +4151,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -3849,10 +4172,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3965,6 +4323,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4113,7 +4480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4152,6 +4519,28 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4240,6 +4629,16 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -4933,6 +5332,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4943,6 +5363,27 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "rand 0.8.6",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5104,7 +5545,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5143,6 +5596,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "typeid"
@@ -5261,7 +5724,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5603,6 +6066,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/llmfit-tui/Cargo.toml
+++ b/llmfit-tui/Cargo.toml
@@ -16,11 +16,16 @@ categories = ["command-line-utilities"]
 name = "llmfit"
 path = "src/main.rs"
 
+[features]
+default = []
+nats = ["async-nats"]
+
 [dependencies]
 llmfit-core = { version = "0.9.0", path = "../llmfit-core" }
 clap = { version = "4.6", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+schemars = "1.0"
 tabled = "0.20"
 colored = "3.1"
 csv = "1.4"
@@ -29,7 +34,9 @@ crossterm = "0.29"
 arboard = "3.4"
 dirs = "6.0"
 axum = "0.8"
-tokio = { version = "1.50", features = ["rt-multi-thread", "signal", "net"] }
+tokio = { version = "1.50", features = ["rt-multi-thread", "signal", "net", "io-std"] }
+rmcp = { version = "1.6", features = ["server", "macros", "transport-io"] }
+async-nats = { version = "0.48", optional = true }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/llmfit-tui/src/events.rs
+++ b/llmfit-tui/src/events.rs
@@ -1,0 +1,91 @@
+use llmfit_core::hardware::SystemSpecs;
+use serde::Serialize;
+use std::sync::Arc;
+
+use crate::serve_shared;
+
+pub struct EventPublisher {
+    client: async_nats::Client,
+    hostname: String,
+}
+
+#[derive(Serialize)]
+struct EventEnvelope<'a, T: Serialize> {
+    timestamp: String,
+    hostname: &'a str,
+    event_type: &'a str,
+    version: &'static str,
+    data: &'a T,
+}
+
+impl EventPublisher {
+    pub async fn connect(nats_url: &str) -> Result<Self, String> {
+        let client = async_nats::connect(nats_url)
+            .await
+            .map_err(|e| format!("NATS connection failed: {e}"))?;
+
+        let hostname = std::env::var("HOSTNAME")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "unknown-node".to_string());
+
+        Ok(Self { client, hostname })
+    }
+
+    pub async fn publish_system(&self, specs: &SystemSpecs) {
+        let data = serve_shared::system_json(specs);
+        self.publish("system", &data).await;
+    }
+
+    pub async fn publish_event<T: Serialize>(&self, event_type: &str, data: &T) {
+        self.publish(event_type, data).await;
+    }
+
+    async fn publish<T: Serialize>(&self, event_type: &str, data: &T) {
+        let subject = format!("llmfit.{}.{}", event_type, self.hostname);
+        let envelope = EventEnvelope {
+            timestamp: chrono_now(),
+            hostname: &self.hostname,
+            event_type,
+            version: "1",
+            data,
+        };
+
+        let payload = match serde_json::to_vec(&envelope) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                eprintln!("[llmfit-events] serialization error: {e}");
+                return;
+            }
+        };
+
+        if let Err(e) = self.client.publish(subject, payload.into()).await {
+            eprintln!("[llmfit-events] publish error: {e}");
+        }
+    }
+}
+
+/// Spawn a background task that publishes system specs every 60 seconds.
+pub fn start_periodic_publisher(publisher: Arc<EventPublisher>, specs: SystemSpecs) {
+    tokio::spawn(async move {
+        // Publish immediately on startup
+        publisher.publish_system(&specs).await;
+
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        interval.tick().await; // skip the first (immediate) tick
+        loop {
+            interval.tick().await;
+            publisher.publish_system(&specs).await;
+        }
+    });
+}
+
+fn chrono_now() -> String {
+    // Simple ISO 8601 timestamp without pulling in chrono crate
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs();
+    // Format as seconds since epoch — simple and sortable
+    format!("{secs}")
+}

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1,7 +1,11 @@
 mod display;
 mod download_history;
+#[cfg(feature = "nats")]
+mod events;
 mod filter_config;
+mod mcp_server;
 mod serve_api;
+mod serve_shared;
 mod theme;
 mod tui_app;
 mod tui_events;
@@ -677,6 +681,18 @@ AGENT USAGE:
         /// Port to listen on
         #[arg(long, default_value = "8787")]
         port: u16,
+
+        /// Run as MCP server on stdio instead of HTTP
+        #[arg(long)]
+        mcp: bool,
+
+        /// Publish events to NATS (requires nats feature)
+        #[arg(long)]
+        send_events: bool,
+
+        /// NATS server URL
+        #[arg(long, env = "NATS_URL", default_value = "nats://localhost:4222")]
+        nats_url: String,
     },
 
     /// Benchmark inference performance against running providers
@@ -2710,10 +2726,38 @@ fn main() {
                 run_model(&model, server, port, ngl, ctx_size);
             }
 
-            Commands::Serve { host, port } => {
-                if let Err(err) = serve_api::run_serve(&host, port, &overrides, context_limit) {
-                    eprintln!("Error: {}", err);
+            Commands::Serve {
+                host,
+                port,
+                mcp,
+                send_events,
+                nats_url,
+            } => {
+                #[cfg(not(feature = "nats"))]
+                if send_events {
+                    eprintln!(
+                        "Error: --send-events requires the 'nats' feature. Rebuild with: cargo build --features nats"
+                    );
                     std::process::exit(1);
+                }
+                #[cfg(not(feature = "nats"))]
+                let _ = (&send_events, &nats_url);
+
+                if mcp {
+                    if let Err(err) = mcp_server::run_mcp_server(&overrides, context_limit) {
+                        eprintln!("Error: {}", err);
+                        std::process::exit(1);
+                    }
+                } else {
+                    #[cfg(feature = "nats")]
+                    if send_events {
+                        eprintln!("NATS events enabled, publishing to {}", nats_url);
+                    }
+
+                    if let Err(err) = serve_api::run_serve(&host, port, &overrides, context_limit) {
+                        eprintln!("Error: {}", err);
+                        std::process::exit(1);
+                    }
                 }
             }
 

--- a/llmfit-tui/src/mcp_server.rs
+++ b/llmfit-tui/src/mcp_server.rs
@@ -1,0 +1,435 @@
+use llmfit_core::fit::{
+    FitLevel, InferenceRuntime, ModelFit, SortColumn, backend_compatible,
+    rank_models_by_fit_opts_col,
+};
+use llmfit_core::hardware::{GpuBackend, SystemSpecs};
+use llmfit_core::models::{LlmModel, ModelDatabase, UseCase};
+use llmfit_core::plan::{PlanRequest, estimate_model_plan};
+use llmfit_core::providers::{
+    DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider, ModelProvider,
+    OllamaProvider, VllmProvider,
+};
+use rmcp::handler::server::{router::tool::ToolRouter, wrapper::Parameters};
+use rmcp::{ServerHandler, ServiceExt, tool, tool_handler, tool_router};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::serve_shared;
+
+// --- Tool input schemas ---
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct RecommendModelsParams {
+    /// Maximum number of models to return (default: 10)
+    pub limit: Option<usize>,
+    /// Filter by use case: general, coding, reasoning, chat, multimodal, embedding
+    pub use_case: Option<String>,
+    /// Minimum fit level: perfect, good, marginal
+    pub min_fit: Option<String>,
+    /// Filter by runtime: mlx, llamacpp, vllm
+    pub runtime: Option<String>,
+    /// Filter by license string
+    pub license: Option<String>,
+    /// Sort by: score, tps, params, mem, ctx, date
+    pub sort: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct SearchModelsParams {
+    /// Search query (matches model name, provider, parameters, use case)
+    pub query: String,
+    /// Maximum number of results to return (default: 10)
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct PlanHardwareParams {
+    /// Model name to plan for
+    pub model: String,
+    /// Context window size (default: 8192)
+    pub context: Option<u32>,
+    /// Quantization level (e.g. Q4_K_M, Q8_0)
+    pub quant: Option<String>,
+    /// Target tokens per second
+    pub target_tps: Option<f64>,
+}
+
+// --- Tool output types ---
+
+#[derive(Serialize)]
+struct RuntimeInfo {
+    name: &'static str,
+    installed: bool,
+}
+
+#[derive(Serialize)]
+struct InstalledModel {
+    name: String,
+    runtime: String,
+}
+
+// --- MCP Server ---
+
+#[derive(Clone)]
+pub struct LlmfitMcpServer {
+    specs: SystemSpecs,
+    models: Vec<LlmModel>,
+    context_limit: Option<u32>,
+    node_name: String,
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_handler]
+impl ServerHandler for LlmfitMcpServer {}
+
+#[tool_router]
+impl LlmfitMcpServer {
+    pub fn new(
+        specs: SystemSpecs,
+        models: Vec<LlmModel>,
+        context_limit: Option<u32>,
+        node_name: String,
+    ) -> Self {
+        Self {
+            specs,
+            models,
+            context_limit,
+            node_name,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Get this node's hardware specifications including RAM, GPU, CPU details
+    #[tool(
+        name = "get_system_specs",
+        description = "Get hardware specs for this node (RAM, GPU, CPU)"
+    )]
+    async fn get_system_specs(&self) -> String {
+        let result = serde_json::json!({
+            "node": self.node_name,
+            "system": serve_shared::system_json(&self.specs),
+        });
+        serde_json::to_string_pretty(&result).unwrap_or_default()
+    }
+
+    /// Recommend LLM models that fit this system's hardware
+    #[tool(
+        name = "recommend_models",
+        description = "Recommend LLM models that fit this system's hardware, with optional filtering by use case, fit level, runtime, and license"
+    )]
+    async fn recommend_models(&self, params: Parameters<RecommendModelsParams>) -> String {
+        let params = params.0;
+        let limit = params.limit.unwrap_or(10);
+        let sort_column = parse_sort(params.sort.as_deref());
+        let min_fit = parse_min_fit(params.min_fit.as_deref());
+        let runtime_filter = parse_runtime(params.runtime.as_deref());
+        let use_case_filter = parse_use_case(params.use_case.as_deref());
+
+        let mut fits = self.analyze_all();
+
+        if let Some(min) = min_fit {
+            fits.retain(|f| fit_at_least(f.fit_level, min));
+        } else {
+            fits.retain(|f| f.fit_level != FitLevel::TooTight);
+        }
+
+        if let Some(rt) = runtime_filter {
+            fits.retain(|f| f.runtime == rt);
+        }
+
+        if let Some(uc) = use_case_filter {
+            fits.retain(|f| f.use_case == uc);
+        }
+
+        if let Some(ref lic) = params.license {
+            fits.retain(|f| llmfit_core::models::matches_license_filter(&f.model.license, lic));
+        }
+
+        let total = fits.len();
+        let mut ranked = rank_models_by_fit_opts_col(fits, false, sort_column);
+        ranked.truncate(limit);
+
+        let result = serde_json::json!({
+            "total_models": total,
+            "returned_models": ranked.len(),
+            "models": ranked.iter().map(serve_shared::fit_to_json).collect::<Vec<_>>(),
+        });
+        serde_json::to_string_pretty(&result).unwrap_or_default()
+    }
+
+    /// Search for models by name, provider, or use case
+    #[tool(
+        name = "search_models",
+        description = "Search for LLM models by name, provider, or use case"
+    )]
+    async fn search_models(&self, params: Parameters<SearchModelsParams>) -> String {
+        let params = params.0;
+        let limit = params.limit.unwrap_or(10);
+        let search_lower = params.query.to_lowercase();
+
+        let mut fits = self.analyze_all();
+        fits.retain(|f| {
+            f.model.name.to_lowercase().contains(&search_lower)
+                || f.model.provider.to_lowercase().contains(&search_lower)
+                || f.model
+                    .parameter_count
+                    .to_lowercase()
+                    .contains(&search_lower)
+                || f.model.use_case.to_lowercase().contains(&search_lower)
+                || f.use_case.label().to_lowercase().contains(&search_lower)
+        });
+        fits.retain(|f| f.fit_level != FitLevel::TooTight);
+
+        let total = fits.len();
+        let mut ranked = rank_models_by_fit_opts_col(fits, false, SortColumn::Score);
+        ranked.truncate(limit);
+
+        let result = serde_json::json!({
+            "query": params.query,
+            "total_matches": total,
+            "returned_models": ranked.len(),
+            "models": ranked.iter().map(serve_shared::fit_to_json).collect::<Vec<_>>(),
+        });
+        serde_json::to_string_pretty(&result).unwrap_or_default()
+    }
+
+    /// Plan hardware requirements for running a specific model
+    #[tool(
+        name = "plan_hardware",
+        description = "Plan hardware requirements for running a specific model at a given context window size"
+    )]
+    async fn plan_hardware(&self, params: Parameters<PlanHardwareParams>) -> String {
+        let params = params.0;
+        let model = self
+            .models
+            .iter()
+            .find(|m| m.name.eq_ignore_ascii_case(&params.model));
+
+        let Some(model) = model else {
+            return serde_json::json!({
+                "error": format!("model '{}' not found", params.model),
+            })
+            .to_string();
+        };
+
+        let request = PlanRequest {
+            context: params.context.unwrap_or(8192),
+            quant: params.quant,
+            target_tps: params.target_tps,
+            kv_quant: None,
+        };
+
+        match estimate_model_plan(model, &request, &self.specs) {
+            Ok(estimate) => {
+                serde_json::to_string_pretty(&serde_json::json!(estimate)).unwrap_or_default()
+            }
+            Err(e) => serde_json::json!({ "error": e }).to_string(),
+        }
+    }
+
+    /// Check which inference runtimes are installed and available
+    #[tool(
+        name = "get_runtimes",
+        description = "Check which local inference runtimes (Ollama, MLX, llama.cpp, vLLM, etc.) are installed"
+    )]
+    async fn get_runtimes(&self) -> String {
+        let mut set = tokio::task::JoinSet::new();
+        set.spawn_blocking(|| RuntimeInfo {
+            name: "ollama",
+            installed: OllamaProvider::new().is_available(),
+        });
+        set.spawn_blocking(|| RuntimeInfo {
+            name: "mlx",
+            installed: MlxProvider::new().is_available(),
+        });
+        set.spawn_blocking(|| RuntimeInfo {
+            name: "llamacpp",
+            installed: LlamaCppProvider::new().is_available(),
+        });
+        set.spawn_blocking(|| RuntimeInfo {
+            name: "docker_model_runner",
+            installed: DockerModelRunnerProvider::new().is_available(),
+        });
+        set.spawn_blocking(|| RuntimeInfo {
+            name: "lmstudio",
+            installed: LmStudioProvider::new().is_available(),
+        });
+        set.spawn_blocking(|| RuntimeInfo {
+            name: "vllm",
+            installed: VllmProvider::new().is_available(),
+        });
+
+        let mut runtimes = Vec::new();
+        while let Some(result) = set.join_next().await {
+            if let Ok(info) = result {
+                runtimes.push(info);
+            }
+        }
+
+        let result = serde_json::json!({ "runtimes": runtimes });
+        serde_json::to_string_pretty(&result).unwrap_or_default()
+    }
+
+    /// List models currently installed in local inference runtimes
+    #[tool(
+        name = "get_installed_models",
+        description = "List models currently installed in local inference runtimes (Ollama, MLX, llama.cpp, etc.)"
+    )]
+    async fn get_installed_models(&self) -> String {
+        let mut set = tokio::task::JoinSet::new();
+        set.spawn_blocking(|| {
+            let p = OllamaProvider::new();
+            ("ollama", p.is_available(), p.installed_models())
+        });
+        set.spawn_blocking(|| {
+            let p = MlxProvider::new();
+            ("mlx", p.is_available(), p.installed_models())
+        });
+        set.spawn_blocking(|| {
+            let p = LlamaCppProvider::new();
+            ("llamacpp", p.is_available(), p.installed_models())
+        });
+        set.spawn_blocking(|| {
+            let p = DockerModelRunnerProvider::new();
+            (
+                "docker_model_runner",
+                p.is_available(),
+                p.installed_models(),
+            )
+        });
+        set.spawn_blocking(|| {
+            let p = LmStudioProvider::new();
+            ("lmstudio", p.is_available(), p.installed_models())
+        });
+        set.spawn_blocking(|| {
+            let p = VllmProvider::new();
+            ("vllm", p.is_available(), p.installed_models())
+        });
+
+        let mut models = Vec::new();
+        while let Some(result) = set.join_next().await {
+            if let Ok((name, available, installed)) = result {
+                if available {
+                    for model_name in installed {
+                        models.push(InstalledModel {
+                            name: model_name,
+                            runtime: name.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
+        let result = serde_json::json!({ "models": models });
+        serde_json::to_string_pretty(&result).unwrap_or_default()
+    }
+}
+
+impl LlmfitMcpServer {
+    fn analyze_all(&self) -> Vec<ModelFit> {
+        let is_apple_silicon = self.specs.backend == GpuBackend::Metal && self.specs.unified_memory;
+        let mut fits: Vec<ModelFit> = self
+            .models
+            .iter()
+            .filter(|m| backend_compatible(m, &self.specs))
+            .map(|m| {
+                ModelFit::analyze_with_forced_runtime(m, &self.specs, self.context_limit, None)
+            })
+            .collect();
+
+        if !is_apple_silicon {
+            fits.retain(|f| !f.model.is_mlx_only());
+        }
+
+        fits
+    }
+}
+
+// --- Entry point ---
+
+pub fn run_mcp_server(
+    overrides: &super::HardwareOverrides,
+    context_limit: Option<u32>,
+) -> Result<(), String> {
+    let specs = super::detect_specs(overrides);
+    let db = ModelDatabase::new();
+    let models = db.get_all_models().clone();
+    let node_name = std::env::var("HOSTNAME")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "unknown-node".to_string());
+
+    let server = LlmfitMcpServer::new(specs, models, context_limit, node_name);
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("failed to start tokio runtime: {e}"))?;
+
+    runtime.block_on(async move {
+        let transport = rmcp::transport::io::stdio();
+        let service = server
+            .serve(transport)
+            .await
+            .map_err(|e| format!("MCP server error: {e}"))?;
+        service
+            .waiting()
+            .await
+            .map_err(|e| format!("MCP server terminated: {e}"))?;
+        Ok(())
+    })
+}
+
+// --- Helper parsers ---
+
+fn parse_sort(raw: Option<&str>) -> SortColumn {
+    match raw.unwrap_or("score").trim().to_lowercase().as_str() {
+        "tps" | "tokens" | "throughput" => SortColumn::Tps,
+        "params" | "parameters" => SortColumn::Params,
+        "mem" | "memory" | "mem_pct" => SortColumn::MemPct,
+        "ctx" | "context" => SortColumn::Ctx,
+        "date" | "release" => SortColumn::ReleaseDate,
+        "use" | "use_case" => SortColumn::UseCase,
+        _ => SortColumn::Score,
+    }
+}
+
+fn parse_min_fit(raw: Option<&str>) -> Option<FitLevel> {
+    raw.map(|s| match s.trim().to_lowercase().as_str() {
+        "perfect" => FitLevel::Perfect,
+        "good" => FitLevel::Good,
+        "marginal" => FitLevel::Marginal,
+        _ => FitLevel::Marginal,
+    })
+}
+
+fn parse_runtime(raw: Option<&str>) -> Option<InferenceRuntime> {
+    raw.and_then(|s| match s.trim().to_lowercase().as_str() {
+        "mlx" => Some(InferenceRuntime::Mlx),
+        "llamacpp" | "llama.cpp" | "llama_cpp" => Some(InferenceRuntime::LlamaCpp),
+        "vllm" => Some(InferenceRuntime::Vllm),
+        _ => None,
+    })
+}
+
+fn parse_use_case(raw: Option<&str>) -> Option<UseCase> {
+    raw.and_then(|s| match s.trim().to_lowercase().as_str() {
+        "coding" | "code" => Some(UseCase::Coding),
+        "reasoning" | "reason" => Some(UseCase::Reasoning),
+        "chat" => Some(UseCase::Chat),
+        "multimodal" | "vision" => Some(UseCase::Multimodal),
+        "embedding" | "embed" => Some(UseCase::Embedding),
+        "general" => Some(UseCase::General),
+        _ => None,
+    })
+}
+
+fn fit_at_least(actual: FitLevel, minimum: FitLevel) -> bool {
+    let rank = |fit: FitLevel| match fit {
+        FitLevel::Perfect => 3,
+        FitLevel::Good => 2,
+        FitLevel::Marginal => 1,
+        FitLevel::TooTight => 0,
+    };
+    rank(actual) >= rank(minimum)
+}

--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -21,6 +21,8 @@ use llmfit_core::providers::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::serve_shared;
+
 include!(concat!(env!("OUT_DIR"), "/web_assets.rs"));
 
 static ASSET_MAP: LazyLock<HashMap<&'static str, &'static EmbeddedAsset>> =
@@ -949,108 +951,12 @@ fn active_filters_json(query: &ModelsQuery, top_only: bool) -> serde_json::Value
     })
 }
 
-fn fit_level_code(fit_level: FitLevel) -> &'static str {
-    match fit_level {
-        FitLevel::Perfect => "perfect",
-        FitLevel::Good => "good",
-        FitLevel::Marginal => "marginal",
-        FitLevel::TooTight => "too_tight",
-    }
-}
-
-fn run_mode_code(run_mode: llmfit_core::fit::RunMode) -> &'static str {
-    match run_mode {
-        llmfit_core::fit::RunMode::Gpu => "gpu",
-        llmfit_core::fit::RunMode::TensorParallel => "tensor_parallel",
-        llmfit_core::fit::RunMode::MoeOffload => "moe_offload",
-        llmfit_core::fit::RunMode::CpuOffload => "cpu_offload",
-        llmfit_core::fit::RunMode::CpuOnly => "cpu_only",
-    }
-}
-
-fn runtime_code(runtime: InferenceRuntime) -> &'static str {
-    match runtime {
-        InferenceRuntime::Mlx => "mlx",
-        InferenceRuntime::LlamaCpp => "llamacpp",
-        InferenceRuntime::Vllm => "vllm",
-    }
-}
-
 fn system_json(specs: &SystemSpecs) -> serde_json::Value {
-    let gpus_json: Vec<serde_json::Value> = specs
-        .gpus
-        .iter()
-        .map(|g| {
-            serde_json::json!({
-                "name": g.name,
-                "vram_gb": g.vram_gb.map(round2),
-                "backend": g.backend.label(),
-                "count": g.count,
-                "unified_memory": g.unified_memory,
-            })
-        })
-        .collect();
-
-    serde_json::json!({
-        "total_ram_gb": round2(specs.total_ram_gb),
-        "available_ram_gb": round2(specs.available_ram_gb),
-        "cpu_cores": specs.total_cpu_cores,
-        "cpu_name": specs.cpu_name,
-        "has_gpu": specs.has_gpu,
-        "gpu_vram_gb": specs.gpu_vram_gb.map(round2),
-        "gpu_name": specs.gpu_name,
-        "gpu_count": specs.gpu_count,
-        "unified_memory": specs.unified_memory,
-        "backend": specs.backend.label(),
-        "gpus": gpus_json,
-    })
+    serve_shared::system_json(specs)
 }
 
 fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
-    serde_json::json!({
-        "name": fit.model.name,
-        "provider": fit.model.provider,
-        "parameter_count": fit.model.parameter_count,
-        "params_b": round2(fit.model.params_b()),
-        "context_length": fit.model.context_length,
-        "use_case": fit.model.use_case,
-        "category": fit.use_case.label(),
-        "release_date": fit.model.release_date,
-        "is_moe": fit.model.is_moe,
-        "fit_level": fit_level_code(fit.fit_level),
-        "fit_label": fit.fit_text(),
-        "run_mode": run_mode_code(fit.run_mode),
-        "run_mode_label": fit.run_mode_text(),
-        "score": round1(fit.score),
-        "score_components": {
-            "quality": round1(fit.score_components.quality),
-            "speed": round1(fit.score_components.speed),
-            "fit": round1(fit.score_components.fit),
-            "context": round1(fit.score_components.context),
-        },
-        "estimated_tps": round1(fit.estimated_tps),
-        "runtime": runtime_code(fit.runtime),
-        "runtime_label": fit.runtime_text(),
-        "best_quant": fit.best_quant,
-        "memory_required_gb": round2(fit.memory_required_gb),
-        "memory_available_gb": round2(fit.memory_available_gb),
-        "moe_offloaded_gb": fit.moe_offloaded_gb.map(round2),
-        "total_memory_gb": round2(fit.memory_required_gb + fit.moe_offloaded_gb.unwrap_or(0.0)),
-        "utilization_pct": round1(fit.utilization_pct),
-        "notes": fit.notes,
-        "gguf_sources": fit.model.gguf_sources,
-        "capabilities": fit.model.capabilities,
-        "license": fit.model.license,
-        "supports_tp": fit.model.valid_tp_sizes(),
-    })
-}
-
-fn round1(v: f64) -> f64 {
-    (v * 10.0).round() / 10.0
-}
-
-fn round2(v: f64) -> f64 {
-    (v * 100.0).round() / 100.0
+    serve_shared::fit_to_json(fit)
 }
 
 #[cfg(test)]

--- a/llmfit-tui/src/serve_shared.rs
+++ b/llmfit-tui/src/serve_shared.rs
@@ -1,0 +1,106 @@
+use llmfit_core::fit::{FitLevel, InferenceRuntime, ModelFit, RunMode};
+use llmfit_core::hardware::SystemSpecs;
+
+pub fn system_json(specs: &SystemSpecs) -> serde_json::Value {
+    let gpus_json: Vec<serde_json::Value> = specs
+        .gpus
+        .iter()
+        .map(|g| {
+            serde_json::json!({
+                "name": g.name,
+                "vram_gb": g.vram_gb.map(round2),
+                "backend": g.backend.label(),
+                "count": g.count,
+                "unified_memory": g.unified_memory,
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "total_ram_gb": round2(specs.total_ram_gb),
+        "available_ram_gb": round2(specs.available_ram_gb),
+        "cpu_cores": specs.total_cpu_cores,
+        "cpu_name": specs.cpu_name,
+        "has_gpu": specs.has_gpu,
+        "gpu_vram_gb": specs.gpu_vram_gb.map(round2),
+        "gpu_name": specs.gpu_name,
+        "gpu_count": specs.gpu_count,
+        "unified_memory": specs.unified_memory,
+        "backend": specs.backend.label(),
+        "gpus": gpus_json,
+    })
+}
+
+pub fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
+    serde_json::json!({
+        "name": fit.model.name,
+        "provider": fit.model.provider,
+        "parameter_count": fit.model.parameter_count,
+        "params_b": round2(fit.model.params_b()),
+        "context_length": fit.model.context_length,
+        "use_case": fit.model.use_case,
+        "category": fit.use_case.label(),
+        "release_date": fit.model.release_date,
+        "is_moe": fit.model.is_moe,
+        "fit_level": fit_level_code(fit.fit_level),
+        "fit_label": fit.fit_text(),
+        "run_mode": run_mode_code(fit.run_mode),
+        "run_mode_label": fit.run_mode_text(),
+        "score": round1(fit.score),
+        "score_components": {
+            "quality": round1(fit.score_components.quality),
+            "speed": round1(fit.score_components.speed),
+            "fit": round1(fit.score_components.fit),
+            "context": round1(fit.score_components.context),
+        },
+        "estimated_tps": round1(fit.estimated_tps),
+        "runtime": runtime_code(fit.runtime),
+        "runtime_label": fit.runtime_text(),
+        "best_quant": fit.best_quant,
+        "memory_required_gb": round2(fit.memory_required_gb),
+        "memory_available_gb": round2(fit.memory_available_gb),
+        "moe_offloaded_gb": fit.moe_offloaded_gb.map(round2),
+        "total_memory_gb": round2(fit.memory_required_gb + fit.moe_offloaded_gb.unwrap_or(0.0)),
+        "utilization_pct": round1(fit.utilization_pct),
+        "notes": fit.notes,
+        "gguf_sources": fit.model.gguf_sources,
+        "capabilities": fit.model.capabilities,
+        "license": fit.model.license,
+        "supports_tp": fit.model.valid_tp_sizes(),
+    })
+}
+
+pub fn fit_level_code(fit_level: FitLevel) -> &'static str {
+    match fit_level {
+        FitLevel::Perfect => "perfect",
+        FitLevel::Good => "good",
+        FitLevel::Marginal => "marginal",
+        FitLevel::TooTight => "too_tight",
+    }
+}
+
+pub fn run_mode_code(run_mode: RunMode) -> &'static str {
+    match run_mode {
+        RunMode::Gpu => "gpu",
+        RunMode::TensorParallel => "tensor_parallel",
+        RunMode::MoeOffload => "moe_offload",
+        RunMode::CpuOffload => "cpu_offload",
+        RunMode::CpuOnly => "cpu_only",
+    }
+}
+
+pub fn runtime_code(runtime: InferenceRuntime) -> &'static str {
+    match runtime {
+        InferenceRuntime::Mlx => "mlx",
+        InferenceRuntime::LlamaCpp => "llamacpp",
+        InferenceRuntime::Vllm => "vllm",
+    }
+}
+
+pub fn round1(v: f64) -> f64 {
+    (v * 10.0).round() / 10.0
+}
+
+pub fn round2(v: f64) -> f64 {
+    (v * 100.0).round() / 100.0
+}


### PR DESCRIPTION
## Summary

- Adds `llmfit serve --mcp` which runs an MCP server over stdio, exposing 6 tools for agent discovery (system specs, model recommendations, search, hardware planning, runtime checks, installed models)
- Adds `llmfit serve --send-events` (behind `nats` cargo feature) to publish hardware/model events to NATS on `llmfit.{event_type}.{hostname}` subjects for Sympozium membrane integration
- Extracts shared formatting logic into `serve_shared.rs` to avoid duplication between HTTP and MCP code paths

## Test plan

- [x] All 387 existing tests pass (`cargo test`)
- [x] Builds without `nats` feature (default)
- [x] Builds with `nats` feature (`cargo build --features nats`)
- [x] MCP `initialize` → returns server info
- [x] MCP `tools/list` → returns all 6 tools with correct JSON schemas
- [x] MCP `tools/call get_system_specs` → returns hardware JSON
- [x] MCP `tools/call recommend_models` → returns filtered model list
- [x] HTTP `llmfit serve` unchanged behavior verified
- [ ] NATS integration test with local NATS server