### PR TITLE
feat: auto-detect system RAM bandwidth for MoE-offload estimates

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -28,6 +28,11 @@ pub struct CalcConfig {
     /// Scoring weights per use case: (quality, speed, fit, context).
     #[serde(default)]
     pub scoring_weights: ScoringWeights,
+    /// System RAM (DDR) bandwidth in GB/s, used for MoE-offload estimates.
+    /// None = auto: LLMFIT_DDR_BANDWIDTH env var if set, otherwise measured
+    /// once per process, otherwise a conservative 50 GB/s.
+    #[serde(default)]
+    pub ddr_bandwidth_gbps: Option<f64>,
 }
 
 impl Default for CalcConfig {
@@ -37,6 +42,7 @@ impl Default for CalcConfig {
             efficiency: default_efficiency(),
             run_mode_factors: RunModeFactors::default(),
             scoring_weights: ScoringWeights::default(),
+            ddr_bandwidth_gbps: None,
         }
     }
 }
@@ -1048,11 +1054,6 @@ pub fn rank_models_by_fit_opts_col(
 ///  - Google, "Efficiently Scaling Transformer Inference" (arXiv:2211.05102)
 ///  - ggerganov, llama.cpp NVIDIA T4 benchmarks (Discussion #4225)
 
-/// Read the system DDR bandwidth (GB/s) from the `LLMFIT_DDR_BANDWIDTH` env var,
-/// falling back to a conservative 50 GB/s default (DDR4-3200 dual-channel).
-///
-/// Override: `export LLMFIT_DDR_BANDWIDTH=90` for DDR5-5600 dual-channel, etc.
-/// Typical values: DDR4-3200 dual-channel ~50 GB/s, DDR5-5600 dual-channel ~90 GB/s.
 /// VRAM utilization threshold above which MoE cache-pressure penalty applies.
 /// Below this, inactive experts don't significantly compete for L2 cache.
 const VRAM_PRESSURE_UTIL_THRESHOLD: f64 = 0.60;
@@ -1076,11 +1077,25 @@ macro_rules! debug_log {
     };
 }
 
