### PR TITLE
feat: add RamaLama as a detection provider

### DIFF
--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -3,7 +3,7 @@ use crate::hardware::SystemSpecs;
 use crate::models::ModelDatabase;
 use crate::providers::{
     self, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
-    ModelProvider, OllamaProvider, VllmProvider,
+    ModelProvider, OllamaProvider, RamaLamaProvider, VllmProvider,
 };
 use std::collections::HashSet;
 
@@ -25,6 +25,8 @@ pub struct InstalledIndex {
     pub lmstudio_count: usize,
     pub vllm: HashSet<String>,
     pub vllm_count: usize,
+    pub ramalama: HashSet<String>,
+    pub ramalama_count: usize,
 }
 
 impl InstalledIndex {
@@ -42,6 +44,8 @@ impl InstalledIndex {
             lmstudio_count: 0,
             vllm: HashSet::new(),
             vllm_count: 0,
+            ramalama: HashSet::new(),
+            ramalama_count: 0,
         }
     }
 
@@ -73,6 +77,10 @@ impl InstalledIndex {
                 let p = VllmProvider::new();
                 p.installed_models_counted()
             });
+            let ramalama = s.spawn(|| {
+                let p = RamaLamaProvider::new();
+                p.installed_models_counted()
+            });
 
             let (ollama, ollama_count) = ollama.join().unwrap();
             let mlx = mlx.join().unwrap();
@@ -80,6 +88,7 @@ impl InstalledIndex {
             let (docker_mr, docker_mr_count) = docker_mr.join().unwrap();
             let (lmstudio, lmstudio_count) = lmstudio.join().unwrap();
             let (vllm, vllm_count) = vllm.join().unwrap();
+            let (ramalama, ramalama_count) = ramalama.join().unwrap();
 
             Self {
                 ollama,
@@ -93,6 +102,8 @@ impl InstalledIndex {
                 lmstudio_count,
                 vllm,
                 vllm_count,
+                ramalama,
+                ramalama_count,
             }
         })
     }
@@ -105,6 +116,7 @@ impl InstalledIndex {
             || providers::is_model_installed_docker_mr(model_name, &self.docker_mr)
             || providers::is_model_installed_lmstudio(model_name, &self.lmstudio)
             || providers::is_model_installed_vllm(model_name, &self.vllm)
+            || providers::is_model_installed_ramalama(model_name, &self.ramalama)
     }
 
     /// Returns the display names of all providers that have this model
