### PR TITLE
fix: pin Docker builder to bookworm to match runtime glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 # Multi-stage build for llmfit
 # Stage 1: Build the Rust binary
 # rustc >= 1.95 required: sysinfo 0.39.x bumped its MSRV to 1.95.
-FROM rust:1.95-slim AS builder
+# Pin the Debian release to match the runtime stage (bookworm). The default
+# rust:1.95-slim base tracks trixie (glibc 2.39), which links the binary
+# against symbols the bookworm runtime (glibc 2.36) does not provide, so the
+# binary fails to start with "GLIBC_2.39 not found". Keep both stages on the
+# same release so the linked glibc is always available at runtime.
+FROM rust:1.95-slim-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Problem

`docker run ghcr.io/alexsjones/llmfit` (latest / v0.9.33) fails immediately:

```
/usr/local/bin/llmfit: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

This is a fatal load-time failure, not a warning — the binary never starts, on any host. v0.9.31 worked because it predated the regression.

## Root cause

The builder stage used `rust:1.95-slim`, whose default Debian base has moved to **trixie (glibc 2.41)**. That links the release binary against `GLIBC_2.39+` symbols. The runtime stage is `debian:bookworm-slim` (**glibc 2.36**), which doesn't provide them.

Verified across images:

| Image | glibc |
|---|---|
| `debian:bookworm-slim` (runtime) | 2.36 |
| `rust:1.95-slim` (old builder → trixie) | 2.41 |
| `rust:1.95-slim-bookworm` (new builder) | 2.36 |

## Fix

Pin the builder to `rust:1.95-slim-bookworm` so both stages use glibc 2.36 and the binary only references symbols available at runtime.

Fixes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)