### PR TITLE
Fix stale installed model detection

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -532,6 +532,59 @@ fn scan_hf_cache_for_mlx() -> HashSet<String> {
     set
 }
 
+/// Scan HuggingFace cache directories for GGUF models downloaded via `hf download`.
+///
+/// Unlike the directory-name heuristic removed in this PR, this verifies that actual
+/// `.gguf` files exist inside the repo's snapshots before reporting it as installed.
+fn scan_hf_cache_for_gguf() -> (HashSet<String>, usize) {
+    let mut set = HashSet::new();
+    let mut count = 0usize;
+    for cache_dir in dirs_hf_cache_all() {
+        let Ok(entries) = std::fs::read_dir(&cache_dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            let Some(rest) = name_str.strip_prefix("models--") else {
+                continue;
+            };
+            let mut parts = rest.splitn(2, "--");
+            let Some(owner) = parts.next() else {
+                continue;
+            };
+            let Some(repo) = parts.next() else {
+                continue;
+            };
+
+            // Only count repos that actually have .gguf files in a snapshot.
+            let snapshots_dir = entry.path().join("snapshots");
+            let Ok(snapshots) = std::fs::read_dir(&snapshots_dir) else {
+                continue;
+            };
+            let has_gguf = snapshots.flatten().any(|snap| {
+                std::fs::read_dir(snap.path())
+                    .map(|files| {
+                        files.flatten().any(|f| {
+                            f.path().extension().and_then(|e| e.to_str()) == Some("gguf")
+                        })
+                    })
+                    .unwrap_or(false)
+            });
+            if !has_gguf {
+                continue;
+            }
+
+            count += 1;
+            let owner_lower = owner.to_lowercase();
+            let repo_lower = repo.to_lowercase();
+            set.insert(format!("{}/{}", owner_lower, repo_lower));
+            set.insert(repo_lower);
+        }
+    }
+    (set, count)
+}
+
 impl ModelProvider for MlxProvider {
     fn name(&self) -> &str {
         "MLX"
@@ -701,6 +754,11 @@ impl LlamaCppProvider {
                 }
             }
         }
+        // Also scan the HuggingFace cache for GGUF models downloaded via `hf download`.
+        // This covers models not tracked in llmfit's download history.
+        let (hf_set, hf_count) = scan_hf_cache_for_gguf();
+        count += hf_count;
+        set.extend(hf_set);
         (set, count)
     }
 

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -218,17 +218,14 @@ impl OllamaProvider {
         let count = tags.models.len();
         for m in tags.models {
             let lower = m.name.to_lowercase();
-            set.insert(lower.clone());
-            if let Some(family) = lower.split(':').next() {
-                set.insert(family.to_string());
-            }
+            set.insert(lower);
         }
         (true, set, count)
     }
 
     /// Like `installed_models`, but also returns the true model count.
-    /// The HashSet may have fewer entries than 2*count due to family-name deduplication,
-    /// so `len() / 2` is unreliable for counting models.
+    /// The HashSet is used for matching, while `count` preserves Ollama's true
+    /// model count as reported by `/api/tags`.
     pub fn installed_models_counted(&self) -> (HashSet<String>, usize) {
         let mut set = HashSet::new();
         let Ok(resp) = ureq::get(&self.api_url("tags"))
@@ -245,10 +242,7 @@ impl OllamaProvider {
         let count = tags.models.len();
         for m in tags.models {
             let lower = m.name.to_lowercase();
-            set.insert(lower.clone());
-            if let Some(family) = lower.split(':').next() {
-                set.insert(family.to_string());
-            }
+            set.insert(lower);
         }
         (set, count)
     }
@@ -472,6 +466,38 @@ fn is_likely_gguf_repo(repo_lower: &str) -> bool {
     repo_lower.contains("-gguf") || repo_lower.ends_with("gguf")
 }
 
+/// Return all candidate HuggingFace cache directories.
+///
+/// The HF CLI always uses `~/.cache/huggingface/hub` (XDG-style) regardless
+/// of platform, but `dirs::cache_dir()` returns `~/Library/Caches` on macOS.
+/// We check both to handle either location.
+fn dirs_hf_cache_all() -> Vec<std::path::PathBuf> {
+    let mut dirs = Vec::new();
+
+    if let Ok(cache) = std::env::var("HF_HOME") {
+        dirs.push(std::path::PathBuf::from(cache).join("hub"));
+        return dirs;
+    }
+
+    // Platform-native cache dir (e.g. ~/Library/Caches on macOS)
+    if let Some(cache) = dirs::cache_dir() {
+        dirs.push(cache.join("huggingface").join("hub"));
+    }
+
+    // XDG-style ~/.cache (what the HF CLI actually uses on all platforms)
+    if let Some(home) = dirs::home_dir() {
+        let xdg = home.join(".cache").join("huggingface").join("hub");
+        if !dirs.iter().any(|d| d == &xdg) {
+            dirs.push(xdg);
+        }
+    }
+
+    if dirs.is_empty() {
+        dirs.push(std::path::PathBuf::from("/tmp/.cache/huggingface/hub"));
+    }
+    dirs
+}
+
 /// Scan HuggingFace cache directories for MLX model directories.
 fn scan_hf_cache_for_mlx() -> HashSet<String> {
     let mut set = HashSet::new();
@@ -504,74 +530,6 @@ fn scan_hf_cache_for_mlx() -> HashSet<String> {
         }
     }
     set
-}
-
-/// Scan HuggingFace cache directories for GGUF model directories.
-fn scan_hf_cache_for_gguf() -> (HashSet<String>, usize) {
-    let mut set = HashSet::new();
-    let mut count = 0usize;
-    for cache_dir in dirs_hf_cache_all() {
-        let Ok(entries) = std::fs::read_dir(&cache_dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            let Some(rest) = name_str.strip_prefix("models--") else {
-                continue;
-            };
-            let mut parts = rest.splitn(2, "--");
-            let Some(owner) = parts.next() else {
-                continue;
-            };
-            let Some(repo) = parts.next() else {
-                continue;
-            };
-
-            if !is_likely_gguf_repo(&repo.to_lowercase()) {
-                continue;
-            }
-
-            count += 1;
-            let owner_lower = owner.to_lowercase();
-            let repo_lower = repo.to_lowercase();
-            set.insert(format!("{}/{}", owner_lower, repo_lower));
-            set.insert(repo_lower);
-        }
-    }
-    (set, count)
-}
-
-/// Return all candidate HuggingFace cache directories.
-///
-/// The HF CLI always uses `~/.cache/huggingface/hub` (XDG-style) regardless
-/// of platform, but `dirs::cache_dir()` returns `~/Library/Caches` on macOS.
-/// We check both to handle either location.
-fn dirs_hf_cache_all() -> Vec<std::path::PathBuf> {
-    let mut dirs = Vec::new();
-
-    if let Ok(cache) = std::env::var("HF_HOME") {
-        dirs.push(std::path::PathBuf::from(cache).join("hub"));
-        return dirs;
-    }
-
-    // Platform-native cache dir (e.g. ~/Library/Caches on macOS)
-    if let Some(cache) = dirs::cache_dir() {
-        dirs.push(cache.join("huggingface").join("hub"));
-    }
-
-    // XDG-style ~/.cache (what the HF CLI actually uses on all platforms)
-    if let Some(home) = dirs::home_dir() {
-        let xdg = home.join(".cache").join("huggingface").join("hub");
-        if !dirs.iter().any(|d| d == &xdg) {
-            dirs.push(xdg);
-        }
-    }
-
-    if dirs.is_empty() {
-        dirs.push(std::path::PathBuf::from("/tmp/.cache/huggingface/hub"));
-    }
-    dirs
 }
 
 impl ModelProvider for MlxProvider {
@@ -743,10 +701,6 @@ impl LlamaCppProvider {
                 }
             }
         }
