### PR TITLE
chore: refresh localmaxxing benchmark cache (384 → 448 measurements)

### DIFF
--- a/llmfit-core/data/benchmark_cache.json
+++ b/llmfit-core/data/benchmark_cache.json
@@ -1,5 +1,5 @@
 {
-  "scraped_at": "2026-06-23T11:17:24Z",
+  "scraped_at": "2026-07-03T05:29:36Z",
   "presets": {
     "RTX 5090 (32 GB)": {
       "rows": [
@@ -30,7 +30,7 @@
             "displayName": "NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
             "family": null,
             "params": 32,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -93,7 +93,7 @@
             "displayName": "NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
             "family": null,
             "params": 32,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -193,6 +193,69 @@
           "myEmoji": null
         },
         {
+          "id": "cmqzl6kti02q2oe01l9sp10zx",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 1,
+          "tokSOut": 252.6,
+          "tokSPrefill": 1,
+          "tokSTotal": null,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T19:04:05.862Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "ollama run",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "deepreinforce-ai/Ornith-1.0-35B-GGUF",
+            "displayName": "Ornith-1.0-35B-GGUF",
+            "family": null,
+            "params": 35,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5090",
+            "gpuCount": 1,
+            "vramGb": 32,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "Ryzen 7 3700X",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "ollama",
+            "engineVersion": null,
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmofsls3m0004kz040gg4rw88",
+            "username": "rubysuelocal-rgb",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
+          "rank": 4,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
           "id": "cmp4l1szd0016ql01ya8wbyv9",
           "contextLength": 262144,
           "prefillTokens": null,
@@ -219,7 +282,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -251,7 +314,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 4,
+          "rank": 5,
           "reactionCounts": {
             "fire": 1
           },
@@ -284,7 +347,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -316,7 +379,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 5,
+          "rank": 6,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -379,7 +442,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 6,
+          "rank": 7,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -445,7 +508,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 7,
+          "rank": 8,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -476,7 +539,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -508,7 +571,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 8,
+          "rank": 9,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -539,7 +602,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -571,7 +634,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 9,
+          "rank": 10,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -634,7 +697,73 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 10,
+          "rank": 11,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqyxx9c901nyoe01tdp4i4hx",
+          "contextLength": 200000,
+          "prefillTokens": 50,
+          "batchSize": 1,
+          "ttftMs": 78,
+          "tokSOut": 207.6,
+          "tokSPrefill": 712.6,
+          "tokSTotal": 202.2,
+          "peakVramGb": 30.2,
+          "createdAt": "2026-06-29T08:12:59.914Z",
+          "notes": "Did couple runs and hits 190 to 205t/s as total t/s. Windows eats 2Gb Vram on default.\nprompt was \"Write a Python function that calculates the Fibonacci sequence up to the nth number. Include type hints and docstrings. Then explain the time complexity.\" with output cut when 2048 tokens hit.",
+          "engineFlags": {
+            "commandSnippet": "llama-server.exe -m \"E:/LLM/gemma-4-31B-it-qat-UD-Q4_K_XL.gguf\" --model-draft \"E:/LLM/draft/mtp-gemma-4-31B-it.gguf\" --mmproj \"E:/LLM/mmproj-F16_gat.gguf\" --spec-type draft-mtp --spec-draft-n-max 8 --spec-draft-n-min 3 --port 8080 -ngl all --spec-draft-ngl all -b 2048 -ub 256 --ctx-size 200000  --cache-type-k q5_0 --cache-type-v q5_0 --flash-attn on --cache-ram 0 --jinja --no-mmap --mlock --no-host --metrics --log-timestamps --log-prefix --log-colors off --reasoning off \n",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": "auto",
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": true,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "unsloth/gemma-4-31B-it-qat-GGUF",
+            "displayName": "gemma-4-31B-it-qat-GGUF",
+            "family": "Gemma",
+            "params": 31,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-31B-it-qat-q4_0-unquantized",
+              "displayName": "gemma-4-31B-it-qat-q4_0-unquantized"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5090",
+            "gpuCount": 1,
+            "vramGb": 32,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "Ryzen 7 3700X",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "_beellama-preview-v0.3.2-bin-win-cuda-13.1-x64",
+            "quantization": "Q4_K_XL",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqywampi01kvoe011uhto9nb",
+            "username": "Raitzi56",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
+          "rank": 12,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -700,7 +829,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 11,
+          "rank": 13,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -731,7 +860,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -763,7 +892,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 12,
+          "rank": 14,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -829,7 +958,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 13,
+          "rank": 15,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -860,7 +989,7 @@
             "displayName": "GLM-4.7-Flash",
             "family": null,
             "params": 31,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -892,7 +1021,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 14,
+          "rank": 16,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -923,7 +1052,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -955,7 +1084,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 15,
+          "rank": 17,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -986,7 +1115,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -1018,7 +1147,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 16,
+          "rank": 18,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1049,7 +1178,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -1081,7 +1210,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 17,
+          "rank": 19,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1112,7 +1241,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -1144,7 +1273,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 18,
+          "rank": 20,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1210,7 +1339,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 19,
+          "rank": 21,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1276,7 +1405,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 20,
+          "rank": 22,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1342,7 +1471,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 21,
+          "rank": 23,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1408,7 +1537,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 22,
+          "rank": 24,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1474,7 +1603,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 23,
+          "rank": 25,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1540,7 +1669,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 24,
+          "rank": 26,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1606,7 +1735,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 25,
+          "rank": 27,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1672,7 +1801,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 26,
+          "rank": 28,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1738,7 +1867,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 27,
+          "rank": 29,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1804,7 +1933,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 28,
+          "rank": 30,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1867,7 +1996,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 29,
+          "rank": 31,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1930,7 +2059,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 30,
+          "rank": 32,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -1993,7 +2122,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 31,
+          "rank": 33,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -2056,7 +2185,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 32,
+          "rank": 34,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -2119,7 +2248,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 33,
+          "rank": 35,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -2182,7 +2311,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 34,
+          "rank": 36,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -2248,7 +2377,73 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 35,
+          "rank": 37,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr12irkh010eld01w7zjfjld",
+          "contextLength": 148000,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 66.9,
+          "tokSPrefill": null,
+          "tokSTotal": 88.2,
+          "peakVramGb": 27.78,
+          "createdAt": "2026-06-30T19:57:14.129Z",
+          "notes": "Official NVIDIA NVFP4 quant of Qwen3.6-27B (modelopt v0.45 MIXED_PRECISION: MLP W4A16_NVFP4, attention FP8, calibrated FP8 KV). vLLM 0.24.0, single-stream (max-num-seqs=1), no spec-decode, max-model-len 148000. Median of 3 (2 warmups), 163-tok prompt / 512 out, client-observed HTTP timing. On consumer Blackwell sm_120 the W4A16 MLP rides the Marlin dequant path (no native FP4 GEMM for weight-only 4-bit). Display attached to the 5090 (~10% pstate cost). tokSOut=decode throughput.",
+          "engineFlags": {
+            "commandSnippet": "vllm serve nvidia/Qwen3.6-27B-NVFP4 --quantization modelopt --gpu-memory-utilization 0.88 --max-model-len 148000 --max-num-seqs 1 --max-num-batched-tokens 2048 --hf-overrides '{\"language_model_only\": true}' --enable-prefix-caching --reasoning-parser qwen3 --port 8000",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": "fp8",
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "nvidia/Qwen3.6-27B-NVFP4",
+            "displayName": "Qwen3.6-27B-NVFP4",
+            "family": "Qwen",
+            "params": 28,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-27B",
+              "displayName": "Qwen3.6-27B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5090",
+            "gpuCount": 1,
+            "vramGb": 32,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "Ryzen 7 3700X",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "vllm",
+            "engineVersion": "0.24.0",
+            "quantization": "NVFP4 modelopt-mixed W4A16+FP8",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmof7gocp0015gv041vcnngqj",
+            "username": "Skiipy",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
+          "rank": 38,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -2314,7 +2509,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 36,
+          "rank": 39,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -2380,7 +2575,7 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 37,
+          "rank": 40,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -2443,7 +2638,73 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 38,
+          "rank": 41,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr2iwjkx06copi01sghfjxa7",
+          "contextLength": 131072,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 384.6501670777798,
+          "tokSOut": 55.0032779122321,
+          "tokSPrefill": 969.479676911928,
+          "tokSTotal": null,
+          "peakVramGb": null,
+          "createdAt": "2026-07-01T20:23:36.993Z",
+          "notes": "Automated import from local Hermes benchmark JSON nvidia-Qwen3.6-27B-NVFP4-vllm0.24.0-20260630-152900.json. tokSOut/tokSPrefill are medians from matched prompts; TTFT is from the streaming case. Temperature 0 benchmark requests. FlashInfer sampler disabled in launcher; TRITON_ATTN/CUTLASS path. Local filesystem paths redacted from commandSnippet.",
+          "engineFlags": {
+            "commandSnippet": "vllm serve nvidia/Qwen3.6-27B-NVFP4 --served-model-name nvidia/Qwen3.6-27B-NVFP4 --generation-config vllm --max-model-len 131072 --max-num-seqs 64 --gpu-memory-utilization 0.90 --kv-cache-dtype fp8 --attention-backend TRITON_ATTN --linear-backend cutlass --moe-backend cutlass --language-model-only --trust-remote-code",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": "fp8",
+            "attentionBackend": "TRITON_ATTN",
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "nvidia/Qwen3.6-27B-NVFP4",
+            "displayName": "Qwen3.6-27B-NVFP4",
+            "family": "Qwen",
+            "params": 28,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-27B",
+              "displayName": "Qwen3.6-27B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5090",
+            "gpuCount": 1,
+            "vramGb": 32,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "Ryzen 7 3700X",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "vllm",
+            "engineVersion": "0.24.0",
+            "quantization": "NVFP4",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmr2he5mf06bxpi01w9w860we",
+            "username": "thetom",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
+          "rank": 42,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -2506,7 +2767,73 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 39,
+          "rank": 43,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr2iwjvn06cspi01jphtk06h",
+          "contextLength": 131072,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 1041.522165993229,
+          "tokSOut": 51.20383359063977,
+          "tokSPrefill": 1988.673221259261,
+          "tokSTotal": null,
+          "peakVramGb": null,
+          "createdAt": "2026-07-01T20:23:37.380Z",
+          "notes": "Automated import from local Hermes benchmark JSON hermes-benchmark-results-llamacpp-nvfp4/nvidia-Qwen3.6-27B-NVFP4-llamacpp-20260630-154200.json. Converted GGUF from local HF checkpoint. tokSOut/tokSPrefill are medians from matched prompts; TTFT is from the streaming case. Temperature 0 benchmark requests. Local filesystem paths redacted from commandSnippet.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m Qwen3.6-27B-NVFP4.gguf --host 0.0.0.0 --port 8003 -ngl 999 -c 131072 -fa on -ctk q8_0 -ctv turbo4 --jinja --chat-template-kwargs {enable_thinking:false} --reasoning off --reasoning-budget 0 --no-mmap -b 4096 -ub 512 -np 1",
+            "tensorParallel": null,
+            "gpuLayers": 999,
+            "kvCacheDtype": "q8_0",
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "nvidia/Qwen3.6-27B-NVFP4",
+            "displayName": "Qwen3.6-27B-NVFP4",
+            "family": "Qwen",
+            "params": 28,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-27B",
+              "displayName": "Qwen3.6-27B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5090",
+            "gpuCount": 1,
+            "vramGb": 32,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "Ryzen 7 3700X",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "NVFP4",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmr2he5mf06bxpi01w9w860we",
+            "username": "thetom",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
+          "rank": 44,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -2572,15 +2899,396 @@
           },
           "hardwareGroupLabel": "RTX 5090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
-          "rank": 40,
+          "rank": 45,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqvtbfc902z7qr013snr3okd",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 250,
+          "tokSOut": 38,
+          "tokSPrefill": 1500,
+          "tokSTotal": 60,
+          "peakVramGb": 64,
+          "createdAt": "2026-06-27T03:40:44.265Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "hf",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "google/gemma-4-31B-it",
+            "displayName": "gemma-4-31B-it",
+            "family": "Gemma",
+            "params": 33,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-31B",
+              "displayName": "gemma-4-31B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5090",
+            "gpuCount": 1,
+            "vramGb": 32,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "Ryzen 7 3700X",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q8_0",
+            "backend": "cpu"
+          },
+          "user": {
+            "id": "cmqvsex2402xvqr01b5ythrjp",
+            "username": "sergoabe",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
+          "rank": 46,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqvsv3rn02ylqr0134tdp4f2",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 200,
+          "tokSOut": 20,
+          "tokSPrefill": 1200,
+          "tokSTotal": 30,
+          "peakVramGb": 16,
+          "createdAt": "2026-06-27T03:28:02.772Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "hf",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.6-27B",
+            "displayName": "Qwen3.6-27B",
+            "family": "Qwen",
+            "params": 28,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5090",
+            "gpuCount": 1,
+            "vramGb": 32,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "Ryzen 7 3700X",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "ollama",
+            "engineVersion": null,
+            "quantization": "Q8_0",
+            "backend": "cpu"
+          },
+          "user": {
+            "id": "cmqvsex2402xvqr01b5ythrjp",
+            "username": "sergoabe",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5090",
+          "rank": 47,
           "reactionCounts": {},
           "myEmoji": null
         }
       ],
-      "total": 40
+      "total": 47
     },
     "RTX 5080 (16 GB)": {
       "rows": [
+        {
+          "id": "cmqzbtn8902hsoe012ipenqyw",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 14.3,
+          "tokSOut": 448.11,
+          "tokSPrefill": 35896.7,
+          "tokSTotal": 2134,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:42:05.913Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/maxious/llama-master/build-cuda/bin/llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/Llama-3.2-1B.Q8_0.gguf -p 512 -n 128 -fa 1",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "meta-llama/Llama-3.2-1B-Instruct",
+            "displayName": "Llama-3.2-1B-Instruct",
+            "family": "Llama",
+            "params": 1,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q8_0",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 1,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzbysgw02iboe0142t8ebme",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 48.4,
+          "tokSOut": 222.39,
+          "tokSPrefill": 10586.3,
+          "tokSTotal": 1025.8,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:46:05.984Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/maxious/llama-master/build-cuda/bin/llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/gpt-oss-20b-Q8_0.gguf -p 512 -n 128 -fa 1",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "openai/gpt-oss-20b",
+            "displayName": "gpt-oss-20b",
+            "family": "Gpt",
+            "params": 22,
+            "isMoE": true,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q8_0",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 2,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzbuxf902hyoe01vx1nde7k",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 81.2,
+          "tokSOut": 201.59,
+          "tokSPrefill": 6305.88,
+          "tokSTotal": 893.7,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:43:05.782Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/maxious/llama-master/build-cuda/bin/llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/llama-2-7b.Q2_K.gguf -p 512 -n 128 -fa 1",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "meta-llama/Llama-2-7b-hf",
+            "displayName": "Llama-2-7b-hf",
+            "family": "Llama",
+            "params": 7,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q2_K",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 3,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzc037h02ihoe01s9bopvme",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 117.4,
+          "tokSOut": 187.57,
+          "tokSPrefill": 4361.22,
+          "tokSTotal": 800.2,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:47:06.558Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/maxious/llama-master/build-cuda/bin/llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/Qwen3.6-35B-A3B-APEX-MTP-I-Mini.gguf -p 512 -n 128 -fa 1",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.6-35B-A3B",
+            "displayName": "Qwen3.6-35B-A3B",
+            "family": "Qwen",
+            "params": 36,
+            "isMoE": true,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "APEX-MTP-I-Mini",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 4,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
         {
           "id": "cmolpeunj000el2045o540qlc",
           "contextLength": 131072,
@@ -2608,7 +3316,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -2640,12 +3348,456 @@
           },
           "hardwareGroupLabel": "RTX 5080",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
-          "rank": 1,
+          "rank": 5,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzbw7x802i3oe015d8ps3i2",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 60.7,
+          "tokSOut": 148.35,
+          "tokSPrefill": 8429.6,
+          "tokSTotal": 693,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:44:06.044Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/maxious/llama-master/build-cuda/bin/llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/Meta-Llama-3-8B-Instruct-Q4_0.gguf -p 512 -n 128 -fa 1",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "meta-llama/Meta-Llama-3-8B-Instruct",
+            "displayName": "Meta-Llama-3-8B-Instruct",
+            "family": "Llama",
+            "params": 8,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_0",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 6,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzc586s02ivoe01ci25u28c",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 67.4,
+          "tokSOut": 142.540208,
+          "tokSPrefill": 7601.499711,
+          "tokSTotal": 663,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:51:06.293Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/Meta-Llama-3-8B-Instruct-Q4_0.gguf -p 512 -n 128 -d 2048 -o json",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "meta-llama/Meta-Llama-3-8B-Instruct",
+            "displayName": "Meta-Llama-3-8B-Instruct",
+            "family": "Llama",
+            "params": 8,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_0",
+            "backend": null
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 7,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzc6hz802j0oe01bdebz72l",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 72.9,
+          "tokSOut": 135.00005,
+          "tokSPrefill": 7025.115985,
+          "tokSTotal": 626.8,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:52:05.637Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/Meta-Llama-3-8B-Instruct-Q4_0.gguf -p 512 -n 128 -d 4096 -o json",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "meta-llama/Meta-Llama-3-8B-Instruct",
+            "displayName": "Meta-Llama-3-8B-Instruct",
+            "family": "Llama",
+            "params": 8,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_0",
+            "backend": null
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 8,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzc7sjb02j5oe012cqu2jcn",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 86,
+          "tokSOut": 123.94137,
+          "tokSPrefill": 5951.850186,
+          "tokSTotal": 572.1,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:53:05.976Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/Meta-Llama-3-8B-Instruct-Q4_0.gguf -p 512 -n 128 -d 8192 -o json",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "meta-llama/Meta-Llama-3-8B-Instruct",
+            "displayName": "Meta-Llama-3-8B-Instruct",
+            "family": "Llama",
+            "params": 8,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_0",
+            "backend": null
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 9,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzc3y5p02iqoe01vbb3fxqf",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 120.8,
+          "tokSOut": 105.319416,
+          "tokSPrefill": 4237.621905,
+          "tokSTotal": 479,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:50:06.638Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/Meta-Llama-3-8B-Instruct-Q4_0.gguf -p 512 -n 128 -d 16384 -o json",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "meta-llama/Meta-Llama-3-8B-Instruct",
+            "displayName": "Meta-Llama-3-8B-Instruct",
+            "family": "Llama",
+            "params": 8,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_0",
+            "backend": null
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 10,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzbxhuf02i8oe01hp1zn8kp",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 81.5,
+          "tokSOut": 79.63,
+          "tokSPrefill": 6285.85,
+          "tokSTotal": 378.9,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:45:05.559Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/maxious/llama-master/build-cuda/bin/llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/Qwopus3.5-9B-Coder-MTP-Q8_0.gguf -p 512 -n 128 -fa 1",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.5-9B",
+            "displayName": "Qwen3.5-9B",
+            "family": "Qwen",
+            "params": 9,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.5-9B-Base",
+              "displayName": "Qwen3.5-9B-Base"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q8_0",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 11,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzc92o002jaoe017h8htgvi",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 251.6,
+          "tokSOut": 79.464004,
+          "tokSPrefill": 2034.997834,
+          "tokSTotal": 343.6,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T14:54:05.760Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m /run/media/maxious/6C4A1C714A1C39F2/koboldcpp/Meta-Llama-3-8B-Instruct-Q4_0.gguf -p 512 -n 128 -d 32768 -o json",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "meta-llama/Meta-Llama-3-8B-Instruct",
+            "displayName": "Meta-Llama-3-8B-Instruct",
+            "family": "Llama",
+            "params": 8,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 5080",
+            "gpuCount": 1,
+            "vramGb": 16,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 9800X3D 8-Core Processor",
+            "os": "Ubuntu 26.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_0",
+            "backend": null
+          },
+          "user": {
+            "id": "cmqz5ajcj024roe01nncjtqug",
+            "username": "maxiosu",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 5080",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 5080",
+          "rank": 12,
           "reactionCounts": {},
           "myEmoji": null
         }
       ],
-      "total": 1
+      "total": 12
     },
     "RTX 4090 (24 GB)": {
       "rows": [
@@ -2874,7 +4026,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -2937,7 +4089,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -4230,6 +5382,137 @@
     "RTX 3090 (24 GB)": {
       "rows": [
         {
+          "id": "cmr1w30ik01lald01jc64n2to",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 666.67,
+          "tokSPrefill": 26185.13,
+          "tokSTotal": null,
+          "peakVramGb": null,
+          "createdAt": "2026-07-01T09:44:47.708Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "LiquidAI/LFM2.5-1.2B-Instruct-GGUF",
+            "displayName": "LFM2.5-1.2B-Instruct-GGUF",
+            "family": "Llama",
+            "params": 1,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "LiquidAI/LFM2.5-1.2B-Instruct",
+              "displayName": "LFM2.5-1.2B-Instruct"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 1,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_K_M",
+            "backend": null
+          },
+          "user": {
+            "id": "cmr1thkb201jnld015tybcisv",
+            "username": "KruxOS",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 1,
+          "reactionCounts": {
+            "fire": 1
+          },
+          "myEmoji": null
+        },
+        {
+          "id": "cmqwkq5tz03jrqr012wkfy7f3",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 23,
+          "tokSOut": 365.49,
+          "tokSPrefill": null,
+          "tokSTotal": null,
+          "peakVramGb": 22.3,
+          "createdAt": "2026-06-27T16:28:01.415Z",
+          "notes": "Code prompt (800 max tokens).",
+          "engineFlags": {
+            "commandSnippet": "python3 -m sglang.launch_server --model-path baidu/Unlimited-OCR --port 30001 --host 0.0.0.0",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "baidu/Unlimited-OCR",
+            "displayName": "Unlimited-OCR",
+            "family": null,
+            "params": 3,
+            "isMoE": true,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 1,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "sglang",
+            "engineVersion": null,
+            "quantization": "fp16",
+            "backend": null
+          },
+          "user": {
+            "id": "cmqwjykcz03itqr01d9grslvl",
+            "username": "AlphaGrit",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 2,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
           "id": "cmp4dpnef00c4pc01awn43jqk",
           "contextLength": 163840,
           "prefillTokens": null,
@@ -4291,10 +5574,76 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 1,
+          "rank": 3,
           "reactionCounts": {
             "fire": 1
           },
+          "myEmoji": null
+        },
+        {
+          "id": "cmqrwecvn00hnqr0107l5m9m0",
+          "contextLength": 262144,
+          "prefillTokens": 0,
+          "batchSize": 1,
+          "ttftMs": 1675.36,
+          "tokSOut": 177.55,
+          "tokSPrefill": null,
+          "tokSTotal": 136.73,
+          "peakVramGb": null,
+          "createdAt": "2026-06-24T09:55:55.188Z",
+          "notes": "DiffusionGemma 26B A4B FP8 dynamic on 2x RTX 3090 via vLLM, tensor parallel 2, full 262144 context, single streaming request, 5 measured 1000-token runs after 1 warmup. PCIe 3.0 host, no NVLink. Performance-window run with GPU power autotune paused and GPUs 8-9 at 280W during a UK heatwave; normal 60C cooling policy throttled this setup, so more testing is planned when ambient temperatures improve.",
+          "engineFlags": {
+            "commandSnippet": "vllm serve RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic --served-model-name diffusiongemma-26b-a4b --trust-remote-code --tensor-parallel-size 2 --max-model-len 262144 --gpu-memory-utilization 0.82 --max-num-seqs 1 --max-num-batched-tokens 2048 --enforce-eager --kv-cache-dtype auto --attention-backend TRITON_ATTN",
+            "tensorParallel": 2,
+            "gpuLayers": null,
+            "kvCacheDtype": "auto",
+            "attentionBackend": "TRITON_ATTN",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic",
+            "displayName": "diffusiongemma-26B-A4B-it-FP8-dynamic",
+            "family": "Gemma",
+            "params": 26,
+            "isMoE": true,
+            "baseModel": {
+              "hfId": "google/diffusiongemma-26B-A4B-it",
+              "displayName": "diffusiongemma-26B-A4B-it"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "vllm",
+            "engineVersion": "0.22.1rc1.dev357+g74b5964f0",
+            "quantization": "FP8 dynamic",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmoq9dv9j0004jo04acsuadcp",
+            "username": "Mattsav",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 4,
+          "reactionCounts": {},
           "myEmoji": null
         },
         {
@@ -4324,7 +5673,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -4356,7 +5705,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 2,
+          "rank": 5,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -4422,7 +5771,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 3,
+          "rank": 6,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -4453,7 +5802,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -4485,7 +5834,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 4,
+          "rank": 7,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -4551,7 +5900,7 @@
           },
           "hardwareGroupLabel": "RTX 3090 Ti",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090 ti",
-          "rank": 5,
+          "rank": 8,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -4582,7 +5931,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -4614,7 +5963,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 6,
+          "rank": 9,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -4680,7 +6029,73 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 7,
+          "rank": 10,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr2l2fml06gzpi017d27my3h",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 248.07,
+          "tokSOut": 144.39,
+          "tokSPrefill": 2063.93,
+          "tokSTotal": null,
+          "peakVramGb": 2.17,
+          "createdAt": "2026-07-01T21:24:11.038Z",
+          "notes": "Benchmarked using llama-cpp-python v0.3.29 on Windows 11 with LiquidAI LFM2.5-230M-GGUF.",
+          "engineFlags": {
+            "commandSnippet": "python benchmark_lfm.py",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": false,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "LiquidAI/LFM2.5-230M",
+            "displayName": "LFM2.5-230M",
+            "family": null,
+            "params": 0,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "LiquidAI/LFM2.5-230M-Base",
+              "displayName": "LFM2.5-230M-Base"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 1,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "0.3.29",
+            "quantization": "Q4_K_M",
+            "backend": null
+          },
+          "user": {
+            "id": "cmr2k8drq06fwpi010stmfgjl",
+            "username": "DJLougen",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 11,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -4743,7 +6158,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 8,
+          "rank": 12,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -4806,7 +6221,7 @@
           },
           "hardwareGroupLabel": "RTX 3090 Ti",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090 ti",
-          "rank": 9,
+          "rank": 13,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -4837,7 +6252,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -4869,7 +6284,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 10,
+          "rank": 14,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -4935,7 +6350,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 11,
+          "rank": 15,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5001,7 +6416,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 12,
+          "rank": 16,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5032,7 +6447,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -5064,7 +6479,136 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 13,
+          "rank": 17,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqw5k4t4039gqr014q060hv2",
+          "contextLength": 262144,
+          "prefillTokens": 0,
+          "batchSize": 1,
+          "ttftMs": 86.39,
+          "tokSOut": 136.5,
+          "tokSPrefill": null,
+          "tokSTotal": 134.91,
+          "peakVramGb": null,
+          "createdAt": "2026-06-27T09:23:25.912Z",
+          "notes": "Ornith-1.0 35B GGUF Q4_K_M on 2x RTX 3090 via llama.cpp CUDA, full 262144 context, q4_0 KV cache, flash-attn, no prompt cache, single streaming request, 5 measured 1000-token runs after 1 warmup, no-thinking template forced with chat_template_kwargs enable_thinking=false. layer split 1,1. Performance-window run with GPU power autotune paused and test GPUs capped at 350W. Peak temperatures were 81C and 79C; no hardware slowdown and only one software thermal sample observed. PCIe 3.0 host, no NVLink.",
+          "engineFlags": {
+            "commandSnippet": "llama-server --model ornith-1.0-35b-Q4_K_M.gguf --ctx-size 262144 --cache-type-k q4_0 --cache-type-v q4_0 --parallel 1 --batch-size 1024 --ubatch-size 256 --flash-attn on --n-gpu-layers 999 --split-mode layer --tensor-split 1,1 --jinja --reasoning-format deepseek --reasoning auto --no-cache-prompt --cache-ram 0",
+            "tensorParallel": 2,
+            "gpuLayers": 999,
+            "kvCacheDtype": "q4_0",
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "deepreinforce-ai/Ornith-1.0-35B-GGUF",
+            "displayName": "Ornith-1.0-35B-GGUF",
+            "family": null,
+            "params": 35,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "8655 (277ff5fff)",
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmoq9dv9j0004jo04acsuadcp",
+            "username": "Mattsav",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 18,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqwk0xm103j4qr01yh0euwks",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 71,
+          "tokSOut": 135.12,
+          "tokSPrefill": null,
+          "tokSTotal": null,
+          "peakVramGb": 45.1,
+          "createdAt": "2026-06-27T16:08:24.362Z",
+          "notes": "Code prompt (800 max tokens). Running with Speculative Decoding (MTP) enabled with 4 speculative tokens.",
+          "engineFlags": {
+            "commandSnippet": "vllm serve google/gemma-4-31b-it -q int4 -tp 2 --gpu-memory-utilization 0.95",
+            "tensorParallel": 2,
+            "gpuLayers": null,
+            "kvCacheDtype": "int8_per_token_head",
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "google/gemma-4-31B-it",
+            "displayName": "gemma-4-31B-it",
+            "family": "Gemma",
+            "params": 33,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-31B",
+              "displayName": "gemma-4-31B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "vllm",
+            "engineVersion": null,
+            "quantization": "int4",
+            "backend": null
+          },
+          "user": {
+            "id": "cmqwjykcz03itqr01d9grslvl",
+            "username": "AlphaGrit",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 19,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5095,7 +6639,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -5127,7 +6671,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 14,
+          "rank": 20,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5193,7 +6737,7 @@
           },
           "hardwareGroupLabel": "RTX 3090 Ti",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090 ti",
-          "rank": 15,
+          "rank": 21,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5224,7 +6768,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -5256,7 +6800,7 @@
           },
           "hardwareGroupLabel": "RTX 3090 Ti",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090 ti",
-          "rank": 16,
+          "rank": 22,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5322,7 +6866,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 17,
+          "rank": 23,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5388,7 +6932,70 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 18,
+          "rank": 24,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqw5k2wu039dqr01j2yh9kg5",
+          "contextLength": 262144,
+          "prefillTokens": 0,
+          "batchSize": 1,
+          "ttftMs": 94.42,
+          "tokSOut": 124.12,
+          "tokSPrefill": null,
+          "tokSTotal": 122.69,
+          "peakVramGb": null,
+          "createdAt": "2026-06-27T09:23:23.454Z",
+          "notes": "Ornith-1.0 35B GGUF Q4_K_M on 1x RTX 3090 via llama.cpp CUDA, full 262144 context, q4_0 KV cache, flash-attn, no prompt cache, single streaming request, 5 measured 1000-token runs after 1 warmup, no-thinking template forced with chat_template_kwargs enable_thinking=false. single GPU. Performance-window run with GPU power autotune paused and test GPUs capped at 350W. GPU reached 89C and software thermal slowdown was observed in 22 telemetry samples, so later runs tapered. Host is PCIe 3.0/no NVLink; this row uses one card.",
+          "engineFlags": {
+            "commandSnippet": "llama-server --model ornith-1.0-35b-Q4_K_M.gguf --ctx-size 262144 --cache-type-k q4_0 --cache-type-v q4_0 --parallel 1 --batch-size 1024 --ubatch-size 256 --flash-attn on --n-gpu-layers 999 --jinja --reasoning-format deepseek --reasoning auto --no-cache-prompt --cache-ram 0",
+            "tensorParallel": 1,
+            "gpuLayers": 999,
+            "kvCacheDtype": "q4_0",
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "deepreinforce-ai/Ornith-1.0-35B-GGUF",
+            "displayName": "Ornith-1.0-35B-GGUF",
+            "family": null,
+            "params": 35,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 1,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "8655 (277ff5fff)",
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmoq9dv9j0004jo04acsuadcp",
+            "username": "Mattsav",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 25,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5454,7 +7061,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 19,
+          "rank": 26,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5520,7 +7127,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 20,
+          "rank": 27,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5586,7 +7193,7 @@
           },
           "hardwareGroupLabel": "RTX 3090 Ti",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090 ti",
-          "rank": 21,
+          "rank": 28,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5652,7 +7259,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 22,
+          "rank": 29,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5718,7 +7325,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 23,
+          "rank": 30,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5784,7 +7391,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 24,
+          "rank": 31,
           "reactionCounts": {
             "100": 1
           },
@@ -5852,7 +7459,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 25,
+          "rank": 32,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5918,7 +7525,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 26,
+          "rank": 33,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -5984,7 +7591,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 27,
+          "rank": 34,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6050,7 +7657,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 28,
+          "rank": 35,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6116,7 +7723,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 29,
+          "rank": 36,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6182,7 +7789,73 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 30,
+          "rank": 37,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzx2qo2000xph01ondx41qt",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 548.71,
+          "tokSOut": 71.4,
+          "tokSPrefill": 98.4,
+          "tokSTotal": 75.3,
+          "peakVramGb": null,
+          "createdAt": "2026-06-30T00:37:02.210Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "# Remote endpoint: http://localhost:8024  servedModel: Ornstein3.6-27B-MTP-NSC-ACE-SABER-Q6_K-MTP.gguf",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "family": "Qwen",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
+              "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q6_K",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqwjykcz03itqr01d9grslvl",
+            "username": "AlphaGrit",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 38,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6248,7 +7921,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 31,
+          "rank": 39,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6314,7 +7987,7 @@
           },
           "hardwareGroupLabel": "RTX 3090 Ti",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090 ti",
-          "rank": 32,
+          "rank": 40,
           "reactionCounts": {
             "fire": 1
           },
@@ -6382,7 +8055,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 33,
+          "rank": 41,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6448,7 +8121,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 34,
+          "rank": 42,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6514,7 +8187,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 35,
+          "rank": 43,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6580,7 +8253,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 36,
+          "rank": 44,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6646,7 +8319,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 37,
+          "rank": 45,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6712,7 +8385,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 38,
+          "rank": 46,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6778,7 +8451,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 39,
+          "rank": 47,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6844,7 +8517,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 40,
+          "rank": 48,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6910,7 +8583,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 41,
+          "rank": 49,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -6976,7 +8649,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 42,
+          "rank": 50,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7042,7 +8715,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 43,
+          "rank": 51,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7108,7 +8781,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 44,
+          "rank": 52,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7174,7 +8847,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 45,
+          "rank": 53,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7240,7 +8913,73 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 46,
+          "rank": 54,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzp3mq602svoe01j36x92fs",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 129.34,
+          "tokSOut": 49.5,
+          "tokSPrefill": 247.4,
+          "tokSTotal": 54.5,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T20:53:46.830Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "# Remote endpoint: http://localhost:8020  servedModel: Ornstein3.6-27B-MTP-NSC-ACE-SABER-Q4_K_M-MTP.gguf",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "family": "Qwen",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
+              "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqwjykcz03itqr01d9grslvl",
+            "username": "AlphaGrit",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 55,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7306,7 +9045,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 47,
+          "rank": 56,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7372,8 +9111,139 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 48,
+          "rank": 57,
           "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzqofkz02u5oe0194jx9zuv",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 140.2,
+          "tokSOut": 47.2,
+          "tokSPrefill": 228.3,
+          "tokSTotal": 51.9,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T21:37:56.963Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "# Remote endpoint: http://localhost:8020  servedModel: Ornstein3.6-27B-MTP-NSC-ACE-SABER-Q6_K-MTP.gguf",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "family": "Qwen",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
+              "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q6_K",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqwjykcz03itqr01d9grslvl",
+            "username": "AlphaGrit",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 58,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzoacbj02seoe01owp0h17a",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 124.68,
+          "tokSOut": 46.7,
+          "tokSPrefill": 272.7,
+          "tokSTotal": 51.9,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T20:31:00.320Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "# Remote endpoint: http://localhost:8070  servedModel: Qwen3.6-27B-Q4_K_M.gguf",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.6-27B",
+            "displayName": "Qwen3.6-27B",
+            "family": "Qwen",
+            "params": 28,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqwjykcz03itqr01d9grslvl",
+            "username": "AlphaGrit",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 59,
+          "reactionCounts": {
+            "chad": 1
+          },
           "myEmoji": null
         },
         {
@@ -7438,7 +9308,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 49,
+          "rank": 60,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7504,7 +9374,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 50,
+          "rank": 61,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7570,7 +9440,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 51,
+          "rank": 62,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7636,7 +9506,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 52,
+          "rank": 63,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7702,7 +9572,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 53,
+          "rank": 64,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7765,7 +9635,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 54,
+          "rank": 65,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7831,7 +9701,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 55,
+          "rank": 66,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7897,7 +9767,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 56,
+          "rank": 67,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -7963,7 +9833,73 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 57,
+          "rank": 68,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqzs3k7s02uroe010cb8tchm",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 202.07,
+          "tokSOut": 40.8,
+          "tokSPrefill": 158.4,
+          "tokSTotal": 44.6,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T22:17:42.425Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "# Remote endpoint: http://localhost:8020  servedModel: Ornstein3.6-27B-MTP-NSC-ACE-SABER-Q6_K-MTP.gguf",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "family": "Qwen",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
+              "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q6_K",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqwjykcz03itqr01d9grslvl",
+            "username": "AlphaGrit",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 69,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8029,7 +9965,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 58,
+          "rank": 70,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8095,7 +10031,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 59,
+          "rank": 71,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8158,7 +10094,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 60,
+          "rank": 72,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8224,7 +10160,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 61,
+          "rank": 73,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8290,7 +10226,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 62,
+          "rank": 74,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8356,7 +10292,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 63,
+          "rank": 75,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8419,7 +10355,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 64,
+          "rank": 76,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8485,7 +10421,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 65,
+          "rank": 77,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8551,7 +10487,7 @@
           },
           "hardwareGroupLabel": "RTX 3090 Ti",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090 ti",
-          "rank": 66,
+          "rank": 78,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8617,7 +10553,7 @@
           },
           "hardwareGroupLabel": "RTX 3090 Ti",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090 ti",
-          "rank": 67,
+          "rank": 79,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8683,7 +10619,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 68,
+          "rank": 80,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8749,7 +10685,7 @@
           },
           "hardwareGroupLabel": "RTX 3090 Ti",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090 ti",
-          "rank": 69,
+          "rank": 81,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8815,7 +10751,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 70,
+          "rank": 82,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8881,7 +10817,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 71,
+          "rank": 83,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -8947,7 +10883,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 72,
+          "rank": 84,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9013,7 +10949,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 73,
+          "rank": 85,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9079,7 +11015,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 74,
+          "rank": 86,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9145,7 +11081,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 75,
+          "rank": 87,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9211,7 +11147,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 76,
+          "rank": 88,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9277,7 +11213,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 77,
+          "rank": 89,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9343,7 +11279,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 78,
+          "rank": 90,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9409,7 +11345,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 79,
+          "rank": 91,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9475,7 +11411,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 80,
+          "rank": 92,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9541,7 +11477,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 81,
+          "rank": 93,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9607,7 +11543,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 82,
+          "rank": 94,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9673,7 +11609,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 83,
+          "rank": 95,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9739,7 +11675,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 84,
+          "rank": 96,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9805,7 +11741,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 85,
+          "rank": 97,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9871,7 +11807,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 86,
+          "rank": 98,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -9937,7 +11873,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 87,
+          "rank": 99,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10003,7 +11939,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 88,
+          "rank": 100,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10069,7 +12005,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 89,
+          "rank": 101,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10135,7 +12071,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 90,
+          "rank": 102,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10201,7 +12137,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 91,
+          "rank": 103,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10267,7 +12203,73 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 92,
+          "rank": 104,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqqqup2b01a2qo01lwvrysjs",
+          "contextLength": 262144,
+          "prefillTokens": 0,
+          "batchSize": 1,
+          "ttftMs": 92.2,
+          "tokSOut": 22.08,
+          "tokSPrefill": null,
+          "tokSTotal": 22.04,
+          "peakVramGb": null,
+          "createdAt": "2026-06-23T14:32:53.604Z",
+          "notes": "GLM-5.2 REAP50 Q3_K_M GGUF on 10x RTX 3090 via llama.cpp CUDA, 262144 context, q4_0 K/V cache, server-side reasoning disabled, single streaming request, 5 measured 1000-token runs after 1 warmup. PCIe 3.0 host, no NVLink. Real-use note: in day-to-day local agent and chat workflows, this GLM-5.2 trial did not perform as well as the restored Qwen 27B coordinator despite the benchmark result.",
+          "engineFlags": {
+            "commandSnippet": "llama-server --ctx-size 262144 --cache-type-k q4_0 --cache-type-v q4_0 --parallel 1 --flash-attn on --split-mode layer --tensor-split 1,1,1,1,1,1,1,1,1,1 --n-gpu-layers 999 --jinja --reasoning off --no-webui",
+            "tensorParallel": 10,
+            "gpuLayers": 999,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "pipenetwork/GLM-5.2-REAP50-Q3_K_M-GGUF",
+            "displayName": "GLM-5.2-REAP50-Q3_K_M-GGUF",
+            "family": "Llama",
+            "params": null,
+            "isMoE": true,
+            "baseModel": {
+              "hfId": "zai-org/GLM-5.2",
+              "displayName": "GLM-5.2"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 10,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "2x Intel Xeon Silver 4214R",
+            "os": "Ubuntu 24.04.3 LTS",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "9738 (upstream commit e27f30859)",
+            "quantization": "Q3_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmoq9dv9j0004jo04acsuadcp",
+            "username": "Mattsav",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 105,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10333,7 +12335,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 93,
+          "rank": 106,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10399,7 +12401,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 94,
+          "rank": 107,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10465,7 +12467,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 95,
+          "rank": 108,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10531,7 +12533,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 96,
+          "rank": 109,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10597,7 +12599,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 97,
+          "rank": 110,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10663,7 +12665,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 98,
+          "rank": 111,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10729,7 +12731,7 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 99,
+          "rank": 112,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -10795,12 +12797,471 @@
           },
           "hardwareGroupLabel": "RTX 3090",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
-          "rank": 100,
+          "rank": 113,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmpcfx7yh0023nw01rg9yifow",
+          "contextLength": 262144,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 20.807,
+          "tokSPrefill": 99.955,
+          "tokSTotal": null,
+          "peakVramGb": 22.81,
+          "createdAt": "2026-05-19T09:38:26.825Z",
+          "notes": "Batch/ubatch sweep: batch=256 ubatch=256 | Buun fork MTP | ",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m Ornstein3.6-27B-MTP-NSC-ACE-SABER-Q4_K_M-MTP.gguf --batch-size 256 --ubatch-size 256 --flash-attn on --cache-type-k turbo4 --cache-type-v turbo4 --no-mmap --n-gpu-layers all --fit off --ctx-size 262144 --parallel 1 --spec-type draft-mtp --spec-draft-n-max 4 --spec-draft-n-min 2",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": "turbo4",
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": true,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "family": "Qwen",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
+              "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 1,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "buun-llama-cpp speed-experiments",
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmoihfonv000cl80430zk8sn3",
+            "username": "gkraker04",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 114,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmpcg1fcn002cnw01kz00v46j",
+          "contextLength": 262144,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 20.44,
+          "tokSPrefill": 99.133,
+          "tokSTotal": null,
+          "peakVramGb": 22.81,
+          "createdAt": "2026-05-19T09:41:43.031Z",
+          "notes": "Batch/ubatch sweep: batch=512 ubatch=256 | Buun fork MTP | ",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m Ornstein3.6-27B-MTP-NSC-ACE-SABER-Q4_K_M-MTP.gguf --batch-size 512 --ubatch-size 256 --flash-attn on --cache-type-k turbo4 --cache-type-v turbo4 --no-mmap --n-gpu-layers all --fit off --ctx-size 262144 --parallel 1 --spec-type draft-mtp --spec-draft-n-max 4 --spec-draft-n-min 2",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": "turbo4",
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": true,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "family": "Qwen",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
+              "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 1,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "buun-llama-cpp speed-experiments",
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmoihfonv000cl80430zk8sn3",
+            "username": "gkraker04",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 115,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmofefde70002ie04ag5nc5pd",
+          "contextLength": 32768,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 1658.53,
+          "tokSOut": 19.22,
+          "tokSPrefill": null,
+          "tokSTotal": 38.18,
+          "peakVramGb": 22.1,
+          "createdAt": "2026-04-26T06:40:10.640Z",
+          "notes": "PC dual-RTX-3090 (Ti+FE), llama.cpp -sm row TP=2. Qwen 3.6 27B DENSE at unsloth UD-Q8_K_XL (33 GB). 512/512 single-stream, 20 prompts. KV q8_0. Full PC dense 27B llama.cpp ladder: Q4 24.16 / Q6 22.23 / Q8 19.22 t/s. For comparison, vLLM FP8 same model: 44.17 t/s \u2014 vLLM kernel + FP8 ~2x faster than llama.cpp Q8.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m Qwen3.6-27B-UD-Q8_K_XL.gguf -ngl 999 -fa 1 --no-mmap --mlock -c 32768 -sm row -ts 1,1 -ctk q8_0 -ctv q8_0 -b 4096 -ub 4096 --parallel 1",
+            "tensorParallel": 2,
+            "gpuLayers": 999,
+            "kvCacheDtype": "q8_0",
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "unsloth/Qwen3.6-27B-GGUF",
+            "displayName": "Qwen3.6-27B-GGUF",
+            "family": "Qwen",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-27B",
+              "displayName": "Qwen3.6-27B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b8870",
+            "quantization": "UD-Q8_K_XL",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmof7gocp0015gv041vcnngqj",
+            "username": "Skiipy",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 116,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmofeyn1i000gl204hiwvdqj0",
+          "contextLength": 32768,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 2263.37,
+          "tokSOut": 14.38,
+          "tokSPrefill": null,
+          "tokSTotal": 33.5,
+          "peakVramGb": 20.7,
+          "createdAt": "2026-04-26T06:55:09.606Z",
+          "notes": "PC dual-RTX-3090 (Ti+FE), llama.cpp -sm row TP=2. Gemma 4 31B IT at unsloth UD-Q6_K_XL (26 GB). 512/512 single-stream, 20 prompts. KV q8_0. Bench used Qwen tokenizer for synthetic prompts (Gemma tokenizer is gated) \u2014 output token count is server-reported, throughput accurate; TTFT slightly inflated due to vocab mismatch. Gemma 4 dense ~25% slower than Qwen 3.6 27B dense Q6 on same rig (14.38 vs 22.23 t/s).",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m gemma-4-31B-it-UD-Q6_K_XL.gguf -ngl 999 -fa 1 --no-mmap --mlock -c 32768 -sm row -ts 1,1 -ctk q8_0 -ctv q8_0 -b 4096 -ub 4096 --parallel 1",
+            "tensorParallel": 2,
+            "gpuLayers": 999,
+            "kvCacheDtype": "q8_0",
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "unsloth/gemma-4-31B-it-GGUF",
+            "displayName": "gemma-4-31B-it-GGUF",
+            "family": "Gemma",
+            "params": 31,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-31B-it",
+              "displayName": "gemma-4-31B-it"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 2,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b8870",
+            "quantization": "UD-Q6_K_XL",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmof7gocp0015gv041vcnngqj",
+            "username": "Skiipy",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 117,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmpcg9u9s002unw01ialm8fv8",
+          "contextLength": 262144,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 12.038,
+          "tokSPrefill": 69.226,
+          "tokSTotal": null,
+          "peakVramGb": 23.67,
+          "createdAt": "2026-05-19T09:48:15.616Z",
+          "notes": "Batch/ubatch sweep: batch=1024 ubatch=1024 | Buun fork MTP | ",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m Ornstein3.6-27B-MTP-NSC-ACE-SABER-Q4_K_M-MTP.gguf --batch-size 1024 --ubatch-size 1024 --flash-attn on --cache-type-k turbo4 --cache-type-v turbo4 --no-mmap --n-gpu-layers all --fit off --ctx-size 262144 --parallel 1 --spec-type draft-mtp --spec-draft-n-max 4 --spec-draft-n-min 2",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": "turbo4",
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": true,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER-GGUF",
+            "family": "Qwen",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "GestaltLabs/Ornstein3.6-27B-MTP-NSC-ACE-SABER",
+              "displayName": "Ornstein3.6-27B-MTP-NSC-ACE-SABER"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 1,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "buun-llama-cpp speed-experiments",
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmoihfonv000cl80430zk8sn3",
+            "username": "gkraker04",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 118,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmoto5q5v001rqu01cskl831f",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 646.6,
+          "tokSOut": 11.02,
+          "tokSPrefill": 55.97,
+          "tokSTotal": null,
+          "peakVramGb": null,
+          "createdAt": "2026-05-06T06:21:23.251Z",
+          "notes": "llama.cpp benchmark on RTX 3090 (24GB). Q4_K_M quantization of Qwen3.6-35B-A3B-UD variant. CUDA forward compatibility warning expected (kernel 580.126 vs NVML 580.142) but GPU functional.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m /home/fido/qwen3.6-35b-a3b-gguf/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf -ngl 99 -c 2048 -t 6",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.6-35B-A3B",
+            "displayName": "Qwen3.6-35B-A3B",
+            "family": "Qwen",
+            "params": 36,
+            "isMoE": true,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 1,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD EPYC 7543",
+            "os": "Ubuntu 24.04",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "5dd1025",
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmotnu2eg001bqu0113rx4lfh",
+            "username": "mattions",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 119,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmowla4rq004io201otfp0rdo",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 142,
+          "tokSOut": 5.54,
+          "tokSPrefill": null,
+          "tokSTotal": 5.53,
+          "peakVramGb": 155.9,
+          "createdAt": "2026-05-08T07:24:08.487Z",
+          "notes": "Kimi-K2.5 IQ1_S GGUF feasibility row on 8x RTX 3090. Full offload did not fit; first stable route used n_gpu_layers=48 with substantial CPU offload, so this is not a speed-match row. 3 measured 512-token runs after 1 warmup; wall tok/s varied 6.21, 6.44, 3.94. Raw log: /home/mattsav/Documents/data/glm51_8x3090_20260507/kimi_k25_iq1s_8x_ngl48_b512_bench512.log",
+          "engineFlags": {
+            "commandSnippet": "CUDA_VISIBLE_DEVICES=2,3,4,5,6,7,8,9 llama-server -m /data/models/kimi-k25-gguf/bartowski-moonshotai-kimi-k25-iq1s/moonshotai_Kimi-K2.5-IQ1_S-00001-of-00006.gguf -c 4096 -b 512 -ub 128 -ngl 48 --split-mode layer --tensor-split 1,1,1,1,1,1,1,1 -fa -ctk q4_0 -ctv q4_0",
+            "tensorParallel": 8,
+            "gpuLayers": 48,
+            "kvCacheDtype": "q4_0",
+            "attentionBackend": "llama.cpp CUDA",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "bartowski/moonshotai_Kimi-K2.5-GGUF",
+            "displayName": "moonshotai_Kimi-K2.5-GGUF",
+            "family": null,
+            "params": null,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "moonshotai/Kimi-K2.5",
+              "displayName": "Kimi-K2.5"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3090",
+            "gpuCount": 8,
+            "vramGb": 24,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "2x Intel Xeon Silver 4214R",
+            "os": "Ubuntu 24.04.3 LTS",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "8178 (3e6ab244a)",
+            "quantization": "IQ1_S",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmoq9dv9j0004jo04acsuadcp",
+            "username": "Mattsav",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3090",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3090",
+          "rank": 120,
           "reactionCounts": {},
           "myEmoji": null
         }
       ],
-      "total": 107
+      "total": 120
     },
     "RTX 3080 (10 GB)": {
       "rows": [
@@ -12138,7 +14599,7 @@
             "hfId": "agentica-org/DeepCoder-14B-Preview",
             "displayName": "DeepCoder-14B-Preview",
             "family": "Deepseek-R1",
-            "params": 14,
+            "params": 15,
             "isMoE": false,
             "baseModel": {
               "hfId": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
@@ -12535,7 +14996,7 @@
             "displayName": "gpt-oss-20b",
             "family": "Gpt",
             "params": 22,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -13105,6 +15566,72 @@
           "myEmoji": null
         },
         {
+          "id": "cmr49f6xo004knv01olxnwh2z",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 109,
+          "tokSOut": 196.06,
+          "tokSPrefill": 4719,
+          "tokSTotal": 610,
+          "peakVramGb": 6.94,
+          "createdAt": "2026-07-03T01:33:43.260Z",
+          "notes": "LFM2.5-8B-A1B (8.5B total, ~1B active), lfm2moe MoE architecture with leading dense blocks. Q4_K_M quant. Fully offloaded (-ngl 99). Native context 128K. Max context = 128K (native limit, VRAM headroom available). Fedora 43, CUDA 13.0, driver 580.159.04. Greedy decode, flash attn on.",
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m LFM2.5-8B-A1B-Q4_K_M.gguf -p 512 -n 128 -ngl 99 -fa on -r 3 -o json",
+            "tensorParallel": 1,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "LiquidAI/LFM2.5-8B-A1B",
+            "displayName": "LFM2.5-8B-A1B",
+            "family": null,
+            "params": 8,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "LiquidAI/LFM2.5-8B-A1B-Base",
+              "displayName": "LFM2.5-8B-A1B-Base"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9550 / f0156d140",
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 3,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
           "id": "cmpq1uxa4009qpl01geyuhhjh",
           "contextLength": 128000,
           "prefillTokens": null,
@@ -13166,7 +15693,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 3,
+          "rank": 4,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13232,7 +15759,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 4,
+          "rank": 5,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13298,7 +15825,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 5,
+          "rank": 6,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13364,7 +15891,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 6,
+          "rank": 7,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13427,7 +15954,73 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 7,
+          "rank": 8,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3pjxbz06xvpi01add4ufo5",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 111.9,
+          "tokSOut": 133.36,
+          "tokSPrefill": 4611.17,
+          "tokSTotal": 409,
+          "peakVramGb": 3.78,
+          "createdAt": "2026-07-02T16:17:31.775Z",
+          "notes": "Gemma4 E2B (4.6B params, ~2B active) QAT quantized to Q4_0. Fully offloaded (-ngl 99). Fedora 43, CUDA 13.0, driver 580.159.04. Max context = 262144 (native limit, VRAM headroom available). Benchmark at 4096 ctx, greedy decode.",
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m gemma-4-E2B_q4_0-it.gguf -p 512 -n 128 -ngl 99 -fa on -r 3 -o json",
+            "tensorParallel": 1,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "google/gemma-4-E2B-it",
+            "displayName": "gemma-4-E2B-it",
+            "family": "Gemma",
+            "params": 5,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-E2B",
+              "displayName": "gemma-4-E2B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9550 / f0156d140 (gemma4 build)",
+            "quantization": "Q4_0",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 9,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13493,7 +16086,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 8,
+          "rank": 10,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13556,7 +16149,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 9,
+          "rank": 11,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13622,7 +16215,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 10,
+          "rank": 12,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13688,7 +16281,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 11,
+          "rank": 13,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13754,7 +16347,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 12,
+          "rank": 14,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13820,7 +16413,205 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 13,
+          "rank": 15,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3pknsy06y3pi01aads2g4l",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 219,
+          "tokSOut": 89.68,
+          "tokSPrefill": 2339.97,
+          "tokSTotal": 242,
+          "peakVramGb": 4.67,
+          "createdAt": "2026-07-02T16:18:06.082Z",
+          "notes": "Nemotron-3-Nano 4B (3.97B params, 4.0B), nemotron_h architecture, Q4_K_M quant. Fully offloaded (-ngl 99). Fedora 43, CUDA 13.0, driver 580.159.04. Native ctx 262144. Max context = 262144 (native limit, VRAM headroom available). Benchmark at 4096 ctx, greedy decode.",
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m NVIDIA-Nemotron-3-Nano-4B-Q4_K_M.gguf -p 512 -n 128 -ngl 99 -fa on -r 3 -o json",
+            "tensorParallel": 1,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "lmstudio-community/NVIDIA-Nemotron-3-Nano-4B-GGUF",
+            "displayName": "NVIDIA-Nemotron-3-Nano-4B-GGUF",
+            "family": null,
+            "params": 9,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
+              "displayName": "NVIDIA-Nemotron-3-Nano-4B-BF16"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9550 / f0156d140",
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 16,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3ynprv0007nv0192k93bri",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 89.65,
+          "tokSPrefill": 114.92,
+          "tokSTotal": null,
+          "peakVramGb": 9.34,
+          "createdAt": "2026-07-02T20:32:25.148Z",
+          "notes": "Gemma4 12B QAT Q4_K_XL + MTP draft head (Q8_0, 444 MB). OPTIMAL: MTP enabled (--spec-type draft-mtp --spec-draft-n-max 3, draft model gemma-4-12B-it-qat-assistant-MTP-Q8_0.gguf). 42 dense attn layers, fully offloaded. KV cache q4_0. MTP speedup: 2.38x. Acceptance rate: 94% (188/200). Max context with MTP: 196608 (192K) at ~11.5 GB. Fedora 43, CUDA 13.0.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m gemma-4-12B-it-qat-UD-Q4_K_XL.gguf --model-draft gemma-4-12B-it-qat-assistant-MTP-Q8_0.gguf --spec-type draft-mtp --spec-draft-n-max 3 -ngl 99 -fa on -ctk q4_0 -ctv q4_0 -c 196608 -np 1",
+            "tensorParallel": 1,
+            "gpuLayers": 99,
+            "kvCacheDtype": "q4_0",
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": true,
+            "mtpEnabled": true
+          },
+          "model": {
+            "hfId": "google/gemma-4-12B-it",
+            "displayName": "gemma-4-12B-it",
+            "family": "Gemma",
+            "params": 12,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-12B",
+              "displayName": "gemma-4-12B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9775 / be4a6a63e",
+            "quantization": "Q4_K_XL",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 17,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3qzp5206yvpi01u1mwge0j",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 89.65,
+          "tokSPrefill": 114.92,
+          "tokSTotal": null,
+          "peakVramGb": 9.34,
+          "createdAt": "2026-07-02T16:57:47.270Z",
+          "notes": "Gemma4 12B QAT Q4_K_XL + MTP draft head (Q8_0, 444 MB). MTP: --spec-type draft-mtp --spec-draft-n-max 3. Draft model: gemma-4-12B-it-qat-assistant-MTP-Q8_0.gguf. 42 dense attention layers, fully offloaded. KV cache q4_0 (max context). MTP speedup: 2.38x over non-MTP 37.69 tok/s. Acceptance rate: 94% (188/200). Fedora 43, CUDA 13.0.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m gemma-4-12B-it-qat-UD-Q4_K_XL.gguf --model-draft gemma-4-12B-it-qat-assistant-MTP-Q8_0.gguf --spec-type draft-mtp --spec-draft-n-max 3 -ngl 99 -fa on -ctk q4_0 -ctv q4_0 -c 4096",
+            "tensorParallel": 1,
+            "gpuLayers": 99,
+            "kvCacheDtype": "q4_0",
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": true,
+            "mtpEnabled": true
+          },
+          "model": {
+            "hfId": "google/gemma-4-12B-it",
+            "displayName": "gemma-4-12B-it",
+            "family": "Gemma",
+            "params": 12,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-12B",
+              "displayName": "gemma-4-12B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9775 / be4a6a63e",
+            "quantization": "Q4_K_XL",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 18,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13886,7 +16677,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 14,
+          "rank": 19,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -13952,7 +16743,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 15,
+          "rank": 20,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14018,7 +16809,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 16,
+          "rank": 21,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14084,7 +16875,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 17,
+          "rank": 22,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14115,7 +16906,7 @@
             "displayName": "gpt-oss-20b",
             "family": "Gpt",
             "params": 22,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -14147,7 +16938,199 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 18,
+          "rank": 23,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3pjyro06xzpi011kopr4j1",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 207,
+          "tokSOut": 71.64,
+          "tokSPrefill": 2469.66,
+          "tokSTotal": 213,
+          "peakVramGb": 4.9,
+          "createdAt": "2026-07-02T16:17:33.637Z",
+          "notes": "Gemma4 E4B (7.5B params, ~4B active) Q4_K_M quant. Fully offloaded (-ngl 99). Fedora 43, CUDA 13.0, driver 580.159.04. Max context = 262144 (native limit, VRAM headroom available). Benchmark at 4096 ctx, greedy decode.",
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m gemma-4-E4B-it-Q4_K_M.gguf -p 512 -n 128 -ngl 99 -fa on -r 3 -o json",
+            "tensorParallel": 1,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "google/gemma-4-E4B-it",
+            "displayName": "gemma-4-E4B-it",
+            "family": "Gemma",
+            "params": 8,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-E4B",
+              "displayName": "gemma-4-E4B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9550 / f0156d140 (gemma4 build)",
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 24,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqqsyavj01b9qo01n82nq2uk",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 202.9,
+          "tokSOut": 70.49,
+          "tokSPrefill": 2523.78,
+          "tokSTotal": 317,
+          "peakVramGb": null,
+          "createdAt": "2026-06-23T15:31:41.071Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/aarkanum/llama.cpp/build/bin/llama-bench -m /media/aarkanum/external/ollama-models/gemma-4-E4B-it-Q4_K_M.gguf -p 512 -n 128",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "google/gemma-4-E4B",
+            "displayName": "gemma-4-E4B",
+            "family": "Gemma",
+            "params": 8,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqqrtq7901akqo01dtkoj2u9",
+            "username": "BoogerCheeseOnRye",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 25,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqqs9mwl01auqo01kenozv52",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 202.9,
+          "tokSOut": 70.49,
+          "tokSPrefill": 2523.78,
+          "tokSTotal": null,
+          "peakVramGb": null,
+          "createdAt": "2026-06-23T15:12:30.262Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "google/gemma-4-E4B",
+            "displayName": "gemma-4-E4B",
+            "family": "Gemma",
+            "params": 8,
+            "isMoE": false,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqqrtq7901akqo01dtkoj2u9",
+            "username": "BoogerCheeseOnRye",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 26,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14213,7 +17196,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 19,
+          "rank": 27,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14276,7 +17259,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 20,
+          "rank": 28,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14339,7 +17322,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 21,
+          "rank": 29,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14370,7 +17353,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -14402,7 +17385,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 22,
+          "rank": 30,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14468,7 +17451,70 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 23,
+          "rank": 31,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3ynhvk0002nv01hn2vs1zi",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 53.28,
+          "tokSPrefill": 43.87,
+          "tokSTotal": null,
+          "peakVramGb": 11.27,
+          "createdAt": "2026-07-02T20:32:14.912Z",
+          "notes": "MoE 35B/3B act, IQ3_XXS (3.44 bpw). OPTIMAL: MTP enabled (--spec-type draft-mtp --spec-draft-n-max 3), all attention on GPU (-ngl 99), 17 MoE layers CPU/31 GPU (-ncmoe 17), KV cache q8_0, np=1. MTP acceptance ~65%. Also ~6 GB model weights on CPU mmap. Max context with MTP: 64K (65536 at 11.79 GB). Fedora 43, CUDA 13.0.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m Qwen3.6-35B-A3B-UD-IQ3_XXS.gguf --spec-type draft-mtp --spec-draft-n-max 3 -ngl 99 -ncmoe 17 -fa on -ctk q8_0 -ctv q8_0 -np 1 --kv-unified -c 4096",
+            "tensorParallel": 1,
+            "gpuLayers": 99,
+            "kvCacheDtype": "q8_0",
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": true
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.6-35B-A3B",
+            "displayName": "Qwen3.6-35B-A3B",
+            "family": "Qwen",
+            "params": 36,
+            "isMoE": true,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9550 / f0156d140 (MTP build)",
+            "quantization": "IQ3_XXS",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 32,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14534,7 +17580,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 24,
+          "rank": 33,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14600,7 +17646,73 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 25,
+          "rank": 34,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3nemsu06x0pi014h070ylg",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 376,
+          "tokSOut": 41.96,
+          "tokSPrefill": 1455.41,
+          "tokSTotal": 186.5,
+          "peakVramGb": 6.4,
+          "createdAt": "2026-07-02T15:17:25.614Z",
+          "notes": "Dense 9B (8.95B params), Q3_K_M quant from Unsloth. Hybrid arch: 8 attention + 24 Mamba layers, 262144 native ctx. Fully offloaded (-ngl 99). Fedora 43, CUDA 13.0, driver 580.159.04, 16 CPU threads. Max context fitting 12GB VRAM: 180K (180224) at 11.78 GB. Benchmark at 4096 ctx, greedy decode (temp=0). KV cache f16, batch 2048/ubatch 512, flash attn on.",
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m Qwen3.5-9B-Q3_K_M.gguf -p 512 -n 128 -ngl 99 -fa on -r 3 -o json",
+            "tensorParallel": 1,
+            "gpuLayers": 99,
+            "kvCacheDtype": "f16",
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.5-9B",
+            "displayName": "Qwen3.5-9B",
+            "family": "Qwen",
+            "params": 9,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.5-9B-Base",
+              "displayName": "Qwen3.5-9B-Base"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9550 / f0156d140",
+            "quantization": "Q3_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 35,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14666,7 +17778,205 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 26,
+          "rank": 36,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqrmu5w901loqo010ulzuvb7",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 3477.2,
+          "tokSOut": 39.192274,
+          "tokSPrefill": 588.981688,
+          "tokSTotal": 322.7,
+          "peakVramGb": null,
+          "createdAt": "2026-06-24T05:28:16.473Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/aarkanum/llama.cpp/build/bin/llama-bench -m /media/aarkanum/external/ollama-models/Qwen3.6-35B-A3B-UD-Q2_K_XL.gguf -p 2048 -n 128 -ngl 99 -fa on -ctk q8_0 -ctv q8_0 --n-cpu-moe 12 -o json -r 5",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+            "displayName": "Qwen3.6-35B-A3B-MTP-GGUF",
+            "family": "Qwen",
+            "params": 35,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-35B-A3B",
+              "displayName": "Qwen3.6-35B-A3B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q2_K_XL",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqqrtq7901akqo01dtkoj2u9",
+            "username": "BoogerCheeseOnRye",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 37,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqrmifgf01lfqo0178o6d9z1",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 3477.2,
+          "tokSOut": 39.192274,
+          "tokSPrefill": 588.981688,
+          "tokSTotal": 322.7,
+          "peakVramGb": null,
+          "createdAt": "2026-06-24T05:19:08.991Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/aarkanum/llama.cpp/build/bin/llama-bench -m /media/aarkanum/external/ollama-models/Qwen3.6-35B-A3B-UD-Q2_K_XL.gguf -p 2048 -n 128 -ngl 99 -fa on -ctk q8_0 -ctv q8_0 --n-cpu-moe 12 -o json -r 5",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+            "displayName": "Qwen3.6-35B-A3B-MTP-GGUF",
+            "family": "Qwen",
+            "params": 35,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-35B-A3B",
+              "displayName": "Qwen3.6-35B-A3B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q2_K_XL",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqqrtq7901akqo01dtkoj2u9",
+            "username": "BoogerCheeseOnRye",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 38,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3p0jrv06xipi01ecdv11ph",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 419,
+          "tokSOut": 37.69,
+          "tokSPrefill": 1223.14,
+          "tokSTotal": 122,
+          "peakVramGb": 8.69,
+          "createdAt": "2026-07-02T16:02:27.740Z",
+          "notes": "Gemma4 12B QAT (quantization-aware training) model, Q4_K_XL UD quant. 42 dense attention layers. Fully offloaded (-ngl 99). Fedora 43, CUDA 13.0, driver 580.159.04, 16 CPU threads. Max context fitting 12GB VRAM: 106K (106496) at 11.75 GB. Benchmark at 4096 ctx, greedy decode (temp=0). KV cache f16, batch 2048/ubatch 512, flash attn on.",
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m gemma-4-12B-it-qat-UD-Q4_K_XL.gguf -p 512 -n 128 -ngl 99 -fa on -r 3 -o json",
+            "tensorParallel": 1,
+            "gpuLayers": 99,
+            "kvCacheDtype": "f16",
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "google/gemma-4-12B-it",
+            "displayName": "gemma-4-12B-it",
+            "family": "Gemma",
+            "params": 12,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-12B",
+              "displayName": "gemma-4-12B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9550 / f0156d140 (gemma4 build)",
+            "quantization": "Q4_K_XL",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 39,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14732,7 +18042,73 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 27,
+          "rank": 40,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqrlgiln01l3qo01uw7ha0i2",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 915,
+          "tokSOut": 36.519869,
+          "tokSPrefill": 559.573435,
+          "tokSTotal": 144.8,
+          "peakVramGb": null,
+          "createdAt": "2026-06-24T04:49:40.139Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/aarkanum/llama.cpp/build/bin/llama-bench -m /media/aarkanum/external/ollama-models/Qwen3.6-35B-A3B-UD-Q2_K_XL.gguf -p 512 -n 128 -ngl 99 -fa on -ctk q8_0 -ctv q8_0 --n-cpu-moe 12 -o json",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+            "displayName": "Qwen3.6-35B-A3B-MTP-GGUF",
+            "family": "Qwen",
+            "params": 35,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-35B-A3B",
+              "displayName": "Qwen3.6-35B-A3B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q2_K_XL",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqqrtq7901akqo01dtkoj2u9",
+            "username": "BoogerCheeseOnRye",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 41,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14795,7 +18171,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 28,
+          "rank": 42,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14861,7 +18237,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 29,
+          "rank": 43,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14892,7 +18268,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -14924,7 +18300,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 30,
+          "rank": 44,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -14990,7 +18366,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 31,
+          "rank": 45,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -15020,7 +18396,7 @@
             "hfId": "agentica-org/DeepCoder-14B-Preview",
             "displayName": "DeepCoder-14B-Preview",
             "family": "Deepseek-R1",
-            "params": 14,
+            "params": 15,
             "isMoE": false,
             "baseModel": {
               "hfId": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
@@ -15056,7 +18432,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 32,
+          "rank": 46,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -15122,7 +18498,7 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 33,
+          "rank": 47,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -15188,7 +18564,133 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 34,
+          "rank": 48,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3qzewd06yppi01p7uc9yff",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 27.9,
+          "tokSPrefill": 37.93,
+          "tokSTotal": null,
+          "peakVramGb": 5.62,
+          "createdAt": "2026-07-02T16:57:33.997Z",
+          "notes": "MoE 35B/3B act, MTP enabled: --spec-type draft-mtp --spec-draft-n-max 3. Integrated MTP heads in model. 256 experts, 8 active/token. Partial offload: -ngl 40 -ncmoe 40, KV cache q8_0. MTP speedup: +5% over non-MTP 26.55 tok/s (bottlenecked by CPU MoE experts). Acceptance rate: 67.7% (170/251). Fedora 43, CUDA 13.0, driver 580.159.04.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m Qwen3.6-35B-A3B-UD-Q3_K_M.gguf --spec-type draft-mtp --spec-draft-n-max 3 -ngl 40 -ncmoe 40 -fa on -ctk q8_0 -ctv q8_0 -c 4096",
+            "tensorParallel": 1,
+            "gpuLayers": 40,
+            "kvCacheDtype": "q8_0",
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": true
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.6-35B-A3B",
+            "displayName": "Qwen3.6-35B-A3B",
+            "family": "Qwen",
+            "params": 36,
+            "isMoE": true,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9550 / f0156d140 (MTP build)",
+            "quantization": "Q3_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 49,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr3q3dqa06y7pi017tpq2jg7",
+          "contextLength": 4096,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 1476,
+          "tokSOut": 26.55,
+          "tokSPrefill": 347.04,
+          "tokSTotal": 55,
+          "peakVramGb": 4.73,
+          "createdAt": "2026-07-02T16:32:39.491Z",
+          "notes": "MoE 35B total / 3B active per token (256 experts, 8 active). Q3_K_M UD quant from unsloth. Partial offload: 40 layers GPU (-ngl 40), 40 MoE layers CPU (-ncmoe 40). KV cache q8_0 to reduce VRAM. MTP variant but benchmarked with standard generation. Additional ~11 GB model weights on CPU (mmap page cache). Fedora 43, CUDA 13.0, driver 580.159.04, 16 CPU threads. Max context = 262144 (native limit, fits at 8.07 GB VRAM). Benchmark at 4096 ctx, greedy decode.",
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m Qwen3.6-35B-A3B-UD-Q3_K_M.gguf -p 512 -n 128 -ngl 40 -ncmoe 40 -fa on -ctk q8_0 -ctv q8_0 -r 3 -o json",
+            "tensorParallel": 1,
+            "gpuLayers": 40,
+            "kvCacheDtype": "q8_0",
+            "attentionBackend": "flash_attn",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.6-35B-A3B",
+            "displayName": "Qwen3.6-35B-A3B",
+            "family": "Qwen",
+            "params": 36,
+            "isMoE": true,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "b9550 / f0156d140 (MTP build)",
+            "quantization": "Q3_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqjl8xsp00mjnv01uq4z2m8m",
+            "username": "darioooooo0o",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 50,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -15251,7 +18753,73 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 35,
+          "rank": 51,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqrlmeid01l6qo01n9hocnod",
+          "contextLength": 2048,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 3009.2,
+          "tokSOut": 15.78757,
+          "tokSPrefill": 170.145519,
+          "tokSTotal": 57.6,
+          "peakVramGb": null,
+          "createdAt": "2026-06-24T04:54:14.774Z",
+          "notes": null,
+          "engineFlags": {
+            "commandSnippet": "/home/aarkanum/llama.cpp/build/bin/llama-bench -m /media/aarkanum/external/ollama-models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf -p 512 -n 128 -ngl 99 -fa on -ctk q8_0 -ctv q8_0 --n-cpu-moe 48 -o json",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+            "displayName": "Qwen3.6-35B-A3B-MTP-GGUF",
+            "family": "Qwen",
+            "params": 35,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-35B-A3B",
+              "displayName": "Qwen3.6-35B-A3B"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "RTX 3060",
+            "gpuCount": 1,
+            "vramGb": 12,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": null,
+            "os": null,
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_K_M",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqqrtq7901akqo01dtkoj2u9",
+            "username": "BoogerCheeseOnRye",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "RTX 3060",
+          "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
+          "rank": 52,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -15317,12 +18885,12 @@
           },
           "hardwareGroupLabel": "RTX 3060",
           "hardwareGroupKey": "DISCRETE_GPU:rtx 3060",
-          "rank": 36,
+          "rank": 53,
           "reactionCounts": {},
           "myEmoji": null
         }
       ],
-      "total": 36
+      "total": 53
     },
     "A100 (80 GB)": {
       "rows": [],
@@ -15333,8 +18901,75 @@
       "total": 0
     },
     "H100 (80 GB)": {
-      "rows": [],
-      "total": 0
+      "rows": [
+        {
+          "id": "cmqz6p4gl025toe01l70kn28a",
+          "contextLength": 8192,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 260,
+          "tokSOut": 1369.3,
+          "tokSPrefill": 130.8,
+          "tokSTotal": 983.3,
+          "peakVramGb": null,
+          "createdAt": "2026-06-29T12:18:36.885Z",
+          "notes": "`lmx benchmark run vllm   --mode remote   --base-url http://localhost:8000   --hf-id RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic   --served-model RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic   --quantization fp8   --max-tokens 4096`",
+          "engineFlags": {
+            "commandSnippet": "sudo docker run --gpus all   --privileged --ipc=host -p 8000:8000   -v ~/.cache/huggingface:/root/.cache/huggingface   vllm/vllm-openai:gemma RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic   --max-num-seqs 4   --tensor-parallel-size 1",
+            "tensorParallel": 1,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": "FA4",
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "RedHatAI/diffusiongemma-26B-A4B-it-FP8-dynamic",
+            "displayName": "diffusiongemma-26B-A4B-it-FP8-dynamic",
+            "family": "Gemma",
+            "params": 26,
+            "isMoE": true,
+            "baseModel": {
+              "hfId": "google/diffusiongemma-26B-A4B-it",
+              "displayName": "diffusiongemma-26B-A4B-it"
+            }
+          },
+          "hardware": {
+            "hwClass": "DISCRETE_GPU",
+            "gpuName": "H100",
+            "gpuCount": 1,
+            "vramGb": 80,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "Intel(R) Xeon(R) Platinum 8481C",
+            "os": "Ubuntu 22.04.5 LTS",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "vllm",
+            "engineVersion": "0.24.0 (dev)",
+            "quantization": "FP8",
+            "backend": "cuda"
+          },
+          "user": {
+            "id": "cmqz33l6e0231oe010lk3smio",
+            "username": "joaogante",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "H100",
+          "hardwareGroupKey": "DISCRETE_GPU:h100",
+          "rank": 1,
+          "reactionCounts": {},
+          "myEmoji": null
+        }
+      ],
+      "total": 1
     },
     "L40S (48 GB)": {
       "rows": [],
@@ -16605,7 +20240,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -17253,7 +20888,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -17316,7 +20951,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -20362,7 +23997,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -21010,7 +24645,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -21073,7 +24708,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -23728,8 +27363,336 @@
       "total": 4
     },
     "Apple M4 Pro (48 GB)": {
-      "rows": [],
-      "total": 0
+      "rows": [
+        {
+          "id": "cmqw2nbhr036tqr01x5x4dln8",
+          "contextLength": 2176,
+          "prefillTokens": 2048,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 65.346,
+          "tokSPrefill": 782.941,
+          "tokSTotal": null,
+          "peakVramGb": 15.74,
+          "createdAt": "2026-06-27T08:01:55.695Z",
+          "notes": "TERMINAL OUTPUT:\nTiming with prompt_tokens=2048, generation_tokens=128, batch_size=1.\nTrial 1:  prompt_tps=786.761, generation_tps=65.851, peak_memory=15.739, total_time=4.663.\nTrial 2:  prompt_tps=779.919, generation_tps=65.151, peak_memory=15.739, total_time=4.717.\nTrial 3:  prompt_tps=779.763, generation_tps=66.030, peak_memory=15.740, total_time=4.707.\nTrial 4:  prompt_tps=780.749, generation_tps=65.593, peak_memory=15.740, total_time=4.697.\nTrial 5:  prompt_tps=787.512, generation_tps=64.102, peak_memory=15.741, total_time=4.729.\nAverages: prompt_tps=782.941, generation_tps=65.346, peak_memory=15.740.",
+          "engineFlags": {
+            "commandSnippet": "mlx_lm.benchmark --model /Users/c/.lmstudio/models/lmstudio-community/gemma-4-26B-A4B-it-QAT-MLX-4bit -p 2048 -g 128",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "lmstudio-community/gemma-4-26B-A4B-it-QAT-MLX-4bit",
+            "displayName": "gemma-4-26B-A4B-it-QAT-MLX-4bit",
+            "family": "Gemma",
+            "params": 5,
+            "isMoE": true,
+            "baseModel": null
+          },
+          "hardware": {
+            "hwClass": "UNIFIED",
+            "gpuName": null,
+            "gpuCount": 1,
+            "vramGb": null,
+            "chipVendor": "Apple",
+            "chipFamily": "M4",
+            "chipVariant": "M4 Pro",
+            "unifiedMemoryGb": 48,
+            "cpu": null,
+            "os": "macOS",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "mlx",
+            "engineVersion": "0.31.3",
+            "quantization": "MLX-4bit",
+            "backend": "metal"
+          },
+          "user": {
+            "id": "cmqvzeywp033qqr01ip5f8qt4",
+            "username": "chiming",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "M4 Pro",
+          "hardwareGroupKey": "UNIFIED:m4 pro",
+          "rank": 1,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqw2fmdq036nqr01afl6qpwv",
+          "contextLength": 2176,
+          "prefillTokens": 2048,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 47.785,
+          "tokSPrefill": 802.29,
+          "tokSTotal": null,
+          "peakVramGb": 6.198,
+          "createdAt": "2026-06-27T07:55:56.558Z",
+          "notes": "TERMINAL OUTPUT:\nTiming with prompt_tokens=2048, generation_tokens=128, batch_size=1.\nTrial 1:  prompt_tps=802.914, generation_tps=48.418, peak_memory=6.197, total_time=5.358.\nTrial 2:  prompt_tps=802.942, generation_tps=48.428, peak_memory=6.198, total_time=5.348.\nTrial 3:  prompt_tps=798.449, generation_tps=46.837, peak_memory=6.198, total_time=5.458.\nTrial 4:  prompt_tps=803.347, generation_tps=47.214, peak_memory=6.199, total_time=5.433.\nTrial 5:  prompt_tps=803.798, generation_tps=48.029, peak_memory=6.199, total_time=5.391.\nAverages: prompt_tps=802.290, generation_tps=47.785, peak_memory=6.198.",
+          "engineFlags": {
+            "commandSnippet": "mlx_lm.benchmark --model /Users/c/.lmstudio/models/mlx-community/Qwen3.5-4B-MLX-8bit -p 2048 -g 128",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "mlx-community/Qwen3.5-4B-MLX-8bit",
+            "displayName": "Qwen3.5-4B-MLX-8bit",
+            "family": "Qwen",
+            "params": 2,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.5-4B",
+              "displayName": "Qwen3.5-4B"
+            }
+          },
+          "hardware": {
+            "hwClass": "UNIFIED",
+            "gpuName": null,
+            "gpuCount": 1,
+            "vramGb": null,
+            "chipVendor": "Apple",
+            "chipFamily": "M4",
+            "chipVariant": "M4 Pro",
+            "unifiedMemoryGb": 48,
+            "cpu": null,
+            "os": "macOS",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "mlx",
+            "engineVersion": "0.31.3",
+            "quantization": "MLX-8bit",
+            "backend": "metal"
+          },
+          "user": {
+            "id": "cmqvzeywp033qqr01ip5f8qt4",
+            "username": "chiming",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "M4 Pro",
+          "hardwareGroupKey": "UNIFIED:m4 pro",
+          "rank": 2,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqw1kxb7035xqr01hjd6ubdf",
+          "contextLength": 640,
+          "prefillTokens": 512,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 47.12,
+          "tokSPrefill": 741.26,
+          "tokSTotal": null,
+          "peakVramGb": null,
+          "createdAt": "2026-06-27T07:32:04.388Z",
+          "notes": "10 threads\ntest - pp512: 741.26 \u00b1 5.93 tps\ntest - tg128: 47.12 \u00b1 0.88 tps",
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m /Users/c/.lmstudio/models/unsloth/Qwen3.6-35B-A3B-GGUF/Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf -ngl 99 -fa 1 ",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "unsloth/Qwen3.6-35B-A3B-GGUF",
+            "displayName": "Qwen3.6-35B-A3B-GGUF",
+            "family": "Qwen",
+            "params": 35,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-35B-A3B",
+              "displayName": "Qwen3.6-35B-A3B"
+            }
+          },
+          "hardware": {
+            "hwClass": "UNIFIED",
+            "gpuName": null,
+            "gpuCount": 1,
+            "vramGb": null,
+            "chipVendor": "Apple",
+            "chipFamily": "M4",
+            "chipVariant": "M4 Pro",
+            "unifiedMemoryGb": 48,
+            "cpu": null,
+            "os": "macOS",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "build: 3fc4e1052 (9820)",
+            "quantization": "Q4_K_XL",
+            "backend": "metal"
+          },
+          "user": {
+            "id": "cmqvzeywp033qqr01ip5f8qt4",
+            "username": "chiming",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "M4 Pro",
+          "hardwareGroupKey": "UNIFIED:m4 pro",
+          "rank": 3,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqw2bwk3036iqr01r1h58vg2",
+          "contextLength": 2176,
+          "prefillTokens": 2048,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 27.37,
+          "tokSPrefill": 445.48,
+          "tokSTotal": null,
+          "peakVramGb": 11.18,
+          "createdAt": "2026-06-27T07:53:03.123Z",
+          "notes": "TERMINAL OUTPUT:\nTiming with prompt_tokens=2048, generation_tokens=128, batch_size=1.\nTrial 1:  prompt_tps=441.423, generation_tps=27.521, peak_memory=11.182, total_time=9.448.\nTrial 2:  prompt_tps=448.397, generation_tps=27.389, peak_memory=11.182, total_time=9.406.\nTrial 3:  prompt_tps=442.409, generation_tps=27.442, peak_memory=11.183, total_time=9.479.\nTrial 4:  prompt_tps=449.098, generation_tps=27.950, peak_memory=11.183, total_time=9.302.\nTrial 5:  prompt_tps=446.090, generation_tps=26.567, peak_memory=11.184, total_time=9.571.\nAverages: prompt_tps=445.484, generation_tps=27.374, peak_memory=11.183.",
+          "engineFlags": {
+            "commandSnippet": "mlx_lm.benchmark --model /Users/c/.lmstudio/models/mlx-community/Qwen3.5-9B-MLX-8bit -p 2048 -g 128",
+            "tensorParallel": null,
+            "gpuLayers": null,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "mlx-community/Qwen3.5-9B-MLX-8bit",
+            "displayName": "Qwen3.5-9B-MLX-8bit",
+            "family": "Qwen",
+            "params": 3,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.5-9B",
+              "displayName": "Qwen3.5-9B"
+            }
+          },
+          "hardware": {
+            "hwClass": "UNIFIED",
+            "gpuName": null,
+            "gpuCount": 1,
+            "vramGb": null,
+            "chipVendor": "Apple",
+            "chipFamily": "M4",
+            "chipVariant": "M4 Pro",
+            "unifiedMemoryGb": 48,
+            "cpu": null,
+            "os": "macOS",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "mlx",
+            "engineVersion": "0.31.3",
+            "quantization": "MLX-8bit",
+            "backend": "metal"
+          },
+          "user": {
+            "id": "cmqvzeywp033qqr01ip5f8qt4",
+            "username": "chiming",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "M4 Pro",
+          "hardwareGroupKey": "UNIFIED:m4 pro",
+          "rank": 4,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqw1n3wx0360qr0199fgmgv1",
+          "contextLength": 640,
+          "prefillTokens": 512,
+          "batchSize": 1,
+          "ttftMs": null,
+          "tokSOut": 11.99,
+          "tokSPrefill": 122.63,
+          "tokSTotal": null,
+          "peakVramGb": null,
+          "createdAt": "2026-06-27T07:33:46.257Z",
+          "notes": "10 threads\ntest - pp512: 122.63 \u00b1 0.16 tps\ntest - tg128: 11.99 \u00b1 0.05 tps",
+          "engineFlags": {
+            "commandSnippet": "llama-bench -m /Users/c/.lmstudio/models/unsloth/Qwen3.6-27B-GGUF/Qwen3.6-27B-UD-Q4_K_XL.gguf -ngl 99 -fa 1",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": true,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "unsloth/Qwen3.6-27B-GGUF",
+            "displayName": "Qwen3.6-27B-GGUF",
+            "family": "Qwen",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.6-27B",
+              "displayName": "Qwen3.6-27B"
+            }
+          },
+          "hardware": {
+            "hwClass": "UNIFIED",
+            "gpuName": null,
+            "gpuCount": 1,
+            "vramGb": null,
+            "chipVendor": "Apple",
+            "chipFamily": "M4",
+            "chipVariant": "M4 Pro",
+            "unifiedMemoryGb": 48,
+            "cpu": null,
+            "os": "macOS",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": "build: 3fc4e1052 (9820)",
+            "quantization": "Q4_K_XL",
+            "backend": "metal"
+          },
+          "user": {
+            "id": "cmqvzeywp033qqr01ip5f8qt4",
+            "username": "chiming",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "M4 Pro",
+          "hardwareGroupKey": "UNIFIED:m4 pro",
+          "rank": 5,
+          "reactionCounts": {},
+          "myEmoji": null
+        }
+      ],
+      "total": 5
     },
     "Apple M4 Pro (24 GB)": {
       "rows": [],
@@ -23784,7 +27747,7 @@
             "displayName": "gpt-oss-20b",
             "family": "Gpt",
             "params": 22,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -23847,7 +27810,7 @@
             "displayName": "Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
             "family": null,
             "params": 33,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -24543,6 +28506,204 @@
           "myEmoji": null
         },
         {
+          "id": "cmr2oodnn06jbpi015ypot1mv",
+          "contextLength": 65536,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 1537,
+          "tokSOut": 39.6,
+          "tokSPrefill": 329,
+          "tokSTotal": null,
+          "peakVramGb": 3.5,
+          "createdAt": "2026-07-01T23:05:13.763Z",
+          "notes": "Qwen3.5-4B re-test (v2) via Vulkan RADV Mesa 25.0.7 on Radeon 780M iGPU \u2014 CPU_ONLY placeholder as iGPU not yet in hardware DB. 506 prompt \u2192 512 output tokens. Measured decode at 39.6 tok/s, prefill 329 tok/s.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m Qwen3.5-4B-UD-Q4_K_XL.gguf -c 65536 -ngl 99 --temp 0.0 --no-mmap --port 8080",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.5-4B",
+            "displayName": "Qwen3.5-4B",
+            "family": "Qwen",
+            "params": 4,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.5-4B-Base",
+              "displayName": "Qwen3.5-4B-Base"
+            }
+          },
+          "hardware": {
+            "hwClass": "CPU_ONLY",
+            "gpuName": null,
+            "gpuCount": 1,
+            "vramGb": null,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 8745H w/ Radeon 780M",
+            "os": "Fedora 43",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_K_XL",
+            "backend": "vulkan"
+          },
+          "user": {
+            "id": "cmq4zhqwf003vpf01il7hkajy",
+            "username": "asa394",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "AMD Ryzen 7 8745H w/ Radeon 780M",
+          "hardwareGroupKey": "CPU_ONLY:amd ryzen 7 8745h w/ radeon 780m",
+          "rank": 7,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmr2twz8606m5pi01809xj1o2",
+          "contextLength": 256000,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 1534,
+          "tokSOut": 30.6,
+          "tokSPrefill": 334,
+          "tokSTotal": null,
+          "peakVramGb": 4,
+          "createdAt": "2026-07-02T01:31:53.047Z",
+          "notes": "Gemma4-26B-A4B (MoE 3.8B active / 25.2B total) via Vulkan RADV Mesa 25.0.7 on Radeon 780M iGPU \u2014 CPU_ONLY placeholder. IQ4_XS quantization. 513 prompt \u2192 512 output tokens. Running on 4GB VRAM with CPU offload.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m gemma-4-26B-A4B-it-UD-IQ4_XS.gguf -c 256000 -ngl 99 --temp 0.0 --no-mmap --port 8082",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "google/gemma-4-26B-A4B-it",
+            "displayName": "gemma-4-26B-A4B-it",
+            "family": "Gemma",
+            "params": 27,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "google/gemma-4-26B-A4B",
+              "displayName": "gemma-4-26B-A4B"
+            }
+          },
+          "hardware": {
+            "hwClass": "CPU_ONLY",
+            "gpuName": null,
+            "gpuCount": 1,
+            "vramGb": null,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 8745H w/ Radeon 780M",
+            "os": "Fedora 43",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "IQ4_XS",
+            "backend": "vulkan"
+          },
+          "user": {
+            "id": "cmq4zhqwf003vpf01il7hkajy",
+            "username": "asa394",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "AMD Ryzen 7 8745H w/ Radeon 780M",
+          "hardwareGroupKey": "CPU_ONLY:amd ryzen 7 8745h w/ radeon 780m",
+          "rank": 8,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
+          "id": "cmqz3ljia023soe0118qzcuxu",
+          "contextLength": 65536,
+          "prefillTokens": null,
+          "batchSize": 1,
+          "ttftMs": 3639,
+          "tokSOut": 28,
+          "tokSPrefill": 347,
+          "tokSTotal": null,
+          "peakVramGb": 3.5,
+          "createdAt": "2026-06-29T10:51:50.914Z",
+          "notes": "Qwen3.5-4B re-test via Vulkan (RADV Mesa 25.0.7) on Radeon 780M iGPU \u2014 CPU_ONLY placeholder. Streaming-verified TTFT. 1,261 prompt \u2192 512 output tokens.",
+          "engineFlags": {
+            "commandSnippet": "llama-server -m Qwen3.5-4B-UD-Q4_K_XL.gguf -c 65536 -ngl 99 --temp 0.0 --no-mmap --port 8080",
+            "tensorParallel": null,
+            "gpuLayers": 99,
+            "kvCacheDtype": null,
+            "attentionBackend": null,
+            "flashAttn": null,
+            "specDecoding": false,
+            "mtpEnabled": false
+          },
+          "model": {
+            "hfId": "Qwen/Qwen3.5-4B",
+            "displayName": "Qwen3.5-4B",
+            "family": "Qwen",
+            "params": 4,
+            "isMoE": false,
+            "baseModel": {
+              "hfId": "Qwen/Qwen3.5-4B-Base",
+              "displayName": "Qwen3.5-4B-Base"
+            }
+          },
+          "hardware": {
+            "hwClass": "CPU_ONLY",
+            "gpuName": null,
+            "gpuCount": 1,
+            "vramGb": null,
+            "chipVendor": null,
+            "chipFamily": null,
+            "chipVariant": null,
+            "unifiedMemoryGb": null,
+            "cpu": "AMD Ryzen 7 8745H w/ Radeon 780M",
+            "os": "Fedora 43",
+            "isHeterogeneousGpu": false,
+            "gpuSlots": []
+          },
+          "engine": {
+            "engineName": "llama.cpp",
+            "engineVersion": null,
+            "quantization": "Q4_K_XL",
+            "backend": "vulkan"
+          },
+          "user": {
+            "id": "cmq4zhqwf003vpf01il7hkajy",
+            "username": "asa394",
+            "verified": false,
+            "verifiedAt": null,
+            "pro": false
+          },
+          "hardwareGroupLabel": "AMD Ryzen 7 8745H w/ Radeon 780M",
+          "hardwareGroupKey": "CPU_ONLY:amd ryzen 7 8745h w/ radeon 780m",
+          "rank": 9,
+          "reactionCounts": {},
+          "myEmoji": null
+        },
+        {
           "id": "cmovrue8s00ajp101j30t2qku",
           "contextLength": 2048,
           "prefillTokens": null,
@@ -24604,7 +28765,7 @@
           },
           "hardwareGroupLabel": "Intel R Core TM Ultra 7 155H",
           "hardwareGroupKey": "CPU_ONLY:intel r core tm ultra 7 155h",
-          "rank": 7,
+          "rank": 10,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -24670,7 +28831,7 @@
           },
           "hardwareGroupLabel": "AMD Ryzen 7 8745H w/ Radeon 780M",
           "hardwareGroupKey": "CPU_ONLY:amd ryzen 7 8745h w/ radeon 780m",
-          "rank": 8,
+          "rank": 11,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -24736,7 +28897,7 @@
           },
           "hardwareGroupLabel": "AMD Ryzen 7 8745H w/ Radeon 780M Graphics",
           "hardwareGroupKey": "CPU_ONLY:amd ryzen 7 8745h w/ radeon 780m graphics",
-          "rank": 9,
+          "rank": 12,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -24802,7 +28963,7 @@
           },
           "hardwareGroupLabel": "AMD Ryzen 7 8745H w/ Radeon 780M",
           "hardwareGroupKey": "CPU_ONLY:amd ryzen 7 8745h w/ radeon 780m",
-          "rank": 10,
+          "rank": 13,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -24868,7 +29029,7 @@
           },
           "hardwareGroupLabel": "Intel R Core TM Ultra 7 155H",
           "hardwareGroupKey": "CPU_ONLY:intel r core tm ultra 7 155h",
-          "rank": 11,
+          "rank": 14,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -24934,7 +29095,7 @@
           },
           "hardwareGroupLabel": "AMD Ryzen 7 8745H w/ Radeon 780M",
           "hardwareGroupKey": "CPU_ONLY:amd ryzen 7 8745h w/ radeon 780m",
