### PR TITLE
feat: add global --tui flag to force interactive TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ This prints JSON from `llmfit recommend` command. The JSON could be further quer
 ```
 podman run ghcr.io/alexsjones/llmfit recommend --use-case coding | jq '.models[].name'
 ```
+To launch the interactive TUI instead, pass the global `--tui` flag:
+```sh
+docker run --rm -it ghcr.io/alexsjones/llmfit --tui
+```
 
 ### From source
 ```sh

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -168,6 +168,12 @@ struct Cli {
     #[arg(long, value_name = "TOKENS", value_parser = clap::value_parser!(u32).range(1..))]
     max_context: Option<u32>,
 
+    /// Force the interactive TUI, ignoring any subcommand or output flags.
+    /// Useful in Docker where a baked-in CMD would otherwise run a subcommand:
+    /// docker run --rm -it ghcr.io/alexsjones/llmfit --tui
+    #[arg(long, global = true)]
+    tui: bool,
+
     /// Do not auto-start the background dashboard server
     #[arg(long, global = true)]
     no_dashboard: bool,
@@ -2565,14 +2571,25 @@ fn main() {
         cpu_cores: cli.cpu_cores,
     };
     let auto_dashboard = !cli.no_dashboard
-        && !cli.json
-        && !matches!(cli.command.as_ref(), Some(Commands::Serve { .. }));
+        && (cli.tui
+            || (!cli.json && !matches!(cli.command.as_ref(), Some(Commands::Serve { .. }))));
 
     let _dashboard_guard = if auto_dashboard {
         ensure_dashboard_available(&overrides, context_limit)
     } else {
         None
     };
+
+    // --tui forces the interactive TUI regardless of any subcommand or
+    // output flags, so a Docker image with a baked-in CMD can still launch
+    // the TUI: docker run --rm -it ghcr.io/alexsjones/llmfit --tui
+    if cli.tui {
+        if let Err(e) = run_tui(&overrides, context_limit, cli.api_key) {
+            eprintln!("Error running TUI: {}", e);
+            std::process::exit(1);
+        }
+        return;
+    }
 
     // If a subcommand is given, use classic CLI mode
     if let Some(command) = cli.command {


### PR DESCRIPTION
## Summary
- Adds a global `--tui` flag that forces the interactive TUI regardless of any subcommand or output flags.
- Makes the TUI reachable from the published Docker image without entrypoint overrides — args after the image name replace the baked-in `recommend --json` CMD, so `docker run --rm -it ghcr.io/alexsjones/llmfit --tui` just works.
- Documents the invocation in the README Docker/Podman section.
- `--tui` also re-enables the auto-dashboard the way default TUI mode does.

Closes #547

## Test plan
- `cargo build` / `cargo test` / `cargo fmt --check` all pass
- Smoke-tested: `llmfit recommend --json --tui` attempts TUI launch (dispatch override works); `llmfit recommend --json` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)