### PR TITLE
fix(docker): bump builder image to rust 1.95 (sysinfo MSRV)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Multi-stage build for llmfit
 # Stage 1: Build the Rust binary
-FROM rust:1.88-slim AS builder
+# rustc >= 1.95 required: sysinfo 0.39.x bumped its MSRV to 1.95.
+FROM rust:1.95-slim AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Problem
The Docker image build fails on `main`:

```
error: rustc 1.88.0 is not supported by the following package:
  sysinfo@0.39.3 requires rustc 1.95
```

`sysinfo` 0.39.x (pulled in via the recent dependabot bump) raised its MSRV to **1.95**, but the Dockerfile builder stage was still pinned to `rust:1.88-slim`.

## Fix
Bump the builder base image to `rust:1.95-slim`.

Verified locally that the exact failing command — `cargo build --release -p llmfit` — succeeds under rustc 1.95.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)