### PR TITLE
fix: resolve #185 — Windows security block

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "target"

--- a/llmfit-core/tests/cargo_config.rs
+++ b/llmfit-core/tests/cargo_config.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+#[test]
+fn cargo_config_exists() {
+    let config_path = workspace_root().join(".cargo/config.toml");
+    assert!(
+        config_path.exists(),
+        ".cargo/config.toml should exist at the workspace root"
+    );
+}
+
+#[test]
+fn cargo_config_pins_target_dir_inside_repo() {
+    let config_path = workspace_root().join(".cargo/config.toml");
+    let contents =
+        fs::read_to_string(&config_path).expect("failed to read .cargo/config.toml");
+
+    assert!(
+        contents.contains("[build]"),
+        ".cargo/config.toml should contain a [build] section"
+    );
+    assert!(
+        contents.contains("target-dir = \"target\""),
+        "build.target-dir should be pinned to \"target\""
+    );
+}


### PR DESCRIPTION
## Summary

Add a workspace-level Cargo config that pins the build output to a `target/` directory inside the repo. This ensures that contributors who clone and build locally (Option 2 in the README) never have build scripts executed from `%LOCALAPPDATA%\Temp`, sidestepping the Windows application-control block for the from-source path. Note this only affects local builds of the repo; it does not change behavior of `cargo install` from crates.io (which always uses a temp dir), so it complements rather than replaces the documentation fix

Fixes #185

## Changes

- `.cargo/config.toml` *(new)*
- `llmfit-core/tests/cargo_config.rs` *(new)*

## Why

`.cargo/config.toml`: Add a workspace-level Cargo config that pins the build output to a `target/` directory inside the repo. This ensures that contributors who clone and build locally (Option 2 in the README) never have build scripts executed from `%LOCALAPPDATA%\Temp`, sidestepping the Windows application-control block for the from-source path. Note this only affects local builds of the repo; it does not change behavior of `cargo install` from crates.io (which always uses a temp dir), so it complements rather than replaces the documentation fix.