-        // Also scan the HuggingFace cache for GGUF repos downloaded via `hf download`
-        let (hf_set, hf_count) = scan_hf_cache_for_gguf();
-        count += hf_count;
-        set.extend(hf_set);
         (set, count)
     }
 
@@ -2638,29 +2592,39 @@ pub fn has_gguf_mapping(hf_name: &str) -> bool {
     lookup_gguf_repo(hf_name).is_some()
 }
 
-/// Check if a model is installed in the llama.cpp cache.
-pub fn is_model_installed_llamacpp(hf_name: &str, installed: &HashSet<String>) -> bool {
-    let repo = hf_name
-        .split('/')
-        .next_back()
-        .unwrap_or(hf_name)
+fn normalize_llamacpp_key(name: &str) -> String {
+    let mut key = name
+        .rsplit_once('/')
+        .map(|(_, tail)| tail)
+        .unwrap_or(name)
         .to_lowercase();
+    let shard_info = parse_shard_info(&key);
 
-    // Direct match on model name stem
-    if installed.contains(&repo) {
-        return true;
+    if key.ends_with(".gguf") {
+        key.truncate(key.len() - ".gguf".len());
     }
 
-    // Check with common suffixes stripped
-    let stripped = repo
-        .replace("-instruct", "")
-        .replace("-chat", "")
-        .replace("-hf", "")
-        .replace("-it", "");
+    if let Some((idx, total)) = shard_info {
+        let shard_suffix = format!("-{:05}-of-{:05}", idx, total);
+        if let Some(pos) = key.rfind(&shard_suffix) {
+            key.truncate(pos);
+        }
+    }
 
-    installed.iter().any(|name| {
-        name.contains(&repo) || name.contains(&stripped) || repo.contains(name.as_str())
-    })
+    if let Some(base) = strip_gguf_quant_suffix(&key) {
+        key = base;
+    }
+
+    key
+}
+
+/// Check if a model is installed in the llama.cpp cache.
+pub fn is_model_installed_llamacpp(hf_name: &str, installed: &HashSet<String>) -> bool {
+    let candidate = normalize_llamacpp_key(hf_name);
+    installed
+        .iter()
+        .map(|name| normalize_llamacpp_key(name))
+        .any(|name| name == candidate)
 }
 
 /// Given an HF model name, return the best GGUF repo to pull from.
@@ -3165,16 +3129,15 @@ pub fn hf_name_to_ollama_candidates(hf_name: &str) -> Vec<String> {
         .to_lowercase();
 
     let base = strip_trailing_common_model_suffixes(&repo);
+    let had_common_suffix = base != repo;
 
     let mut candidates = Vec::new();
 
     // Try to split off the size tag (e.g. "qwen3-coder-30b-a3b" → ("qwen3-coder", "30b-a3b"))
     // Ollama uses "name:size" format, so we look for a size-like segment.
-    if let Some((name, size)) = split_name_and_size(&base) {
+    if had_common_suffix && let Some((name, size)) = split_name_and_size(&base) {
         // "name:size" is the primary Ollama format
         candidates.push(format!("{}:{}", name, size));
-        // Also try bare family name (Ollama inserts both into the installed set)
-        candidates.push(name.to_string());
     }
 
     // Also try the full lowered name and stripped name as-is
@@ -3234,6 +3197,17 @@ pub fn ollama_pull_tag(hf_name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!("{}_{}_{}", name, std::process::id(), stamp))
+    }
 
     #[test]
     fn test_hf_name_to_mlx_candidates() {
@@ -3337,6 +3311,32 @@ mod tests {
             "Qwen/Qwen2.5-14B-Instruct",
             &installed
         ));
+    }
+
+    #[test]
+    fn test_installed_models_counted_uses_models_dir_only() {
+        let root = unique_temp_dir("llmfit-models");
+        let models_dir = root.join("models");
+        let unrelated_cache = root.join("huggingface").join("hub");
+
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::create_dir_all(&unrelated_cache).unwrap();
+        fs::write(models_dir.join("kept.gguf"), b"gguf").unwrap();
+        fs::write(unrelated_cache.join("ignored.gguf"), b"gguf").unwrap();
+
+        let provider = LlamaCppProvider {
+            models_dir: models_dir.clone(),
+            llama_cli: None,
+            llama_server: None,
+            server_running: false,
+        };
+
+        let (set, count) = provider.installed_models_counted();
+        assert_eq!(count, 1);
+        assert!(set.contains("kept"));
+        assert!(!set.contains("ignored"));
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]
@@ -3488,6 +3488,33 @@ mod tests {
 
         assert!(is_model_installed(
             "Qwen/Qwen2.5-Coder-7B-Instruct",
+            &installed
+        ));
+    }
+
+    #[test]
+    fn test_ollama_family_key_does_not_mark_all_sizes_installed() {
+        let mut installed = HashSet::new();
+        installed.insert("qwen2.5-coder".to_string());
+
+        assert!(!is_model_installed(
+            "Qwen/Qwen2.5-Coder-14B-Instruct",
+            &installed
+        ));
+    }
+
+    #[test]
+    fn test_ollama_specific_size_does_not_mark_other_sizes_installed() {
+        let mut installed = HashSet::new();
+        installed.insert("qwen2.5-coder:0.5b".to_string());
+
+        assert!(is_model_installed(
+            "Qwen/Qwen2.5-Coder-0.5B-Instruct",
+            &installed
+        ));
+        assert!(!is_model_installed("Qwen/Qwen2.5-Coder-0.5B", &installed));
+        assert!(!is_model_installed(
+            "Qwen/Qwen2.5-Coder-14B-Instruct",
             &installed
         ));
     }
@@ -4001,8 +4028,18 @@ mod tests {
     #[test]
     fn test_is_model_installed_llamacpp_stripped_suffixes() {
         let mut installed = HashSet::new();
-        installed.insert("llama-3.1-8b".to_string());
+        installed.insert("Llama-3.1-8B-Instruct-Q8_0.gguf".to_string());
         assert!(is_model_installed_llamacpp(
+            "meta-llama/Llama-3.1-8B-Instruct",
+            &installed
+        ));
+    }
+
+    #[test]
+    fn test_is_model_installed_llamacpp_rejects_substring_false_positive() {
+        let mut installed = HashSet::new();
+        installed.insert("Qwen2.5-Coder-7B-Instruct-Q8_0.gguf".to_string());
+        assert!(!is_model_installed_llamacpp(
             "meta-llama/Llama-3.1-8B-Instruct",
             &installed
         ));

--- a/llmfit-tui/src/download_history.rs
+++ b/llmfit-tui/src/download_history.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Result of a completed download.
@@ -19,6 +20,30 @@ pub struct DownloadRecord {
     pub timestamp: u64,
     /// File path on disk, for providers that store files directly (e.g. LlamaCpp).
     pub file_path: Option<String>,
+    /// All file paths written by the download when a model is split across shards.
+    /// When empty, `file_path` is used as the legacy single-file path.
+    #[serde(default)]
+    pub download_paths: Vec<String>,
+    /// Expected total size of the downloaded files in bytes, when known.
+    #[serde(default)]
+    pub expected_size_bytes: Option<u64>,
+}
+
+impl DownloadRecord {
+    pub(crate) fn recorded_paths(&self) -> Vec<String> {
+        if !self.download_paths.is_empty() {
+            self.download_paths.clone()
+        } else {
+            self.file_path.iter().cloned().collect()
+        }
+    }
+
+    pub(crate) fn resolved_paths(&self) -> Vec<PathBuf> {
+        self.recorded_paths()
+            .into_iter()
+            .filter_map(|raw| resolve_recorded_path(&raw))
+            .collect()
+    }
 }
 
 /// Persistent download history, saved to `~/.config/llmfit/download_history.json`.
@@ -73,10 +98,118 @@ impl DownloadHistory {
         }
     }
 
+    /// Return the number of validated llama.cpp downloads currently present on disk.
+    pub fn valid_llamacpp_downloads(&self) -> (HashSet<String>, usize) {
+        let mut installed = HashSet::new();
+        for record in &self.records {
+            if record.provider != "llama.cpp" {
+                continue;
+            }
+            if !matches!(record.result, DownloadResult::Success) {
+                continue;
+            }
+
+            let paths = record.resolved_paths();
+            if paths.is_empty() {
+                continue;
+            }
+
+            let mut total_size = 0u64;
+            let mut complete = true;
+            for path in &paths {
+                let Ok(meta) = fs::metadata(path) else {
+                    complete = false;
+                    break;
+                };
+                let size = meta.len();
+                if size == 0 {
+                    complete = false;
+                    break;
+                }
+                total_size += size;
+            }
+            if !complete {
+                continue;
+            }
+
+            if let Some(expected) = record.expected_size_bytes
+                && total_size != expected
+            {
+                continue;
+            }
+
+            installed.insert(record.model_name.to_lowercase());
+        }
+        let count = installed.len();
+        (installed, count)
+    }
+
     pub fn epoch_now() -> u64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0)
+    }
+}
+
+fn resolve_recorded_path(raw: &str) -> Option<PathBuf> {
+    let path = Path::new(raw);
+    if path.is_absolute() {
+        Some(path.to_path_buf())
+    } else {
+        Some(dirs::cache_dir()?.join("llmfit").join("models").join(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_dir(name: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("llmfit-download-history-{name}-{unique}"));
+        fs::create_dir_all(&dir).expect("create test dir");
+        dir
+    }
+
+    #[test]
+    fn valid_llamacpp_downloads_requires_existing_files_and_matching_size() {
+        let dir = test_dir("matching-size");
+        let file = dir.join("model.gguf");
+        fs::write(&file, [1u8, 2, 3, 4]).expect("write test file");
+
+        let record = DownloadRecord {
+            model_name: "Foo/Bar".to_string(),
+            provider: "llama.cpp".to_string(),
+            result: DownloadResult::Success,
+            timestamp: 1,
+            file_path: Some(file.display().to_string()),
+            download_paths: vec![file.display().to_string()],
+            expected_size_bytes: Some(4),
+        };
+        let history = DownloadHistory {
+            records: vec![record.clone()],
+        };
+
+        let (installed, count) = history.valid_llamacpp_downloads();
+        assert_eq!(count, 1);
+        assert!(installed.contains("foo/bar"));
+
+        let mut partial_history = history.clone();
+        partial_history.records[0].expected_size_bytes = Some(5);
+        let (_, partial_count) = partial_history.valid_llamacpp_downloads();
+        assert_eq!(partial_count, 0);
+
+        let mut missing_history = history;
+        let missing_path = dir.join("missing.gguf");
+        missing_history.records[0].file_path = Some(missing_path.display().to_string());
+        missing_history.records[0].download_paths = vec![missing_path.display().to_string()];
+        let (_, missing_count) = missing_history.valid_llamacpp_downloads();
+        assert_eq!(missing_count, 0);
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -740,6 +740,14 @@ AGENT USAGE:
         #[arg(long)]
         skip: Option<String>,
     },
+
+    /// Debug installed-model detection.
+    #[command(hide = true)]
+    DebugInstalled {
+        /// Limit matched model rows printed in text mode.
+        #[arg(short = 'n', long)]
+        limit: Option<usize>,
+    },
 }
 
 /// Bundled hardware override options from CLI flags.
@@ -1030,6 +1038,211 @@ fn run_fit(
         }
         display::display_model_fits(&fits);
     }
+}
+
+fn matching_installed_keys(
+    model_name: &str,
+    installed: &std::collections::HashSet<String>,
+    matcher: fn(&str, &std::collections::HashSet<String>) -> bool,
+) -> Vec<String> {
+    let mut matches = installed
+        .iter()
+        .filter_map(|key| {
+            let singleton = std::iter::once(key.clone()).collect();
+            matcher(model_name, &singleton).then(|| key.clone())
+        })
+        .collect::<Vec<_>>();
+    matches.sort();
+    matches
+}
+
+fn run_debug_installed(
+    limit: Option<usize>,
+    json_output: bool,
+    overrides: &HardwareOverrides,
+    _context_limit: Option<u32>,
+) {
+    use llmfit_core::providers::{
+        self as provs, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
+        ModelProvider, OllamaProvider, VllmProvider,
+    };
+
+    let specs = detect_specs(overrides);
+    let db = ModelDatabase::new();
+
+    let mut ollama = OllamaProvider::new();
+    let (ollama_available, ollama_installed, ollama_count) = ollama.detect_with_installed();
+    let mlx = MlxProvider::new();
+    let (mlx_available, mlx_installed) = mlx.detect_with_installed();
+    let docker_mr = DockerModelRunnerProvider::new();
+    let (docker_available, docker_installed, docker_count) = docker_mr.detect_with_installed();
+    let lmstudio = LmStudioProvider::new();
+    let (lmstudio_available, lmstudio_installed, lmstudio_count) = lmstudio.detect_with_installed();
+    let vllm = VllmProvider::new();
+    let (vllm_available, vllm_installed, vllm_count) = vllm.detect_with_installed();
+
+    let mut llamacpp = LlamaCppProvider::new();
+    if let Some(ref dir) = filter_config::FilterConfig::load().download_dir {
+        let path = std::path::PathBuf::from(dir);
+        if path.is_dir() {
+            llamacpp.set_models_dir(path);
+        }
+    }
+    let download_history = download_history::DownloadHistory::load();
+    let llama_history_has_records = download_history
+        .records
+        .iter()
+        .any(|record| record.provider == "llama.cpp");
+    let (llamacpp_installed, llamacpp_count, llamacpp_source) = if llama_history_has_records {
+        let validated = download_history.valid_llamacpp_downloads();
+        if validated.1 > 0 {
+            (validated.0, validated.1, "validated_history")
+        } else {
+            let scanned = llamacpp.installed_models_counted();
+            (scanned.0, scanned.1, "models_dir_fallback")
+        }
+    } else {
+        let scanned = llamacpp.installed_models_counted();
+        (scanned.0, scanned.1, "models_dir")
+    };
+
+    let mut rows = Vec::new();
+    for model in db
+        .get_all_models()
+        .iter()
+        .filter(|m| backend_compatible(m, &specs))
+    {
+        let mut providers = Vec::new();
+        let ollama_keys =
+            matching_installed_keys(&model.name, &ollama_installed, provs::is_model_installed);
+        if !ollama_keys.is_empty() {
+            providers.push(serde_json::json!({"provider": "Ollama", "keys": ollama_keys}));
+        }
+        let mlx_keys =
+            matching_installed_keys(&model.name, &mlx_installed, provs::is_model_installed_mlx);
+        if !mlx_keys.is_empty() {
+            providers.push(serde_json::json!({"provider": "MLX", "keys": mlx_keys}));
+        }
+        let llamacpp_keys = matching_installed_keys(
+            &model.name,
+            &llamacpp_installed,
+            provs::is_model_installed_llamacpp,
+        );
+        if !llamacpp_keys.is_empty() {
+            providers.push(serde_json::json!({"provider": "llama.cpp", "keys": llamacpp_keys}));
+        }
+        let docker_keys = matching_installed_keys(
+            &model.name,
+            &docker_installed,
+            provs::is_model_installed_docker_mr,
+        );
+        if !docker_keys.is_empty() {
+            providers.push(serde_json::json!({"provider": "Docker", "keys": docker_keys}));
+        }
+        let lmstudio_keys = matching_installed_keys(
+            &model.name,
+            &lmstudio_installed,
+            provs::is_model_installed_lmstudio,
+        );
+        if !lmstudio_keys.is_empty() {
+            providers.push(serde_json::json!({"provider": "LM Studio", "keys": lmstudio_keys}));
+        }
+        let vllm_keys =
+            matching_installed_keys(&model.name, &vllm_installed, provs::is_model_installed_vllm);
+        if !vllm_keys.is_empty() {
+            providers.push(serde_json::json!({"provider": "vLLM", "keys": vllm_keys}));
+        }
+
+        if !providers.is_empty() {
+            rows.push(serde_json::json!({
+                "model": model.name,
+                "providers": providers,
+            }));
+        }
+    }
+
+    let summary = serde_json::json!({
+        "providers": {
+            "ollama": {
+                "available": ollama_available,
+                "count": ollama_count,
+                "keys": sorted_values(&ollama_installed),
+            },
+            "mlx": {
+                "available": mlx_available,
+                "count": mlx_installed.len(),
+                "keys": sorted_values(&mlx_installed),
+            },
+            "llamacpp": {
+                "available": llamacpp.is_available(),
+                "count": llamacpp_count,
+                "source": llamacpp_source,
+                "models_dir": llamacpp.models_dir().display().to_string(),
+                "keys": sorted_values(&llamacpp_installed),
+            },
+            "docker": {
+                "available": docker_available,
+                "count": docker_count,
+                "keys": sorted_values(&docker_installed),
+            },
+            "lmstudio": {
+                "available": lmstudio_available,
+                "count": lmstudio_count,
+                "keys": sorted_values(&lmstudio_installed),
+            },
+            "vllm": {
+                "available": vllm_available,
+                "count": vllm_count,
+                "keys": sorted_values(&vllm_installed),
+            },
+        },
+        "installed_model_count": rows.len(),
+        "installed_models": rows,
+    });
+
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&summary).expect("JSON serialization failed")
+        );
+        return;
+    }
+
+    println!(
+        "Installed model rows matched: {}",
+        summary["installed_model_count"]
+    );
+    println!(
+        "Provider counts: Ollama={} MLX={} llama.cpp={} ({}) Docker={} LM Studio={} vLLM={}",
+        ollama_count,
+        mlx_installed.len(),
+        llamacpp_count,
+        llamacpp_source,
+        docker_count,
+        lmstudio_count,
+        vllm_count
+    );
+    println!("llama.cpp dir: {}", llamacpp.models_dir().display());
+
+    for row in rows.iter().take(limit.unwrap_or(usize::MAX)) {
+        let model = row["model"].as_str().unwrap_or("<unknown>");
+        println!("{}", model);
+        if let Some(providers) = row["providers"].as_array() {
+            for provider in providers {
+                println!(
+                    "  {}: {}",
+                    provider["provider"].as_str().unwrap_or("<provider>"),
+                    provider["keys"]
+                );
+            }
+        }
+    }
+}
+
+fn sorted_values(values: &std::collections::HashSet<String>) -> Vec<String> {
+    let mut values = values.iter().cloned().collect::<Vec<_>>();
+    values.sort();
+    values
 }
 
 fn fit_matches_filter(fit: &ModelFit, filter: FitArg) -> bool {
@@ -2545,7 +2758,10 @@ fn main() {
     };
     let auto_dashboard = !cli.no_dashboard
         && !cli.json
-        && !matches!(cli.command.as_ref(), Some(Commands::Serve { .. }));
+        && !matches!(
+            cli.command.as_ref(),
+            Some(Commands::Serve { .. } | Commands::DebugInstalled { .. })
+        );
 
     let _dashboard_guard = if auto_dashboard {
         ensure_dashboard_available(&overrides, context_limit)
@@ -2795,6 +3011,10 @@ fn main() {
                 } else {
                     run_bench(model, &provider, url, runs, all, json);
                 }
+            }
+
+            Commands::DebugInstalled { limit } => {
+                run_debug_installed(limit, cli.json, &overrides, context_limit);
             }
         }
         return;

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -9,6 +9,7 @@ use llmfit_core::providers::{
 use llmfit_core::quality;
 
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::mpsc;
 use std::thread;
 
@@ -458,6 +459,12 @@ impl ActivePullProvider {
     }
 }
 
