### PR TITLE
refactor: extract duplicated provider detection and fit pipeline into InstalledIndex

### DIFF
--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -1,0 +1,152 @@
+use crate::fit::{InferenceRuntime, ModelFit};
+use crate::hardware::SystemSpecs;
+use crate::models::ModelDatabase;
+use crate::providers::{
+    self, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
+    ModelProvider, OllamaProvider, VllmProvider,
+};
+use std::collections::HashSet;
+
+/// Aggregated installed-model sets from all supported inference providers.
+///
+/// A single point of truth used by both the CLI and the TUI to check which
+/// models are locally installed. Replaces the scattered `HashSet<String>` fields
+/// that used to live on each caller's struct.
+#[derive(Debug, Clone)]
+pub struct InstalledIndex {
+    pub ollama: HashSet<String>,
+    pub ollama_count: usize,
+    pub mlx: HashSet<String>,
+    pub llamacpp: HashSet<String>,
+    pub llamacpp_count: usize,
+    pub docker_mr: HashSet<String>,
+    pub docker_mr_count: usize,
+    pub lmstudio: HashSet<String>,
+    pub lmstudio_count: usize,
+    pub vllm: HashSet<String>,
+    pub vllm_count: usize,
+}
+
+impl InstalledIndex {
+    /// Build an empty index — used as a placeholder while providers load.
+    pub fn empty() -> Self {
+        Self {
+            ollama: HashSet::new(),
+            ollama_count: 0,
+            mlx: HashSet::new(),
+            llamacpp: HashSet::new(),
+            llamacpp_count: 0,
+            docker_mr: HashSet::new(),
+            docker_mr_count: 0,
+            lmstudio: HashSet::new(),
+            lmstudio_count: 0,
+            vllm: HashSet::new(),
+            vllm_count: 0,
+        }
+    }
+
+    /// Synchronously detect installed models across all providers.
+    /// Suitable for CLI paths; the TUI performs detection in background
+    /// threads and populates the index fields individually.
+    pub fn detect_all() -> Self {
+        let (ollama, ollama_count) = {
+            let p = OllamaProvider::new();
+            p.installed_models_counted()
+        };
+        let mlx = MlxProvider::new().installed_models();
+        let (llamacpp, llamacpp_count) = {
+            let p = LlamaCppProvider::new();
+            p.installed_models_counted()
+        };
+        let (docker_mr, docker_mr_count) = {
+            let p = DockerModelRunnerProvider::new();
+            p.installed_models_counted()
+        };
+        let (lmstudio, lmstudio_count) = {
+            let p = LmStudioProvider::new();
+            p.installed_models_counted()
+        };
+        let (vllm, vllm_count) = {
+            let p = VllmProvider::new();
+            p.installed_models_counted()
+        };
+
+        Self {
+            ollama,
+            ollama_count,
+            mlx,
+            llamacpp,
+            llamacpp_count,
+            docker_mr,
+            docker_mr_count,
+            lmstudio,
+            lmstudio_count,
+            vllm,
+            vllm_count,
+        }
+    }
+
+    /// Returns `true` when the model is installed in **any** provider.
+    pub fn is_installed(&self, model_name: &str) -> bool {
+        providers::is_model_installed(model_name, &self.ollama)
+            || providers::is_model_installed_mlx(model_name, &self.mlx)
+            || providers::is_model_installed_llamacpp(model_name, &self.llamacpp)
+            || providers::is_model_installed_docker_mr(model_name, &self.docker_mr)
+            || providers::is_model_installed_lmstudio(model_name, &self.lmstudio)
+            || providers::is_model_installed_vllm(model_name, &self.vllm)
+    }
+
+    /// Returns the display names of all providers that have this model
+    /// installed. Used by the detail panel in the TUI.
+    pub fn installed_providers(&self, model_name: &str) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        if providers::is_model_installed(model_name, &self.ollama) {
+            out.push("Ollama");
+        }
+        if providers::is_model_installed_mlx(model_name, &self.mlx) {
+            out.push("MLX");
+        }
+        if providers::is_model_installed_llamacpp(model_name, &self.llamacpp) {
+            out.push("llama.cpp");
+        }
+        if providers::is_model_installed_docker_mr(model_name, &self.docker_mr) {
+            out.push("Docker");
+        }
+        if providers::is_model_installed_lmstudio(model_name, &self.lmstudio) {
+            out.push("LM Studio");
+        }
+        if providers::is_model_installed_vllm(model_name, &self.vllm) {
+            out.push("vLLM");
+        }
+        out
+    }
+}
+
+/// Build a complete `Vec<ModelFit>` with installed markers populated.
+///
+/// Filters models that are backend-incompatible, runs fit analysis, marks
+/// each fit's `installed` flag from the given index, and returns the results
+/// **unsorted** so the caller can apply its own sort criteria.
+pub fn build_model_fits(
+    db: &ModelDatabase,
+    specs: &SystemSpecs,
+    installed: &InstalledIndex,
+    context_limit: Option<u32>,
+    forced_runtime: Option<InferenceRuntime>,
+) -> Vec<ModelFit> {
+    use crate::fit::backend_compatible;
+
+    db.get_all_models()
+        .iter()
+        .filter(|m| backend_compatible(m, specs))
+        .map(|m| {
+            let mut fit = if let Some(rt) = forced_runtime {
+                ModelFit::analyze_with_forced_runtime(m, specs, context_limit, Some(rt))
+            } else {
+                ModelFit::analyze_with_context_limit(m, specs, context_limit)
+            };
+            fit.installed = installed.is_installed(&m.name);
+            fit
+        })
+        .collect()
+}

--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -45,45 +45,56 @@ impl InstalledIndex {
         }
     }
 
-    /// Synchronously detect installed models across all providers.
-    /// Suitable for CLI paths; the TUI performs detection in background
-    /// threads and populates the index fields individually.
+    /// Detect installed models across all providers in parallel.
+    ///
+    /// Each provider query is issued on its own thread so that a single
+    /// offline/slow backend (worst case ~1.5 s timeout) doesn't serialize
+    /// into ~9 s of total blocking time for the CLI path.
     pub fn detect_all() -> Self {
-        let (ollama, ollama_count) = {
-            let p = OllamaProvider::new();
-            p.installed_models_counted()
-        };
-        let mlx = MlxProvider::new().installed_models();
-        let (llamacpp, llamacpp_count) = {
-            let p = LlamaCppProvider::new();
-            p.installed_models_counted()
-        };
-        let (docker_mr, docker_mr_count) = {
-            let p = DockerModelRunnerProvider::new();
-            p.installed_models_counted()
-        };
-        let (lmstudio, lmstudio_count) = {
-            let p = LmStudioProvider::new();
-            p.installed_models_counted()
-        };
-        let (vllm, vllm_count) = {
-            let p = VllmProvider::new();
-            p.installed_models_counted()
-        };
+        std::thread::scope(|s| {
+            let ollama = s.spawn(|| {
+                let p = OllamaProvider::new();
+                p.installed_models_counted()
+            });
+            let mlx = s.spawn(|| MlxProvider::new().installed_models());
+            let llamacpp = s.spawn(|| {
+                let p = LlamaCppProvider::new();
+                p.installed_models_counted()
+            });
+            let docker_mr = s.spawn(|| {
+                let p = DockerModelRunnerProvider::new();
+                p.installed_models_counted()
+            });
+            let lmstudio = s.spawn(|| {
+                let p = LmStudioProvider::new();
+                p.installed_models_counted()
+            });
+            let vllm = s.spawn(|| {
+                let p = VllmProvider::new();
+                p.installed_models_counted()
+            });
 
-        Self {
-            ollama,
-            ollama_count,
-            mlx,
-            llamacpp,
-            llamacpp_count,
-            docker_mr,
-            docker_mr_count,
-            lmstudio,
-            lmstudio_count,
-            vllm,
-            vllm_count,
-        }
+            let (ollama, ollama_count) = ollama.join().unwrap();
+            let mlx = mlx.join().unwrap();
+            let (llamacpp, llamacpp_count) = llamacpp.join().unwrap();
+            let (docker_mr, docker_mr_count) = docker_mr.join().unwrap();
+            let (lmstudio, lmstudio_count) = lmstudio.join().unwrap();
+            let (vllm, vllm_count) = vllm.join().unwrap();
+
+            Self {
+                ollama,
+                ollama_count,
+                mlx,
+                llamacpp,
+                llamacpp_count,
+                docker_mr,
+                docker_mr_count,
+                lmstudio,
+                lmstudio_count,
+                vllm,
+                vllm_count,
+            }
+        })
     }
 
     /// Returns `true` when the model is installed in **any** provider.

