### PR TITLE
feat: serve over a Unix domain socket (--unix-socket)

### DIFF
--- a/API.md
+++ b/API.md
@@ -34,6 +34,25 @@ http://127.0.0.1:8787
 
 To expose outside localhost, pass `--host 0.0.0.0`.
 
+### Unix domain socket
+
+For same-host consumers that should not touch the network at all (e.g. a
+sidecar in a `hostNetwork` Kubernetes pod, where a TCP bind would land on the
+node's loopback), listen on a Unix socket instead:
+
+```sh
+llmfit serve --unix-socket /run/llmfit/llmfit.sock
+```
+
+The socket is created with mode `0660`; a stale socket file from a previous
+instance is replaced automatically. All HTTP endpoints are identical:
+
+```sh
+curl --unix-socket /run/llmfit/llmfit.sock http://localhost/api/v1/system
+```
+
+`--unix-socket` conflicts with `--host`/`--port` and is unix-platforms only.
+
 If you are building from source and want the dashboard embedded in `llmfit`, build web assets first:
 
 ```sh

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -727,6 +727,14 @@ AGENT USAGE:
         #[arg(long, default_value = "8787")]
         port: u16,
 
+        /// Listen on a Unix domain socket instead of TCP (unix platforms
+        /// only). Any stale socket file is replaced; the socket is created
+        /// with mode 0660. Intended for same-host/same-pod consumers (e.g.
+        /// the llmfit-dra DRA driver sidecar) where a TCP port on the host
+        /// network is undesirable.
+        #[arg(long, value_name = "PATH", conflicts_with_all = ["host", "port"])]
+        unix_socket: Option<std::path::PathBuf>,
+
         /// Run as MCP server on stdio instead of HTTP
         #[arg(long)]
         mcp: bool,
@@ -2768,6 +2776,7 @@ fn main() {
             Commands::Serve {
                 host,
                 port,
+                unix_socket,
                 mcp,
                 send_events,
                 nats_url,
@@ -2793,7 +2802,13 @@ fn main() {
                         eprintln!("NATS events enabled, publishing to {}", nats_url);
                     }
 
-                    if let Err(err) = serve_api::run_serve(&host, port, &overrides, context_limit) {
+                    if let Err(err) = serve_api::run_serve(
+                        &host,
+                        port,
+                        unix_socket.as_deref(),
+                        &overrides,
+                        context_limit,
+                    ) {
                         eprintln!("Error: {}", err);
                         std::process::exit(1);
                     }

--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -141,14 +141,10 @@ type ApiResult<T> = Result<T, ApiError>;
 pub fn run_serve(
     host: &str,
     port: u16,
+    unix_socket: Option<&std::path::Path>,
     overrides: &super::HardwareOverrides,
     context_limit: Option<u32>,
 ) -> Result<(), String> {
-    let ip: IpAddr = host
-        .parse()
-        .map_err(|_| format!("invalid --host value: '{host}'"))?;
-    let addr = SocketAddr::new(ip, port);
-
     let specs = super::detect_specs(overrides);
     let db = ModelDatabase::new();
     let all_models = db.get_all_models().clone();
@@ -170,36 +166,83 @@ pub fn run_serve(
 
     let app = build_router(state);
 
-    println!("llmfit dashboard listening on http://{}/", addr);
-    println!("  API models: http://{}/api/v1/models", addr);
-    println!("  GET /health");
-    println!("  GET /api/v1/system");
-    println!("  GET /api/v1/models?limit=20&min_fit=marginal&sort=score");
-    println!("  GET /api/v1/models/top?limit=5&use_case=coding&min_fit=good");
-    println!("  GET /api/v1/models/<name>");
-
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .map_err(|e| format!("failed to start tokio runtime: {e}"))?;
 
-    runtime
-        .block_on(async move {
-            let listener = tokio::net::TcpListener::bind(addr)
-                .await
-                .map_err(|e| ApiError::internal(format!("bind failed on {addr}: {e}")))?;
+    match unix_socket {
+        Some(path) => {
+            #[cfg(unix)]
+            {
+                println!("llmfit dashboard listening on unix://{}", path.display());
+                println!("  GET /health");
+                println!("  GET /api/v1/system");
+                println!("  GET /api/v1/models?limit=20&min_fit=marginal&sort=score");
+                runtime
+                    .block_on(async move {
+                        if let Some(parent) = path.parent() {
+                            let _ = std::fs::create_dir_all(parent);
+                        }
+                        // A stale file from a previous instance blocks bind
+                        // (the path can outlive the process, e.g. a pod
+                        // volume across container restarts).
+                        let _ = std::fs::remove_file(path);
+                        let listener = tokio::net::UnixListener::bind(path).map_err(|e| {
+                            ApiError::internal(format!("bind failed on {}: {e}", path.display()))
+                        })?;
+                        // Same-host peers only; group-accessible, not world.
+                        use std::os::unix::fs::PermissionsExt;
+                        let _ =
+                            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o660));
+                        axum::serve(listener, app.into_make_service())
+                            .with_graceful_shutdown(async {
+                                let _ = tokio::signal::ctrl_c().await;
+                            })
+                            .await
+                            .map_err(|e| ApiError::internal(format!("server error: {e}")))
+                    })
+                    .map_err(|e| e.message)
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = path;
+                Err("--unix-socket is only supported on unix platforms".to_string())
+            }
+        }
+        None => {
+            let ip: IpAddr = host
+                .parse()
+                .map_err(|_| format!("invalid --host value: '{host}'"))?;
+            let addr = SocketAddr::new(ip, port);
 
-            axum::serve(
-                listener,
-                app.into_make_service_with_connect_info::<SocketAddr>(),
-            )
-            .with_graceful_shutdown(async {
-                let _ = tokio::signal::ctrl_c().await;
-            })
-            .await
-            .map_err(|e| ApiError::internal(format!("server error: {e}")))
-        })
-        .map_err(|e| e.message)
+            println!("llmfit dashboard listening on http://{}/", addr);
+            println!("  API models: http://{}/api/v1/models", addr);
+            println!("  GET /health");
+            println!("  GET /api/v1/system");
+            println!("  GET /api/v1/models?limit=20&min_fit=marginal&sort=score");
+            println!("  GET /api/v1/models/top?limit=5&use_case=coding&min_fit=good");
+            println!("  GET /api/v1/models/<name>");
+
+            runtime
+                .block_on(async move {
+                    let listener = tokio::net::TcpListener::bind(addr)
+                        .await
+                        .map_err(|e| ApiError::internal(format!("bind failed on {addr}: {e}")))?;
+
+                    axum::serve(
+                        listener,
+                        app.into_make_service_with_connect_info::<SocketAddr>(),
+                    )
+                    .with_graceful_shutdown(async {
+                        let _ = tokio::signal::ctrl_c().await;
+                    })
+                    .await
+                    .map_err(|e| ApiError::internal(format!("server error: {e}")))
+                })
+                .map_err(|e| e.message)
+        }
+    }
 }
 
 fn build_router(state: Arc<AppState>) -> Router {


### PR DESCRIPTION
## Summary
- `llmfit serve --unix-socket <path>` serves the identical HTTP router (health, /api/v1/*) over a `tokio::net::UnixListener` instead of TCP
- Socket created `0660`; stale socket files from previous instances are replaced (restarts over persistent paths — pod volumes — just work)
- Conflicts with `--host`/`--port`; unix platforms only (clear error elsewhere)
- API.md documents the mode with a curl example

## Motivation
The llmfit-dra DRA driver is moving from shelling out to `llmfit --json system` per probe cycle to consuming the versioned REST API from a long-lived `llmfit serve` sidecar. That pod runs `hostNetwork` (its uevent listener needs the host netns), so a TCP bind — even `127.0.0.1` — lands on the **node's** loopback: port collisions and node-wide exposure. A Unix socket on a shared pod volume is invisible to the host network and access-controlled by mount topology + file modes.

## Testing
- `cargo test -p llmfit` (53 tests) green; `cargo fmt` clean
- Manual: serve over `/tmp/…sock` → `curl --unix-socket` on `/health` and `/api/v1/system` returns identical payloads to TCP; restart over the stale socket succeeds; `--unix-socket --port` rejected by clap

🤖 Generated with [Claude Code](https://claude.com/claude-code)