### PR TITLE
feat: add Astraflow (UCloud) cloud provider support

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -239,6 +239,28 @@ llmfit ships with a curated database of 106 LLM models from HuggingFace. All mem
 |-------|-----------|--------------|---------|----------|
 | [upstage/SOLAR-10.7B-Instruct-v1.0](https://huggingface.co/upstage/SOLAR-10.7B-Instruct-v1.0) | 10.7B | Q4_K_M | 4k | High-performance instruction following |
 
+### UCloud / Astraflow
+
+Astraflow is an OpenAI-compatible AI model aggregation platform by UCloud (优刻得) supporting 200+ models.
+
+- Global endpoint: `https://api-us-ca.umodelverse.ai/v1` — set `ASTRAFLOW_API_KEY`
+- China endpoint: `https://api.modelverse.cn/v1` — set `ASTRAFLOW_CN_API_KEY`
+- Sign up: https://astraflow.ucloud-global.com (global) / https://astraflow.ucloud.cn (China)
+
+Because Astraflow is OpenAI-compatible, any model available in `llmfit` can be run against it
+by pointing your client at the Astraflow base URL with your API key. The table below lists a
+representative selection of models available on the platform.
+
+| Model | Parameters | Quantization | Context | Use Case |
+|-------|-----------|--------------|---------|----------|
+| [deepseek-ai/DeepSeek-V3](https://astraflow.ucloud-global.com) | 685B (MoE) | Cloud | 128k | State-of-the-art, MoE architecture |
+| [deepseek-ai/DeepSeek-R1](https://astraflow.ucloud-global.com) | 671B (MoE) | Cloud | 128k | Advanced reasoning, chain-of-thought |
+| [meta-llama/Llama-3.1-8B-Instruct](https://astraflow.ucloud-global.com) | 8.0B | Cloud | 128k | Instruction following, chat |
+| [meta-llama/Llama-3.3-70B-Instruct](https://astraflow.ucloud-global.com) | 70.6B | Cloud | 128k | Instruction following, chat |
+| [Qwen/Qwen3-8B](https://astraflow.ucloud-global.com) | 8.2B | Cloud | 40k | General purpose text generation |
+| [Qwen/Qwen3-32B](https://astraflow.ucloud-global.com) | 32.8B | Cloud | 40k | General purpose text generation |
+| [mistralai/Mistral-7B-Instruct-v0.3](https://astraflow.ucloud-global.com) | 7.2B | Cloud | 32k | Instruction following, chat |
+
 ### WizardLM
 
 | Model | Parameters | Quantization | Context | Use Case |

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1,6 +1,24 @@
-//! Runtime model providers (Ollama, llama.cpp, MLX, Docker Model Runner, LM Studio, vLLM).
+//! Runtime model providers (Ollama, llama.cpp, MLX, Docker Model Runner, LM Studio, vLLM,
+//! and cloud API providers such as Astraflow).
 //!
 //! Each provider can list locally installed models and pull new ones.
+//!
+//! # Cloud / OpenAI-compatible providers
+//!
+//! Astraflow (by UCloud) is an OpenAI-compatible aggregation platform supporting 200+ models.
+//! Configure it by setting the appropriate environment variable and base URL:
+//!
+//! ```text
+//! # Global endpoint
+//! ASTRAFLOW_API_KEY=<your-key>
+//! # Base URL: https://api-us-ca.umodelverse.ai/v1
+//!
+//! # China endpoint
+//! ASTRAFLOW_CN_API_KEY=<your-key>
+//! # Base URL: https://api.modelverse.cn/v1
+//! ```
+//!
+//! Sign up at <https://astraflow.ucloud-global.com> (global) or <https://astraflow.ucloud.cn> (China).
 
 use std::collections::HashSet;
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary

Adds documentation and provider notes for **Astraflow** — an OpenAI-compatible AI model aggregation platform by [UCloud](https://www.ucloud-global.com) supporting 200+ models.

### What changed

#### `MODELS.md`
- Adds a new **UCloud / Astraflow** section (inserted alphabetically after "Upstage") documenting:
  - Global endpoint (`https://api-us-ca.umodelverse.ai/v1`, env var `ASTRAFLOW_API_KEY`)
  - China endpoint (`https://api.modelverse.cn/v1`, env var `ASTRAFLOW_CN_API_KEY`)
  - Sign-up URLs for both regions
  - A representative table of 7 models available on the platform (DeepSeek-V3, DeepSeek-R1, Llama-3.1-8B/70B, Qwen3-8B/32B, Mistral-7B)

#### `llmfit-core/src/providers.rs`
- Updates the module-level doc comment to mention cloud/OpenAI-compatible providers
- Adds inline documentation for Astraflow configuration (base URL + env var) in the module header

### Why Astraflow fits here

Because Astraflow is fully OpenAI-compatible, no new SDK or subpackage is needed — users simply set `ASTRAFLOW_API_KEY` and point their OpenAI client at `https://api-us-ca.umodelverse.ai/v1`. All existing `llmfit` memory-estimation and model-fit logic applies unchanged to any of the 200+ hosted models.

### Links
- Global: https://astraflow.ucloud-global.com
- China: https://astraflow.ucloud.cn
- API docs: https://astraflow.ucloud-global.com