### PR TITLE
feat: speed up provider navigation when holding shift (gh-571)

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -9,8 +9,9 @@ use llmfit_core::providers::{
 use llmfit_core::quality;
 
 use std::collections::{HashMap, HashSet};
+use std::ops::Add;
 use std::sync::mpsc;
-use std::thread;
+use std::{cmp, thread};
 
 use ratatui::widgets::TableState;
 
@@ -2303,16 +2304,16 @@ impl App {
         self.input_mode = InputMode::Normal;
     }
 
-    pub fn provider_popup_up(&mut self) {
+    pub fn provider_popup_up(&mut self, step: usize) {
         if self.provider_cursor > 0 {
-            self.provider_cursor -= 1;
+            self.provider_cursor = self.provider_cursor.saturating_sub(step);
         }
     }
 
-    pub fn provider_popup_down(&mut self) {
+    pub fn provider_popup_down(&mut self, step: usize) {
         let len = self.provider_filtered_indices().len();
         if self.provider_cursor + 1 < len {
-            self.provider_cursor += 1;
+            self.provider_cursor = cmp::min(len - 1, self.provider_cursor + step);
         }
     }
 

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -300,11 +300,14 @@ fn handle_search_mode(app: &mut App, key: KeyEvent) {
 
 fn handle_provider_popup_mode(app: &mut App, key: KeyEvent) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
     match key.code {
         KeyCode::Esc => app.close_provider_popup(),
 
-        KeyCode::Up => app.provider_popup_up(),
-        KeyCode::Down => app.provider_popup_down(),
+        KeyCode::Up if shift => app.provider_popup_up(25),
+        KeyCode::Down if shift => app.provider_popup_down(25),
+        KeyCode::Up => app.provider_popup_up(1),
+        KeyCode::Down => app.provider_popup_down(1),
 
         // Space toggles too (provider names never contain spaces).
         KeyCode::Enter | KeyCode::Char(' ') => app.provider_popup_toggle(),

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2889,7 +2889,7 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             "PLAN".to_string(),
         ),
         InputMode::ProviderPopup => (
-            "  ↑↓/jk:navigate  Space:toggle  a:all/none  Esc:close".to_string(),
+            "  ↑↓:navigate (+Shift:speed up)  Space:toggle  a:all/none  Esc:close".to_string(),
             "PROVIDERS".to_string(),
         ),
         InputMode::UseCasePopup => (


### PR DESCRIPTION
PR implements feature request from #571.

When holding shift the up/down navigation in TUI providers select advances by 25 providers instead of 1.

I tested it manually.

Not sure if it's idiomatic rust code.