### PR TITLE
fix(tui): make provider filter input cursor-aware and ASCII-only

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -46,6 +46,32 @@ fn next_grapheme_boundary(value: &str, index: usize) -> usize {
         .unwrap_or_else(|| value.len())
 }
 
+fn insert_ascii_graphic_input(value: &mut String, cursor: &mut usize, c: char) {
+    if !c.is_ascii_graphic() {
+        return;
+    }
+
+    *cursor = floor_char_boundary(value, *cursor);
+    value.insert(*cursor, c);
+    *cursor += c.len_utf8();
+}
+
+fn backspace_grapheme_input(value: &mut String, cursor: &mut usize) {
+    if *cursor > 0 {
+        let prev = previous_grapheme_boundary(value, *cursor);
+        value.drain(prev..*cursor);
+        *cursor = prev;
+    }
+}
+
+fn delete_grapheme_input(value: &mut String, cursor: usize) {
+    if cursor < value.len() {
+        let cursor = floor_char_boundary(value, cursor);
+        let next = next_grapheme_boundary(value, cursor);
+        value.drain(cursor..next);
+    }
+}
+
 /// Messages sent from background provider-detection threads back to the main TUI.
 pub enum ProviderDetectionMsg {
     Ollama {
@@ -569,6 +595,7 @@ pub struct App {
     // Provider popup
     pub provider_cursor: usize,
     pub provider_search: String,
+    pub provider_search_cursor_position: usize,
     pub use_case_cursor: usize,
     pub capability_cursor: usize,
     pub download_provider_cursor: usize,
@@ -1068,6 +1095,7 @@ impl App {
             plan_error: None,
             provider_cursor: 0,
             provider_search: String::new(),
+            provider_search_cursor_position: 0,
             use_case_cursor: 0,
             capability_cursor: 0,
             download_provider_cursor: 0,
@@ -2335,12 +2363,14 @@ impl App {
     pub fn open_provider_popup(&mut self) {
         self.input_mode = InputMode::ProviderPopup;
         self.provider_search.clear();
+        self.provider_search_cursor_position = 0;
         self.provider_cursor = 0;
     }
 
     pub fn close_provider_popup(&mut self) {
         self.input_mode = InputMode::Normal;
         self.provider_search.clear();
+        self.provider_search_cursor_position = 0;
     }
 
     /// Indices into `self.providers` that match the current fuzzy search query,
@@ -2355,17 +2385,57 @@ impl App {
     }
 
     pub fn provider_search_input(&mut self, c: char) {
-        self.provider_search.push(c);
+        insert_ascii_graphic_input(
+            &mut self.provider_search,
+            &mut self.provider_search_cursor_position,
+            c,
+        );
         self.clamp_provider_cursor();
     }
 
     pub fn provider_search_backspace(&mut self) {
-        self.provider_search.pop();
+        backspace_grapheme_input(
+            &mut self.provider_search,
+            &mut self.provider_search_cursor_position,
+        );
         self.clamp_provider_cursor();
+    }
+
+    pub fn provider_search_delete(&mut self) {
+        delete_grapheme_input(
+            &mut self.provider_search,
+            self.provider_search_cursor_position,
+        );
+        self.clamp_provider_cursor();
+    }
+
+    pub fn provider_search_cursor_left(&mut self) {
+        if self.provider_search_cursor_position > 0 {
+            self.provider_search_cursor_position = previous_grapheme_boundary(
+                &self.provider_search,
+                self.provider_search_cursor_position,
+            );
+        }
+    }
+
+    pub fn provider_search_cursor_right(&mut self) {
+        if self.provider_search_cursor_position < self.provider_search.len() {
+            self.provider_search_cursor_position =
+                next_grapheme_boundary(&self.provider_search, self.provider_search_cursor_position);
+        }
+    }
+
+    pub fn provider_search_cursor_home(&mut self) {
+        self.provider_search_cursor_position = 0;
+    }
+
+    pub fn provider_search_cursor_end(&mut self) {
+        self.provider_search_cursor_position = self.provider_search.len();
     }
 
     pub fn provider_search_clear(&mut self) {
         self.provider_search.clear();
+        self.provider_search_cursor_position = 0;
         self.clamp_provider_cursor();
     }
 
@@ -4455,6 +4525,35 @@ mod tests {
         // Char not present
         assert!(!fuzzy_match("ollamax", "Ollama"));
         assert!(!fuzzy_match("z", "Anthropic"));
+    }
+
+    #[test]
+    fn ascii_graphic_input_inserts_at_cursor_and_rejects_non_ascii() {
+        let mut value = "Ollma".to_string();
+        let mut cursor = "Oll".len();
+
+        insert_ascii_graphic_input(&mut value, &mut cursor, 'a');
+        assert_eq!(value, "Ollama");
+        assert_eq!(cursor, "Olla".len());
+
+        insert_ascii_graphic_input(&mut value, &mut cursor, '你');
+        insert_ascii_graphic_input(&mut value, &mut cursor, ' ');
+        assert_eq!(value, "Ollama");
+        assert_eq!(cursor, "Olla".len());
+    }
+
+    #[test]
+    fn grapheme_input_backspace_and_delete_edit_at_cursor() {
+        let mut value = "LLaamCpp".to_string();
+        let mut cursor = "LLa".len();
+
+        backspace_grapheme_input(&mut value, &mut cursor);
+        assert_eq!(value, "LLamCpp");
+        assert_eq!(cursor, "LL".len());
+
+        delete_grapheme_input(&mut value, cursor);
+        assert_eq!(value, "LLmCpp");
+        assert_eq!(cursor, "LL".len());
     }
 
     #[test]

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -312,18 +312,27 @@ fn handle_provider_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Up => app.provider_popup_up(1),
         KeyCode::Down => app.provider_popup_down(1),
 
+        KeyCode::Left => app.provider_search_cursor_left(),
+        KeyCode::Right => app.provider_search_cursor_right(),
+        KeyCode::Home => app.provider_search_cursor_home(),
+        KeyCode::End => app.provider_search_cursor_end(),
+
         // Space toggles too (provider names never contain spaces).
         KeyCode::Enter | KeyCode::Char(' ') => app.provider_popup_toggle(),
 
         KeyCode::Backspace => app.provider_search_backspace(),
+        KeyCode::Delete => app.provider_search_delete(),
 
         // Ctrl shortcuts (typing plain letters filters, so these are modified).
         KeyCode::Char('u') if ctrl => app.provider_search_clear(),
         KeyCode::Char('a') if ctrl => app.provider_popup_select_all(),
         KeyCode::Char('n') if ctrl => app.provider_popup_clear_all(),
 
-        // Any other printable character filters the provider list.
-        KeyCode::Char(c) if !ctrl => app.provider_search_input(c),
+        // Plain printable ASCII filters the provider list. Reject modified
+        // character events such as macOS Option/Command-arrow artifacts.
+        KeyCode::Char(c) if is_plain_provider_filter_char(c, key.modifiers) => {
+            app.provider_search_input(c)
+        }
 
         _ => {}
     }
@@ -337,6 +346,17 @@ fn allows_search_text_input(modifiers: KeyModifiers) -> bool {
             | KeyModifiers::HYPER
             | KeyModifiers::META,
     )
+}
+
+fn is_plain_provider_filter_char(c: char, modifiers: KeyModifiers) -> bool {
+    c.is_ascii_graphic()
+        && !modifiers.intersects(
+            KeyModifiers::CONTROL
+                | KeyModifiers::ALT
+                | KeyModifiers::SUPER
+                | KeyModifiers::HYPER
+                | KeyModifiers::META,
+        )
 }
 
 fn handle_plan_mode(app: &mut App, key: KeyEvent) {
@@ -731,5 +751,23 @@ mod tests {
         assert!(!allows_search_text_input(
             KeyModifiers::SUPER | KeyModifiers::SHIFT
         ));
+    }
+
+    #[test]
+    fn provider_filter_text_accepts_plain_ascii_graphic_chars() {
+        assert!(is_plain_provider_filter_char('o', KeyModifiers::NONE));
+        assert!(is_plain_provider_filter_char('O', KeyModifiers::SHIFT));
+        assert!(is_plain_provider_filter_char('-', KeyModifiers::NONE));
+    }
+
+    #[test]
+    fn provider_filter_text_rejects_non_ascii_space_and_modified_chars() {
+        assert!(!is_plain_provider_filter_char('你', KeyModifiers::NONE));
+        assert!(!is_plain_provider_filter_char(' ', KeyModifiers::NONE));
+        assert!(!is_plain_provider_filter_char('b', KeyModifiers::ALT));
+        assert!(!is_plain_provider_filter_char('f', KeyModifiers::ALT));
+        assert!(!is_plain_provider_filter_char('a', KeyModifiers::SUPER));
+        assert!(!is_plain_provider_filter_char('e', KeyModifiers::SUPER));
+        assert!(!is_plain_provider_filter_char('x', KeyModifiers::CONTROL));
     }
 }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2560,21 +2560,32 @@ fn draw_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 
     // Search input row.
     let mut lines: Vec<Line> = Vec::with_capacity(inner_height + 1);
+    let search_prefix = " / ";
+    let search_inner_width = popup_width.saturating_sub(2) as usize;
+    let search_query_width = search_inner_width.saturating_sub(search_prefix.len());
+    let (visible_provider_search, provider_cursor_offset) = visible_search_query(
+        &app.provider_search,
+        app.provider_search_cursor_position,
+        search_query_width,
+    );
     let search_display = if app.provider_search.is_empty() {
-        Span::styled(
-            " / type to filter",
-            Style::default().fg(tc.muted).add_modifier(Modifier::ITALIC),
-        )
+        Line::from(vec![
+            Span::styled(search_prefix, Style::default().fg(tc.fg)),
+            Span::styled(
+                "type to filter",
+                Style::default().fg(tc.muted).add_modifier(Modifier::ITALIC),
+            ),
+        ])
     } else {
-        Span::styled(
-            format!(" / {}", app.provider_search),
-            Style::default().fg(tc.fg).add_modifier(Modifier::BOLD),
-        )
+        Line::from(vec![
+            Span::styled(search_prefix, Style::default().fg(tc.fg)),
+            Span::styled(
+                visible_provider_search,
+                Style::default().fg(tc.fg).add_modifier(Modifier::BOLD),
+            ),
+        ])
     };
-    lines.push(Line::from(vec![
-        search_display,
-        Span::styled("_", Style::default().fg(tc.accent_secondary)),
-    ]));
+    lines.push(search_display);
 
     if filtered.is_empty() {
         lines.push(Line::from(Span::styled(
@@ -2665,6 +2676,15 @@ fn draw_provider_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, popup_area);
+
+    let cursor_x = popup_area.x
+        + 1
+        + search_prefix.len() as u16
+        + provider_cursor_offset.min(search_query_width as u16);
+    let cursor_y = popup_area.y + 1;
+    if cursor_x < popup_area.x + popup_area.width.saturating_sub(1) {
+        frame.set_cursor_position((cursor_x, cursor_y));
+    }
 }
 
 fn draw_use_case_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {


### PR DESCRIPTION
## Summary

Fixes the Provider popup filter input so it behaves like a proper cursor-aware text field.

## Changes

- Add cursor-aware editing for the Provider popup filter input.
- Support left/right cursor movement, Home/End, Backspace, and Delete.
- Keep long filter text within the popup input row using horizontal scrolling.
- Restrict Provider filter input to printable ASCII characters.
- Prevent modified key artifacts, such as macOS Option/Command arrow sequences, from being inserted as text.

## Testing

- `cargo fmt --check`
- `cargo test -p llmfit provider_filter_text`
- `cargo test -p llmfit ascii_graphic_input`
- `cargo test -p llmfit grapheme_input`
- `cargo test -p llmfit`
- `cargo clippy -p llmfit --all-targets`
