### PR TITLE
ci: release-please token fallback (RELEASE_TOKEN → GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,10 +13,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # RELEASE_TOKEN (a PAT) lets CI run on the release PR; fall back to the
+      # default workflow token when the secret isn't configured. `secrets`
+      # can't be referenced in job-level `if:` conditions, so the fallback
+      # lives in the expression itself (unset secret == empty == falsy).
       - uses: googleapis/release-please-action@v5.0.0
         id: release
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -24,7 +28,7 @@ jobs:
         if: steps.release.outputs.pr
         with:
           ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Update Cargo.lock
         if: steps.release.outputs.pr


### PR DESCRIPTION
Uses `${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` in both token inputs so the workflow works whether or not the `RELEASE_TOKEN` PAT secret is configured.

Context: a job-level `if: secrets.RELEASE_TOKEN == ''` is invalid — the `secrets` context isn't available in job-level `if:` conditions (only `github`, `needs`, `vars`, `inputs`), which produces the "Unrecognized named-value: 'secrets'" workflow validation error. The `||` fallback inside `with:` achieves the same intent without an `if`.

Note: when the fallback `GITHUB_TOKEN` is used, CI won't auto-trigger on release-please's PRs (GitHub suppresses workflow runs from the default token) — that's the reason RELEASE_TOKEN exists; the fallback just keeps the workflow from failing when it's absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)