+#[derive(Debug, Clone)]
+struct PendingLlamaCppDownload {
+    download_paths: Vec<String>,
+    expected_size_bytes: Option<u64>,
+}
+
 fn sort_column_from_label(s: &str) -> SortColumn {
     match s {
         "Score" => SortColumn::Score,
@@ -559,6 +566,7 @@ pub struct App {
     pub pull_percent: Option<f64>,
     pub pull_model_name: Option<String>,
     pull_provider: Option<ActivePullProvider>,
+    pending_llamacpp_download: Option<PendingLlamaCppDownload>,
     pub download_capabilities: HashMap<String, DownloadCapability>,
     download_capability_inflight: HashSet<String>,
     download_capability_tx: mpsc::Sender<(String, DownloadCapability)>,
@@ -698,6 +706,7 @@ impl App {
     pub fn with_specs_and_context(specs: SystemSpecs, context_limit: Option<u32>) -> Self {
         let real_specs = specs.clone();
         let db = ModelDatabase::new();
+        let download_history = DownloadHistory::load();
 
         // Detect llama.cpp synchronously (local filesystem check, fast)
         let mut llamacpp = LlamaCppProvider::new();
@@ -709,7 +718,20 @@ impl App {
         }
         let llamacpp_available = llamacpp.is_available();
         let llamacpp_detection_hint = llamacpp.detection_hint().to_string();
-        let (llamacpp_installed, llamacpp_installed_count) = llamacpp.installed_models_counted();
+        let llama_history_has_records = download_history
+            .records
+            .iter()
+            .any(|record| record.provider == "llama.cpp");
+        let (llamacpp_installed, llamacpp_installed_count) = if llama_history_has_records {
+            let validated = download_history.valid_llamacpp_downloads();
+            if validated.1 > 0 {
+                validated
+            } else {
+                llamacpp.installed_models_counted()
+            }
+        } else {
+            llamacpp.installed_models_counted()
+        };
 
         // Start with empty provider state — detection runs in background
         let ollama = OllamaProvider::new();
@@ -1053,6 +1075,7 @@ impl App {
             pull_percent: None,
             pull_model_name: None,
             pull_provider: None,
+            pending_llamacpp_download: None,
             download_capabilities: HashMap::new(),
             download_capability_inflight: HashSet::new(),
             download_capability_tx,
@@ -1061,7 +1084,7 @@ impl App {
             confirm_download: false,
             show_downloads: false,
             dm_focus: DownloadManagerFocus::History,
-            download_history: DownloadHistory::load(),
+            download_history,
             dm_history_cursor: 0,
             dm_history_scroll: 0,
             dm_confirm_delete: false,
@@ -1164,7 +1187,7 @@ impl App {
             app.filter_mem_pct_max_input = v.clone();
         }
 
-        app.apply_filters();
+        app.refresh_installed();
         app.re_sort();
         app.preselect_initial_best_fit();
         app.enqueue_capability_probes_for_visible(24);
@@ -1749,7 +1772,6 @@ impl App {
         let record = &self.download_history.records[actual_idx];
         let provider_name = record.provider.clone();
         let model_name = record.model_name.clone();
-        let file_path = record.file_path.clone();
         let was_error = matches!(record.result, DownloadResult::Error(_));
 
         // For failed downloads, just remove the history entry — there's nothing
@@ -1765,16 +1787,21 @@ impl App {
         let result = match provider_name.as_str() {
             "Ollama" => self.ollama.delete_model(&model_name),
             "llama.cpp" => {
-                if let Some(ref path) = file_path {
-                    let p = std::path::Path::new(path);
-                    if p.exists() {
-                        std::fs::remove_file(p).map_err(|e| format!("Failed to delete file: {}", e))
-                    } else {
-                        Err("File not found on disk".to_string())
+                let mut delete_error: Option<String> = None;
+                for path in record.resolved_paths() {
+                    match std::fs::remove_file(&path) {
+                        Ok(()) => {}
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(e) => {
+                            delete_error = Some(format!("Failed to delete file: {}", e));
+                            break;
+                        }
                     }
+                }
+                if let Some(err) = delete_error {
+                    Err(err)
                 } else {
-                    // Try matching by name in the models dir
-                    self.llamacpp.delete_model(&model_name)
+                    Ok(())
                 }
             }
             _ => Err(format!("Deletion not supported for {}", provider_name)),
@@ -2985,6 +3012,63 @@ impl App {
         self.fit_filter = self.fit_filter.next();
     }
 
+    pub fn reset_filters(&mut self) {
+        self.search_query.clear();
+        self.cursor_position = 0;
+        self.fit_filter = FitFilter::All;
+        self.availability_filter = AvailabilityFilter::All;
+        self.tp_filter = TpFilter::All;
+        self.sort_ascending = false;
+        self.filter_sort_ascending = false;
+
+        for selected in &mut self.selected_providers {
+            *selected = true;
+        }
+        for selected in &mut self.selected_use_cases {
+            *selected = true;
+        }
+        for selected in &mut self.selected_capabilities {
+            *selected = true;
+        }
+        for selected in &mut self.selected_quants {
+            *selected = true;
+        }
+        for selected in &mut self.selected_run_modes {
+            *selected = true;
+        }
+        for selected in &mut self.selected_params_buckets {
+            *selected = true;
+        }
+        for selected in &mut self.selected_licenses {
+            *selected = true;
+        }
+        for selected in &mut self.selected_runtimes {
+            *selected = true;
+        }
+
+        self.filter_params_min_input.clear();
+        self.filter_params_max_input.clear();
+        self.filter_mem_pct_min_input.clear();
+        self.filter_mem_pct_max_input.clear();
+        self.filter_field = FilterPopupField::ParamsMin;
+        self.filter_cursor_position = 0;
+
+        if self.input_mode == InputMode::FilterPopup {
+            self.filter_snapshot = Some(FilterSnapshot {
+                params_min: String::new(),
+                params_max: String::new(),
+                mem_pct_min: String::new(),
+                mem_pct_max: String::new(),
+                sort_ascending: self.sort_ascending,
+                fit_filter: self.fit_filter,
+            });
+        } else {
+            self.filter_snapshot = None;
+        }
+
+        self.re_sort();
+    }
+
     pub fn apply_filter_popup(&mut self) {
         self.filter_snapshot = None;
         self.sort_ascending = self.filter_sort_ascending;
@@ -3320,6 +3404,38 @@ impl App {
         }
     }
 
+    fn prepare_llamacpp_download(&self, repo: &str) -> Result<PendingLlamaCppDownload, String> {
+        let files = LlamaCppProvider::list_repo_gguf_files(repo);
+        if files.is_empty() {
+            return Err(format!("No GGUF files found in repository '{}'", repo));
+        }
+
+        let (filename, expected_size_bytes) = LlamaCppProvider::select_best_gguf(&files, 999.0)
+            .or_else(|| files.first().cloned())
+            .ok_or_else(|| format!("No GGUF files found in repository '{}'", repo))?;
+
+        let resolved_paths = providers::collect_shard_set(&files, &filename)
+            .unwrap_or_else(|| vec![(filename.clone(), expected_size_bytes)])
+            .into_iter()
+            .map(|(path, _)| path)
+            .collect::<Vec<_>>();
+
+        let mut download_paths = Vec::with_capacity(resolved_paths.len());
+        for path in resolved_paths {
+            let local_name = Path::new(&path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| format!("Invalid GGUF file path: {}", path))?;
+            let local_path = self.llamacpp.models_dir().join(local_name);
+            download_paths.push(local_path.display().to_string());
+        }
+
+        Ok(PendingLlamaCppDownload {
+            download_paths,
+            expected_size_bytes: Some(expected_size_bytes),
+        })
+    }
+
     /// Start downloading a GGUF model via the llama.cpp provider.
     fn start_llamacpp_download_for_model(&mut self, model_name: String) {
         // Check catalog gguf_sources first (instant), then fall back to HTTP probe
@@ -3335,12 +3451,21 @@ impl App {
             return;
         };
 
+        let pending_download = match self.prepare_llamacpp_download(&repo) {
+            Ok(pending) => pending,
+            Err(e) => {
+                self.pull_status = Some(format!("GGUF download failed: {}", e));
+                return;
+            }
+        };
+
         match self.llamacpp.start_pull(&repo) {
             Ok(handle) => {
                 self.pull_model_name = Some(model_name);
                 self.pull_status = Some(format!("Downloading GGUF from {}...", repo));
                 self.pull_percent = Some(0.0);
                 self.pull_provider = Some(ActivePullProvider::LlamaCpp);
+                self.pending_llamacpp_download = Some(pending_download);
                 self.pull_active = Some(handle);
             }
             Err(e) => {
@@ -3432,6 +3557,18 @@ impl App {
                     let done_msg = format!("Download complete via {}!", provider_label);
                     self.pull_status = Some(done_msg);
 
+                    let pending_download = self.pending_llamacpp_download.take();
+                    let (file_path, download_paths, expected_size_bytes) =
+                        if let Some(pending) = pending_download {
+                            (
+                                pending.download_paths.first().cloned(),
+                                pending.download_paths,
+                                pending.expected_size_bytes,
+                            )
+                        } else {
+                            (None, Vec::new(), None)
+                        };
+
                     // Record in download history
                     self.download_history.add_record(DownloadRecord {
                         model_name: self
@@ -3441,7 +3578,9 @@ impl App {
                         provider: provider_label,
                         result: DownloadResult::Success,
                         timestamp: DownloadHistory::epoch_now(),
-                        file_path: None,
+                        file_path,
+                        download_paths,
+                        expected_size_bytes,
                     });
 
                     self.pull_percent = None;
@@ -3458,6 +3597,7 @@ impl App {
                     self.pull_status = Some(format!("Error: {}", e));
 
                     // Record failure in download history
+                    self.pending_llamacpp_download = None;
                     self.download_history.add_record(DownloadRecord {
                         model_name: self
                             .pull_model_name
@@ -3467,6 +3607,8 @@ impl App {
                         result: DownloadResult::Error(e),
                         timestamp: DownloadHistory::epoch_now(),
                         file_path: None,
+                        download_paths: Vec::new(),
+                        expected_size_bytes: None,
                     });
 
                     self.pull_percent = None;
@@ -3480,6 +3622,7 @@ impl App {
                     self.pull_percent = None;
                     self.pull_active = None;
                     self.pull_provider = None;
+                    self.pending_llamacpp_download = None;
                     self.refresh_installed();
                     return;
                 }
@@ -3576,7 +3719,21 @@ impl App {
         self.ollama_installed = ollama_set;
         self.ollama_installed_count = ollama_count;
         self.mlx_installed = self.mlx.installed_models();
-        let (llamacpp_set, llamacpp_count) = self.llamacpp.installed_models_counted();
+        let llama_history_has_records = self
+            .download_history
+            .records
+            .iter()
+            .any(|record| record.provider == "llama.cpp");
+        let (llamacpp_set, llamacpp_count) = if llama_history_has_records {
+            let validated = self.download_history.valid_llamacpp_downloads();
+            if validated.1 > 0 {
+                validated
+            } else {
+                self.llamacpp.installed_models_counted()
+            }
+        } else {
+            self.llamacpp.installed_models_counted()
+        };
         self.llamacpp_installed = llamacpp_set;
         self.llamacpp_installed_count = llamacpp_count;
         let (docker_mr_set, docker_mr_count) = self.docker_mr.installed_models_counted();
@@ -4178,7 +4335,33 @@ fn command_exists(name: &str) -> bool {
 mod tests {
     use super::*;
     use llmfit_core::fit::{InferenceRuntime, RunMode, ScoreComponents};
+    use llmfit_core::hardware::{GpuBackend, GpuInfo, SystemSpecs};
     use llmfit_core::models::{LlmModel, ModelFormat, UseCase};
+
+    fn test_specs() -> SystemSpecs {
+        SystemSpecs {
+            total_ram_gb: 32.0,
+            available_ram_gb: 24.0,
+            total_cpu_cores: 8,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: true,
+            gpu_vram_gb: Some(8.0),
+            total_gpu_vram_gb: Some(8.0),
+            gpu_name: Some("Test GPU".to_string()),
+            gpu_count: 1,
+            unified_memory: false,
+            backend: GpuBackend::Cuda,
+            gpus: vec![GpuInfo {
+                name: "Test GPU".to_string(),
+                vram_gb: Some(8.0),
+                backend: GpuBackend::Cuda,
+                count: 1,
+                unified_memory: false,
+            }],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        }
+    }
 
     fn test_model(name: &str) -> LlmModel {
         LlmModel {
@@ -4262,5 +4445,93 @@ mod tests {
 
         assert_eq!(App::initial_best_fit_row(&[0, 1], &fits), 0);
         assert_eq!(App::initial_best_fit_row(&[], &fits), 0);
+    }
+
+    #[test]
+    fn reset_filters_restores_all_filters_and_popup_snapshot() {
+        let mut app = App::with_specs_and_context(test_specs(), None);
+
+        app.search_query = "qwen".to_string();
+        app.cursor_position = app.search_query.len();
+        app.fit_filter = FitFilter::Good;
+        app.availability_filter = AvailabilityFilter::Installed;
+        app.tp_filter = TpFilter::Tp4;
+        app.sort_ascending = true;
+        app.filter_sort_ascending = true;
+        app.filter_params_min_input = "7".to_string();
+        app.filter_params_max_input = "70".to_string();
+        app.filter_mem_pct_min_input = "10".to_string();
+        app.filter_mem_pct_max_input = "90".to_string();
+
+        for selected in &mut app.selected_providers {
+            *selected = false;
+        }
+        for selected in &mut app.selected_use_cases {
+            *selected = false;
+        }
+        for selected in &mut app.selected_capabilities {
+            *selected = false;
+        }
+        for selected in &mut app.selected_quants {
+            *selected = false;
+        }
+        for selected in &mut app.selected_run_modes {
+            *selected = false;
+        }
+        for selected in &mut app.selected_params_buckets {
+            *selected = false;
+        }
+        for selected in &mut app.selected_licenses {
+            *selected = false;
+        }
+        for selected in &mut app.selected_runtimes {
+            *selected = false;
+        }
+
+        app.input_mode = InputMode::FilterPopup;
+        app.reset_filters();
+
+        assert!(app.search_query.is_empty());
+        assert_eq!(app.cursor_position, 0);
+        assert_eq!(app.fit_filter, FitFilter::All);
+        assert_eq!(app.availability_filter, AvailabilityFilter::All);
+        assert_eq!(app.tp_filter, TpFilter::All);
+        assert!(!app.sort_ascending);
+        assert!(!app.filter_sort_ascending);
+        assert!(app.filter_params_min_input.is_empty());
+        assert!(app.filter_params_max_input.is_empty());
+        assert!(app.filter_mem_pct_min_input.is_empty());
+        assert!(app.filter_mem_pct_max_input.is_empty());
+        let is_apple_silicon = app.specs.backend == GpuBackend::Metal && app.specs.unified_memory;
+        let expected_visible = app
+            .all_fits
+            .iter()
+            .filter(|fit| !fit.model.is_mlx_only() || is_apple_silicon)
+            .count();
+        assert_eq!(app.filtered_fits.len(), expected_visible);
+        assert!(app.selected_providers.iter().all(|&v| v));
+        assert!(app.selected_use_cases.iter().all(|&v| v));
+        assert!(app.selected_capabilities.iter().all(|&v| v));
+        assert!(app.selected_quants.iter().all(|&v| v));
+        assert!(app.selected_run_modes.iter().all(|&v| v));
+        assert!(app.selected_params_buckets.iter().all(|&v| v));
+        assert!(app.selected_licenses.iter().all(|&v| v));
+        assert!(app.selected_runtimes.iter().all(|&v| v));
+
+        app.filter_params_min_input = "123".to_string();
+        app.filter_params_max_input = "456".to_string();
+        app.filter_mem_pct_min_input = "12".to_string();
+        app.filter_mem_pct_max_input = "34".to_string();
+        app.sort_ascending = true;
+        app.fit_filter = FitFilter::Good;
+        app.close_filter_popup();
+
+        assert!(app.filter_params_min_input.is_empty());
+        assert!(app.filter_params_max_input.is_empty());
+        assert!(app.filter_mem_pct_min_input.is_empty());
+        assert!(app.filter_mem_pct_max_input.is_empty());
+        assert!(!app.sort_ascending);
+        assert_eq!(app.fit_filter, FitFilter::All);
+        assert_eq!(app.input_mode, InputMode::Normal);
     }
 }

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -142,6 +142,9 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
         // Search
         KeyCode::Char('/') => app.enter_search(),
 
+        // Reset all filters
+        KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => app.reset_filters(),
+
         // Fit filter
         KeyCode::Char('f') => app.cycle_fit_filter(),
 
@@ -204,7 +207,10 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
                 || app.lmstudio_available
                 || app.vllm_available =>
         {
-            app.refresh_installed()
+            app.refresh_installed();
+            if app.pull_active.is_none() {
+                app.pull_status = Some("Refreshed installed models".to_string());
+            }
         }
 
         // Download manager view
@@ -624,6 +630,8 @@ fn handle_filter_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Esc | KeyCode::Char('q') => app.close_filter_popup(),
 
         KeyCode::Enter => app.apply_filter_popup(),
+
+        KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => app.reset_filters(),
 
         // Field navigation
         KeyCode::Tab | KeyCode::Down => app.filter_next_field(),

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2897,7 +2897,7 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             "DOWNLOADS".to_string(),
         ),
         InputMode::FilterPopup => (
-            "  Tab/jk:nav  type:range  Space:toggle  Enter:apply  Ctrl-U:clear  Esc:close"
+            "  Tab/jk:nav  type:range  Space:toggle  Enter:apply  Ctrl-F:reset  Ctrl-U:clear  Esc:close"
                 .to_string(),
             "FILTER".to_string(),
         ),
@@ -3253,6 +3253,7 @@ fn draw_help_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         ("Filters", ""),
         ("  f", "Cycle fit filter"),
         ("  F", "Filter popup (range, sort dir)"),
+        ("  Ctrl+F", "Reset all filters"),
         ("  a", "Cycle availability filter"),
         ("  T", "Cycle tensor-parallel filter"),
         ("  P", "Provider filter"),


### PR DESCRIPTION
## Issue

LlmFit was reporting models as downloaded when the download failed (partially downloaded), or deleted. This prevented redownloading the model.

## Summary

- validate llama.cpp download records against files on disk, including expected byte sizes when known
- stop stale or partial GGUF downloads from blocking a fresh pull
- fix installed-state false positives from Ollama family tags such as `qwen2.5-coder`
- add a hidden `debug-installed` diagnostic command that prints provider counts and matched keys
- add `Ctrl+F` reset-all-filters handling and document it in the TUI help/filter popup
- restore HF cache scan for GGUF models downloaded via `hf download` (not tracked in llmfit history), with a tighter file-existence check to avoid the original false positives

## Root Cause

Installed-state matching had two separate false-positive paths. llama.cpp state could be derived from broad cache scans or stale records, and Ollama installed detection inserted synthetic family keys like `qwen2.5-coder`. That family key matched every Qwen2.5-Coder catalog entry, so one installed Ollama model caused dozens of rows to be marked installed and blocked pulls.

## Validation

- `cargo test -p llmfit-core`
- `cargo check -p llmfit`
- `llmfit --json debug-installed` against the reported local state now returns exactly the two expected installed rows: one Ollama model and one llama.cpp GGUF file

---

Used Codex and validated with Claude Code.

This PR was reviewed by Claude Code, which identified one issue: the initial commit removed `scan_hf_cache_for_gguf()`, breaking detection of models downloaded via external tools like `hf download`. That issue has been fixed in the follow-up commit with a tighter implementation that verifies actual `.gguf` file presence before reporting a model as installed, avoiding the false positives that motivated the original removal.