### PR TITLE
Add Apple M5/M5 Pro/M5 Max memory bandwidth entries

### DIFF
--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -2038,6 +2038,15 @@ pub fn gpu_memory_bandwidth_gbps(name: &str) -> Option<f64> {
     }
 
     // ── Apple Silicon (unified memory bandwidth) ───────────────────
+    if lower.contains("m5 max") {
+        return Some(614.0);
+    }
+    if lower.contains("m5 pro") {
+        return Some(307.0);
+    }
+    if lower.contains("m5") {
+        return Some(153.6);
+    }
     if lower.contains("m4 ultra") {
         return Some(819.0);
     }
@@ -2571,6 +2580,18 @@ mod tests {
         assert_eq!(
             super::gpu_memory_bandwidth_gbps("Apple M4 Pro"),
             Some(273.0)
+        );
+        assert_eq!(
+            super::gpu_memory_bandwidth_gbps("Apple M5 Max"),
+            Some(614.0)
+        );
+        assert_eq!(
+            super::gpu_memory_bandwidth_gbps("Apple M5 Pro"),
+            Some(307.0)
+        );
+        assert_eq!(
+            super::gpu_memory_bandwidth_gbps("Apple M5"),
+            Some(153.6)
         );
     }
 

--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -2589,10 +2589,7 @@ mod tests {
             super::gpu_memory_bandwidth_gbps("Apple M5 Pro"),
             Some(307.0)
         );
-        assert_eq!(
-            super::gpu_memory_bandwidth_gbps("Apple M5"),
-            Some(153.6)
-        );
+        assert_eq!(super::gpu_memory_bandwidth_gbps("Apple M5"), Some(153.6));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds M5 (153.6 GB/s), M5 Pro (307 GB/s), and M5 Max (614 GB/s) to the Apple Silicon GPU memory bandwidth lookup table
- Includes corresponding test assertions

## Motivation
The M5 Max was released March 2026 and is already shipping in MacBook Pro 14"/16". Without these entries, `llmfit` falls back to a generic TPS estimate for M5 hardware, producing inaccurate speed predictions. The M5 Max at 614 GB/s is ~12.5% faster than M4 Max (546 GB/s).

## Test plan
- [x] `cargo test -p llmfit-core test_gpu_bandwidth_apple_silicon` passes
- [x] All bandwidth tests pass (`test_gpu_bandwidth_known_gpus`, `test_gpu_bandwidth_amd`, `test_gpu_bandwidth_unknown_returns_none`)

Sources: Apple tech specs, notebookcheck.net

🤖 Generated with [Claude Code](https://claude.com/claude-code)