### PR TITLE
fix(docker): skip HTTP probe on Linux when Docker Desktop is not running

### DIFF
--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -579,7 +579,7 @@ impl SystemSpecs {
         // Filter out integrated GPUs (iGPUs) that have very little VRAM.
         // rocm-smi reports all GPU agents including iGPUs on APUs like
         // Ryzen 9800X3D, which would otherwise inflate the GPU count.
-         // Discrete GPUs have > 2 GB VRAM; iGPUs typically show <= 2 GB.
+        // Discrete GPUs have > 2 GB VRAM; iGPUs typically show <= 2 GB.
         const IGPU_VRAM_THRESHOLD: u64 = 2 * 1024 * 1024 * 1024; // 2 GB
         let discrete_vram: Vec<u64> = per_gpu_vram_bytes
             .iter()

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1415,6 +1415,25 @@ pub struct DockerModelRunnerProvider {
     base_url: String,
 }
 
+/// Check if Docker Desktop is running on Linux by looking for its socket or process.
+/// Returns `true` if Docker Desktop appears to be active, `false` otherwise.
+/// This avoids a slow HTTP timeout on Linux systems without Docker Desktop.
+fn is_docker_desktop_running() -> bool {
+    // Docker Desktop on Linux creates a specific socket path
+    if std::path::Path::new("/run/docker-desktop/docker.sock").exists()
+        || std::path::Path::new(
+            &std::env::var("HOME")
+                .map(|h| format!("{h}/.docker/desktop/docker.sock"))
+                .unwrap_or_default(),
+        )
+        .exists()
+    {
+        return true;
+    }
+    // Fall back to checking if the DOCKER_MODEL_RUNNER_HOST env var is explicitly set
+    std::env::var("DOCKER_MODEL_RUNNER_HOST").is_ok()
+}
+
 fn normalize_docker_mr_host(raw: &str) -> Option<String> {
     let host = raw.trim();
     if host.is_empty() {
@@ -1464,6 +1483,13 @@ impl DockerModelRunnerProvider {
     /// Single-pass startup probe.
     /// Returns `(available, installed_models, count)`.
     pub fn detect_with_installed(&self) -> (bool, HashSet<String>, usize) {
+        // Docker Model Runner is a Docker Desktop feature. On Linux, Docker Desktop
+        // is uncommon. Skip the HTTP probe if Docker Desktop is not running to avoid
+        // a ~800ms timeout on every startup.
+        if cfg!(target_os = "linux") && !is_docker_desktop_running() {
+            return (false, HashSet::new(), 0);
+        }
+
         let mut set = HashSet::new();
         let Ok(resp) = ureq::get(&self.models_url())
             .config()

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1431,7 +1431,10 @@ fn is_docker_desktop_running() -> bool {
         return true;
     }
     // Fall back to checking if the DOCKER_MODEL_RUNNER_HOST env var is explicitly set
-    std::env::var("DOCKER_MODEL_RUNNER_HOST").is_ok()
+    // to a non-empty value (an empty string means the user hasn't configured it).
+    std::env::var("DOCKER_MODEL_RUNNER_HOST")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
 }
 
 fn normalize_docker_mr_host(raw: &str) -> Option<String> {
@@ -4325,5 +4328,31 @@ mod tests {
     fn test_normalize_vllm_host_empty() {
         assert_eq!(normalize_vllm_host(""), None);
         assert_eq!(normalize_vllm_host("  "), None);
+    }
+
+    #[test]
+    fn test_docker_desktop_running_via_env_var() {
+        // Test 1: Non-empty value should detect Docker Desktop
+        unsafe {
+            std::env::set_var("DOCKER_MODEL_RUNNER_HOST", "localhost:12434");
+        }
+        assert!(is_docker_desktop_running());
+
+        // Test 2: Empty string should NOT count as running
+        unsafe {
+            std::env::set_var("DOCKER_MODEL_RUNNER_HOST", "");
+        }
+        assert!(!is_docker_desktop_running());
+
+        // Test 3: Whitespace-only should NOT count as running
+        unsafe {
+            std::env::set_var("DOCKER_MODEL_RUNNER_HOST", "   ");
+        }
+        assert!(!is_docker_desktop_running());
+
+        // Cleanup
+        unsafe {
+            std::env::remove_var("DOCKER_MODEL_RUNNER_HOST");
+        }
     }
 }


### PR DESCRIPTION
## Problem

Docker Model Runner is a Docker Desktop feature. On Linux, Docker Desktop is uncommon, so the startup HTTP probe to `localhost:12434` times out after ~800ms on most Linux systems, slowing down every llmfit startup.

## Solution

Add `is_docker_desktop_running()` which checks for Docker Desktop's presence by:
1. Looking for its socket at `/run/docker-desktop/docker.sock` or `~/.docker/desktop/docker.sock`
2. Falling back to checking if `DOCKER_MODEL_RUNNER_HOST` is explicitly set

If Docker Desktop isn't running on Linux, skip the HTTP probe entirely and return `available=false` immediately.

## Changes

- `llmfit-core/src/providers.rs`: Added `is_docker_desktop_running()` helper and early return in `DockerModelRunnerProvider::detect_with_installed()`

## Testing

- On Linux without Docker Desktop: startup is now instant (no 800ms delay)
- On Linux with Docker Desktop: probe still works normally
- On macOS/Windows: no change in behavior (check only applies to Linux via `cfg!(target_os = "linux")`)
- `cargo check` passes cleanly