### PR TITLE
feat(python): add riscv64 wheel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,11 @@ jobs:
             os: ubuntu-latest
             use-cross: true
 
+          # Linux RISCV64 (glibc)
+          - target: riscv64gc-unknown-linux-gnu
+            os: ubuntu-latest
+            use-cross: true
+
           # macOS Intel (cross-compiled from ARM64 runner)
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -280,6 +285,7 @@ jobs:
           TARGETS=(
             "manylinux_2_17_x86_64:x86_64-unknown-linux-gnu:llmfit:tar.gz"
             "manylinux_2_17_aarch64:aarch64-unknown-linux-gnu:llmfit:tar.gz"
+            "manylinux_2_39_riscv64:riscv64gc-unknown-linux-gnu:llmfit:tar.gz"
             "musllinux_1_2_x86_64:x86_64-unknown-linux-musl:llmfit:tar.gz"
             "musllinux_1_2_aarch64:aarch64-unknown-linux-musl:llmfit:tar.gz"
             "macosx_10_12_x86_64:x86_64-apple-darwin:llmfit:tar.gz"

--- a/llmfit-python/hatch_build.py
+++ b/llmfit-python/hatch_build.py
@@ -41,6 +41,7 @@ from packaging.tags import sys_tags
 TARGET_CONFIGS: dict[str, tuple[str, str]] = {
     "manylinux_2_17_x86_64": ("x86_64-unknown-linux-gnu", "llmfit"),
     "manylinux_2_17_aarch64": ("aarch64-unknown-linux-gnu", "llmfit"),
+    "manylinux_2_39_riscv64": ("riscv64gc-unknown-linux-gnu", "llmfit"),
     "musllinux_1_2_x86_64": ("x86_64-unknown-linux-musl", "llmfit"),
     "musllinux_1_2_aarch64": ("aarch64-unknown-linux-musl", "llmfit"),
     "macosx_10_12_x86_64": ("x86_64-apple-darwin", "llmfit"),


### PR DESCRIPTION
Add a cross build target for riscv64gc-unknown-linux-gnu. Now that there are some RVA23-compliant platforms like the [K3 Pico-ITX](https://www.spacemit.com/community/document/info?lang=en&nodepath=hardware/eco/k3_pico/root_overview.md) available for wider use, it should be possible for users to experiment with LLM tooling on those as well.

I've tested the build through a PR on my fork (where I've disabled builds other than the riscv64 glibc one): https://github.com/threexc/llmfit/pull/1

Here it is running on my K3 Pico-ITX:

```
┌ llmfit ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ CPU: Spacemit(R) X100 (16 cores)  │  RAM: 30.8 GB avail / 31.3 GB total  │  GPU: none (CPU (x86))                                                                                                                 │
│ Ollama: ✗  │  MLX: ✗  │  llama.cpp: ✗ (not in PATH, set LLAMA_CPP_PATH)  │  Docker: ✗  │  LM Studio: ✗  │  vLLM: ✗  │  670 models hidden (incompatible backend)                                                   │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌ Search ───────────────────────────────────────────────────────────────┐┌ Providers (P) ─┐┌ Use Case (U) ──┐┌ Caps (C) ────┐┌ Sort [s] ──────┐┌ Fit [f] Filter [F┐┌ Avail [a] ───────┐┌ TP [T] ────┐┌ Theme [t] ───┐
│Press / to search...                                                   ││ All            ││ All            ││ All          ││ Score ↓        ││All               ││All               ││All         ││ Default      │
└───────────────────────────────────────────────────────────────────────┘└────────────────┘└────────────────┘└──────────────┘└────────────────┘└──────────────────┘└──────────────────┘└────────────┘└──────────────┘
┌ Models (4332/4334) ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────↑
│     Inst  Model                                              Provider     Params   Score ▼  tok/s*   Quant      Disk   Mode    Mem %   Ctx   Date     Fit        Use Case                                         █
│▶ ●   —    Distilled-4bit   Jackrong/MLX-Qwen3.5-35B-A3B-Clau jackrong     34.7B    90       7.9      Q6_K       27.7G  CPU     63%     262k  —        Marginal   Reasoning                                        ║
│  ●   —    Jackrong/MLX-Qwen3.5-35B-A3B-Claude-4.6-Opus-Reaso jackrong     34.7B    90       7.9      Q6_K       27.7G  CPU     63%     262k  —        Marginal   Reasoning                                        ║
│  ●   —    hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoni hesamation   36.0B    90       7.7      Q6_K       28.8G  CPU     65%     262k  —        Marginal   Reasoning                                        ║
│  ●   —    unsloth/DeepSeek-R1-GGUF                           unsloth      29.6B    90       12.2     Q3_K_M     14.2G  CPU     53%     6553k —        Marginal   Reasoning                                        ║
│  ●   —    lordx64/Qwen3.6-35B-A3B-Kimi-K2.6-Reasoning-Distil lordx64      36.0B    90       7.7      Q6_K       28.8G  CPU     65%     262k  —        Marginal   Reasoning                                        ║
│  ●   —    Jackrong/Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning jackrong     36.0B    90       7.7      Q6_K       28.8G  CPU     65%     262k  2026-03  Marginal   Reasoning                                        ║
│  ●   —    lordx64/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning- lordx64      36.0B    90       7.7      Q6_K       28.8G  CPU     65%     262k  —        Marginal   Reasoning                                        ║
│  ●   —    cyburn/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-D cyburn       21.4B    86       10.9     Q8_0       22.4G  CPU     39%     4k    —        Marginal   Reasoning                                        ║
│  ●   —    mconcat/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Dist mconcat      27.4B    86       0.8      Q6_K       21.9G  CPU     79%     262k  —        Marginal   Reasoning                                        ║
│  ●   —    cyburn/Qwen3.6-35B-A3B-Claude-4.7-Opus-Reasoning-D cyburn       27.1B    86       8.5      Q8_0       28.5G  CPU     49%     4k    —        Marginal   Reasoning                                        ║
│  ●   —    Johnblick187/Nexus-Coder-5Q3                       johnblick187 34.7B    84       7.9      Q6_K       27.7G  CPU     63%     262k  —        Marginal   Coding                                           ║
│  ●   —    microsoft/Phi-4-reasoning-vision-15B               Microsoft    15.1B    84       1.2      Q8_0       15.9G  CPU     58%     32k   —        Marginal   Reasoning                                        ║
│  ●   —    Qwen/Qwen3-Coder-30B-A3B-Instruct                  Alibaba      30.5B    83       6.6      Q6_K       24.4G  CPU     55%     262k  —        Marginal   Coding                                           ║
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────↓
 ▶ Jackrong/MLX-Qwen3.5-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-4bit  34.7B  jackrong
 NORMAL  S:simulate  A:config  b:benchmarks  I:live-bench  h:help  Enter:detail  /:search  f:fit  F:filter  s:sort  P:providers  U:use cases  C:caps  R:runtime  q:quit
 ```
 
 Note that there is also a `riscv64a23` toolchain option. We could add that too, if desired, once the manylinux support is there.