@@ -128,6 +140,9 @@ impl InstalledIndex {
         }
         if providers::is_model_installed_vllm(model_name, &self.vllm) {
             out.push("vLLM");
+        }
+        if providers::is_model_installed_ramalama(model_name, &self.ramalama) {
+            out.push("RamaLama");
         }
         out
     }

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -2408,6 +2408,195 @@ pub fn vllm_pull_tag(hf_name: &str) -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
+// RamaLama provider
+// ---------------------------------------------------------------------------
+
+/// RamaLama — container-based model runner with an OpenAI-compatible API.
+///
+/// Exposes `GET /v1/models` to list served models at
+/// `http://localhost:8080` by default. Override with `RAMALAMA_HOST`.
+///
+/// Like vLLM, RamaLama has no runtime pull endpoint — models are served
+/// via `ramalama serve <model>`. The `start_pull` implementation returns
+/// an informational error directing users to serve the desired model.
+pub struct RamaLamaProvider {
+    base_url: String,
+}
+
+fn normalize_ramalama_host(raw: &str) -> Option<String> {
+    let host = raw.trim();
+    if host.is_empty() {
+        return None;
+    }
+
+    if host.starts_with("http://") || host.starts_with("https://") {
+        return Some(host.to_string());
+    }
+
+    if host.contains("://") {
+        return None;
+    }
+
+    Some(format!("http://{host}"))
+}
+
+impl Default for RamaLamaProvider {
+    fn default() -> Self {
+        let base_url = std::env::var("RAMALAMA_HOST")
+            .ok()
+            .and_then(|raw| {
+                let normalized = normalize_ramalama_host(&raw);
+                if normalized.is_none() {
+                    eprintln!(
+                        "Warning: could not parse RAMALAMA_HOST='{}'. \
+                         Expected host:port or http(s)://host:port",
+                        raw
+                    );
+                }
+                normalized
+            })
+            .unwrap_or_else(|| "http://localhost:8080".to_string());
+        Self { base_url }
+    }
+}
+
+impl RamaLamaProvider {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn models_url(&self) -> String {
+        format!("{}/v1/models", self.base_url.trim_end_matches('/'))
+    }
+
+    /// Single-pass startup probe.
+    /// Returns `(available, installed_models, count)`.
+    pub fn detect_with_installed(&self) -> (bool, HashSet<String>, usize) {
+        let mut set = HashSet::new();
+        let Ok(resp) = ureq::get(&self.models_url())
+            .config()
+            .timeout_global(Some(std::time::Duration::from_millis(800)))
+            .build()
+            .call()
+        else {
+            return (false, set, 0);
+        };
+
+        let Ok(list) = resp.into_body().read_json::<RamaLamaModelList>() else {
+            return (true, set, 0);
+        };
+        let models = list.data;
+        let count = models.len();
+        for m in models {
+            let lower = m.id.to_lowercase();
+            set.insert(lower.clone());
+            // Also insert the model part after the publisher
+            // e.g. "meta-llama/Llama-3.1-8B-Instruct" → "llama-3.1-8b-instruct"
+            if let Some(name) = lower.split('/').next_back()
+                && name != lower
+            {
+                set.insert(name.to_string());
+            }
+        }
+        (true, set, count)
+    }
+
+    pub fn installed_models_counted(&self) -> (HashSet<String>, usize) {
+        let (_, set, count) = self.detect_with_installed();
+        (set, count)
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct RamaLamaModelList {
+    data: Vec<RamaLamaModel>,
+}
+
+#[derive(serde::Deserialize)]
+struct RamaLamaModel {
+    /// Model id, e.g. "meta-llama/Llama-3.1-8B-Instruct"
+    id: String,
+}
+
+impl ModelProvider for RamaLamaProvider {
+    fn name(&self) -> &str {
+        "RamaLama"
+    }
+
+    fn is_available(&self) -> bool {
+        ureq::get(&self.models_url())
+            .config()
+            .timeout_global(Some(std::time::Duration::from_secs(2)))
+            .build()
+            .call()
+            .is_ok()
+    }
+
+    fn installed_models(&self) -> HashSet<String> {
+        let (set, _) = self.installed_models_counted();
+        set
+    }
+
+    fn start_pull(&self, _model_tag: &str) -> Result<PullHandle, String> {
+        Err("RamaLama does not support downloading models at runtime. \
+             Serve the desired model with `ramalama serve <model>`."
+            .to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RamaLama name-matching helpers
+// ---------------------------------------------------------------------------
+
+/// RamaLama serves HuggingFace/OCI model names directly. We match against the
+/// model's full HF name and common naming patterns.
+pub fn hf_name_to_ramalama_candidates(hf_name: &str) -> Vec<String> {
+    let repo = hf_name
+        .split('/')
+        .next_back()
+        .unwrap_or(hf_name)
+        .to_lowercase();
+    let mut candidates = vec![hf_name.to_lowercase()];
+    if repo != hf_name.to_lowercase() {
+        candidates.push(repo.clone());
+    }
+    // Strip common suffixes for matching
+    let stripped = repo
+        .replace("-instruct", "")
+        .replace("-chat", "")
+        .replace("-hf", "")
+        .replace("-it", "");
+    if stripped != repo {
+        candidates.push(stripped);
+    }
+    candidates
+}
+
+/// Check if any RamaLama candidates for an HF model appear in the installed set.
+pub fn is_model_installed_ramalama(hf_name: &str, installed: &HashSet<String>) -> bool {
+    let candidates = hf_name_to_ramalama_candidates(hf_name);
+    candidates.iter().any(|candidate| {
+        installed
+            .iter()
+            .any(|installed_name| installed_name.contains(candidate))
+    })
+}
+
+/// RamaLama can serve any HuggingFace model, so we always return true.
+pub fn has_ramalama_mapping(hf_name: &str) -> bool {
+    !hf_name.is_empty()
+}
+
+/// Given an HF model name, return the model identifier to use for RamaLama.
+/// RamaLama accepts HF model names directly.
+pub fn ramalama_pull_tag(hf_name: &str) -> Option<String> {
+    if hf_name.is_empty() {
+        return None;
+    }
+    Some(hf_name.to_string())
+}
+
+// ---------------------------------------------------------------------------
 // Docker Model Runner name-matching helpers
 // ---------------------------------------------------------------------------
 
@@ -4485,6 +4674,75 @@ mod tests {
     fn test_normalize_vllm_host_empty() {
         assert_eq!(normalize_vllm_host(""), None);
         assert_eq!(normalize_vllm_host("  "), None);
+    }
+
+    #[test]
+    fn test_hf_name_to_ramalama_candidates() {
+        let candidates = hf_name_to_ramalama_candidates("meta-llama/Llama-3.1-8B-Instruct");
+        assert!(
+            candidates
+                .iter()
+                .any(|c| c == "meta-llama/llama-3.1-8b-instruct")
+        );
+        assert!(candidates.iter().any(|c| c == "llama-3.1-8b-instruct"));
+        // stripped variant (without -instruct)
+        assert!(candidates.iter().any(|c| c == "llama-3.1-8b"));
+    }
+
+    #[test]
+    fn test_is_model_installed_ramalama() {
+        let mut installed = HashSet::new();
+        installed.insert("meta-llama/llama-3.1-8b-instruct".to_string());
+        assert!(is_model_installed_ramalama(
+            "meta-llama/Llama-3.1-8B-Instruct",
+            &installed
+        ));
+        assert!(!is_model_installed_ramalama(
+            "meta-llama/Llama-3.1-70B-Instruct",
+            &installed
+        ));
+    }
+
+    #[test]
+    fn test_has_ramalama_mapping() {
+        assert!(has_ramalama_mapping("meta-llama/Llama-3.1-8B-Instruct"));
+        assert!(!has_ramalama_mapping(""));
+    }
+
+    #[test]
+    fn test_ramalama_pull_tag() {
+        assert_eq!(
+            ramalama_pull_tag("meta-llama/Llama-3.1-8B-Instruct"),
+            Some("meta-llama/Llama-3.1-8B-Instruct".to_string())
+        );
+        assert_eq!(ramalama_pull_tag(""), None);
+    }
+
+    #[test]
+    fn test_normalize_ramalama_host_with_scheme() {
+        assert_eq!(
+            normalize_ramalama_host("http://myhost:8080"),
+            Some("http://myhost:8080".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_ramalama_host_without_scheme() {
+        assert_eq!(
+            normalize_ramalama_host("myhost:8080"),
+            Some("http://myhost:8080".to_string())
+        );
+    }
+
+    #[test]
+    fn test_normalize_ramalama_host_rejects_unsupported_scheme() {
+        assert_eq!(normalize_ramalama_host("ftp://myhost:8080"), None);
+    }
+
+    #[test]
+    fn test_normalize_ramalama_host_empty() {
+        assert_eq!(normalize_ramalama_host(""), None);
+        assert_eq!(normalize_ramalama_host("  "), None);
     }
 
     #[test]

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -4,7 +4,8 @@ use llmfit_core::models::{Capability, ModelDatabase, UseCase};
 use llmfit_core::plan::{PlanEstimate, PlanRequest, estimate_model_plan};
 use llmfit_core::providers::{
     self, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
-    ModelProvider, OllamaProvider, PullEvent, PullHandle, VllmProvider, command_exists,
+    ModelProvider, OllamaProvider, PullEvent, PullHandle, RamaLamaProvider, VllmProvider,
+    command_exists,
 };
 use llmfit_core::quality;
 
@@ -95,6 +96,11 @@ pub enum ProviderDetectionMsg {
         installed_count: usize,
     },
     Vllm {
+        available: bool,
+        installed: HashSet<String>,
+        installed_count: usize,
+    },
+    RamaLama {
         available: bool,
         installed: HashSet<String>,
         installed_count: usize,
@@ -617,6 +623,8 @@ pub struct App {
     lmstudio: LmStudioProvider,
     pub vllm_available: bool,
     vllm: VllmProvider,
+    pub ramalama_available: bool,
+    ramalama: RamaLamaProvider,
 
     // Download state
     pub pull_active: Option<PullHandle>,
@@ -788,6 +796,8 @@ impl App {
         let lmstudio_available = false;
         let vllm = VllmProvider::new();
         let vllm_available = false;
+        let ramalama = RamaLamaProvider::new();
+        let ramalama_available = false;
         let mut installed = llmfit_core::analysis::InstalledIndex::empty();
         installed.llamacpp = llamacpp_installed;
         installed.llamacpp_count = llamacpp_installed_count;
@@ -845,11 +855,23 @@ impl App {
             });
         }
         {
-            let tx = provider_tx;
+            let tx = provider_tx.clone();
             thread::spawn(move || {
                 let vllm = VllmProvider::new();
                 let (available, installed, installed_count) = vllm.detect_with_installed();
                 let _ = tx.send(ProviderDetectionMsg::Vllm {
+                    available,
+                    installed,
+                    installed_count,
+                });
+            });
+        }
+        {
+            let tx = provider_tx;
+            thread::spawn(move || {
+                let ramalama = RamaLamaProvider::new();
+                let (available, installed, installed_count) = ramalama.detect_with_installed();
+                let _ = tx.send(ProviderDetectionMsg::RamaLama {
                     available,
                     installed,
                     installed_count,
@@ -1094,6 +1116,8 @@ impl App {
             lmstudio,
             vllm_available,
             vllm,
+            ramalama_available,
+            ramalama,
             pull_active: None,
             pull_status: None,
             pull_percent: None,
@@ -3761,6 +3785,7 @@ impl App {
         let (docker_mr, docker_mr_count) = self.docker_mr.installed_models_counted();
         let (lmstudio, lmstudio_count) = self.lmstudio.installed_models_counted();
         let (vllm, vllm_count) = self.vllm.installed_models_counted();
+        let (ramalama, ramalama_count) = self.ramalama.installed_models_counted();
         self.installed = llmfit_core::analysis::InstalledIndex {
             ollama,
             ollama_count,
@@ -3773,6 +3798,8 @@ impl App {
             lmstudio_count,
             vllm,
             vllm_count,
+            ramalama,
+            ramalama_count,
         };
         for fit in &mut self.all_fits {
             fit.installed = self.installed.is_installed(&fit.model.name);
@@ -3917,6 +3944,15 @@ impl App {
                             self.vllm_available = available;
                             self.installed.vllm = installed;
                             self.installed.vllm_count = installed_count;
+                        }
+                        ProviderDetectionMsg::RamaLama {
+                            available,
+                            installed,
+                            installed_count,
+                        } => {
+                            self.ramalama_available = available;
+                            self.installed.ramalama = installed;
+                            self.installed.ramalama_count = installed_count;
                         }
                     }
                 }

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -178,7 +178,8 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
                 || app.mlx_available
                 || app.llamacpp_available
                 || app.lmstudio_available
-                || app.vllm_available =>
+                || app.vllm_available
+                || app.ramalama_available =>
         {
             app.toggle_installed_first()
         }
@@ -202,7 +203,8 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
                 || app.mlx_available
                 || app.llamacpp_available
                 || app.lmstudio_available
-                || app.vllm_available =>
+                || app.vllm_available
+                || app.ramalama_available =>
         {
             app.refresh_installed()
         }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -211,6 +211,17 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         tc.muted
     };
 
+    let ramalama_info = if app.ramalama_available {
+        format!("RamaLama: ✓ ({} models)", app.installed.ramalama_count)
+    } else {
+        "RamaLama: ✗".to_string()
+    };
+    let ramalama_color = if app.ramalama_available {
+        tc.good
+    } else {
+        tc.muted
+    };
+
     let mut hw_spans = Vec::new();
     if app.sim_active {
         hw_spans.push(Span::styled(
@@ -256,6 +267,8 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         Span::styled(lmstudio_info, Style::default().fg(lmstudio_color)),
         Span::styled("  │  ", Style::default().fg(tc.muted)),
         Span::styled(vllm_info, Style::default().fg(vllm_color)),
+        Span::styled("  │  ", Style::default().fg(tc.muted)),
+        Span::styled(ramalama_info, Style::default().fg(ramalama_color)),
     ];
 
     if app.backend_hidden_count > 0 {


### PR DESCRIPTION
Closes #699.

Adds RamaLama alongside the existing vLLM/Ollama/LM Studio/llama.cpp providers. RamaLama serves an OpenAI-compatible API (`GET /v1/models`, default port `8080`), so it mirrors `VllmProvider` almost exactly.

## What this does

- **`RamaLamaProvider`** (`providers.rs`) mirroring `VllmProvider`: `normalize_ramalama_host`, `Default` via `RAMALAMA_HOST` (default `http://localhost:8080`), `detect_with_installed` single-pass probe, and the `ModelProvider` impl. `start_pull` returns an informational error pointing at `ramalama serve <model>` (RamaLama, like vLLM, has no runtime pull endpoint).
- **Name mapping**: `hf_name_to_ramalama_candidates`, `is_model_installed_ramalama`, `has_ramalama_mapping`, `ramalama_pull_tag`.
- **Detection wiring** into `InstalledIndex` (`analysis.rs`): parallel detection thread, `is_installed`, and `installed_providers` (adds the `RamaLama` label to the detail panel).
- **TUI**: `ramalama_available` state + background detection in `tui_app.rs`, wired into the installed-first (`i`) and refresh (`r`) availability gates in `tui_events.rs`, plus a `RamaLama: ✓ (N models)` status-bar entry.
- **Unit tests** mirroring the `test_*_vllm` cases (candidates, install matching, mapping, pull tag, host normalization) - 8 new tests.

## Scope note

Implemented as a **detection** provider per the issue title. Because RamaLama has no runtime-download path (same as vLLM's erroring `start_pull`), it is intentionally **not** wired as a `DownloadProvider` (no download-manager / serve-API / MCP / bench plumbing, and it is not added to the `d` download gate). Happy to add the download-target path as a follow-up if you'd prefer the fuller vLLM mirror.

`RAMALAMA_HOST` follows the same convention as the provider's existing `VLLM_HOST` (which is likewise not surfaced in the README env-var table), so no doc table was touched.

## Testing

- `cargo test` - full workspace suite green (431 core + 46 + 8 + ... , incl. the 8 new `*_ramalama` tests).
- `cargo fmt --check` - clean.
- `cargo clippy --all-targets` (default members) - no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
