### PR TITLE
Web dashboard: stretch layout to full screen width

### DIFF
--- a/llmfit-web/src/styles.css
+++ b/llmfit-web/src/styles.css
@@ -68,9 +68,10 @@ body {
 
 .page-shell {
   position: relative;
-  max-width: 1640px;
+  width: 100%;
+  max-width: 100%;
   margin: 0 auto;
-  padding: 1.1rem;
+  padding: 1.1rem clamp(1.1rem, 2.5vw, 3rem);
   display: grid;
   gap: 0.95rem;
 }


### PR DESCRIPTION
## Summary

The `llmfit serve` web dashboard `.page-shell` container was hard-capped at `max-width: 1640px` and centered with `margin: 0 auto`. On wide / ultrawide displays (e.g. **21:9**) this left large empty margins on both sides and the model table did not use the available horizontal space.

- Removed the fixed cap → layout now fills 100% of the viewport width.
- Added responsive horizontal padding `clamp(1.1rem, 2.5vw, 3rem)` so content keeps comfortable gutters on very wide screens.

Single-line CSS change in `llmfit-web/src/styles.css` (`.page-shell`).

## Testing
- `npm test` → all passing.
- `npm run build` succeeds; verified the rebuilt binary serves the updated bundle via `llmfit serve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)