### PR TITLE
fix: align SortColumn::next with display order of columns in TUI

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -152,14 +152,14 @@ impl SortColumn {
 
     pub fn next(&self) -> Self {
         match self {
+            SortColumn::Params => SortColumn::Score,
             SortColumn::Score => SortColumn::Tps,
-            SortColumn::Tps => SortColumn::Params,
-            SortColumn::Params => SortColumn::MemPct,
+            SortColumn::Tps => SortColumn::MemPct,
             SortColumn::MemPct => SortColumn::Ctx,
             SortColumn::Ctx => SortColumn::ReleaseDate,
             SortColumn::ReleaseDate => SortColumn::UseCase,
             SortColumn::UseCase => SortColumn::Provider,
-            SortColumn::Provider => SortColumn::Score,
+            SortColumn::Provider => SortColumn::Params,
         }
     }
 }


### PR DESCRIPTION
## Problem

In TUI when you cycle sort column by pressing 's' the params column is out of the display order:

<img width="600" alt="llmfit-sort" src="https://github.com/user-attachments/assets/4777476e-9605-461a-9c33-80b63fe5c97a" />

llmfit 0.9.28

## Solution

This PR aligns `SortColumn::next` with display order of columns in TUI, particulary moves params column between provider and score.

Looks like `SortColumn::next` is only used in TUI so `llmift-web` and `llmfit-desktop` shouldn't be affected.

I guess it's not a perfect fix as this bug can be reintroduced after changing display order of columns in TUI or adding another sort column, but more foolproof solution probably would require some refactoring.


