### PR TITLE
fix(fit): CPU-only models that fit with headroom reach Good, not Marginal

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -591,7 +591,8 @@ impl ModelFit {
 /// Pure memory headroom scoring.
 /// - GPU (including Apple Silicon unified memory): can reach Perfect.
 /// - CpuOffload: caps at Good.
-/// - CpuOnly: caps at Marginal -- CPU-only inference is always a compromise.
+/// - CpuOnly: caps at Good -- no GPU acceleration so never Perfect, but a model
+///   that fits with comfortable headroom is genuinely runnable, not Marginal.
 fn score_fit(
     mem_required: f64,
     mem_available: f64,
@@ -630,8 +631,15 @@ fn score_fit(
             }
         }
         RunMode::CpuOnly => {
-            // CPU-only is always a compromise -- cap at Marginal
-            FitLevel::Marginal
+            // CPU-only never reaches Perfect (that requires a GPU), but a model
+            // that fits with comfortable headroom is genuinely runnable -- cap
+            // at Good rather than hiding every CPU-only model behind Marginal.
+            // (Matches the FitLevel::Good contract: "GPU tight, or CPU comfortable".)
+            if mem_available >= mem_required * 1.2 {
+                FitLevel::Good
+            } else {
+                FitLevel::Marginal
+            }
         }
     }
 }
@@ -1624,10 +1632,26 @@ mod tests {
     }
 
     #[test]
-    fn test_score_fit_cpu_caps_at_marginal() {
-        // CPU-only never reaches Perfect
+    fn test_score_fit_cpu_comfortable_is_good() {
+        // CPU-only with comfortable headroom (4 GB of 32 GB) is runnable -> Good.
+        // It never reaches Perfect (recommended 8 GB is met, but Perfect needs a GPU).
         let fit = score_fit(4.0, 32.0, 8.0, RunMode::CpuOnly);
+        assert_eq!(fit, FitLevel::Good);
+    }
+
+    #[test]
+    fn test_score_fit_cpu_tight_is_marginal() {
+        // CPU-only that only just fits (under the 1.2x headroom bar) stays Marginal.
+        let fit = score_fit(8.0, 8.5, 16.0, RunMode::CpuOnly);
         assert_eq!(fit, FitLevel::Marginal);
+    }
+
+    #[test]
+    fn test_score_fit_cpu_never_perfect() {
+        // Even with enormous headroom, CPU-only caps at Good (no GPU -> not Perfect).
+        let fit = score_fit(1.0, 64.0, 2.0, RunMode::CpuOnly);
+        assert_ne!(fit, FitLevel::Perfect);
+        assert_eq!(fit, FitLevel::Good);
     }
 
     #[test]
@@ -1674,8 +1698,10 @@ mod tests {
 
         // Should use CPU path
         assert_eq!(fit.run_mode, RunMode::CpuOnly);
-        // CPU-only caps at Marginal
-        assert_eq!(fit.fit_level, FitLevel::Marginal);
+        // CPU-only with comfortable headroom (7B in 16 GB) is runnable -> Good,
+        // and never Perfect (that requires a GPU).
+        assert_eq!(fit.fit_level, FitLevel::Good);
+        assert_ne!(fit.fit_level, FitLevel::Perfect);
     }
 
     #[test]


### PR DESCRIPTION
## Problem
`score_fit()` hard-capped **every** `RunMode::CpuOnly` model at `Marginal`:

```rust
RunMode::CpuOnly => FitLevel::Marginal, // unconditional
```

So on any machine without a detected GPU, *no* model can ever be `Perfect` or `Good` — even a 1.5B model with gigabytes of RAM to spare. The `Good` and `Perfect` fit filters are therefore **always empty** on those machines, which reads as "nothing is runnable" while `Marginal` / `All` populate fine.

This also contradicts the documented `FitLevel::Good` contract:
```rust
Good, // Fits with headroom (GPU tight, or CPU comfortable)
```
"CPU comfortable" was supposed to be `Good`, but the code never allowed it.

## Likely the real cause behind #635
In #635 the reporter (on an 8 GB machine) sees **Good/Perfect empty, Marginal/All populated**. That's exactly this behaviour: their GPU isn't being detected (`detect_apple_gpu` only matches an "Apple M*" chipset string), so every model takes the CPU-only path and is forced to `Marginal`. (The issue's *other* claims — KV-cache bloat, and `Runnable` being empty while `Marginal` isn't — don't hold up against the current code, so this PR addresses only the reproducible part. Still chasing the GPU-detection question separately on the issue.)

## Change
CPU-only still never reaches `Perfect` (that requires a GPU), but a model that fits with comfortable headroom (`>= 1.2x`, same bar as `CpuOffload` / `MoeOffload`) is now `Good`. Tight CPU-only fits stay `Marginal`.

## Tests
- `llmfit-core`: 383 passed. Updated `test_model_fit_cpu_only` (7B in 16 GB → now `Good`); added `test_score_fit_cpu_comfortable_is_good`, `test_score_fit_cpu_tight_is_marginal`, `test_score_fit_cpu_never_perfect`.
- `llmfit` (TUI): all tests pass.

Refs #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)