### PR TITLE
feat: add `llmfit doctor` hardware diagnostic report

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,10 @@ llmfit fit --perfect -n 5
 # Show detected system specs
 llmfit system
 
+# Hardware diagnostic report for bug reports (raw nvidia-smi/rocm-smi/sysfs
+# output + what llmfit detected) — paste into a GitHub issue
+llmfit doctor
+
 # List all models in the database
 llmfit list
 

--- a/llmfit-core/src/doctor.rs
+++ b/llmfit-core/src/doctor.rs
@@ -1,0 +1,249 @@
+//! Hardware diagnostic dump for bug reports.
+//!
+//! `llmfit doctor` captures the raw output of every external tool the GPU
+//! detection paths in [`crate::hardware`] shell out to, alongside what llmfit
+//! actually detected. Users paste the dump into GitHub issues; each report
+//! then doubles as a parser regression fixture (the verbatim tool output can
+//! be dropped straight into `hardware.rs` tests).
+
+use crate::hardware::SystemSpecs;
+use std::fmt::Write as _;
+
+/// Cap each captured section so a pathological tool can't flood the report.
+const MAX_SECTION_BYTES: usize = 16 * 1024;
+
+/// Run `cmd args…` and return its combined stdout/stderr, or a note that the
+/// tool is unavailable. Never fails: missing tools are part of the diagnosis.
+fn capture(cmd: &str, args: &[&str]) -> String {
+    match std::process::Command::new(cmd).args(args).output() {
+        Ok(out) => {
+            let mut text = String::new();
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if !stdout.trim().is_empty() {
+                text.push_str(stdout.trim_end());
+            }
+            if !stderr.trim().is_empty() {
+                if !text.is_empty() {
+                    text.push_str("\n--- stderr ---\n");
+                }
+                text.push_str(stderr.trim_end());
+            }
+            if text.is_empty() {
+                text = format!("(no output, exit status: {})", out.status);
+            }
+            truncate(text)
+        }
+        Err(e) => format!("(not available: {e})"),
+    }
+}
+
+fn truncate(mut text: String) -> String {
+    if text.len() > MAX_SECTION_BYTES {
+        // Truncate on a char boundary at or below the cap.
+        let mut cut = MAX_SECTION_BYTES;
+        while !text.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        text.truncate(cut);
+        text.push_str("\n… (truncated)");
+    }
+    text
+}
+
+fn section(report: &mut String, title: &str, body: &str) {
+    let _ = writeln!(report, "## {title}\n```\n{body}\n```\n");
+}
+
+/// Walk `/sys/class/drm/card*` and report the fields the sysfs detection
+/// paths read: vendor, device id, driver, and dedicated VRAM if exposed.
+fn sysfs_drm_summary() -> String {
+    let entries = match std::fs::read_dir("/sys/class/drm") {
+        Ok(e) => e,
+        Err(e) => return format!("(not available: {e})"),
+    };
+    let mut cards: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|f| f.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("card") || name.contains('-') {
+            continue;
+        }
+        let device = path.join("device");
+        let read = |f: &str| {
+            std::fs::read_to_string(device.join(f))
+                .map(|s| s.trim().to_string())
+                .unwrap_or_else(|_| "-".to_string())
+        };
+        let driver = std::fs::read_to_string(device.join("uevent"))
+            .ok()
+            .and_then(|u| {
+                u.lines()
+                    .find(|l| l.starts_with("DRIVER="))
+                    .map(|l| l.trim_start_matches("DRIVER=").to_string())
+            })
+            .unwrap_or_else(|| "-".to_string());
+        cards.push(format!(
+            "{name}: vendor={} device={} driver={driver} mem_info_vram_total={}",
+            read("vendor"),
+            read("device"),
+            read("mem_info_vram_total"),
+        ));
+    }
+    if cards.is_empty() {
+        "(no /sys/class/drm cardN entries)".to_string()
+    } else {
+        cards.sort();
+        cards.join("\n")
+    }
+}
+
+/// Build the full diagnostic report as Markdown.
+///
+/// `version` is the binary version string (core doesn't know the crate
+/// version of the caller).
+pub fn collect_diagnostics(version: &str) -> String {
+    let mut report = String::new();
+    let _ = writeln!(report, "# llmfit doctor report\n");
+    let _ = writeln!(
+        report,
+        "Paste this whole report into a GitHub issue at \
+         https://github.com/AlexsJones/llmfit/issues — the raw tool output \
+         below is what lets detection bugs become regression tests. It \
+         contains hardware model names and driver info only.\n"
+    );
+    let _ = writeln!(
+        report,
+        "- llmfit version: {version}\n- OS: {} ({})\n",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    );
+
+    // What llmfit concluded — shown first so mismatches with the raw
+    // output below are immediately visible.
+    let specs = SystemSpecs::detect();
+    section(&mut report, "Detected by llmfit", &format!("{specs:#?}"));
+
+    // NVIDIA
+    section(
+        &mut report,
+        "nvidia-smi (extended query)",
+        &capture(
+            "nvidia-smi",
+            &[
+                "--query-gpu=addressing_mode,memory.total,name",
+                "--format=csv,noheader,nounits",
+            ],
+        ),
+    );
+    section(
+        &mut report,
+        "nvidia-smi (standard query)",
+        &capture(
+            "nvidia-smi",
+            &[
+                "--query-gpu=memory.total,name",
+                "--format=csv,noheader,nounits",
+            ],
+        ),
+    );
+
+    // AMD ROCm
+    section(
+        &mut report,
+        "rocm-smi --showmeminfo vram",
+        &capture("rocm-smi", &["--showmeminfo", "vram"]),
+    );
+    section(
+        &mut report,
+        "rocm-smi --showproductname",
+        &capture("rocm-smi", &["--showproductname"]),
+    );
+
+    if cfg!(target_os = "linux") {
+        section(&mut report, "sysfs DRM cards", &sysfs_drm_summary());
+        section(&mut report, "lspci (display controllers)", &{
+            let full = capture("lspci", &["-nn"]);
+            let filtered: Vec<&str> = full
+                .lines()
+                .filter(|l| {
+                    let lower = l.to_lowercase();
+                    lower.contains("vga")
+                        || lower.contains("3d controller")
+                        || lower.contains("display controller")
+                        || lower.starts_with("(not available")
+                })
+                .collect();
+            if filtered.is_empty() {
+                "(no display controllers listed)".to_string()
+            } else {
+                filtered.join("\n")
+            }
+        });
+    }
+
+    if cfg!(target_os = "macos") {
+        section(
+            &mut report,
+            "system_profiler SPDisplaysDataType",
+            &capture("system_profiler", &["SPDisplaysDataType"]),
+        );
+    }
+
+    if cfg!(target_os = "windows") {
+        section(
+            &mut report,
+            "PowerShell Win32_VideoController",
+            &capture(
+                "powershell",
+                &[
+                    "-NoProfile",
+                    "-Command",
+                    "Get-CimInstance Win32_VideoController | Select-Object Name,AdapterRAM | ForEach-Object { $_.Name + '|' + $_.AdapterRAM }",
+                ],
+            ),
+        );
+    }
+
+    // Vulkan (fallback path on Linux/Windows) and NPUs — cheap to include
+    // everywhere; reported as unavailable where the tool is missing.
+    section(
+        &mut report,
+        "vulkaninfo --summary",
+        &capture("vulkaninfo", &["--summary"]),
+    );
+    section(&mut report, "npu-smi info", &capture("npu-smi", &["info"]));
+
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capture_missing_tool_is_note_not_panic() {
+        let out = capture("definitely-not-a-real-tool-xyz", &[]);
+        assert!(out.starts_with("(not available:"), "{out}");
+    }
+
+    #[test]
+    fn test_truncate_caps_section_and_marks_it() {
+        let big = "x".repeat(MAX_SECTION_BYTES + 100);
+        let out = truncate(big);
+        assert!(out.len() <= MAX_SECTION_BYTES + 20);
+        assert!(out.ends_with("(truncated)"));
+    }
+
+    #[test]
+    fn test_report_contains_key_sections() {
+        let report = collect_diagnostics("0.0.0-test");
+        assert!(report.contains("# llmfit doctor report"));
+        assert!(report.contains("llmfit version: 0.0.0-test"));
+        assert!(report.contains("## Detected by llmfit"));
+        assert!(report.contains("## rocm-smi --showmeminfo vram"));
+        assert!(report.contains("## nvidia-smi (extended query)"));
+    }
+}

--- a/llmfit-core/src/lib.rs
+++ b/llmfit-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod analysis;
 pub mod bench;
 pub mod benchmarks;
 pub mod claim;
+pub mod doctor;
 pub mod fit;
 pub mod hardware;
 pub mod models;

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -204,6 +204,31 @@ AGENT USAGE:
   gpu_backend, unified_memory, os } }")]
     System,
 
+    /// Print a hardware diagnostic report for bug reports
+    #[command(long_about = "\
+Print a hardware diagnostic report for GitHub bug reports.
+
+Captures the raw output of every external tool GPU detection shells out to
+(nvidia-smi, rocm-smi, sysfs, lspci, system_profiler, WMI, vulkaninfo,
+npu-smi) alongside what llmfit actually detected, so detection bugs can be
+reproduced — and turned into regression tests — from the report alone.
+
+PRECONDITIONS:
+  None. Missing tools are reported as unavailable, which is itself useful.
+
+SIDE EFFECTS:
+  None — read-only. Output contains hardware model names and driver info
+  only; no hostnames, usernames, or serial numbers.
+
+EXIT CODES:
+  0  Success
+
+AGENT USAGE:
+  llmfit doctor > llmfit-doctor.md
+
+  Output is Markdown; attach or paste it into a GitHub issue.")]
+    Doctor,
+
     /// Generate a Kubernetes DRA ResourceClaim encoding the model's fit
     #[command(long_about = "\
 Generate a Kubernetes DRA ResourceClaim (or ResourceClaimTemplate) whose CEL