-fn ddr_bandwidth_gbps() -> f64 {
-    std::env::var("LLMFIT_DDR_BANDWIDTH")
+/// System DDR bandwidth (GB/s) used for MoE-offload expert streaming.
+///
+/// Resolution order:
+///  1. `CalcConfig::ddr_bandwidth_gbps` (TUI Advanced Config)
+///  2. `LLMFIT_DDR_BANDWIDTH` env var (e.g. `export LLMFIT_DDR_BANDWIDTH=90`)
+///  3. Measured effective bandwidth (`hardware::measured_ram_bandwidth_gbps`)
+///  4. Conservative 50 GB/s fallback (DDR4-3200 dual-channel)
+fn ddr_bandwidth_gbps(config: &CalcConfig) -> f64 {
+    if let Some(bw) = config.ddr_bandwidth_gbps.filter(|b| *b > 0.0) {
+        return bw;
+    }
+    if let Some(bw) = std::env::var("LLMFIT_DDR_BANDWIDTH")
         .ok()
         .and_then(|v| v.parse::<f64>().ok())
-        .unwrap_or(50.0)
+        .filter(|b| *b > 0.0)
+    {
+        return bw;
+    }
+    crate::hardware::measured_ram_bandwidth_gbps().unwrap_or(50.0)
 }
 
 fn estimate_tps(
@@ -1160,11 +1175,12 @@ fn estimate_tps(
             // ceiling on some systems, but in practice llama.cpp processes
             // offloaded layers on the CPU, so DDR bandwidth is the dominant factor.
             //
-            // Typical DDR bandwidths: DDR4-3200 dual-channel ~50 GB/s,
-            // DDR5-5600 dual-channel ~90 GB/s. We use a conservative 50 GB/s
-            // default which can be overridden via LLMFIT_DDR_BANDWIDTH env var.
+            // DDR bandwidth is resolved per ddr_bandwidth_gbps(): Advanced
+            // Config value, else LLMFIT_DDR_BANDWIDTH env var, else measured
+            // effective bandwidth, else a conservative 50 GB/s (DDR4-3200
+            // dual-channel).
             if run_mode == RunMode::MoeOffload {
-                let ddr_bw = ddr_bandwidth_gbps();
+                let ddr_bw = ddr_bandwidth_gbps(config);
 
                 let expert_read_time = active_gb / ddr_bw; // CPU reads from DDR
                 let gpu_compute_time = active_gb / (bw * efficiency);
@@ -1354,7 +1370,7 @@ fn estimate_tps(
         let estimated_gpu_bw = k * models::quant_bytes_per_param(quant) / fallback_efficiency;
         let bytes_per_param = models::quant_bytes_per_param(quant);
         let active_gb = params * bytes_per_param;
-        let ddr_bw = ddr_bandwidth_gbps();
+        let ddr_bw = ddr_bandwidth_gbps(config);
         let expert_read_time = active_gb / ddr_bw;
         let gpu_compute_time = active_gb / (estimated_gpu_bw * fallback_efficiency);
         base = (1.0 / (expert_read_time + gpu_compute_time)).max(0.1);
@@ -1643,7 +1659,28 @@ mod tests {
 
     /// Test helper: default CalcConfig for direct estimate_tps calls.
     fn test_config() -> CalcConfig {
-        CalcConfig::default()
+        CalcConfig {
+            // Pin DDR bandwidth so MoE-offload estimates don't vary with the
+            // machine running the tests.
+            ddr_bandwidth_gbps: Some(50.0),
+            ..CalcConfig::default()
+        }
+    }
+
+    #[test]
+    fn test_ddr_bandwidth_config_override_wins() {
+        let config = CalcConfig {
+            ddr_bandwidth_gbps: Some(123.0),
+            ..CalcConfig::default()
+        };
+        assert_eq!(ddr_bandwidth_gbps(&config), 123.0);
+
+        // Zero/negative values are invalid and fall through to auto.
+        let config = CalcConfig {
+            ddr_bandwidth_gbps: Some(0.0),
+            ..CalcConfig::default()
+        };
+        assert!(ddr_bandwidth_gbps(&config) > 0.0);
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -3297,7 +3334,9 @@ mod tests {
         // Small VRAM to force MoE offload path
         let system = test_system_with_gpu(64.0, 8.0, "NVIDIA GeForce RTX 4090");
 
-        let fit = ModelFit::analyze(&model, &system);
+        // Pinned DDR bandwidth: the auto-measured value would make this
+        // machine-dependent.
+        let fit = ModelFit::analyze_with_config(&model, &system, test_config());
 
         assert!(
             matches!(fit.run_mode, RunMode::MoeOffload),

--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -1865,6 +1865,9 @@ impl SystemSpecs {
         println!("CPU: {} ({} cores)", self.cpu_name, self.total_cpu_cores);
         println!("Total RAM: {:.2} GB", self.total_ram_gb);
         println!("Available RAM: {:.2} GB", self.available_ram_gb);
+        if let Some(bw) = measured_ram_bandwidth_gbps() {
+            println!("RAM Bandwidth: ~{bw:.0} GB/s (measured)");
+        }
         println!("Backend: {}", self.backend.label());
 
         if self.gpus.is_empty() {
@@ -2048,6 +2051,68 @@ fn read_proc_meminfo_total_gb() -> Option<f64> {
         }
     }
     None
+}
+
+/// Effective system RAM bandwidth in GB/s, measured once per process with a
+/// short multithreaded memcpy sweep (~100 ms total) and cached.
+///
+/// This is *achievable* streaming bandwidth (STREAM-copy convention: bytes
+/// read + bytes written per pass), which is what MoE-offload expert streaming
+/// actually sees — typically 60–80% of the spec-sheet peak. Returns `None`
+/// if the measurement fails or produces an implausible value; callers should
+/// fall back to a conservative constant.
+pub fn measured_ram_bandwidth_gbps() -> Option<f64> {
+    static MEASURED: std::sync::OnceLock<Option<f64>> = std::sync::OnceLock::new();
+    *MEASURED.get_or_init(measure_ram_bandwidth_gbps)
+}
+
+fn measure_ram_bandwidth_gbps() -> Option<f64> {
+    use std::time::{Duration, Instant};
+
+    // Per-thread working set (2 × 32 MiB) must comfortably exceed L3 so we
+    // measure DRAM, not cache. A single thread rarely saturates multi-channel
+    // memory controllers, so spread the sweep across up to 8 cores.
+    const BUF_BYTES: usize = 32 * 1024 * 1024;
+    const MEASURE_WINDOW: Duration = Duration::from_millis(80);
+
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get().min(8))
+        .unwrap_or(4);
+
+    let barrier = std::sync::Barrier::new(threads);
+    let per_thread_gbps: Vec<f64> = std::thread::scope(|scope| {
+        let barrier = &barrier;
+        let handles: Vec<_> = (0..threads)
+            .map(|_| {
+                scope.spawn(move || {
+                    let src = vec![1u8; BUF_BYTES];
+                    let mut dst = vec![0u8; BUF_BYTES];
+                    // Warmup pass faults pages in before the timed window.
+                    dst.copy_from_slice(&src);
+                    std::hint::black_box(&mut dst);
+                    barrier.wait();
+                    let start = Instant::now();
+                    let mut passes = 0u64;
+                    while start.elapsed() < MEASURE_WINDOW {
+                        dst.copy_from_slice(&src);
+                        std::hint::black_box(&mut dst);
+                        passes += 1;
+                    }
+                    let secs = start.elapsed().as_secs_f64();
+                    (passes as f64) * (2 * BUF_BYTES) as f64 / secs / 1e9
+                })
+            })
+            .collect();
+        handles.into_iter().filter_map(|h| h.join().ok()).collect()
+    });
+
+    if per_thread_gbps.len() != threads {
+        return None;
+    }
+    let total: f64 = per_thread_gbps.iter().sum();
+    // Sanity band: below 2 GB/s means the measurement was starved (heavy
+    // contention, throttled VM); above 4000 GB/s means we measured cache.
+    (2.0..=4000.0).contains(&total).then_some(total)
 }
 
 /// Estimate GPU memory bandwidth in GB/s from the GPU model name.
@@ -2735,6 +2800,16 @@ fn estimate_vram_from_name(name: &str) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::SystemSpecs;
+
+    #[test]
+    fn test_measured_ram_bandwidth_plausible_and_cached() {
+        // May legitimately be None on a starved CI runner; when it measures,
+        // the value must sit in the sanity band and be stable across calls.
+        if let Some(bw) = super::measured_ram_bandwidth_gbps() {
+            assert!((2.0..=4000.0).contains(&bw), "implausible bandwidth: {bw}");
+            assert_eq!(super::measured_ram_bandwidth_gbps(), Some(bw));
+        }
+    }
 
     #[test]
     fn test_parse_nvidia_smi_does_not_sum_multi_gpu_vram() {

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -181,6 +181,7 @@ pub enum AdvConfigField {
     FactorTp,         // Run mode factor: Tensor parallel
     FactorCpuOnly,    // Run mode factor: CPU only
     ContextCap,       // Context window cap
+    DdrBandwidth,     // System RAM bandwidth (GB/s) for MoE offload
 }
 
 impl AdvConfigField {
@@ -192,13 +193,15 @@ impl AdvConfigField {
             AdvConfigField::FactorMoe => AdvConfigField::FactorTp,
             AdvConfigField::FactorTp => AdvConfigField::FactorCpuOnly,
             AdvConfigField::FactorCpuOnly => AdvConfigField::ContextCap,
-            AdvConfigField::ContextCap => AdvConfigField::Efficiency,
+            AdvConfigField::ContextCap => AdvConfigField::DdrBandwidth,
+            AdvConfigField::DdrBandwidth => AdvConfigField::Efficiency,
         }
     }
 
     fn prev(self) -> Self {
         match self {
-            AdvConfigField::Efficiency => AdvConfigField::ContextCap,
+            AdvConfigField::Efficiency => AdvConfigField::DdrBandwidth,
+            AdvConfigField::DdrBandwidth => AdvConfigField::ContextCap,
             AdvConfigField::FactorGpu => AdvConfigField::Efficiency,
             AdvConfigField::FactorCpuOffload => AdvConfigField::FactorGpu,
             AdvConfigField::FactorMoe => AdvConfigField::FactorCpuOffload,
@@ -703,6 +706,7 @@ pub struct App {
     pub adv_config_eff_factor_tp: String,
     pub adv_config_eff_factor_cpu_only: String,
     pub adv_config_context_cap_input: String,
+    pub adv_config_ddr_bandwidth_input: String,
 
     // Filter Popup
     pub filter_field: FilterPopupField,
@@ -1154,6 +1158,7 @@ impl App {
             adv_config_eff_factor_tp: "0.9".to_string(),
             adv_config_eff_factor_cpu_only: "0.3".to_string(),
             adv_config_context_cap_input: String::new(), // empty = use default
+            adv_config_ddr_bandwidth_input: String::new(), // empty = auto-detect
             // Filter popup defaults
             filter_field: FilterPopupField::ParamsMin,
             filter_cursor_position: 0,
@@ -3028,6 +3033,10 @@ impl App {
             Some(cap) => cap.to_string(),
             None => String::new(),
         };
+        self.adv_config_ddr_bandwidth_input = match self.calc_config.ddr_bandwidth_gbps {
+            Some(bw) => format!("{bw:.0}"),
+            None => String::new(),
+        };
         self.adv_config_field = AdvConfigField::Efficiency;
         self.adv_config_cursor_position = self.adv_config_efficiency_input.len();
         self.adv_config_dirty = false;
@@ -3190,6 +3199,7 @@ impl App {
             AdvConfigField::FactorTp => &self.adv_config_eff_factor_tp,
             AdvConfigField::FactorCpuOnly => &self.adv_config_eff_factor_cpu_only,
             AdvConfigField::ContextCap => &self.adv_config_context_cap_input,
+            AdvConfigField::DdrBandwidth => &self.adv_config_ddr_bandwidth_input,
         }
     }
 
@@ -3202,6 +3212,7 @@ impl App {
             AdvConfigField::FactorTp => &mut self.adv_config_eff_factor_tp,
             AdvConfigField::FactorCpuOnly => &mut self.adv_config_eff_factor_cpu_only,
             AdvConfigField::ContextCap => &mut self.adv_config_context_cap_input,
+            AdvConfigField::DdrBandwidth => &mut self.adv_config_ddr_bandwidth_input,
         }
     }
 
@@ -3309,6 +3320,15 @@ impl App {
         } else {
             self.adv_config_context_cap_input.parse().ok()
         };
+        // Empty = auto (env var, then measured, then 50 GB/s fallback).
+        let ddr_bandwidth_gbps: Option<f64> = if self.adv_config_ddr_bandwidth_input.is_empty() {
+            None
+        } else {
+            self.adv_config_ddr_bandwidth_input
+                .parse()
+                .ok()
+                .filter(|bw: &f64| *bw > 0.0)
+        };
 
         // Update the config
         self.calc_config = CalcConfig {
@@ -3321,6 +3341,7 @@ impl App {
                 cpu_only,
             },
             context_cap,
+            ddr_bandwidth_gbps,
             ..self.calc_config
         };
 

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -3748,7 +3748,7 @@ fn draw_advanced_config_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
     let area = frame.area();
 
     let popup_width = 52u16.min(area.width.saturating_sub(4));
-    let popup_height = 16u16.min(area.height.saturating_sub(4));
+    let popup_height = 17u16.min(area.height.saturating_sub(4));
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
@@ -3806,6 +3806,11 @@ fn draw_advanced_config_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
             &app.adv_config_context_cap_input,
             AdvConfigField::ContextCap,
         ),
+        (
+            "  DDR GB/s:",
+            &app.adv_config_ddr_bandwidth_input,
+            AdvConfigField::DdrBandwidth,
+        ),
     ];
 
     let mut lines: Vec<Line> = Vec::new();
@@ -3854,6 +3859,7 @@ fn draw_advanced_config_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         AdvConfigField::FactorTp => 5,
         AdvConfigField::FactorCpuOnly => 6,
         AdvConfigField::ContextCap => 7,
+        AdvConfigField::DdrBandwidth => 8,
     };
     let cursor_x = inner.x + 14 + app.adv_config_cursor_position as u16;
     let cursor_y = inner.y + field_row;


### PR DESCRIPTION
## Problem

MoE-offload tok/s estimates assumed a hardcoded **50 GB/s** DDR bandwidth (DDR4-3200 dual-channel) unless the user knew about `LLMFIT_DDR_BANDWIDTH`. On DDR5 / LPDDR5X / multi-channel systems this systematically **underestimated** offload throughput by ~2x, and **overestimated** it on single-channel laptops. This is one of the concrete mechanisms behind the "tok/s estimates don't match reality" criticism (#449, #88, #292).

## Fix

- **`hardware::measured_ram_bandwidth_gbps()`** — measures *effective* streaming bandwidth once per process with a ~100 ms multithreaded memcpy sweep (STREAM-copy convention: read+write bytes counted), cached via `OnceLock`, sanity-banded to [2, 4000] GB/s. Effective bandwidth (typically 60–80% of the spec sheet) is what MoE expert streaming actually sees, so measuring beats any lookup table here.
- **`CalcConfig.ddr_bandwidth_gbps: Option<f64>`** — `None` = auto. Resolution order: Advanced Config value → `LLMFIT_DDR_BANDWIDTH` env var → measured → 50 GB/s last-resort fallback.
- **TUI**: Advanced Config popup (`A`) gains a `DDR GB/s` field; empty = auto.
- **`llmfit system`** now prints the measured value, e.g. on a Lunar Lake laptop (LPDDR5X-8533, ~136 GB/s spec):

  ```
  Total RAM: 30.82 GB
  Available RAM: 18.57 GB
  RAM Bandwidth: ~105 GB/s (measured)
  ```

  — more than 2x the old assumed constant on this machine.

## Determinism

`test_config()` pins 50 GB/s so all existing MoE-offload estimate tests stay machine-independent; new tests cover resolver priority (config > auto) and the measurement sanity band. Full workspace suite passes (425 core + TUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)