### PR TITLE
fix: use cross-platform which crate for binary detection in TUI

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1343,6 +1343,13 @@ pub fn llamacpp_models_dir() -> PathBuf {
     }
 }
 
+/// Check whether a binary is available on the system PATH.
+/// Cross-platform: uses the `which` crate rather than shelling out to a
+/// Unix-only `which` command, so it works on Windows too.
+pub fn command_exists(name: &str) -> bool {
+    which::which(name).is_ok()
+}
+
 /// Find a binary by checking `LLAMA_CPP_PATH` env var, common install
 /// locations, and finally the system PATH via `which`.
 fn find_binary(name: &str) -> Option<String> {

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -4,7 +4,7 @@ use llmfit_core::models::{Capability, ModelDatabase, UseCase};
 use llmfit_core::plan::{PlanEstimate, PlanRequest, estimate_model_plan};
 use llmfit_core::providers::{
     self, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
-    ModelProvider, OllamaProvider, PullEvent, PullHandle, VllmProvider,
+    ModelProvider, OllamaProvider, PullEvent, PullHandle, VllmProvider, command_exists,
 };
 use llmfit_core::quality;
 
@@ -4314,16 +4314,6 @@ impl App {
             }
         }
     }
-}
-
-fn command_exists(name: &str) -> bool {
-    std::process::Command::new("which")
-        .arg(name)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- The TUI's `command_exists()` shelled out to the Unix-only `which` command, so the Ollama binary check (and backend availability indicators depending on it) always failed on Windows — the last remaining Unix-only PATH lookup after core moved to the `which` crate.
- Replaces it with a shared `llmfit_core::providers::command_exists()` helper built on the cross-platform `which` crate already used by `find_binary()`.

Addresses the remaining Windows PATH detection issue from #178 / #188.

## Test plan
- `cargo build`, `cargo clippy --all-targets`, `cargo test` (all 5 suites pass), `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)