@@ -2559,6 +2584,13 @@ fn main() {
                 } else {
                     specs.display();
                 }
+            }
+
+            Commands::Doctor => {
+                print!(
+                    "{}",
+                    llmfit_core::doctor::collect_diagnostics(env!("CARGO_PKG_VERSION"))
+                );
             }
 
             Commands::Claim {


### PR DESCRIPTION
## Summary
Adds a `llmfit doctor` subcommand that prints a Markdown diagnostic report for bug reports: llmfit version, OS/arch, the fully detected `SystemSpecs`, and the **raw output of every tool the detection paths shell out to** — `nvidia-smi` (both query forms), `rocm-smi --showmeminfo vram` / `--showproductname`, a sysfs DRM card walk (vendor/device/driver/VRAM), filtered `lspci -nn`, `system_profiler` (macOS), `Win32_VideoController` via PowerShell (Windows), `vulkaninfo --summary`, and `npu-smi info`.

## Why
Hardware detection is the project's biggest recurring bug category (#638, #609, #303, #175, …) and each fix so far has been reconstructed from partial snippets users happened to paste — #638 literally regressed on a second GPU topology after the first fix. With `doctor`, one command captures everything needed to reproduce a detection bug, and the verbatim tool output drops straight into `hardware.rs` fixture tests (as just done for #638 in #674). Missing tools are reported as unavailable, which is itself diagnostic.

- Sections are capped at 16 KB so a pathological tool can't flood the report.
- Read-only; contains hardware/driver names only.
- README CLI section documents it.

## Tests
3 unit tests (missing-tool capture, section truncation, report structure); verified end-to-end on this machine (`llmfit doctor` produces the full report). Core suite: 397 passed. No new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)