### PR TITLE
feat: add claim subcommand generating Kubernetes DRA ResourceClaims

### DIFF
--- a/llmfit-core/src/claim.rs
+++ b/llmfit-core/src/claim.rs
@@ -1,0 +1,282 @@
+//! Kubernetes DRA claim generation.
+//!
+//! Turns a (model, quantization, min-tok/s) target into a ResourceClaim or
+//! ResourceClaimTemplate whose CEL selector encodes the fit inequality
+//! against attributes published by the llmfit.ai DRA driver (llmfit-dra).
+//! The driver publishes physics inputs (memory capacity, bandwidth); this
+//! module inlines the model-specific constants from the database so the
+//! kube-scheduler can evaluate fit at claim time. Nothing here runs in the
+//! serving path — the output is plain YAML for kubectl/GitOps.
+
+use crate::models::LlmModel;
+
+/// Attribute/driver domain used by llmfit-dra.
+pub const DRIVER_DOMAIN: &str = "llmfit.ai";
+
+/// KV-cache / runtime headroom multiplier applied when the requested quant
+/// differs from the database entry (whose min_vram_gb already includes it).
+const WEIGHTS_HEADROOM: f64 = 1.2;
+
+#[derive(Debug, Clone)]
+pub struct ClaimTarget {
+    pub min_tps: f64,
+    /// Backend efficiency as a percentage (fit.rs default_efficiency = 0.55).
+    pub efficiency_pct: u32,
+    pub device_class: String,
+    /// Emit a ResourceClaimTemplate (for pod templates) instead of a bare
+    /// ResourceClaim.
+    pub template: bool,
+    /// Override the database entry's quantization.
+    pub quant: Option<String>,
+    /// Override the generated metadata.name.
+    pub name: Option<String>,
+}
+
+impl Default for ClaimTarget {
+    fn default() -> Self {
+        Self {
+            min_tps: 20.0,
+            efficiency_pct: 55,
+            device_class: DRIVER_DOMAIN.to_string(),
+            template: false,
+            quant: None,
+            name: None,
+        }
+    }
+}
+
+/// The two constants the CEL selector needs.
+#[derive(Debug, PartialEq)]
+pub struct FitBounds {
+    /// Device memory floor, binary gibibytes (weights + headroom).
+    pub memory_gi: u64,
+    /// Bandwidth floor in GB/s such that bw × efficiency / weights ≥ min_tps.
+    pub min_bandwidth_gbs: u64,
+    /// Weights size used for the bound, for provenance comments.
+    pub weights_gb: f64,
+    pub quant: String,
+}
+
+pub fn fit_bounds(model: &LlmModel, target: &ClaimTarget) -> Result<FitBounds, String> {
+    if target.min_tps <= 0.0 {
+        return Err("--min-tps must be > 0".to_string());
+    }
+    if target.efficiency_pct == 0 || target.efficiency_pct > 100 {
+        return Err("--efficiency must be in 1..=100".to_string());
+    }
+    let quant = target
+        .quant
+        .clone()
+        .unwrap_or_else(|| model.quantization.clone());
+    let weights_gb = model.estimate_disk_gb(&quant);
+    if weights_gb <= 0.0 {
+        return Err(format!(
+            "cannot size model '{}' (unknown parameter count)",
+            model.name
+        ));
+    }
+    // Memory floor: the database's min_vram_gb is authoritative for the
+    // entry's own quant (it already includes KV/runtime headroom); for a
+    // quant override, fall back to weights × headroom.
+    let memory_gb = if quant == model.quantization {
+        model
+            .min_vram_gb
+            .unwrap_or(model.min_ram_gb)
+            .max(weights_gb)
+    } else {
+        weights_gb * WEIGHTS_HEADROOM
+    };
+    // tok/s ≈ bandwidth × efficiency / weights  ⇒  bandwidth ≥ tps × weights / eff
+    let min_bw = target.min_tps * weights_gb * 100.0 / f64::from(target.efficiency_pct);
+    Ok(FitBounds {
+        memory_gi: memory_gb.ceil() as u64,
+        min_bandwidth_gbs: min_bw.ceil() as u64,
+        weights_gb,
+        quant,
+    })
+}
+
+/// DNS-label-safe name derived from the model name, e.g.
+/// "Qwen2.5 32B Instruct" → "qwen2-5-32b-instruct-fit".
+pub fn claim_name(model: &LlmModel) -> String {
+    let mut s: String = model
+        .name
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    while s.contains("--") {
+        s = s.replace("--", "-");
+    }
+    let s = s.trim_matches('-');
+    let mut base = s.chars().take(48).collect::<String>();
+    base = base.trim_matches('-').to_string();
+    format!("{base}-fit")
+}
+
+/// Render the claim YAML. Built as a template string (not serde) so the
+/// output carries provenance comments explaining where every constant came
+/// from — the file is meant to be committed to GitOps repos and read by
+/// humans.
+pub fn render(model: &LlmModel, target: &ClaimTarget) -> Result<String, String> {
+    let b = fit_bounds(model, target)?;
+    let name = target.name.clone().unwrap_or_else(|| claim_name(model));
+    let eff = target.efficiency_pct;
+    let ind = if target.template { "    " } else { "  " };
+    // Continuation lines must sit at exactly the block scalar's content
+    // indentation (first line = ind + 16) for clean YAML folding.
+    let pad = format!("{ind}                ");
+    let cel = format!(
+        "device.capacity['{d}'].memory.compareTo(quantity('{mem}Gi')) >= 0 &&\n\
+         {pad}device.attributes['{d}'].memoryBandwidthGBs >= {bw} &&\n\
+         {pad}device.attributes['{d}'].healthy",
+        d = DRIVER_DOMAIN,
+        mem = b.memory_gi,
+        bw = b.min_bandwidth_gbs,
+    );
+    let header = format!(
+        "# Generated by llmfit claim — do not compute these constants by hand.\n\
+         # model:  {name} ({params:.1}B params, {quant} ≈ {weights:.1} GB weights)\n\
+         # fit:    tok/s ≈ bandwidth × {eff}% / {weights:.1} GB  ⇒  bandwidth ≥ {bw} GB/s for ≥ {tps} tok/s\n\
+         # memory: ≥ {mem} Gi (weights + KV/runtime headroom)\n",
+        name = model.name,
+        params = model.params_b(),
+        quant = b.quant,
+        weights = b.weights_gb,
+        eff = eff,
+        bw = b.min_bandwidth_gbs,
+        tps = target.min_tps,
+        mem = b.memory_gi,
+    );
+    let devices = format!(
+        "devices:\n\
+         {i}  requests:\n\
+         {i}    - name: model\n\
+         {i}      exactly:\n\
+         {i}        deviceClassName: {class}\n\
+         {i}        selectors:\n\
+         {i}          - cel:\n\
+         {i}              expression: >-\n\
+         {i}                {cel}",
+        i = ind,
+        class = target.device_class,
+        cel = cel,
+    );
+    let body = if target.template {
+        format!(
+            "apiVersion: resource.k8s.io/v1\n\
+             kind: ResourceClaimTemplate\n\
+             metadata:\n\
+             \x20 name: {name}\n\
+             spec:\n\
+             \x20 spec:\n\
+             \x20   {devices}\n"
+        )
+    } else {
+        format!(
+            "apiVersion: resource.k8s.io/v1\n\
+             kind: ResourceClaim\n\
+             metadata:\n\
+             \x20 name: {name}\n\
+             spec:\n\
+             \x20 {devices}\n"
+        )
+    };
+    Ok(format!("{header}{body}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(quant: &str, min_vram: Option<f64>) -> LlmModel {
+        serde_json::from_value(serde_json::json!({
+            "name": "Test Model 7B",
+            "provider": "test",
+            "parameter_count": "7B",
+            "parameters_raw": 7_000_000_000u64,
+            "min_ram_gb": 8.0,
+            "recommended_ram_gb": 10.0,
+            "min_vram_gb": min_vram,
+            "quantization": quant,
+            "context_length": 8192,
+            "use_case": "general",
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn bounds_use_db_memory_for_entry_quant() {
+        // Q4_K_M: 7B × 0.58 bpp = 4.06 GB weights; db min_vram 6.0 wins.
+        let b = fit_bounds(&model("Q4_K_M", Some(6.0)), &ClaimTarget::default()).unwrap();
+        assert_eq!(b.memory_gi, 6);
+        // bw ≥ 20 × 4.06 / 0.55 = 147.6… → 148
+        assert_eq!(b.min_bandwidth_gbs, 148);
+        assert_eq!(b.quant, "Q4_K_M");
+    }
+
+    #[test]
+    fn bounds_apply_headroom_on_quant_override() {
+        let t = ClaimTarget {
+            quant: Some("Q8_0".to_string()),
+            ..ClaimTarget::default()
+        };
+        // Q8_0: 7B × 1.05 bpp = 7.35 GB weights; ×1.2 headroom = 8.82 → 9 Gi.
+        let b = fit_bounds(&model("Q4_K_M", Some(6.0)), &t).unwrap();
+        assert_eq!(b.memory_gi, 9);
+        assert_eq!(b.min_bandwidth_gbs, 268); // 20 × 7.35 / 0.55 = 267.3…
+    }
+
+    #[test]
+    fn bounds_reject_nonsense() {
+        assert!(
+            fit_bounds(
+                &model("Q4_K_M", None),
+                &ClaimTarget {
+                    min_tps: 0.0,
+                    ..ClaimTarget::default()
+                }
+            )
+            .is_err()
+        );
+        assert!(
+            fit_bounds(
+                &model("Q4_K_M", None),
+                &ClaimTarget {
+                    efficiency_pct: 0,
+                    ..ClaimTarget::default()
+                }
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn name_is_dns_label_safe() {
+        let mut m = model("Q4_K_M", None);
+        m.name = "Qwen2.5 32B Instruct".to_string();
+        assert_eq!(claim_name(&m), "qwen2-5-32b-instruct-fit");
+    }
+
+    #[test]
+    fn render_claim_yaml_shape() {
+        let y = render(&model("Q4_K_M", Some(6.0)), &ClaimTarget::default()).unwrap();
+        assert!(y.contains("kind: ResourceClaim\n"));
+        assert!(y.contains("name: test-model-7b-fit"));
+        assert!(y.contains("deviceClassName: llmfit.ai"));
+        assert!(y.contains("quantity('6Gi')"));
+        assert!(y.contains("memoryBandwidthGBs >= 148"));
+        assert!(y.contains(".healthy"));
+    }
+
+    #[test]
+    fn render_template_wraps_spec() {
+        let t = ClaimTarget {
+            template: true,
+            ..ClaimTarget::default()
+        };
+        let y = render(&model("Q4_K_M", None), &t).unwrap();
+        assert!(y.contains("kind: ResourceClaimTemplate\n"));
+        assert!(y.contains("spec:\n  spec:\n"));
+    }
+}

--- a/llmfit-core/src/lib.rs
+++ b/llmfit-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod analysis;
 pub mod bench;
 pub mod benchmarks;
+pub mod claim;
 pub mod fit;
 pub mod hardware;
 pub mod models;

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -204,6 +204,51 @@ AGENT USAGE:
   gpu_backend, unified_memory, os } }")]
     System,
 
+    /// Generate a Kubernetes DRA ResourceClaim encoding the model's fit
+    #[command(long_about = "\
+Generate a Kubernetes DRA ResourceClaim (or ResourceClaimTemplate) whose CEL
+selector encodes the model's fit inequality against attributes published by
+the llmfit.ai DRA driver (llmfit-dra). Constants (weights size, memory floor,
+bandwidth floor) are resolved from the model database and inlined; the YAML
+is printed on stdout with provenance comments.
+
+PRECONDITIONS:
+  None locally. Applying the output requires a cluster running llmfit-dra
+  (Kubernetes >= 1.34) with its shipped DeviceClasses.
+
+SIDE EFFECTS:
+  None — prints YAML; pipe to kubectl to apply.
+
+EXIT CODES:
+  0  Success
+  1  Unknown/ambiguous model, or invalid bounds
+
+AGENT USAGE:
+  llmfit claim qwen2.5-32b --min-tps 20 | kubectl apply -f -
+  llmfit claim mistral-7b --template > claim-template.yaml")]
+    Claim {
+        /// Model name (exact or unambiguous partial match)
+        model: String,
+        /// Minimum acceptable decode speed, tokens/second
+        #[arg(long, default_value_t = 20.0)]
+        min_tps: f64,
+        /// Override the database entry's quantization (e.g. Q4_K_M, Q8_0)
+        #[arg(long)]
+        quant: Option<String>,
+        /// Backend efficiency percentage used in the fit inequality
+        #[arg(long, default_value_t = 55)]
+        efficiency: u32,
+        /// DeviceClass the claim requests against
+        #[arg(long, default_value = "llmfit.ai")]
+        device_class: String,
+        /// Emit a ResourceClaimTemplate (for pod templates) instead of a ResourceClaim
+        #[arg(long)]
+        template: bool,
+        /// metadata.name for the generated object (default: derived from the model name)
+        #[arg(long)]
+        name: Option<String>,
+    },
+
     /// List all available LLM models
     #[command(long_about = "\
 List all available LLM models.
@@ -2505,6 +2550,35 @@ fn main() {
                     display::display_json_system(&specs);
                 } else {
                     specs.display();
+                }
+            }
+
+            Commands::Claim {
+                model,
+                min_tps,
+                quant,
+                efficiency,
+                device_class,
+                template,
+                name,
+            } => {
+                let db = ModelDatabase::new();
+                let target = llmfit_core::claim::ClaimTarget {
+                    min_tps,
+                    efficiency_pct: efficiency,
+                    device_class,
+                    template,
+                    quant,
+                    name,
+                };
+                match resolve_model_selector(db.get_all_models(), &model)
+                    .and_then(|m| llmfit_core::claim::render(m, &target))
+                {
+                    Ok(yaml) => print!("{}", yaml),
+                    Err(err) => {
+                        eprintln!("Error: {}", err);
+                        std::process::exit(1);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- New `llmfit claim <model> [--min-tps N] [--quant Q] [--efficiency PCT] [--device-class C] [--template] [--name N]` subcommand
- Resolves the model's weights size (bpp table) and bandwidth floor from the model database and emits a `ResourceClaim` (or `ResourceClaimTemplate` with `--template`) whose CEL selector encodes the fit inequality against attributes published by the llmfit.ai DRA driver ([llmfit-dra](https://github.com/sympozium-ai/llmfit-dra))
- Output is plain YAML on stdout with provenance comments — pipeable: `llmfit claim Qwen/Qwen2.5-7B --min-tps 20 | kubectl apply -f -`
- Logic lives in `llmfit_core::claim` (bounds math + rendering, 6 unit tests); the CLI arm is a thin consumer, per the probe ⋈ index philosophy

## Example output
```yaml
# Generated by llmfit claim — do not compute these constants by hand.
# model:  Qwen/Qwen2.5-7B (7.6B params, Q4_K_M ≈ 4.4 GB weights)
# fit:    tok/s ≈ bandwidth × 55% / 4.4 GB  ⇒  bandwidth ≥ 161 GB/s for ≥ 20 tok/s
# memory: ≥ 5 Gi (weights + KV/runtime headroom)
apiVersion: resource.k8s.io/v1
kind: ResourceClaim
...
```

## Testing
- `cargo test -p llmfit-core`: 389 passed
- End-to-end via llmfit-dra scenario 9 on a live kind cluster (Strix Halo/amdgpu): generated claim applies, the kube-scheduler allocates `gpu0` via the CEL, and the consuming pod reaches Running with matching CDI env

🤖 Generated with [Claude Code](https://claude.com/claude-code)