--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -151,11 +151,8 @@ pub fn build_model_fits(
         .iter()
         .filter(|m| backend_compatible(m, specs))
         .map(|m| {
-            let mut fit = if let Some(rt) = forced_runtime {
-                ModelFit::analyze_with_forced_runtime(m, specs, context_limit, Some(rt))
-            } else {
-                ModelFit::analyze_with_context_limit(m, specs, context_limit)
-            };
+            let mut fit =
+                ModelFit::analyze_with_forced_runtime(m, specs, context_limit, forced_runtime);
             fit.installed = installed.is_installed(&m.name);
             fit
         })

--- a/llmfit-core/src/lib.rs
+++ b/llmfit-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analysis;
 pub mod bench;
 pub mod benchmarks;
 pub mod fit;
@@ -8,6 +9,7 @@ pub mod providers;
 pub mod quality;
 pub mod update;
 
+pub use analysis::{InstalledIndex, build_model_fits};
 pub use fit::{FitLevel, InferenceRuntime, ModelFit, RunMode, ScoreComponents, SortColumn};
 pub use hardware::{GpuBackend, SystemSpecs};
 pub use models::{Capability, LlmModel, ModelDatabase, ModelFormat, UseCase};

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -972,9 +972,8 @@ fn run_fit(
         .filter(|m| !backend_compatible(m, &specs))
         .count();
 
-    let mut fits = llmfit_core::analysis::build_model_fits(
-        &db, &specs, &installed, context_limit, None,
-    );
+    let mut fits =
+        llmfit_core::analysis::build_model_fits(&db, &specs, &installed, context_limit, None);
 
     if perfect {
         fits.retain(|f| f.fit_level == llmfit_core::fit::FitLevel::Perfect);
@@ -1287,9 +1286,8 @@ fn run_recommend(
 
     let installed = llmfit_core::analysis::InstalledIndex::detect_all();
 
-    let mut fits = llmfit_core::analysis::build_model_fits(
-        &db, &specs, &installed, context_limit, forced_rt,
-    );
+    let mut fits =
+        llmfit_core::analysis::build_model_fits(&db, &specs, &installed, context_limit, forced_rt);
 
     // Filter by minimum fit level
     let min_level = match min_fit.to_lowercase().as_str() {

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -957,11 +957,6 @@ fn run_fit(
     overrides: &HardwareOverrides,
     context_limit: Option<u32>,
 ) {
-    use llmfit_core::providers::{
-        self as provs, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
-        ModelProvider, OllamaProvider,
-    };
-
     let specs = detect_specs(overrides);
     let db = ModelDatabase::new();
 
@@ -969,13 +964,7 @@ fn run_fit(
         specs.display();
     }
 
-    // Query installed models across local providers so that `fit.installed`
-    // is populated in both text and JSON output — same behaviour as `recommend`.
-    let ollama_installed = OllamaProvider::new().installed_models();
-    let mlx_installed = MlxProvider::new().installed_models();
-    let llamacpp_installed = LlamaCppProvider::new().installed_models();
-    let docker_mr_installed = DockerModelRunnerProvider::new().installed_models();
-    let lmstudio_installed = LmStudioProvider::new().installed_models();
+    let installed = llmfit_core::analysis::InstalledIndex::detect_all();
 
     let hidden: usize = db
         .get_all_models()
@@ -983,20 +972,9 @@ fn run_fit(
         .filter(|m| !backend_compatible(m, &specs))
         .count();
 
-    let mut fits: Vec<ModelFit> = db
-        .get_all_models()
-        .iter()
-        .filter(|m| backend_compatible(m, &specs))
-        .map(|m| {
-            let mut fit = ModelFit::analyze_with_context_limit(m, &specs, context_limit);
-            fit.installed = provs::is_model_installed(&m.name, &ollama_installed)
-                || provs::is_model_installed_mlx(&m.name, &mlx_installed)
-                || provs::is_model_installed_llamacpp(&m.name, &llamacpp_installed)
-                || provs::is_model_installed_docker_mr(&m.name, &docker_mr_installed)
-                || provs::is_model_installed_lmstudio(&m.name, &lmstudio_installed);
-            fit
-        })
-        .collect();
+    let mut fits = llmfit_core::analysis::build_model_fits(
+        &db, &specs, &installed, context_limit, None,
+    );
 
     if perfect {
         fits.retain(|f| f.fit_level == llmfit_core::fit::FitLevel::Perfect);
@@ -1307,35 +1285,11 @@ fn run_recommend(
             }
         });
 
-    // Query installed models across local providers so that `fit.installed`
-    // is populated for CLI output (same behavior as the TUI). This also causes
-    // backends like Docker Model Runner to receive a probe request when
-    // DOCKER_MODEL_RUNNER_HOST is set.
-    use llmfit_core::providers::{
-        self as provs, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
-        ModelProvider, OllamaProvider,
-    };
-    let ollama_installed = OllamaProvider::new().installed_models();
-    let mlx_installed = MlxProvider::new().installed_models();
-    let llamacpp_installed = LlamaCppProvider::new().installed_models();
-    let docker_mr_installed = DockerModelRunnerProvider::new().installed_models();
-    let lmstudio_installed = LmStudioProvider::new().installed_models();
+    let installed = llmfit_core::analysis::InstalledIndex::detect_all();
 
-    let mut fits: Vec<ModelFit> = db
-        .get_all_models()
-        .iter()
-        .filter(|m| backend_compatible(m, &specs))
-        .map(|m| {
-            let mut fit =
-                ModelFit::analyze_with_forced_runtime(m, &specs, context_limit, forced_rt);
-            fit.installed = provs::is_model_installed(&m.name, &ollama_installed)
-                || provs::is_model_installed_mlx(&m.name, &mlx_installed)
-                || provs::is_model_installed_llamacpp(&m.name, &llamacpp_installed)
-                || provs::is_model_installed_docker_mr(&m.name, &docker_mr_installed)
-                || provs::is_model_installed_lmstudio(&m.name, &lmstudio_installed);
-            fit
-        })
-        .collect();
+    let mut fits = llmfit_core::analysis::build_model_fits(
+        &db, &specs, &installed, context_limit, forced_rt,
+    );
 
     // Filter by minimum fit level
     let min_level = match min_fit.to_lowercase().as_str() {

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -578,28 +578,18 @@ pub struct App {
     // Provider state
     pub ollama_available: bool,
     pub ollama_binary_available: bool,
-    pub ollama_installed: HashSet<String>,
-    pub ollama_installed_count: usize,
+    pub installed: llmfit_core::analysis::InstalledIndex,
     ollama: OllamaProvider,
     pub mlx_available: bool,
-    pub mlx_installed: HashSet<String>,
     mlx: MlxProvider,
     pub llamacpp_available: bool,
-    pub llamacpp_installed: HashSet<String>,
-    pub llamacpp_installed_count: usize,
     pub llamacpp_detection_hint: String,
     llamacpp: LlamaCppProvider,
     pub docker_mr_available: bool,
-    pub docker_mr_installed: HashSet<String>,
-    pub docker_mr_installed_count: usize,
     docker_mr: DockerModelRunnerProvider,
     pub lmstudio_available: bool,
-    pub lmstudio_installed: HashSet<String>,
-    pub lmstudio_installed_count: usize,
     lmstudio: LmStudioProvider,
     pub vllm_available: bool,
-    pub vllm_installed: HashSet<String>,
-    pub vllm_installed_count: usize,
     vllm: VllmProvider,
 
     // Download state
@@ -764,23 +754,27 @@ impl App {
         let ollama = OllamaProvider::new();
         let ollama_available = false;
         let ollama_binary_available = false;
-        let ollama_installed = HashSet::new();
-        let ollama_installed_count = 0;
         let mlx = MlxProvider::new();
         let mlx_available = false;
-        let mlx_installed = HashSet::new();
         let docker_mr = DockerModelRunnerProvider::new();
         let docker_mr_available = false;
-        let docker_mr_installed = HashSet::new();
-        let docker_mr_installed_count = 0;
         let lmstudio = LmStudioProvider::new();
         let lmstudio_available = false;
-        let lmstudio_installed = HashSet::new();
-        let lmstudio_installed_count = 0;
         let vllm = VllmProvider::new();
         let vllm_available = false;
-        let vllm_installed = HashSet::new();
-        let vllm_installed_count = 0;
+        let installed = llmfit_core::analysis::InstalledIndex {
+            ollama: HashSet::new(),
+            ollama_count: 0,
+            mlx: HashSet::new(),
+            llamacpp: llamacpp_installed,
+            llamacpp_count: llamacpp_installed_count,
+            docker_mr: HashSet::new(),
+            docker_mr_count: 0,
+            lmstudio: HashSet::new(),
+            lmstudio_count: 0,
+            vllm: HashSet::new(),
+            vllm_count: 0,
+        };
 
         // Spawn background provider detection for network-based providers
         let (provider_tx, provider_detection_rx) = mpsc::channel();
@@ -861,12 +855,7 @@ impl App {
             .filter(|m| backend_compatible(m, &specs))
             .map(|m| {
                 let mut fit = ModelFit::analyze_with_context_limit(m, &specs, context_limit);
-                fit.installed = providers::is_model_installed(&m.name, &ollama_installed)
-                    || providers::is_model_installed_mlx(&m.name, &mlx_installed)
-                    || providers::is_model_installed_llamacpp(&m.name, &llamacpp_installed)
-                    || providers::is_model_installed_docker_mr(&m.name, &docker_mr_installed)
-                    || providers::is_model_installed_lmstudio(&m.name, &lmstudio_installed)
-                    || providers::is_model_installed_vllm(&m.name, &vllm_installed);
+                fit.installed = installed.is_installed(&m.name);
                 fit
             })
             .collect();
@@ -1075,28 +1064,18 @@ impl App {
             download_provider_model: None,
             ollama_available,
             ollama_binary_available,
-            ollama_installed,
-            ollama_installed_count,
+            installed,
             ollama,
             mlx_available,
-            mlx_installed,
             mlx,
             llamacpp_available,
-            llamacpp_installed,
-            llamacpp_installed_count,
             llamacpp_detection_hint,
             llamacpp,
             docker_mr_available,
-            docker_mr_installed,
-            docker_mr_installed_count,
             docker_mr,
             lmstudio_available,
-            lmstudio_installed,
-            lmstudio_installed_count,
             lmstudio,
             vllm_available,
-            vllm_installed,
-            vllm_installed_count,
             vllm,
             pull_active: None,
             pull_status: None,
@@ -2885,11 +2864,7 @@ impl App {
             .map(|m| {
                 let mut fit =
                     ModelFit::analyze_with_context_limit(m, &self.specs, self.context_limit);
-                fit.installed = providers::is_model_installed(&m.name, &self.ollama_installed)
-                    || providers::is_model_installed_mlx(&m.name, &self.mlx_installed)
-                    || providers::is_model_installed_llamacpp(&m.name, &self.llamacpp_installed)
-                    || providers::is_model_installed_docker_mr(&m.name, &self.docker_mr_installed)
-                    || providers::is_model_installed_lmstudio(&m.name, &self.lmstudio_installed);
+                fit.installed = self.installed.is_installed(&m.name);
                 fit
             })
             .collect();
@@ -3309,11 +3284,7 @@ impl App {
             .map(|m| {
                 let mut fit =
                     ModelFit::analyze_with_config(m, &self.specs, self.calc_config.clone());
-                fit.installed = providers::is_model_installed(&m.name, &self.ollama_installed)
-                    || providers::is_model_installed_mlx(&m.name, &self.mlx_installed)
-                    || providers::is_model_installed_llamacpp(&m.name, &self.llamacpp_installed)
-                    || providers::is_model_installed_docker_mr(&m.name, &self.docker_mr_installed)
-                    || providers::is_model_installed_lmstudio(&m.name, &self.lmstudio_installed);
+                fit.installed = self.installed.is_installed(&m.name);
                 fit
             })
             .collect();
@@ -3722,38 +3693,27 @@ impl App {
 
     /// Re-query all providers for installed models and update all_fits.
     pub fn refresh_installed(&mut self) {
-        let (ollama_set, ollama_count) = self.ollama.installed_models_counted();
-        self.ollama_installed = ollama_set;
-        self.ollama_installed_count = ollama_count;
-        self.mlx_installed = self.mlx.installed_models();
-        let (llamacpp_set, llamacpp_count) = self.llamacpp.installed_models_counted();
-        self.llamacpp_installed = llamacpp_set;
-        self.llamacpp_installed_count = llamacpp_count;
-        let (docker_mr_set, docker_mr_count) = self.docker_mr.installed_models_counted();
-        self.docker_mr_installed = docker_mr_set;
-        self.docker_mr_installed_count = docker_mr_count;
-        let (lmstudio_set, lmstudio_count) = self.lmstudio.installed_models_counted();
-        self.lmstudio_installed = lmstudio_set;
-        self.lmstudio_installed_count = lmstudio_count;
-        let (vllm_set, vllm_count) = self.vllm.installed_models_counted();
-        self.vllm_installed = vllm_set;
-        self.vllm_installed_count = vllm_count;
+        let (ollama, ollama_count) = self.ollama.installed_models_counted();
+        let mlx = self.mlx.installed_models();
+        let (llamacpp, llamacpp_count) = self.llamacpp.installed_models_counted();
+        let (docker_mr, docker_mr_count) = self.docker_mr.installed_models_counted();
+        let (lmstudio, lmstudio_count) = self.lmstudio.installed_models_counted();
+        let (vllm, vllm_count) = self.vllm.installed_models_counted();
+        self.installed = llmfit_core::analysis::InstalledIndex {
+            ollama,
+            ollama_count,
+            mlx,
+            llamacpp,
+            llamacpp_count,
+            docker_mr,
+            docker_mr_count,
+            lmstudio,
+            lmstudio_count,
+            vllm,
+            vllm_count,
+        };
         for fit in &mut self.all_fits {
-            fit.installed = providers::is_model_installed(&fit.model.name, &self.ollama_installed)
-                || providers::is_model_installed_mlx(&fit.model.name, &self.mlx_installed)
-                || providers::is_model_installed_llamacpp(
-                    &fit.model.name,
-                    &self.llamacpp_installed,
-                )
-                || providers::is_model_installed_docker_mr(
-                    &fit.model.name,
-                    &self.docker_mr_installed,
-                )
-                || providers::is_model_installed_lmstudio(
-                    &fit.model.name,
-                    &self.lmstudio_installed,
-                )
-                || providers::is_model_installed_vllm(&fit.model.name, &self.vllm_installed);
+            fit.installed = self.installed.is_installed(&fit.model.name);
         }
         self.re_sort();
         self.enqueue_capability_probes_for_visible(24);
@@ -3858,8 +3818,8 @@ impl App {
                         } => {
                             self.ollama_available = available;
                             self.ollama_binary_available = binary_available;
-                            self.ollama_installed = installed;
-                            self.ollama_installed_count = installed_count;
+                            self.installed.ollama = installed;
+                            self.installed.ollama_count = installed_count;
                             self.ollama = provider;
                         }
                         ProviderDetectionMsg::Mlx {
@@ -3867,7 +3827,7 @@ impl App {
                             installed,
                         } => {
                             self.mlx_available = available;
-                            self.mlx_installed = installed;
+                            self.installed.mlx = installed;
                         }
                         ProviderDetectionMsg::DockerMr {
                             available,
@@ -3875,8 +3835,8 @@ impl App {
                             installed_count,
                         } => {
                             self.docker_mr_available = available;
-                            self.docker_mr_installed = installed;
-                            self.docker_mr_installed_count = installed_count;
+                            self.installed.docker_mr = installed;
+                            self.installed.docker_mr_count = installed_count;
                         }
                         ProviderDetectionMsg::LmStudio {
                             available,
@@ -3884,8 +3844,8 @@ impl App {
                             installed_count,
                         } => {
                             self.lmstudio_available = available;
-                            self.lmstudio_installed = installed;
-                            self.lmstudio_installed_count = installed_count;
+                            self.installed.lmstudio = installed;
+                            self.installed.lmstudio_count = installed_count;
                         }
                         ProviderDetectionMsg::Vllm {
                             available,
@@ -3893,8 +3853,8 @@ impl App {
                             installed_count,
                         } => {
                             self.vllm_available = available;
-                            self.vllm_installed = installed;
-                            self.vllm_installed_count = installed_count;
+                            self.installed.vllm = installed;
+                            self.installed.vllm_count = installed_count;
                         }
                     }
                 }
@@ -3908,25 +3868,7 @@ impl App {
         if got_any {
             // Re-mark installed status for all models
             for fit in &mut self.all_fits {
-                fit.installed =
-                    providers::is_model_installed(&fit.model.name, &self.ollama_installed)
-                        || providers::is_model_installed_mlx(&fit.model.name, &self.mlx_installed)
-                        || providers::is_model_installed_llamacpp(
-                            &fit.model.name,
-                            &self.llamacpp_installed,
-                        )
-                        || providers::is_model_installed_docker_mr(
-                            &fit.model.name,
-                            &self.docker_mr_installed,
-                        )
-                        || providers::is_model_installed_lmstudio(
-                            &fit.model.name,
-                            &self.lmstudio_installed,
-                        )
-                        || providers::is_model_installed_vllm(
-                            &fit.model.name,
-                            &self.vllm_installed,
-                        );
+                fit.installed = self.installed.is_installed(&fit.model.name);
             }
             self.re_sort();
         }
@@ -3989,7 +3931,7 @@ impl App {
             let _ = std::fs::create_dir_all(parent);
         }
         let mut installed: Vec<String> = self
-            .ollama_installed
+            .installed.ollama
             .iter()
             .map(|m| m.strip_suffix(":latest").unwrap_or(m).to_string())
             .collect();
@@ -4020,7 +3962,7 @@ impl App {
 
         // Check if installed models match
         let mut installed: Vec<String> = self
-            .ollama_installed
+            .installed.ollama
             .iter()
             .map(|m| m.strip_suffix(":latest").unwrap_or(m).to_string())
             .collect();
@@ -4113,7 +4055,7 @@ impl App {
         // Deduplicate: strip ":latest" suffix and remove dupes
         let mut seen = std::collections::HashSet::new();
         let mut models: Vec<String> = self
-            .ollama_installed
+            .installed.ollama
             .iter()
             .map(|m| m.strip_suffix(":latest").unwrap_or(m).to_string())
             .filter(|m| seen.insert(m.clone()))

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -3921,7 +3921,8 @@ impl App {
             let _ = std::fs::create_dir_all(parent);
         }
         let mut installed: Vec<String> = self
-            .installed.ollama
+            .installed
+            .ollama
             .iter()
             .map(|m| m.strip_suffix(":latest").unwrap_or(m).to_string())
             .collect();
@@ -3952,7 +3953,8 @@ impl App {
 
         // Check if installed models match
         let mut installed: Vec<String> = self
-            .installed.ollama
+            .installed
+            .ollama
             .iter()
             .map(|m| m.strip_suffix(":latest").unwrap_or(m).to_string())
             .collect();
@@ -4045,7 +4047,8 @@ impl App {
         // Deduplicate: strip ":latest" suffix and remove dupes
         let mut seen = std::collections::HashSet::new();
         let mut models: Vec<String> = self
-            .installed.ollama
+            .installed
+            .ollama
             .iter()
             .map(|m| m.strip_suffix(":latest").unwrap_or(m).to_string())
             .filter(|m| seen.insert(m.clone()))

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -762,19 +762,9 @@ impl App {
         let lmstudio_available = false;
         let vllm = VllmProvider::new();
         let vllm_available = false;
-        let installed = llmfit_core::analysis::InstalledIndex {
-            ollama: HashSet::new(),
-            ollama_count: 0,
-            mlx: HashSet::new(),
-            llamacpp: llamacpp_installed,
-            llamacpp_count: llamacpp_installed_count,
-            docker_mr: HashSet::new(),
-            docker_mr_count: 0,
-            lmstudio: HashSet::new(),
-            lmstudio_count: 0,
-            vllm: HashSet::new(),
-            vllm_count: 0,
-        };
+        let mut installed = llmfit_core::analysis::InstalledIndex::empty();
+        installed.llamacpp = llamacpp_installed;
+        installed.llamacpp_count = llamacpp_installed_count;
 
         // Spawn background provider detection for network-based providers
         let (provider_tx, provider_detection_rx) = mpsc::channel();

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -18,7 +18,6 @@ use crate::tui_app::{
 };
 use llmfit_core::fit::{FitLevel, ModelFit, SortColumn};
 use llmfit_core::hardware::is_running_in_wsl;
-use llmfit_core::providers;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -135,7 +134,7 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     };
 
     let ollama_info = if app.ollama_available {
-        format!("Ollama: ✓ ({} installed)", app.ollama_installed_count)
+        format!("Ollama: ✓ ({} installed)", app.installed.ollama_count)
     } else {
         "Ollama: ✗".to_string()
     };
@@ -146,15 +145,15 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     };
 
     let mlx_info = if app.mlx_available {
-        format!("MLX: ✓ ({} installed)", app.mlx_installed.len())
-    } else if !app.mlx_installed.is_empty() {
-        format!("MLX: ({} cached)", app.mlx_installed.len())
+        format!("MLX: ✓ ({} installed)", app.installed.mlx.len())
+    } else if !app.installed.mlx.is_empty() {
+        format!("MLX: ({} cached)", app.installed.mlx.len())
     } else {
         "MLX: ✗".to_string()
     };
     let mlx_color = if app.mlx_available {
         tc.good
-    } else if !app.mlx_installed.is_empty() {
+    } else if !app.installed.mlx.is_empty() {
         tc.warning
     } else {
         tc.muted
@@ -162,25 +161,25 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
 
     let llamacpp_info = if app.llamacpp_available {
         if app.llamacpp_detection_hint.is_empty() {
-            format!("llama.cpp: ✓ ({} models)", app.llamacpp_installed_count)
+            format!("llama.cpp: ✓ ({} models)", app.installed.llamacpp_count)
         } else {
             format!("llama.cpp: ✓ ({})", app.llamacpp_detection_hint)
         }
-    } else if !app.llamacpp_installed.is_empty() {
-        format!("llama.cpp: ({} cached)", app.llamacpp_installed_count)
+    } else if !app.installed.llamacpp.is_empty() {
+        format!("llama.cpp: ({} cached)", app.installed.llamacpp_count)
     } else {
         format!("llama.cpp: ✗ ({})", app.llamacpp_detection_hint)
     };
     let llamacpp_color = if app.llamacpp_available {
         tc.good
-    } else if !app.llamacpp_installed.is_empty() {
+    } else if !app.installed.llamacpp.is_empty() {
         tc.warning
     } else {
         tc.muted
     };
 
     let docker_mr_info = if app.docker_mr_available {
-        format!("Docker: ✓ ({} models)", app.docker_mr_installed_count)
+        format!("Docker: ✓ ({} models)", app.installed.docker_mr_count)
     } else {
         "Docker: ✗".to_string()
     };
@@ -191,7 +190,7 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     };
 
     let lmstudio_info = if app.lmstudio_available {
-        format!("LM Studio: ✓ ({} models)", app.lmstudio_installed_count)
+        format!("LM Studio: ✓ ({} models)", app.installed.lmstudio_count)
     } else {
         "LM Studio: ✗".to_string()
     };
@@ -202,7 +201,7 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     };
 
     let vllm_info = if app.vllm_available {
-        format!("vLLM: ✓ ({} models)", app.vllm_installed_count)
+        format!("vLLM: ✓ ({} models)", app.installed.vllm_count)
     } else {
         "vLLM: ✗".to_string()
     };
@@ -1779,30 +1778,7 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         Line::from(vec![
             Span::styled("  Installed:   ", Style::default().fg(tc.muted)),
             {
-                let mut installed_providers = Vec::new();
-                if providers::is_model_installed(&fit.model.name, &app.ollama_installed) {
-                    installed_providers.push("Ollama");
-                }
-                if providers::is_model_installed_mlx(&fit.model.name, &app.mlx_installed) {
-                    installed_providers.push("MLX");
-                }
-                if providers::is_model_installed_llamacpp(&fit.model.name, &app.llamacpp_installed)
-                {
-                    installed_providers.push("llama.cpp");
-                }
-                if providers::is_model_installed_docker_mr(
-                    &fit.model.name,
-                    &app.docker_mr_installed,
-                ) {
-                    installed_providers.push("Docker");
-                }
-                if providers::is_model_installed_lmstudio(&fit.model.name, &app.lmstudio_installed)
-                {
-                    installed_providers.push("LM Studio");
-                }
-                if providers::is_model_installed_vllm(&fit.model.name, &app.vllm_installed) {
-                    installed_providers.push("vLLM");
-                }
+                let installed_providers = app.installed.installed_providers(&fit.model.name);
                 let any_available = app.ollama_available
                     || app.mlx_available
                     || app.llamacpp_available


### PR DESCRIPTION
## Problem

Provider-installation detection and the model-fit analysis pipeline are duplicated across three locations:

| Location | Occurrences |
|---|---|
| `main.rs:run_fit()` | ~20 lines |
| `main.rs:run_recommend()` | ~20 lines |
| `tui_app.rs` init + 5 call sites | ~50 lines |

**Behavioral drift**: the TUI checks `is_model_installed_vllm()` but both CLI paths do not — so a model shows "installed" in TUI but not in `llmfit fit --json`.

**Maintenance tax**: adding a new provider (e.g. TensorRT-LLM) requires edits in 3 places.

## Solution

1. **New `llmfit-core/src/analysis.rs`** (160 lines):
   - `InstalledIndex` — aggregates all 6 provider sets + counts, with `is_installed()` and `installed_providers()` methods
   - `build_model_fits()` — shared pipeline: filter backend-compatible → analyze → mark installed
   - `detect_all()` uses `std::thread::scope` to query providers in parallel (worst case ~1.5s vs ~9s serial)

2. CLI paths call `InstalledIndex::detect_all()` + `build_model_fits()`
3. TUI replaces 12 individual `HashSet`/`usize` fields on `App` with one `installed: InstalledIndex`

## Stats

| File | +/- |
|---|---|
| `llmfit-core/src/analysis.rs` | +160 (new) |
| `llmfit-core/src/lib.rs` | +2 |
| `llmfit-tui/src/main.rs` | +8 / -54 |
| `llmfit-tui/src/tui_app.rs` | +51 / -109 |
| `llmfit-tui/src/tui_ui.rs` | +13 / -37 |
| **Total** | **+234 / -200** |

371 lib tests + 7 CLI smoke tests pass. No new clippy warnings.

Closes #624