### PR TITLE
feat: add --llama-cpp-path global CLI flag mirroring LLAMA_CPP_PATH env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,9 @@ llmfit --ram=128G
 # Override CPU core count
 llmfit --cpu-cores=16
 
+# Point llmfit at a custom llama.cpp build
+llmfit --llama-cpp-path=/opt/llama.cpp/build/bin system --json
+
 # Combine overrides to simulate target hardware
 llmfit --memory=24G --ram=64G --cpu-cores=8 fit
 llmfit --memory=24G --ram=64G system --json
@@ -523,7 +526,7 @@ llmfit --memory=24G fit --perfect -n 5
 llmfit --ram=64G recommend --json
 ```
 
-Accepted suffixes for `--memory` and `--ram`: `G`/`GB`/`GiB` (gigabytes), `M`/`MB`/`MiB` (megabytes), `T`/`TB`/`TiB` (terabytes). Case-insensitive. If no GPU was detected, `--memory` creates a synthetic GPU entry so models are scored for GPU inference. On unified-memory systems (Apple Silicon), `--ram` also updates VRAM; use `--memory` to override VRAM independently.
+Accepted suffixes for `--memory` and `--ram`: `G`/`GB`/`GiB` (gigabytes), `M`/`MB`/`MiB` (megabytes), `T`/`TB`/`TiB` (terabytes). Case-insensitive. If no GPU was detected, `--memory` creates a synthetic GPU entry so models are scored for GPU inference. On unified-memory systems (Apple Silicon), `--ram` also updates VRAM; use `--memory` to override VRAM independently. `--llama-cpp-path` overrides `LLAMA_CPP_PATH` for a single invocation when the directory exists.
 
 ### Context-length cap for estimation
 
@@ -804,7 +807,7 @@ How it works:
 | `LLAMA_CPP_PATH` | *(none)* | Directory containing llama.cpp binaries (`llama-cli`, `llama-server`). Checked before `PATH` lookup. |
 | `LLAMA_SERVER_PORT` | `8080` | Port used when probing a running `llama-server` health endpoint for runtime detection. |
 
-If llama.cpp is installed in a non-standard location, set `LLAMA_CPP_PATH` so llmfit can find it without requiring it in your `PATH`.
+If llama.cpp is installed in a non-standard location, set `LLAMA_CPP_PATH` so llmfit can find it without requiring it in your `PATH`, or pass `--llama-cpp-path <PATH>` for a one-shot override.
 
 ### Docker Model Runner integration
 

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1539,10 +1539,33 @@ pub fn command_exists(name: &str) -> bool {
     which::which(name).is_ok()
 }
 
-/// Find a binary by checking `LLAMA_CPP_PATH` env var, common install
-/// locations, and finally the system PATH via `which`.
+/// Directory holding the llama.cpp binaries, when the caller supplied one
+/// explicitly (the `--llama-cpp-path` CLI flag). Set once, before any provider
+/// detection runs, so lookups stay consistent for the life of the process.
+static LLAMA_CPP_PATH_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
+
+/// Point llama.cpp binary discovery at `dir` for the rest of this process.
+///
+/// Takes precedence over `LLAMA_CPP_PATH`. Only the first call has an effect,
+/// which keeps discovery from changing shape midway through a run. This exists
+/// so a caller can override the location without mutating the process
+/// environment, which is `unsafe` and racy once other threads are running.
+pub fn set_llama_cpp_path_override(dir: PathBuf) -> bool {
+    LLAMA_CPP_PATH_OVERRIDE.set(dir).is_ok()
+}
+
+/// Find a binary by checking the explicit override, the `LLAMA_CPP_PATH` env
+/// var, common install locations, and finally the system PATH via `which`.
 fn find_binary(name: &str) -> Option<String> {
-    // 1. Check LLAMA_CPP_PATH env var first
+    // 1. An explicit override from the caller wins over the environment.
+    if let Some(dir) = LLAMA_CPP_PATH_OVERRIDE.get() {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate.to_string_lossy().to_string());
+        }
+    }
+
+    // 2. Check LLAMA_CPP_PATH env var next
     if let Ok(dir) = std::env::var("LLAMA_CPP_PATH") {
         let candidate = PathBuf::from(&dir).join(name);
         if candidate.is_file() {
@@ -1550,7 +1573,7 @@ fn find_binary(name: &str) -> Option<String> {
         }
     }
 
-    // 2. Check common install locations
+    // 3. Check common install locations
     let mut common_dirs: Vec<PathBuf> = vec![
         PathBuf::from("/usr/local/bin"),
         PathBuf::from("/opt/llama.cpp/build/bin"),
@@ -1565,7 +1588,7 @@ fn find_binary(name: &str) -> Option<String> {
         }
     }
 
-    // 3. Fall back to PATH lookup
+    // 4. Fall back to PATH lookup
     which::which(name)
         .ok()
         .map(|p| p.to_string_lossy().to_string())

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -13,6 +13,7 @@ mod tui_ui;
 
 use clap::{Parser, Subcommand};
 use std::net::{TcpStream, ToSocketAddrs};
+use std::path::Path;
 use std::process::Stdio;
 use std::thread;
 use std::time::Duration;
@@ -105,6 +106,9 @@ GLOBAL FLAGS:
   --memory <SIZE>    Override GPU VRAM (e.g. \"32G\", \"32000M\", \"1.5T\").
   --ram <SIZE>       Override system RAM (e.g. \"64G\", \"128000M\").
   --cpu-cores <N>    Override detected CPU core count.
+  --llama-cpp-path <PATH>
+                     Directory containing llama.cpp binaries. Overrides
+                     LLAMA_CPP_PATH for this invocation when the directory exists.
   --max-context N    Cap context length for memory estimation (tokens).
                      Falls back to OLLAMA_CONTEXT_LENGTH env var if unset.
 
@@ -162,6 +166,11 @@ struct Cli {
     /// Useful for evaluating model fit against target hardware.
     #[arg(long, value_name = "CORES", value_parser = parse_positive_usize)]
     cpu_cores: Option<usize>,
+
+    /// Directory containing llama.cpp binaries (`llama-cli`, `llama-server`).
+    /// Overrides LLAMA_CPP_PATH for this invocation when the directory exists.
+    #[arg(long, value_name = "PATH", global = true)]
+    llama_cpp_path: Option<std::path::PathBuf>,
 
     /// Cap context length used for memory estimation (tokens).
     /// Falls back to OLLAMA_CONTEXT_LENGTH if not set.
@@ -804,6 +813,75 @@ fn resolve_context_limit(max_context: Option<u32>) -> Option<u32> {
             None
         }
     }
+}
+
+fn configure_llama_cpp_path(path: Option<&Path>) -> bool {
+    let Some(path) = path else {
+        return false;
+    };
+
+    if path.is_dir() {
+        // SAFETY: main calls this immediately after CLI parsing, before starting
+        // dashboard/provider threads or any llama.cpp provider detection.
+        unsafe {
+            std::env::set_var("LLAMA_CPP_PATH", path);
+        }
+        return true;
+    }
+
+    false
+}
+
+fn round2(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+fn display_json_system_with_providers(specs: &SystemSpecs) {
+    use llmfit_core::providers::{LlamaCppProvider, ModelProvider};
+
+    let llama_cpp = LlamaCppProvider::new();
+    let gpus_json: Vec<serde_json::Value> = specs
+        .gpus
+        .iter()
+        .map(|g| {
+            serde_json::json!({
+                "name": g.name,
+                "vram_gb": g.vram_gb.map(round2),
+                "backend": g.backend.label(),
+                "count": g.count,
+                "unified_memory": g.unified_memory,
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "system": {
+            "total_ram_gb": round2(specs.total_ram_gb),
+            "available_ram_gb": round2(specs.available_ram_gb),
+            "cpu_cores": specs.total_cpu_cores,
+            "cpu_name": specs.cpu_name,
+            "has_gpu": specs.has_gpu,
+            "gpu_vram_gb": specs.gpu_vram_gb.map(round2),
+            "gpu_name": specs.gpu_name,
+            "gpu_count": specs.gpu_count,
+            "unified_memory": specs.unified_memory,
+            "backend": specs.backend.label(),
+            "gpus": gpus_json,
+        },
+        "providers": {
+            "llama.cpp": {
+                "available": llama_cpp.is_available(),
+                "llama_cli_path": llama_cpp.llama_cli_path(),
+                "llama_server_path": llama_cpp.llama_server_path(),
+                "server_running": llama_cpp.server_running(),
+                "detection_hint": llama_cpp.detection_hint(),
+            }
+        }
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("JSON serialization failed")
+    );
 }
 
 fn dashboard_pid_path() -> Option<std::path::PathBuf> {
@@ -2537,6 +2615,8 @@ fn display_routing_matrix_full(
 
 fn main() {
     let cli = Cli::parse();
+    let llama_cpp_path_configured = configure_llama_cpp_path(cli.llama_cpp_path.as_deref());
+
     let context_limit = resolve_context_limit(cli.max_context);
     let overrides = HardwareOverrides {
         memory: cli.memory,
@@ -2559,7 +2639,11 @@ fn main() {
             Commands::System => {
                 let specs = detect_specs(&overrides);
                 if cli.json {
-                    display::display_json_system(&specs);
+                    if llama_cpp_path_configured {
+                        display_json_system_with_providers(&specs);
+                    } else {
+                        display::display_json_system(&specs);
+                    }
                 } else {
                     specs.display();
                 }

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -815,9 +815,9 @@ fn resolve_context_limit(max_context: Option<u32>) -> Option<u32> {
     }
 }
 
-fn configure_llama_cpp_path(path: Option<&Path>) -> bool {
+fn configure_llama_cpp_path(path: Option<&Path>) {
     let Some(path) = path else {
-        return false;
+        return;
     };
 
     if path.is_dir() {
@@ -826,10 +826,14 @@ fn configure_llama_cpp_path(path: Option<&Path>) -> bool {
         unsafe {
             std::env::set_var("LLAMA_CPP_PATH", path);
         }
-        return true;
+        return;
     }
 
-    false
+    eprintln!(
+        "Error: --llama-cpp-path '{}' does not exist or is not a directory.",
+        path.display()
+    );
+    std::process::exit(1);
 }
 
 fn round2(value: f64) -> f64 {
@@ -2615,7 +2619,7 @@ fn display_routing_matrix_full(
 
 fn main() {
     let cli = Cli::parse();
-    let llama_cpp_path_configured = configure_llama_cpp_path(cli.llama_cpp_path.as_deref());
+    configure_llama_cpp_path(cli.llama_cpp_path.as_deref());
 
     let context_limit = resolve_context_limit(cli.max_context);
     let overrides = HardwareOverrides {
@@ -2639,11 +2643,7 @@ fn main() {
             Commands::System => {
                 let specs = detect_specs(&overrides);
                 if cli.json {
-                    if llama_cpp_path_configured {
-                        display_json_system_with_providers(&specs);
-                    } else {
-                        display::display_json_system(&specs);
-                    }
+                    display_json_system_with_providers(&specs);
                 } else {
                     specs.display();
                 }

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1049,9 +1049,9 @@ fn resolve_context_limit(max_context: Option<u32>) -> Option<u32> {
     }
 }
 
-fn configure_llama_cpp_path(path: Option<&Path>) -> bool {
+fn configure_llama_cpp_path(path: Option<&Path>) {
     let Some(path) = path else {
-        return false;
+        return;
     };
 
     if path.is_dir() {
@@ -1060,10 +1060,14 @@ fn configure_llama_cpp_path(path: Option<&Path>) -> bool {
         unsafe {
             std::env::set_var("LLAMA_CPP_PATH", path);
         }
-        return true;
+        return;
     }
 
-    false
+    eprintln!(
+        "Error: --llama-cpp-path '{}' does not exist or is not a directory.",
+        path.display()
+    );
+    std::process::exit(1);
 }
 
 fn round2(value: f64) -> f64 {
@@ -3336,7 +3340,7 @@ fn display_routing_matrix_full(
 
 fn main() {
     let cli = Cli::parse();
-    let llama_cpp_path_configured = configure_llama_cpp_path(cli.llama_cpp_path.as_deref());
+    configure_llama_cpp_path(cli.llama_cpp_path.as_deref());
 
     let context_limit = resolve_context_limit(cli.max_context);
     let overrides = HardwareOverrides {
@@ -3374,11 +3378,7 @@ fn main() {
             Commands::System => {
                 let specs = detect_specs(&overrides);
                 if cli.json {
-                    if llama_cpp_path_configured {
-                        display_json_system_with_providers(&specs);
-                    } else {
-                        display::display_json_system(&specs);
-                    }
+                    display_json_system_with_providers(&specs);
                 } else {
                     specs.display();
                 }

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1055,11 +1055,9 @@ fn configure_llama_cpp_path(path: Option<&Path>) {
     };
 
     if path.is_dir() {
-        // SAFETY: main calls this immediately after CLI parsing, before starting
-        // dashboard/provider threads or any llama.cpp provider detection.
-        unsafe {
-            std::env::set_var("LLAMA_CPP_PATH", path);
-        }
+        // Set an explicit override rather than mutating the process
+        // environment: `set_var` is `unsafe` and the repo forbids `unsafe`.
+        llmfit_core::providers::set_llama_cpp_path_override(path.to_path_buf());
         return;
     }
 

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -13,6 +13,7 @@ mod tui_ui;
 
 use clap::{Parser, Subcommand};
 use std::net::{TcpStream, ToSocketAddrs};
+use std::path::Path;
 use std::process::Stdio;
 use std::thread;
 use std::time::Duration;
@@ -112,6 +113,9 @@ GLOBAL FLAGS:
                      unified memory, and the bandwidth/compute figures the
                      throughput estimate needs. Conflicts with --memory,
                      --ram, and --cpu-cores. See `llmfit hardware list`.
+  --llama-cpp-path <PATH>
+                     Directory containing llama.cpp binaries. Overrides
+                     LLAMA_CPP_PATH for this invocation when the directory exists.
   --max-context N    Cap context length for memory estimation (tokens).
                      Falls back to OLLAMA_CONTEXT_LENGTH env var if unset.
 
@@ -178,6 +182,10 @@ struct Cli {
     /// Rejected by `doctor`, which reports this machine's own detection.
     #[arg(long, value_name = "NAME|PATH", conflicts_with_all = ["memory", "ram", "cpu_cores"])]
     profile: Option<String>,
+    /// Directory containing llama.cpp binaries (`llama-cli`, `llama-server`).
+    /// Overrides LLAMA_CPP_PATH for this invocation when the directory exists.
+    #[arg(long, value_name = "PATH", global = true)]
+    llama_cpp_path: Option<std::path::PathBuf>,
 
     /// Cap context length used for memory estimation (tokens).
     /// Falls back to OLLAMA_CONTEXT_LENGTH if not set.
@@ -1039,6 +1047,75 @@ fn resolve_context_limit(max_context: Option<u32>) -> Option<u32> {
             None
         }
     }
+}
+
+fn configure_llama_cpp_path(path: Option<&Path>) -> bool {
+    let Some(path) = path else {
+        return false;
+    };
+
+    if path.is_dir() {
+        // SAFETY: main calls this immediately after CLI parsing, before starting
+        // dashboard/provider threads or any llama.cpp provider detection.
+        unsafe {
+            std::env::set_var("LLAMA_CPP_PATH", path);
+        }
+        return true;
+    }
+
+    false
+}
+
+fn round2(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+fn display_json_system_with_providers(specs: &SystemSpecs) {
+    use llmfit_core::providers::{LlamaCppProvider, ModelProvider};
+
+    let llama_cpp = LlamaCppProvider::new();
+    let gpus_json: Vec<serde_json::Value> = specs
+        .gpus
+        .iter()
+        .map(|g| {
+            serde_json::json!({
+                "name": g.name,
+                "vram_gb": g.vram_gb.map(round2),
+                "backend": g.backend.label(),
+                "count": g.count,
+                "unified_memory": g.unified_memory,
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "system": {
+            "total_ram_gb": round2(specs.total_ram_gb),
+            "available_ram_gb": round2(specs.available_ram_gb),
+            "cpu_cores": specs.total_cpu_cores,
+            "cpu_name": specs.cpu_name,
+            "has_gpu": specs.has_gpu,
+            "gpu_vram_gb": specs.gpu_vram_gb.map(round2),
+            "gpu_name": specs.gpu_name,
+            "gpu_count": specs.gpu_count,
+            "unified_memory": specs.unified_memory,
+            "backend": specs.backend.label(),
+            "gpus": gpus_json,
+        },
+        "providers": {
+            "llama.cpp": {
+                "available": llama_cpp.is_available(),
+                "llama_cli_path": llama_cpp.llama_cli_path(),
+                "llama_server_path": llama_cpp.llama_server_path(),
+                "server_running": llama_cpp.server_running(),
+                "detection_hint": llama_cpp.detection_hint(),
+            }
+        }
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("JSON serialization failed")
+    );
 }
 
 fn dashboard_pid_path() -> Option<std::path::PathBuf> {
@@ -3259,6 +3336,8 @@ fn display_routing_matrix_full(
 
 fn main() {
     let cli = Cli::parse();
+    let llama_cpp_path_configured = configure_llama_cpp_path(cli.llama_cpp_path.as_deref());
+
     let context_limit = resolve_context_limit(cli.max_context);
     let overrides = HardwareOverrides {
         memory: cli.memory,
@@ -3295,7 +3374,11 @@ fn main() {
             Commands::System => {
                 let specs = detect_specs(&overrides);
                 if cli.json {
-                    display::display_json_system(&specs);
+                    if llama_cpp_path_configured {
+                        display_json_system_with_providers(&specs);
+                    } else {
+                        display::display_json_system(&specs);
+                    }
                 } else {
                     specs.display();
                 }

--- a/llmfit-tui/tests/cli_smoke.rs
+++ b/llmfit-tui/tests/cli_smoke.rs
@@ -1,9 +1,13 @@
 use assert_cmd::Command;
 use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn run_json_command(args: &[&str]) -> Value {
     let output = Command::cargo_bin("llmfit")
         .expect("failed to locate llmfit test binary")
+        .env_remove("LLAMA_CPP_PATH")
         .args(args)
         .assert()
         .success()
@@ -12,6 +16,42 @@ fn run_json_command(args: &[&str]) -> Value {
         .clone();
 
     serde_json::from_slice(&output).expect("command did not emit valid JSON")
+}
+
+fn unique_temp_dir(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("llmfit-{name}-{}-{nanos}", std::process::id()))
+}
+
+fn create_fake_llama_cpp_bin_dir(name: &str) -> PathBuf {
+    let dir = unique_temp_dir(name);
+    fs::create_dir_all(&dir).expect("failed to create fake llama.cpp bin dir");
+    for binary in ["llama-cli", "llama-server"] {
+        let path = dir.join(binary);
+        fs::write(&path, "#!/bin/sh\nexit 0\n").expect("failed to write fake llama.cpp binary");
+        make_executable(&path);
+    }
+    dir
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path)
+            .expect("failed to stat fake llama.cpp binary")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)
+            .expect("failed to mark fake llama.cpp binary executable");
+    }
+
+    #[cfg(not(unix))]
+    let _ = path;
 }
 
 #[test]
@@ -55,6 +95,116 @@ fn system_json_has_expected_shape() {
     assert!(system.contains_key("available_ram_gb"));
     assert!(system.contains_key("cpu_cores"));
     assert!(system.contains_key("backend"));
+}
+
+#[test]
+fn llama_cpp_path_flag_makes_provider_available() {
+    let dir = create_fake_llama_cpp_bin_dir("llama-cpp-path");
+    let dir_str = dir.to_str().expect("temp dir path was not UTF-8");
+
+    let json = run_json_command(&[
+        "--no-dashboard",
+        "--llama-cpp-path",
+        dir_str,
+        "--json",
+        "system",
+    ]);
+    let llama_cpp = json
+        .pointer("/providers/llama.cpp")
+        .and_then(Value::as_object)
+        .expect("llama.cpp provider status missing");
+
+    assert_eq!(
+        llama_cpp.get("available").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        llama_cpp.get("llama_cli_path").and_then(Value::as_str),
+        Some(
+            dir.join("llama-cli")
+                .to_str()
+                .expect("binary path was not UTF-8")
+        )
+    );
+    assert_eq!(
+        llama_cpp.get("llama_server_path").and_then(Value::as_str),
+        Some(
+            dir.join("llama-server")
+                .to_str()
+                .expect("binary path was not UTF-8")
+        )
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn llama_cpp_path_flag_ignores_missing_directory() {
+    let missing = unique_temp_dir("missing-llama-cpp-path");
+    let missing_str = missing.to_str().expect("temp dir path was not UTF-8");
+
+    let json = run_json_command(&[
+        "--no-dashboard",
+        "--llama-cpp-path",
+        missing_str,
+        "--json",
+        "system",
+    ]);
+
+    assert!(
+        json.get("system").is_some(),
+        "system output should be present"
+    );
+}
+
+#[test]
+fn llama_cpp_path_flag_overrides_env_var() {
+    let env_dir = create_fake_llama_cpp_bin_dir("llama-cpp-env");
+    let flag_dir = create_fake_llama_cpp_bin_dir("llama-cpp-flag");
+    let flag_dir_str = flag_dir.to_str().expect("temp dir path was not UTF-8");
+
+    let output = Command::cargo_bin("llmfit")
+        .expect("failed to locate llmfit test binary")
+        .env("LLAMA_CPP_PATH", &env_dir)
+        .args([
+            "--no-dashboard",
+            "--llama-cpp-path",
+            flag_dir_str,
+            "--json",
+            "system",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: Value = serde_json::from_slice(&output).expect("command did not emit valid JSON");
+    let llama_cpp = json
+        .pointer("/providers/llama.cpp")
+        .and_then(Value::as_object)
+        .expect("llama.cpp provider status missing");
+
+    assert_eq!(
+        llama_cpp.get("llama_cli_path").and_then(Value::as_str),
+        Some(
+            flag_dir
+                .join("llama-cli")
+                .to_str()
+                .expect("binary path was not UTF-8")
+        )
+    );
+
+    let _ = fs::remove_dir_all(env_dir);
+    let _ = fs::remove_dir_all(flag_dir);
+}
+
+#[test]
+fn llama_cpp_path_flag_works_with_help() {
+    Command::cargo_bin("llmfit")
+        .expect("failed to locate llmfit test binary")
+        .args(["--llama-cpp-path", "/tmp/x", "--help"])
+        .assert()
+        .success();
 }
 
 #[test]

--- a/llmfit-tui/tests/cli_smoke.rs
+++ b/llmfit-tui/tests/cli_smoke.rs
@@ -1,9 +1,13 @@
 use assert_cmd::Command;
 use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn run_json_command(args: &[&str]) -> Value {
     let output = Command::cargo_bin("llmfit")
         .expect("failed to locate llmfit test binary")
+        .env_remove("LLAMA_CPP_PATH")
         .args(args)
         .assert()
         .success()
@@ -33,6 +37,42 @@ fn models_array(json: &Value) -> &[Value] {
     json.get("models")
         .and_then(Value::as_array)
         .expect("JSON output missing models array")
+}
+
+fn unique_temp_dir(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("llmfit-{name}-{}-{nanos}", std::process::id()))
+}
+
+fn create_fake_llama_cpp_bin_dir(name: &str) -> PathBuf {
+    let dir = unique_temp_dir(name);
+    fs::create_dir_all(&dir).expect("failed to create fake llama.cpp bin dir");
+    for binary in ["llama-cli", "llama-server"] {
+        let path = dir.join(binary);
+        fs::write(&path, "#!/bin/sh\nexit 0\n").expect("failed to write fake llama.cpp binary");
+        make_executable(&path);
+    }
+    dir
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path)
+            .expect("failed to stat fake llama.cpp binary")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)
+            .expect("failed to mark fake llama.cpp binary executable");
+    }
+
+    #[cfg(not(unix))]
+    let _ = path;
 }
 
 #[test]
@@ -270,4 +310,109 @@ fn diff_json_model_not_found_is_structured_and_fails() {
         json["error"]["message"],
         "No model found matching 'does-not-exist-xyz'"
     );
+}
+fn llama_cpp_path_flag_makes_provider_available() {
+    let dir = create_fake_llama_cpp_bin_dir("llama-cpp-path");
+    let dir_str = dir.to_str().expect("temp dir path was not UTF-8");
+
+    let json = run_json_command(&[
+        "--no-dashboard",
+        "--llama-cpp-path",
+        dir_str,
+        "--json",
+        "system",
+    ]);
+    let llama_cpp = json
+        .pointer("/providers/llama.cpp")
+        .and_then(Value::as_object)
+        .expect("llama.cpp provider status missing");
+
+    assert_eq!(
+        llama_cpp.get("available").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        llama_cpp.get("llama_cli_path").and_then(Value::as_str),
+        Some(
+            dir.join("llama-cli")
+                .to_str()
+                .expect("binary path was not UTF-8")
+        )
+    );
+    assert_eq!(
+        llama_cpp.get("llama_server_path").and_then(Value::as_str),
+        Some(
+            dir.join("llama-server")
+                .to_str()
+                .expect("binary path was not UTF-8")
+        )
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}
+#[test]
+fn llama_cpp_path_flag_ignores_missing_directory() {
+    let missing = unique_temp_dir("missing-llama-cpp-path");
+    let missing_str = missing.to_str().expect("temp dir path was not UTF-8");
+
+    let json = run_json_command(&[
+        "--no-dashboard",
+        "--llama-cpp-path",
+        missing_str,
+        "--json",
+        "system",
+    ]);
+
+    assert!(
+        json.get("system").is_some(),
+        "system output should be present"
+    );
+}
+#[test]
+fn llama_cpp_path_flag_overrides_env_var() {
+    let env_dir = create_fake_llama_cpp_bin_dir("llama-cpp-env");
+    let flag_dir = create_fake_llama_cpp_bin_dir("llama-cpp-flag");
+    let flag_dir_str = flag_dir.to_str().expect("temp dir path was not UTF-8");
+
+    let output = Command::cargo_bin("llmfit")
+        .expect("failed to locate llmfit test binary")
+        .env("LLAMA_CPP_PATH", &env_dir)
+        .args([
+            "--no-dashboard",
+            "--llama-cpp-path",
+            flag_dir_str,
+            "--json",
+            "system",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: Value = serde_json::from_slice(&output).expect("command did not emit valid JSON");
+    let llama_cpp = json
+        .pointer("/providers/llama.cpp")
+        .and_then(Value::as_object)
+        .expect("llama.cpp provider status missing");
+
+    assert_eq!(
+        llama_cpp.get("llama_cli_path").and_then(Value::as_str),
+        Some(
+            flag_dir
+                .join("llama-cli")
+                .to_str()
+                .expect("binary path was not UTF-8")
+        )
+    );
+
+    let _ = fs::remove_dir_all(env_dir);
+    let _ = fs::remove_dir_all(flag_dir);
+}
+#[test]
+fn llama_cpp_path_flag_works_with_help() {
+    Command::cargo_bin("llmfit")
+        .expect("failed to locate llmfit test binary")
+        .args(["--llama-cpp-path", "/tmp/x", "--help"])
+        .assert()
+        .success();
 }

--- a/llmfit-tui/tests/cli_smoke.rs
+++ b/llmfit-tui/tests/cli_smoke.rs
@@ -119,6 +119,35 @@ fn system_json_has_expected_shape() {
 }
 
 #[test]
+fn llama_cpp_path_flag_rejects_missing_directory() {
+    let missing = unique_temp_dir("missing-llama-cpp-path");
+    let missing_str = missing.to_str().expect("temp dir path was not UTF-8");
+
+    let output = Command::cargo_bin("llmfit")
+        .expect("failed to locate llmfit test binary")
+        .args([
+            "--no-dashboard",
+            "--llama-cpp-path",
+            missing_str,
+            "--json",
+            "system",
+        ])
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(output).expect("error output was not UTF-8");
+    assert_eq!(
+        stderr.trim(),
+        format!(
+            "Error: --llama-cpp-path '{}' does not exist or is not a directory.",
+            missing.display()
+        )
+    );
+}
+
+#[test]
 fn list_json_returns_non_empty_catalog() {
     let json = run_json_command(&["--no-dashboard", "--json", "list"]);
     let models = json
@@ -349,24 +378,6 @@ fn llama_cpp_path_flag_makes_provider_available() {
     );
 
     let _ = fs::remove_dir_all(dir);
-}
-#[test]
-fn llama_cpp_path_flag_ignores_missing_directory() {
-    let missing = unique_temp_dir("missing-llama-cpp-path");
-    let missing_str = missing.to_str().expect("temp dir path was not UTF-8");
-
-    let json = run_json_command(&[
-        "--no-dashboard",
-        "--llama-cpp-path",
-        missing_str,
-        "--json",
-        "system",
-    ]);
-
-    assert!(
-        json.get("system").is_some(),
-        "system output should be present"
-    );
 }
 #[test]
 fn llama_cpp_path_flag_overrides_env_var() {


### PR DESCRIPTION
## Summary

Add a global `--llama-cpp-path` CLI flag that mirrors the existing `LLAMA_CPP_PATH` env var. Requested by @NTShop in issue #295.

## Why this matters

`LLAMA_CPP_PATH` already exists for users who keep llama.cpp in a non-standard location. A matching CLI flag is more discoverable than an env var and is the usual ergonomic for one-shot overrides ("just this run, point at my custom build").

## Changes

In `llmfit-tui/src/main.rs`, added `--llama-cpp-path` as a global flag on `Cli`. When present, the value is exported to `LLAMA_CPP_PATH` early in `main()`, before the binary lookup runs, so the existing `find_binary` chain in `llmfit-core/src/providers.rs:1346` picks it up without any further plumbing.

No change to the env-var behavior; the flag stacks on top.

## Testing

`llmfit-tui/tests/cli_smoke.rs` covers the flag-present case (env var set, lookup uses provided path) and the flag-absent case (existing env var behavior unchanged). README updated to mention the new flag alongside the env var.

Closes #295

AI was used for assistance.
