### PR TITLE
fix(hardware): detect generic-named MI50-class accelerators (issue #638)

### DIFF
--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -645,20 +645,37 @@ impl SystemSpecs {
         // Block format: name is after the last colon on a "Card Series" line,
         // e.g. "GPU[0] : Card Series: AMD Radeon RX 7600". The colon guard
         // avoids matching a tabular "Card Series" column header (no colon).
-        let block: Vec<String> = text
-            .lines()
-            .filter_map(|line| {
-                if line.to_lowercase().contains("card series") && line.contains(':') {
-                    line.rsplit(':')
-                        .next()
-                        .map(|n| n.trim().to_string())
-                        .filter(|n| !n.is_empty())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let mut block: Vec<String> = Vec::new();
+        let mut gfx_versions: Vec<String> = Vec::new();
+        for line in text.lines() {
+            let lower = line.to_lowercase();
+            if lower.contains("card series")
+                && line.contains(':')
+                && let Some(name) = line.rsplit(':').next().map(|n| n.trim().to_string())
+                && !name.is_empty()
+            {
+                block.push(name);
+            } else if lower.contains("gfx version")
+                && line.contains(':')
+                && let Some(gfx) = line.rsplit(':').next().map(|g| g.trim().to_string())
+                && !gfx.is_empty()
+            {
+                gfx_versions.push(gfx);
+            }
+        }
         if !block.is_empty() {
+            // Disambiguate generic series names with the GFX version when
+            // available: some accelerators (e.g. Instinct MI50/MI60) report
+            // `Card Series: AMD Radeon Graphics`, which would otherwise be
+            // indistinguishable from — and grouped with — an APU iGPU that
+            // reports the same generic name (issue #638).
+            if gfx_versions.len() == block.len() {
+                for (name, gfx) in block.iter_mut().zip(&gfx_versions) {
+                    if Self::is_integrated_gpu_name(name) {
+                        *name = format!("{name} ({gfx})");
+                    }
+                }
+            }
             return block;
         }
 
@@ -1115,7 +1132,7 @@ impl SystemSpecs {
     fn prefer_discrete_gpus(gpus: Vec<GpuInfo>) -> Vec<GpuInfo> {
         let discrete: Vec<GpuInfo> = gpus
             .iter()
-            .filter(|g| !Self::is_integrated_gpu_name(&g.name))
+            .filter(|g| !Self::is_integrated_gpu(&g.name, g.vram_gb))
             .cloned()
             .collect();
 
@@ -1125,6 +1142,24 @@ impl SystemSpecs {
         } else {
             discrete
         }
+    }
+
+    /// VRAM-aware integrated-GPU check.
+    ///
+    /// Intel iGPU product names (UHD/HD/Iris) are conclusive, but the AMD
+    /// "Radeon Graphics" pattern is ambiguous: datacenter accelerators like
+    /// the Instinct MI50/MI60 report the generic `Card Series: AMD Radeon
+    /// Graphics` through rocm-smi on some firmware. No true iGPU has this
+    /// much *dedicated* VRAM, so a large-VRAM AMD-generic device is treated
+    /// as discrete rather than dropped (issue #638).
+    fn is_integrated_gpu(name: &str, vram_gb: Option<f64>) -> bool {
+        const AMD_GENERIC_DISCRETE_VRAM_GB: f64 = 8.0;
+        if !Self::is_integrated_gpu_name(name) {
+            return false;
+        }
+        let lower = name.to_lowercase();
+        let amd_generic = lower.contains("radeon") && !lower.contains("(integrated)");
+        !(amd_generic && vram_gb.unwrap_or(0.0) >= AMD_GENERIC_DISCRETE_VRAM_GB)
     }
 
     /// Heuristic: returns true when the GPU name matches known integrated GPU
@@ -3664,5 +3699,111 @@ Device  Node  VRAM Total Memory (B)   VRAM Total Used Memory (B)
         assert_eq!(gpus.len(), 1);
         assert_eq!(gpus[0].count, 2);
         assert_eq!(gpus[0].name, "AMD GPU");
+    }
+
+    // Regression for issue #638 (keyz182): verbatim rocm-smi block output
+    // from a mixed system — a 32 GB MI50 that reports the generic
+    // `Card Series: AMD Radeon Graphics`, a 16 GB MI50 with the proper
+    // Instinct name, and a 512 MB Cezanne iGPU. The generic-named 32 GB
+    // card must survive both the iGPU VRAM filter and prefer_discrete_gpus,
+    // and must not be grouped with the iGPU that shares its generic name.
+    #[test]
+    fn test_parse_rocm_smi_mixed_mi50s_generic_name_and_igpu() {
+        let vram_text = "\
+============================ ROCm System Management Interface ============================
+================================== Memory Usage (Bytes) ==================================
+GPU[0]\t\t: VRAM Total Memory (B): 34342961152
+GPU[0]\t\t: VRAM Total Used Memory (B): 25227759616
+GPU[1]\t\t: VRAM Total Memory (B): 17163091968
+GPU[1]\t\t: VRAM Total Used Memory (B): 7695077376
+GPU[2]\t\t: VRAM Total Memory (B): 536870912
+GPU[2]\t\t: VRAM Total Used Memory (B): 18165760
+==========================================================================================
+================================== End of ROCm SMI Log ===================================";
+
+        let product_text = "\
+============================ ROCm System Management Interface ============================
+====================================== Product Info ======================================
+GPU[0]\t\t: Card Series: \t\tAMD Radeon Graphics
+GPU[0]\t\t: Card Model: \t\t0x66a0
+GPU[0]\t\t: Card Vendor: \t\tAdvanced Micro Devices, Inc. [AMD/ATI]
+GPU[0]\t\t: Card SKU: \t\tD1640200
+GPU[0]\t\t: Subsystem ID: \t0x081e
+GPU[0]\t\t: Device Rev: \t\t0x00
+GPU[0]\t\t: Node ID: \t\t1
+GPU[0]\t\t: GUID: \t\t45854
+GPU[0]\t\t: GFX Version: \t\tgfx906
+GPU[1]\t\t: Card Series: \t\tAMD Instinct MI60 / MI50
+GPU[1]\t\t: Card Model: \t\t0x66a1
+GPU[1]\t\t: Card Vendor: \t\tAdvanced Micro Devices, Inc. [AMD/ATI]
+GPU[1]\t\t: Card SKU: \t\tD1631400
+GPU[1]\t\t: Subsystem ID: \t0x0834
+GPU[1]\t\t: Device Rev: \t\t0x02
+GPU[1]\t\t: Node ID: \t\t2
+GPU[1]\t\t: GUID: \t\t28640
+GPU[1]\t\t: GFX Version: \t\tgfx906
+GPU[2]\t\t: Card Series: \t\tAMD Radeon Graphics
+GPU[2]\t\t: Card Model: \t\t0x1638
+GPU[2]\t\t: Card Vendor: \t\tAdvanced Micro Devices, Inc. [AMD/ATI]
+GPU[2]\t\t: Card SKU: \t\tCEZANNE
+GPU[2]\t\t: Subsystem ID: \t0x1636
+GPU[2]\t\t: Device Rev: \t\t0xc8
+GPU[2]\t\t: Node ID: \t\t3
+GPU[2]\t\t: GUID: \t\t48746
+GPU[2]\t\t: GFX Version: \t\tgfx90c
+==========================================================================================
+================================== End of ROCm SMI Log ===================================";
+
+        let gpus = SystemSpecs::parse_rocm_smi_output(vram_text, Some(product_text));
+
+        assert_eq!(
+            gpus.len(),
+            2,
+            "both MI50s must be detected, iGPU excluded: {gpus:?}"
+        );
+        let big = gpus
+            .iter()
+            .find(|g| g.vram_gb.unwrap_or(0.0) > 30.0)
+            .expect("32 GB MI50 missing");
+        let small = gpus
+            .iter()
+            .find(|g| {
+                let v = g.vram_gb.unwrap_or(0.0);
+                v > 15.0 && v < 17.0
+            })
+            .expect("16 GB MI50 missing");
+        // Generic name disambiguated with the GFX version.
+        assert_eq!(big.name, "AMD Radeon Graphics (gfx906)");
+        assert!(small.name.contains("MI60 / MI50"));
+
+        // The generic-named 32 GB accelerator must survive the global
+        // discrete-preference filter alongside the properly named card.
+        let filtered = SystemSpecs::prefer_discrete_gpus(gpus);
+        assert_eq!(
+            filtered.len(),
+            2,
+            "prefer_discrete_gpus must not drop a 32 GB accelerator: {filtered:?}"
+        );
+    }
+
+    #[test]
+    fn test_prefer_discrete_gpus_drops_small_generic_radeon_keeps_large() {
+        use super::GpuBackend;
+        let mk = |name: &str, vram: f64| super::GpuInfo {
+            name: name.to_string(),
+            vram_gb: Some(vram),
+            backend: GpuBackend::Rocm,
+            count: 1,
+            unified_memory: false,
+        };
+        let gpus = vec![
+            mk("AMD Radeon Graphics", 32.0), // mislabeled MI50-class accelerator
+            mk("AMD Radeon(TM) Graphics", 0.5), // true APU iGPU
+            mk("AMD Instinct MI60 / MI50", 16.0),
+        ];
+        let result = SystemSpecs::prefer_discrete_gpus(gpus);
+        assert_eq!(result.len(), 2, "{result:?}");
+        assert!(result.iter().any(|g| g.vram_gb == Some(32.0)));
+        assert!(result.iter().any(|g| g.name.contains("Instinct")));
     }
 }


### PR DESCRIPTION
## Summary
Fixes the remaining multi-GPU regression reported by @keyz182 in #638: on a mixed system (32 GB MI50 + 16 GB MI50 + Cezanne iGPU), only the 16 GB card was detected.

Root cause: the 32 GB MI50 reports `Card Series: AMD Radeon Graphics` through rocm-smi. The ROCm parser handled it fine — but the **global** `prefer_discrete_gpus` filter then classified it as an iGPU from its name alone and silently dropped it.

- `prefer_discrete_gpus` is now VRAM-aware via a new `is_integrated_gpu(name, vram)`: an AMD generic-named device with **≥ 8 GB dedicated VRAM** is discrete (no true iGPU reports that much dedicated VRAM). Intel UHD/HD/Iris names remain conclusive regardless of reported memory, preserving the Windows WMI shared-memory behavior.
- Block-format ROCm names are disambiguated with the GFX version (`AMD Radeon Graphics (gfx906)`) so a mislabeled accelerator isn't *grouped* with an APU iGPU that shares the generic name — and users can identify the silicon.
- Regression test embeds keyz182's **verbatim** `rocm-smi --showmeminfo vram` / `--showproductname` output: asserts both MI50s detected (32 GB + 16 GB), the iGPU excluded, and the generic-named card surviving `prefer_discrete_gpus`.

## Tests
- 2 new tests; full `llmfit-core` lib suite green (392 passed).
- No new clippy warnings (17 pre-existing before and after).

Closes the ROCm portion of #638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)