### PR TITLE
fix: bundle WebView2 bootstrapper for Windows desktop app

### DIFF
--- a/llmfit-desktop/tauri.conf.json
+++ b/llmfit-desktop/tauri.conf.json
@@ -5,6 +5,11 @@
   "build": {
     "frontendDist": "./ui"
   },
+  "bundle": {
+    "windows": {
+      "webviewInstallMode": "downloadBootstrapper"
+    }
+  },
   "app": {
     "withGlobalTauri": true,
     "windows": [


### PR DESCRIPTION
## Summary

- Adds `webviewInstallMode: "downloadBootstrapper"` to `tauri.conf.json` so the Windows installer automatically downloads and installs WebView2 if it's missing

## Context

Users on Windows 10 without WebView2 pre-installed hit "This app can't run on your PC" (#195). The root cause is that `tauri.conf.json` had no `bundle` section, so Tauri used defaults which don't include a WebView2 bootstrapper. SignPath signing is already in place — this was the missing piece.

Fixes #195

## Test plan

- [ ] Build desktop app with `cargo tauri build` targeting Windows
- [ ] Install on a clean Windows 10 VM without WebView2
- [ ] Verify the installer prompts to download/install WebView2 automatically
- [ ] Verify the app launches successfully after WebView2 is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)