### PR TITLE
fix(docker): drop COPY of removed root data/ directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ COPY Cargo.toml Cargo.lock ./
 COPY llmfit-core/ ./llmfit-core/
 COPY llmfit-tui/ ./llmfit-tui/
 COPY llmfit-desktop/ ./llmfit-desktop/
-COPY data/ ./data/
 
 # Build release binary for llmfit-tui
 RUN cargo build --release -p llmfit


### PR DESCRIPTION
## Summary
- The Docker image builds for `v0.9.36` and `v0.9.37` fail instantly with `"/data": not found` — `Dockerfile` still ran `COPY data/ ./data/`, but the root `data/` directory was removed in cf64a5b / fe89b82 (it held byte-identical duplicates of `llmfit-core/data/`, which is what the build actually embeds via `include_str!`).
- Removes the stale `COPY` line. `llmfit-core/data/` is already covered by `COPY llmfit-core/ ./llmfit-core/`.

## Testing
- Built the Dockerfile's builder stage up to the `cargo build` step against the real context — all `COPY` steps resolve.

Note: since `docker.yml` only triggers on tag pushes, the missing `0.9.36`/`0.9.37` images won't backfill from this merge — the next release tag will publish normally, or the workflow can be run via `workflow_dispatch` to refresh `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #687