### PR TITLE
feat(tui): fuzzy search in provider filter popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Launches the interactive terminal UI. Your system specs (CPU, RAM, GPU name, VRA
 | `V`                        | Enter Select mode (column-based filtering)                            |
 | `t`                        | Cycle color theme (saved automatically)                               |
 | `p`                        | Open Plan mode for selected model (hardware planning)                 |
-| `P`                        | Open provider filter popup                                            |
+| `P`                        | Open provider filter popup (type to fuzzy-filter providers)          |
 | `U`                        | Open use-case filter popup                                            |
 | `C`                        | Open capability filter popup                                          |
 | `L`                        | Open license filter popup                                             |

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -471,6 +471,26 @@ fn sort_column_from_label(s: &str) -> SortColumn {
     }
 }
 
+/// Case-insensitive subsequence ("fuzzy") match: returns true when every
+/// character of `query` appears in `candidate` in order (not necessarily
+/// contiguous). An empty query matches everything.
+fn fuzzy_match(query: &str, candidate: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let mut q = query.chars().flat_map(char::to_lowercase).peekable();
+    for c in candidate.chars().flat_map(char::to_lowercase) {
+        if let Some(&qc) = q.peek() {
+            if c == qc {
+                q.next();
+            }
+        } else {
+            break;
+        }
+    }
+    q.peek().is_none()
+}
+
 pub struct App {
     pub should_quit: bool,
     pub input_mode: InputMode,
@@ -520,6 +540,7 @@ pub struct App {
 
     // Provider popup
     pub provider_cursor: usize,
+    pub provider_search: String,
     pub use_case_cursor: usize,
     pub capability_cursor: usize,
     pub download_provider_cursor: usize,
@@ -1018,6 +1039,7 @@ impl App {
             plan_estimate: None,
             plan_error: None,
             provider_cursor: 0,
+            provider_search: String::new(),
             use_case_cursor: 0,
             capability_cursor: 0,
             download_provider_cursor: 0,
@@ -2228,11 +2250,48 @@ impl App {
 
     pub fn open_provider_popup(&mut self) {
         self.input_mode = InputMode::ProviderPopup;
-        // Don't reset cursor -- keep it where it was last time
+        self.provider_search.clear();
+        self.provider_cursor = 0;
     }
 
     pub fn close_provider_popup(&mut self) {
         self.input_mode = InputMode::Normal;
+        self.provider_search.clear();
+    }
+
+    /// Indices into `self.providers` that match the current fuzzy search query,
+    /// in display order. With an empty query this is every provider.
+    pub fn provider_filtered_indices(&self) -> Vec<usize> {
+        self.providers
+            .iter()
+            .enumerate()
+            .filter(|(_, name)| fuzzy_match(&self.provider_search, name))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    pub fn provider_search_input(&mut self, c: char) {
+        self.provider_search.push(c);
+        self.clamp_provider_cursor();
+    }
+
+    pub fn provider_search_backspace(&mut self) {
+        self.provider_search.pop();
+        self.clamp_provider_cursor();
+    }
+
+    pub fn provider_search_clear(&mut self) {
+        self.provider_search.clear();
+        self.clamp_provider_cursor();
+    }
+
+    fn clamp_provider_cursor(&mut self) {
+        let len = self.provider_filtered_indices().len();
+        if len == 0 {
+            self.provider_cursor = 0;
+        } else if self.provider_cursor >= len {
+            self.provider_cursor = len - 1;
+        }
     }
 
     pub fn open_use_case_popup(&mut self) {
@@ -2251,31 +2310,38 @@ impl App {
     }
 
     pub fn provider_popup_down(&mut self) {
-        if self.provider_cursor + 1 < self.providers.len() {
+        let len = self.provider_filtered_indices().len();
+        if self.provider_cursor + 1 < len {
             self.provider_cursor += 1;
         }
     }
 
     pub fn provider_popup_toggle(&mut self) {
-        if self.provider_cursor < self.selected_providers.len() {
-            self.selected_providers[self.provider_cursor] =
-                !self.selected_providers[self.provider_cursor];
+        let filtered = self.provider_filtered_indices();
+        if let Some(&idx) = filtered.get(self.provider_cursor) {
+            self.selected_providers[idx] = !self.selected_providers[idx];
             self.apply_filters();
         }
     }
 
+    /// Toggle all currently-visible (matching) providers. If they are all
+    /// selected, deselect them; otherwise select them all.
     pub fn provider_popup_select_all(&mut self) {
-        let all_selected = self.selected_providers.iter().all(|&s| s);
+        let filtered = self.provider_filtered_indices();
+        if filtered.is_empty() {
+            return;
+        }
+        let all_selected = filtered.iter().all(|&i| self.selected_providers[i]);
         let new_val = !all_selected;
-        for s in &mut self.selected_providers {
-            *s = new_val;
+        for &i in &filtered {
+            self.selected_providers[i] = new_val;
         }
         self.apply_filters();
     }
 
     pub fn provider_popup_clear_all(&mut self) {
-        for s in &mut self.selected_providers {
-            *s = false;
+        for &i in &self.provider_filtered_indices() {
+            self.selected_providers[i] = false;
         }
         self.apply_filters();
     }
@@ -4262,5 +4328,25 @@ mod tests {
 
         assert_eq!(App::initial_best_fit_row(&[0, 1], &fits), 0);
         assert_eq!(App::initial_best_fit_row(&[], &fits), 0);
+    }
+
+    #[test]
+    fn fuzzy_match_empty_query_matches_everything() {
+        assert!(fuzzy_match("", "Ollama"));
+        assert!(fuzzy_match("", ""));
+    }
+
+    #[test]
+    fn fuzzy_match_is_case_insensitive_subsequence() {
+        // Contiguous substring
+        assert!(fuzzy_match("oll", "Ollama"));
+        // Non-contiguous subsequence, mixed case
+        assert!(fuzzy_match("opn", "OpenAI"));
+        assert!(fuzzy_match("MLX", "mlx"));
+        // Order matters
+        assert!(!fuzzy_match("alo", "Ollama"));
+        // Char not present
+        assert!(!fuzzy_match("ollamax", "Ollama"));
+        assert!(!fuzzy_match("z", "Anthropic"));
     }
 }

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -299,16 +299,25 @@ fn handle_search_mode(app: &mut App, key: KeyEvent) {
 }
 
 fn handle_provider_popup_mode(app: &mut App, key: KeyEvent) {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     match key.code {
-        KeyCode::Esc | KeyCode::Char('P') | KeyCode::Char('q') => app.close_provider_popup(),
+        KeyCode::Esc => app.close_provider_popup(),
 
-        KeyCode::Up | KeyCode::Char('k') => app.provider_popup_up(),
-        KeyCode::Down | KeyCode::Char('j') => app.provider_popup_down(),
+        KeyCode::Up => app.provider_popup_up(),
+        KeyCode::Down => app.provider_popup_down(),
 
-        KeyCode::Char(' ') | KeyCode::Enter => app.provider_popup_toggle(),
+        // Space toggles too (provider names never contain spaces).
+        KeyCode::Enter | KeyCode::Char(' ') => app.provider_popup_toggle(),
 
-        KeyCode::Char('a') => app.provider_popup_select_all(),
-        KeyCode::Char('c') => app.provider_popup_clear_all(),
+        KeyCode::Backspace => app.provider_search_backspace(),
+
+        // Ctrl shortcuts (typing plain letters filters, so these are modified).
+        KeyCode::Char('u') if ctrl => app.provider_search_clear(),
+        KeyCode::Char('a') if ctrl => app.provider_popup_select_all(),
+        KeyCode::Char('n') if ctrl => app.provider_popup_clear_all(),
+
+        // Any other printable character filters the provider list.
+        KeyCode::Char(c) if !ctrl => app.provider_search_input(c),
 
         _ => {}
     }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2471,9 +2471,7 @@ fn draw_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
     let search_display = if app.provider_search.is_empty() {
         Span::styled(
             " / type to filter",
-            Style::default()
-                .fg(tc.muted)
-                .add_modifier(Modifier::ITALIC),
+            Style::default().fg(tc.muted).add_modifier(Modifier::ITALIC),
         )
     } else {
         Span::styled(

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2439,9 +2439,16 @@ fn draw_plan(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
 fn draw_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
     let area = frame.area();
 
+    let filtered = app.provider_filtered_indices();
+
     let max_name_len = app.providers.iter().map(|p| p.len()).max().unwrap_or(10);
-    let popup_width = (max_name_len as u16 + 10).min(area.width.saturating_sub(4));
-    let popup_height = (app.providers.len() as u16 + 2).min(area.height.saturating_sub(4));
+    // Width must also fit the search box / hint line.
+    let popup_width = (max_name_len as u16 + 10)
+        .max(28)
+        .min(area.width.saturating_sub(4));
+    // +2 borders, +1 search row. List body shows at most all matches.
+    let list_rows = (filtered.len().max(1) as u16).min(area.height.saturating_sub(6));
+    let popup_height = (list_rows + 3).min(area.height.saturating_sub(4));
 
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
@@ -2449,28 +2456,55 @@ fn draw_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 
     frame.render_widget(Clear, popup_area);
 
-    let inner_height = popup_height.saturating_sub(2) as usize;
+    // The list body is the popup height minus borders (2) minus the search row (1).
+    let inner_height = popup_height.saturating_sub(3) as usize;
     let total = app.providers.len();
 
     let scroll_offset = if app.provider_cursor >= inner_height {
-        app.provider_cursor - inner_height + 1
+        app.provider_cursor + 1 - inner_height
     } else {
         0
     };
 
-    let lines: Vec<Line> = app
-        .providers
-        .iter()
-        .enumerate()
-        .skip(scroll_offset)
-        .take(inner_height)
-        .map(|(i, name)| {
+    // Search input row.
+    let mut lines: Vec<Line> = Vec::with_capacity(inner_height + 1);
+    let search_display = if app.provider_search.is_empty() {
+        Span::styled(
+            " / type to filter",
+            Style::default()
+                .fg(tc.muted)
+                .add_modifier(Modifier::ITALIC),
+        )
+    } else {
+        Span::styled(
+            format!(" / {}", app.provider_search),
+            Style::default().fg(tc.fg).add_modifier(Modifier::BOLD),
+        )
+    };
+    lines.push(Line::from(vec![
+        search_display,
+        Span::styled("_", Style::default().fg(tc.accent_secondary)),
+    ]));
+
+    if filtered.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " (no matching providers)",
+            Style::default().fg(tc.muted),
+        )));
+    } else {
+        for (pos, &i) in filtered
+            .iter()
+            .enumerate()
+            .skip(scroll_offset)
+            .take(inner_height)
+        {
+            let name = &app.providers[i];
             let checkbox = if app.selected_providers[i] {
                 "[x]"
             } else {
                 "[ ]"
             };
-            let is_cursor = i == app.provider_cursor;
+            let is_cursor = pos == app.provider_cursor;
 
             let style = if is_cursor {
                 if app.selected_providers[i] {
@@ -2490,12 +2524,24 @@ fn draw_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
                 Style::default().fg(tc.muted)
             };
 
-            Line::from(Span::styled(format!(" {} {}", checkbox, name), style))
-        })
-        .collect();
+            lines.push(Line::from(Span::styled(
+                format!(" {} {}", checkbox, name),
+                style,
+            )));
+        }
+    }
 
     let active_count = app.selected_providers.iter().filter(|&&s| s).count();
-    let title = format!(" Providers ({}/{}) ", active_count, total);
+    let title = if app.provider_search.is_empty() {
+        format!(" Providers ({}/{}) ", active_count, total)
+    } else {
+        format!(
+            " Providers ({}/{}) — {} match ",
+            active_count,
+            total,
+            filtered.len()
+        )
+    };
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -2510,14 +2556,14 @@ fn draw_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         .title_bottom(
             Line::from(vec![
                 Span::styled(
-                    " a",
+                    " ^a",
                     Style::default()
                         .fg(tc.accent_secondary)
                         .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(": all | ", Style::default().fg(tc.muted)),
                 Span::styled(
-                    "c",
+                    "^n",
                     Style::default()
                         .fg(tc.accent_secondary)
                         .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
Closes #589

## What

Adds type-to-fuzzy-filter to the provider filter popup (opened with `P`), as requested in #589. Typing now narrows the provider list with case-insensitive subsequence matching (fzf-style — characters must appear in order but not contiguously).

## Behavior

- **Type any character** → filters the provider list
- **Up / Down** → move the cursor through matches
- **Enter / Space** → toggle the selected provider (Space is safe — provider names contain no spaces)
- **Backspace** → delete a search character
- **Ctrl+U** → clear the search query
- **Ctrl+A** → select all currently-visible (matching) providers
- **Ctrl+N** → clear all visible selections
- **Esc** → close

The popup shows a search input row, an `N match` count in the title while filtering, and an empty-state line when nothing matches. Because plain letters now feed the filter, the old single-key `a`/`c` all/clear shortcuts moved to `Ctrl+A`/`Ctrl+N`.

## Tests

- Added unit tests for the new `fuzzy_match` helper
- `cargo test` and `cargo clippy` pass with no new warnings