### PR TITLE
feat: pin Huihui-Qwen3.6-35B-A3B-abliterated and add GGUF source

### DIFF
--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -107,6 +107,7 @@ TARGET_MODELS = [
     # Qwen 3.6 (native multimodal + hybrid attention, Apr 2026)
     "Qwen/Qwen3.6-27B",
     "Qwen/Qwen3.6-35B-A3B",
+    "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated",
     # Microsoft Phi
     "microsoft/phi-3-mini-4k-instruct",
     "microsoft/Phi-3-medium-14b-instruct",
@@ -336,6 +337,7 @@ MOE_ACTIVE_PARAMS = {
     "Qwen/Qwen3.5-122B-A10B": 10_000_000_000,
     "Qwen/Qwen3.5-397B-A17B": 17_000_000_000,
     "Qwen/Qwen3.6-35B-A3B": 3_000_000_000,
+    "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated": 3_000_000_000,  # Qwen3.6-35B-A3B finetune
     "meta-llama/Llama-4-Scout-17B-16E-Instruct": 17_000_000_000,
     "meta-llama/Llama-4-Maverick-17B-128E-Instruct": 17_000_000_000,
     "xai-org/grok-1": 86_000_000_000,


### PR DESCRIPTION
## Summary
Closes #656.

The model was already in the catalog via auto-discovery, but had no `gguf_sources` (so the TUI Downloads panel showed nothing) and wasn't pinned, so it could drop out of future scrapes.

- Adds `huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated` to `TARGET_MODELS` in the scraper
- Adds a `MOE_ACTIVE_PARAMS` fallback (3B active, matching base `Qwen/Qwen3.6-35B-A3B` per the issue's suggestion)
- Enriches the existing catalog entry with the `mradermacher/Huihui-Qwen3.6-35B-A3B-abliterated-GGUF` source and aligns `active_parameters` with the published 3B figure

## Test plan
- `cargo build` / `cargo test -p llmfit-core` pass
- `llmfit info huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated` resolves with correct params, quant table, and GGUF availability
- Verified no duplicate catalog entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)