-          "rank": 12,
+          "rank": 15,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -24965,7 +29126,7 @@
             "displayName": "Qwen3.6-35B-A3B",
             "family": "Qwen",
             "params": 36,
-            "isMoE": false,
+            "isMoE": true,
             "baseModel": null
           },
           "hardware": {
@@ -24997,7 +29158,7 @@
           },
           "hardwareGroupLabel": "Intel R Core TM Ultra 7 155H",
           "hardwareGroupKey": "CPU_ONLY:intel r core tm ultra 7 155h",
-          "rank": 13,
+          "rank": 16,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -25063,7 +29224,7 @@
           },
           "hardwareGroupLabel": "Intel R Core TM Ultra 7 155H",
           "hardwareGroupKey": "CPU_ONLY:intel r core tm ultra 7 155h",
-          "rank": 14,
+          "rank": 17,
           "reactionCounts": {},
           "myEmoji": null
         },
@@ -25129,12 +29290,12 @@
           },
           "hardwareGroupLabel": "Qualcomm Snapdragon 888 ARM64",
           "hardwareGroupKey": "CPU_ONLY:qualcomm snapdragon 888 arm64",
-          "rank": 15,
+          "rank": 18,
           "reactionCounts": {},
           "myEmoji": null
         }
       ],
-      "total": 15
+      "total": 18
     }
   }
 }


### PR DESCRIPTION
Authenticated refresh of `llmfit-core/data/benchmark_cache.json` (previously 10 days stale). 27 presets, 448 rows — RTX 3090 alone now has 120 measured runs.

Beyond the fresher leaderboard fallback, this is the raw material for the estimate-calibration loop discussed in #112/#119: measured `tokSOut` per (hardware preset × model × quant) to validate `estimate_tps` against. A follow-up will add a validation harness in core that replays these rows through the estimator using each preset's bandwidth profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)