### PR TITLE
fix(tui): handle unicode download directory input

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1789,6 +1789,47 @@ impl App {
         self.dm_editing_dir = true;
     }
 
+    pub fn insert_dm_dir_char(&mut self, c: char) {
+        self.dm_dir_cursor = floor_char_boundary(&self.dm_dir_input, self.dm_dir_cursor);
+        self.dm_dir_input.insert(self.dm_dir_cursor, c);
+        self.dm_dir_cursor += c.len_utf8();
+    }
+
+    pub fn dm_dir_backspace(&mut self) {
+        self.dm_dir_cursor = floor_char_boundary(&self.dm_dir_input, self.dm_dir_cursor);
+        if self.dm_dir_cursor > 0 {
+            let prev = previous_grapheme_boundary(&self.dm_dir_input, self.dm_dir_cursor);
+            self.dm_dir_input.drain(prev..self.dm_dir_cursor);
+            self.dm_dir_cursor = prev;
+        }
+    }
+
+    pub fn dm_dir_delete(&mut self) {
+        self.dm_dir_cursor = floor_char_boundary(&self.dm_dir_input, self.dm_dir_cursor);
+        if self.dm_dir_cursor < self.dm_dir_input.len() {
+            let next = next_grapheme_boundary(&self.dm_dir_input, self.dm_dir_cursor);
+            self.dm_dir_input.drain(self.dm_dir_cursor..next);
+        }
+    }
+
+    pub fn dm_dir_cursor_left(&mut self) {
+        if self.dm_dir_cursor > 0 {
+            self.dm_dir_cursor = previous_grapheme_boundary(&self.dm_dir_input, self.dm_dir_cursor);
+        }
+    }
+
+    pub fn dm_dir_cursor_right(&mut self) {
+        self.dm_dir_cursor = floor_char_boundary(&self.dm_dir_input, self.dm_dir_cursor);
+        if self.dm_dir_cursor < self.dm_dir_input.len() {
+            self.dm_dir_cursor = next_grapheme_boundary(&self.dm_dir_input, self.dm_dir_cursor);
+        }
+    }
+
+    pub fn dm_dir_clear(&mut self) {
+        self.dm_dir_input.clear();
+        self.dm_dir_cursor = 0;
+    }
+
     pub fn apply_download_dir(&mut self) {
         let path = std::path::PathBuf::from(&self.dm_dir_input);
         if let Err(e) = std::fs::create_dir_all(&path) {
@@ -4287,7 +4328,30 @@ fn command_exists(name: &str) -> bool {
 mod tests {
     use super::*;
     use llmfit_core::fit::{InferenceRuntime, RunMode, ScoreComponents};
+    use llmfit_core::hardware::GpuBackend;
     use llmfit_core::models::{LlmModel, ModelFormat, UseCase};
+
+    fn test_app() -> App {
+        App::with_specs_and_context(
+            SystemSpecs {
+                total_ram_gb: 16.0,
+                available_ram_gb: 12.0,
+                total_cpu_cores: 8,
+                cpu_name: "Test CPU".to_string(),
+                has_gpu: false,
+                gpu_vram_gb: None,
+                total_gpu_vram_gb: None,
+                gpu_name: None,
+                gpu_count: 0,
+                unified_memory: false,
+                backend: GpuBackend::CpuX86,
+                gpus: Vec::new(),
+                cluster_mode: false,
+                cluster_node_count: 0,
+            },
+            None,
+        )
+    }
 
     fn test_model(name: &str) -> LlmModel {
         LlmModel {
@@ -4411,5 +4475,69 @@ mod tests {
 
         assert_eq!(next_grapheme_boundary(query, after_a), after_ni);
         assert_eq!(previous_grapheme_boundary(query, after_ni), after_a);
+    }
+
+    #[test]
+    fn download_dir_input_handles_multibyte_text_without_invalid_boundaries() {
+        let mut app = test_app();
+
+        app.insert_dm_dir_char('模');
+        app.insert_dm_dir_char('型');
+        app.insert_dm_dir_char('一');
+
+        assert_eq!(app.dm_dir_input, "模型一");
+        assert_eq!(app.dm_dir_cursor, "模型一".len());
+
+        app.dm_dir_cursor_left();
+        assert_eq!(app.dm_dir_cursor, "模型".len());
+
+        app.insert_dm_dir_char('二');
+        assert_eq!(app.dm_dir_input, "模型二一");
+        assert_eq!(app.dm_dir_cursor, "模型二".len());
+
+        app.dm_dir_backspace();
+        assert_eq!(app.dm_dir_input, "模型一");
+        assert_eq!(app.dm_dir_cursor, "模型".len());
+    }
+
+    #[test]
+    fn download_dir_input_deletes_whole_emoji_graphemes() {
+        let mut app = test_app();
+        app.dm_dir_input = "a👩‍💻b".to_string();
+        app.dm_dir_cursor = "a".len();
+
+        app.dm_dir_delete();
+        assert_eq!(app.dm_dir_input, "ab");
+        assert_eq!(app.dm_dir_cursor, "a".len());
+
+        app.insert_dm_dir_char('🚀');
+        assert_eq!(app.dm_dir_input, "a🚀b");
+        assert_eq!(app.dm_dir_cursor, "a🚀".len());
+
+        app.dm_dir_backspace();
+        assert_eq!(app.dm_dir_input, "ab");
+        assert_eq!(app.dm_dir_cursor, "a".len());
+    }
+
+    #[test]
+    fn download_dir_input_repairs_non_boundary_cursor_before_editing() {
+        let mut app = test_app();
+        app.dm_dir_input = "一a".to_string();
+        app.dm_dir_cursor = 1;
+
+        app.insert_dm_dir_char('二');
+        assert_eq!(app.dm_dir_input, "二一a");
+        assert_eq!(app.dm_dir_cursor, "二".len());
+    }
+
+    #[test]
+    fn download_dir_backspace_repairs_non_boundary_cursor_before_editing() {
+        let mut app = test_app();
+        app.dm_dir_input = "一a".to_string();
+        app.dm_dir_cursor = 2;
+
+        app.dm_dir_backspace();
+        assert_eq!(app.dm_dir_input, "一a");
+        assert_eq!(app.dm_dir_cursor, 0);
     }
 }

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -569,28 +569,22 @@ fn handle_download_manager_mode(app: &mut App, key: KeyEvent) {
                 app.dm_editing_dir = false;
             }
             KeyCode::Backspace => {
-                if app.dm_dir_cursor > 0 {
-                    app.dm_dir_cursor -= 1;
-                    app.dm_dir_input.remove(app.dm_dir_cursor);
-                }
+                app.dm_dir_backspace();
+            }
+            KeyCode::Delete => {
+                app.dm_dir_delete();
             }
             KeyCode::Left => {
-                if app.dm_dir_cursor > 0 {
-                    app.dm_dir_cursor -= 1;
-                }
+                app.dm_dir_cursor_left();
             }
             KeyCode::Right => {
-                if app.dm_dir_cursor < app.dm_dir_input.len() {
-                    app.dm_dir_cursor += 1;
-                }
+                app.dm_dir_cursor_right();
             }
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                app.dm_dir_input.clear();
-                app.dm_dir_cursor = 0;
+                app.dm_dir_clear();
             }
             KeyCode::Char(c) => {
-                app.dm_dir_input.insert(app.dm_dir_cursor, c);
-                app.dm_dir_cursor += 1;
+                app.insert_dm_dir_char(c);
             }
             _ => {}
         }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -22,6 +22,8 @@ use llmfit_core::providers;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
+const DM_MODELS_DIR_LABEL: &str = "  Models dir:  ";
+
 pub fn draw(frame: &mut Frame, app: &mut App) {
     let tc = app.theme.colors();
 
@@ -348,6 +350,12 @@ fn visible_search_query(query: &str, cursor_position: usize, width: usize) -> (S
         .min(width.saturating_sub(1)) as u16;
 
     (visible, cursor_offset)
+}
+
+fn visible_dm_dir_input(input: &str, cursor: usize, inner_width: u16) -> (String, u16) {
+    let label_width = UnicodeWidthStr::width(DM_MODELS_DIR_LABEL) as u16;
+    let input_width = inner_width.saturating_sub(label_width) as usize;
+    visible_search_query(input, cursor, input_width)
 }
 
 fn floor_grapheme_boundary(value: &str, index: usize) -> usize {
@@ -3909,7 +3917,10 @@ fn draw_downloads(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             vertical: 1,
             horizontal: 1,
         });
-        let cursor_x = inner.x + 14 + app.dm_dir_cursor as u16;
+        let label_width = UnicodeWidthStr::width(DM_MODELS_DIR_LABEL) as u16;
+        let (_, cursor_offset) =
+            visible_dm_dir_input(&app.dm_dir_input, app.dm_dir_cursor, inner.width);
+        let cursor_x = inner.x + label_width + cursor_offset;
         let cursor_y = inner.y;
         if cursor_x < inner.x + inner.width {
             frame.set_cursor_position((cursor_x, cursor_y));
@@ -3980,23 +3991,22 @@ fn draw_dm_config(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         .border_style(border_style)
         .title(" Config ");
 
-    let dir_display = if app.dm_editing_dir {
-        app.dm_dir_input.as_str()
+    let visible_dir = if app.dm_editing_dir {
+        let inner_width = area.width.saturating_sub(2);
+        visible_dm_dir_input(&app.dm_dir_input, app.dm_dir_cursor, inner_width).0
     } else {
-        // Show current models dir from the llamacpp provider
-        // We use the public function as a fallback display
-        ""
+        String::new()
     };
 
     let line = if app.dm_editing_dir {
         Line::from(vec![
-            Span::styled("  Models dir:  ", Style::default().fg(tc.muted)),
-            Span::styled(dir_display, Style::default().fg(tc.fg)),
+            Span::styled(DM_MODELS_DIR_LABEL, Style::default().fg(tc.muted)),
+            Span::styled(visible_dir, Style::default().fg(tc.fg)),
             Span::styled("█", Style::default().fg(tc.accent)),
         ])
     } else {
         Line::from(vec![
-            Span::styled("  Models dir:  ", Style::default().fg(tc.muted)),
+            Span::styled(DM_MODELS_DIR_LABEL, Style::default().fg(tc.muted)),
             Span::styled(
                 app.llamacpp_models_dir().display().to_string(),
                 Style::default().fg(tc.fg),
@@ -5360,6 +5370,16 @@ mod tests {
         assert_eq!(
             visible_search_query("你好世界abc", "你好世界abc".len(), 6),
             ("界abc".to_string(), 5)
+        );
+    }
+
+    #[test]
+    fn visible_dm_dir_input_keeps_unicode_cursor_visible() {
+        let input = "/tmp/模型/一二三四";
+
+        assert_eq!(
+            visible_dm_dir_input(input, input.len(), (DM_MODELS_DIR_LABEL.len() + 8) as u16),
+            ("二三四".to_string(), 6)
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the Download Manager models-dir editor so non-ASCII paths can be edited safely in the TUI.

## Changes

- Handle models-dir cursor movement, insertion, Backspace, and Delete on valid grapheme boundaries.
- Prevent panics when editing non-ASCII filesystem paths (for example, Chinese or Japanese path segments).
- Keep long edited paths visible with a bounded horizontal viewport in the Config row.
- Add focused regression tests for Unicode path editing and viewport rendering.

## Verification

- `cargo fmt --check`
- `cargo test -p llmfit download_dir_input`
- `cargo test -p llmfit visible_dm_dir_input`
- `cargo test -p llmfit`
- `cargo clippy -p llmfit --all-targets`
- Verified in a Linux `rust:1.88-bookworm` container.
- Verified downloading a GGUF file into a non-ASCII path (Chinese path segment).
- Verified `llmfit run <non-ASCII-path-to-gguf>` resolves the file path before failing only because `llama-cli` is not installed in the container.
