### PR TITLE
docs: add dedicated Code signing section (SignPath Foundation requirement)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -973,6 +973,18 @@ cp -r skills/llmfit-advisor ~/.openclaw/skills/
 
 ---
 
+## コード署名
+
+llmfit の Windows リリースバイナリは [SignPath.io](https://about.signpath.io/) によりデジタル署名（Authenticode）されており、コード署名証明書は [SignPath Foundation](https://signpath.org/) から無償で提供されています。
+
+署名は[リリースパイプライン](.github/workflows/release.yml)で自動的に行われます。署名に提出されるのは GitHub Actions によって本リポジトリからビルドされた成果物のみで、署名リクエストはプロジェクトメンテナー（[@AlexsJones](https://github.com/AlexsJones)）が承認します。
+
+**コード署名ポリシー：**[SignPath Foundation のコード署名ポリシーと利用規約](https://signpath.org/terms)を参照してください。
+
+**プライバシー：**本プログラムは、ユーザーまたは本プログラムをインストール・操作する人が明示的に要求しない限り、他のネットワークシステムへ情報を送信することはありません。llmfit が外部サービスにアクセスするのは、該当機能（モデルのダウンロード、ランタイムプロバイダーへの問い合わせ、コミュニティリーダーボードなど）を明示的に使用した場合のみです。
+
+---
+
 ## ライセンス
 
 MIT

--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,18 @@ If you're looking for a different approach, check out [llm-checker](https://gith
 
 ---
 
+## Code signing
+
+llmfit's Windows release binaries are digitally signed (Authenticode) via [SignPath.io](https://about.signpath.io/), with a free code signing certificate provided by the [SignPath Foundation](https://signpath.org/).
+
+Signing happens automatically in the [release pipeline](.github/workflows/release.yml): only artifacts built by GitHub Actions from this repository are submitted for signing, and signing requests are approved by the project maintainer ([@AlexsJones](https://github.com/AlexsJones)).
+
+**Code signing policy:** see the [SignPath Foundation code signing policy and terms](https://signpath.org/terms).
+
+**Privacy:** this program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it. llmfit only contacts external services when you explicitly use the corresponding feature (e.g. model downloads, runtime provider queries, or the community leaderboard).
+
+---
+
 ## License
 
 MIT

--- a/README.zh.md
+++ b/README.zh.md
@@ -982,6 +982,18 @@ Agent 会在后台调用 `llmfit recommend --json`，解读结果，并提议用
 
 ---
 
+## 代码签名
+
+llmfit 的 Windows 发布二进制文件通过 [SignPath.io](https://about.signpath.io/) 进行数字签名（Authenticode），代码签名证书由 [SignPath Foundation](https://signpath.org/) 免费提供。
+
+签名在[发布流水线](.github/workflows/release.yml)中自动完成：只有由 GitHub Actions 从本仓库构建的产物才会提交签名，签名请求由项目维护者（[@AlexsJones](https://github.com/AlexsJones)）审批。
+
+**代码签名政策：**参见 [SignPath Foundation 代码签名政策与条款](https://signpath.org/terms)。
+
+**隐私：**除非用户或安装/运行本程序的人员明确请求，本程序不会向其他联网系统传输任何信息。llmfit 仅在你明确使用相应功能时才会访问外部服务（例如模型下载、运行时提供商查询或社区排行榜）。
+
+---
+
 ## 许可证
 
 MIT


### PR DESCRIPTION
## Summary

SignPath Foundation's review (email from Phillip Deng, 2026-07-03) flagged that the project is missing a dedicated, clearly visible **Code Signing** section — the only public mention so far was the badge in the README header.

This PR adds a standalone `## Code signing` section (placed between *Alternatives* and *License*, not embedded in the install instructions) to `README.md`, mirrored in `README.zh.md` and `README.ja.md`. It:

- states that Windows release binaries are Authenticode-signed via [SignPath.io](https://about.signpath.io/), with the certificate provided by the [SignPath Foundation](https://signpath.org/)
- links the code signing policy ([signpath.org/terms](https://signpath.org/terms))
- describes how signing works in our pipeline: only GitHub Actions builds from this repo are submitted, approvals by the maintainer
- includes the standard privacy statement (verified against the code: llmfit only makes network calls on explicit user action — downloads, provider queries, leaderboard)

Once merged, we can ping SignPath so they mark the project as completed on their side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)