### PR TITLE
fix: add Gemma 4 QAT models and fallback HF search

### DIFF
--- a/llmfit-core/src/update.rs
+++ b/llmfit-core/src/update.rs
@@ -428,11 +428,7 @@ fn hf_get_list(sort: &str, limit: usize, token: Option<&str>) -> Result<Vec<HfAp
 /// (`num_hidden_layers`, `num_attention_heads`, `num_key_value_heads`,
 /// `head_dim`). The fetch is best-effort and silently degrades to `None`.
 fn map_to_llm_model(hf: HfApiModel, token: Option<&str>) -> Option<LlmModel> {
-    let accepted_pipelines = [
-        "text-generation",
-        "image-text-to-text",
-        "any-to-any",
-    ];
+    let accepted_pipelines = ["text-generation", "image-text-to-text", "any-to-any"];
     let is_tg = hf
         .pipeline_tag
         .as_deref()

--- a/llmfit-core/src/update.rs
+++ b/llmfit-core/src/update.rs
@@ -428,8 +428,19 @@ fn hf_get_list(sort: &str, limit: usize, token: Option<&str>) -> Result<Vec<HfAp
 /// (`num_hidden_layers`, `num_attention_heads`, `num_key_value_heads`,
 /// `head_dim`). The fetch is best-effort and silently degrades to `None`.
 fn map_to_llm_model(hf: HfApiModel, token: Option<&str>) -> Option<LlmModel> {
-    let is_tg = hf.pipeline_tag.as_deref() == Some("text-generation")
-        || hf.tags.iter().any(|t| t == "text-generation");
+    let accepted_pipelines = [
+        "text-generation",
+        "image-text-to-text",
+        "any-to-any",
+    ];
+    let is_tg = hf
+        .pipeline_tag
+        .as_deref()
+        .is_some_and(|p| accepted_pipelines.contains(&p))
+        || hf
+            .tags
+            .iter()
+            .any(|t| accepted_pipelines.contains(&t.as_str()));
     if !is_tg {
         return None;
     }

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -2615,9 +2615,7 @@ fn main() {
                         for (id, desc) in hf_results.iter().take(20) {
                             println!("{:<50} {}", id, desc);
                         }
-                        println!(
-                            "\nTo download: llmfit download <repository>"
-                        );
+                        println!("\nTo download: llmfit download <repository>");
                         println!(
                             "Tip: run 'llmfit update' to add trending models to the local index."
                         );

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -2599,7 +2599,32 @@ fn main() {
             Commands::Search { query } => {
                 let db = ModelDatabase::new();
                 let results = db.find_model(&query);
-                display::display_search_results(&results, &query);
+                if results.is_empty() {
+                    // Fallback: search HuggingFace directly for GGUF models
+                    use llmfit_core::providers::LlamaCppProvider;
+                    println!(
+                        "\nNo local models found matching '{}'. Searching HuggingFace...\n",
+                        query
+                    );
+                    let hf_results = LlamaCppProvider::search_hf_gguf(&query);
+                    if hf_results.is_empty() {
+                        println!("No models found matching '{}'.", query);
+                    } else {
+                        println!("{:<50} Type", "Repository");
+                        println!("{}", "-".repeat(65));
+                        for (id, desc) in hf_results.iter().take(20) {
+                            println!("{:<50} {}", id, desc);
+                        }
+                        println!(
+                            "\nTo download: llmfit download <repository>"
+                        );
+                        println!(
+                            "Tip: run 'llmfit update' to add trending models to the local index."
+                        );
+                    }
+                } else {
+                    display::display_search_results(&results, &query);
+                }
             }
 
             Commands::Info { model } => {


### PR DESCRIPTION
## Summary

Fixes #613

- **Backfill embedded database** with 7 Unsloth Gemma 4 QAT GGUF models (12B, 26B-A4B, 31B, E4B, E2B, E4B-mobile, E2B-mobile) so they are immediately searchable
- **Fallback live HF search** — when `llmfit search` finds no local matches, it now queries HuggingFace directly for GGUF repos, making any model on HF discoverable without needing it in the local index
- **Fix pipeline_tag filter** in `llmfit update` to also accept `image-text-to-text` and `any-to-any` tags (the QAT models use these multimodal tags instead of `text-generation`, which was why `llmfit update` never picked them up)

## Test plan

- [x] `cargo test --lib` — 370 tests pass
- [x] `llmfit search "qat-GGUF"` returns the 5 non-mobile QAT models
- [x] `llmfit search "unsloth/gemma-4-12B-it-qat-GGUF"` finds exact match
- [x] `llmfit search "gemma-4"` includes QAT models in the 159 results
- [x] Fallback HF search triggers when no local results match

🤖 Generated with [Claude Code](https://claude.com/claude-code)