### PR TITLE
feat(tui): add ollama_name field to JSON output

### DIFF
--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -6,6 +6,7 @@ use llmfit_core::fit::{FitLevel, ModelFit, RunMode, SortColumn};
 use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::LlmModel;
 use llmfit_core::plan::PlanEstimate;
+use llmfit_core::providers::ollama_pull_tag as ollama_name_for;
 use tabled::{Table, Tabled, settings::Style};
 
 #[derive(Tabled)]
@@ -737,6 +738,7 @@ fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "installed": fit.installed,
         "capabilities": fit.model.capabilities.iter().map(|c| c.label()).collect::<Vec<_>>(),
         "capability_ids": serde_json::to_value(&fit.model.capabilities).unwrap(),
+        "ollama_name": ollama_name_for(&fit.model.name),
     })
 }
 


### PR DESCRIPTION
## Summary

Adds an `ollama_name` field to the JSON output produced by `llmfit recommend --json`
and the REST API (`/api/v1/models`, `/api/v1/models/top`).

The value is the string to pass directly to `ollama pull` (e.g. `"llama3.1:8b"`),
or `null` if the model has no known Ollama mapping.

## Motivation

Consumers of the JSON output (scripts, integrations, web UIs) currently have no
machine-readable way to know whether a recommended model is available on Ollama,
or what tag to use. The `OLLAMA_MAPPINGS` table already exists in
`llmfit-core/src/providers.rs` and is exposed via `ollama_pull_tag()`. This change
surfaces it in the output.

## Changes

- `llmfit-tui/src/display.rs`: import `ollama_pull_tag` and include the result as
  `"ollama_name"` in `fit_to_json()`. This propagates to all JSON surfaces:
  CLI `--json` flag and the REST API server.

## Example output

```json
{
  "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
  "ollama_name": "deepseek-r1:7b",
  ...
}
```

## Testing

[X] cargo test --lib: `test result: ok. 370 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.98s`
[X] output:

```
cargo run --bin llmfit -- recommend --json --limit 100 2>/dev/null | python3 -c "import sys, json; data=json.load(sys.stdin); [print(f\"{m['name'][:55]:<55} -> {m['ollama_name']}\") for m in data['models'] if m.get('ollama_name')]"
deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct             -> deepseek-coder-v2:16b
deepseek-ai/DeepSeek-R1-Distill-Qwen-7B                 -> deepseek-r1:7b
deepseek-ai/DeepSeek-R1-Distill-Qwen-14B                -> deepseek-r1:14b
Qwen/Qwen2.5-Coder-7B-Instruct                          -> qwen2.5-coder:7b
bigcode/starcoder2-7b                                   -> starcoder2:7b
Qwen/Qwen2.5-Coder-14B-Instruct                         -> qwen2.5-coder:14b
google/gemma-3-12b-it                                   -> gemma3:12b
microsoft/Phi-4-mini-reasoning                          -> phi4-mini-reasoning
microsoft/Orca-2-7b                                     -> orca2:7b
bigcode/starcoder2-15b                                  -> starcoder2:15b
microsoft/Phi-4-reasoning                               -> phi4-reasoning
google/gemma-3n-E4B-it                                  -> gemma3n:e4b
```