### PR TITLE
feat: expose estimate basis and local verification commands (#292)

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -206,6 +206,27 @@ pub struct ScoreComponents {
     pub context: f64,
 }
 
+/// The inputs behind `estimated_tps`, exposed so users can see exactly what
+/// the estimate assumes and reproduce it locally (issue #292).
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct EstimateBasis {
+    /// `"gpu_bandwidth_roofline"` — derived from the GPU's memory bandwidth;
+    /// `"backend_constant"` — GPU not in the bandwidth table, per-backend
+    /// heuristic constant used; `"cpu_constant"` — CPU-only path;
+    /// `"unsupported"` — no estimate produced.
+    pub method: String,
+    /// GPU memory bandwidth assumed (GB/s), when the roofline path was used.
+    pub gpu_bandwidth_gbps: Option<f64>,
+    /// System RAM bandwidth assumed for MoE expert streaming (GB/s);
+    /// only set for MoE-offload runs.
+    pub ddr_bandwidth_gbps: Option<f64>,
+    /// Efficiency factor applied to raw bandwidth (default 0.55).
+    pub efficiency: f64,
+    /// The estimate models single-request *generation* throughput at this
+    /// context length. Prompt processing (prefill/TTFT) is not estimated.
+    pub assumed_context: u32,
+}
+
 #[derive(Clone, serde::Serialize)]
 pub struct ModelFit {
     pub model: LlmModel,
@@ -230,6 +251,9 @@ pub struct ModelFit {
     /// A "Perfect" fit with an 8k usable context out of a 262k window is a
     /// very different proposition for coding work (issue #621).
     pub usable_context: u32,
+    /// What the tok/s estimate assumes — method, bandwidths, efficiency —
+    /// so the number can be reproduced and verified (issue #292).
+    pub estimate_basis: EstimateBasis,
 }
 
 impl ModelFit {
@@ -334,6 +358,10 @@ impl ModelFit {
                 fits_with_turboquant: false,
                 effective_context_length: estimation_ctx,
                 usable_context: 0,
+                estimate_basis: EstimateBasis {
+                    method: "unsupported".to_string(),
+                    ..EstimateBasis::default()
+                },
             };
         }
 
@@ -530,6 +558,31 @@ impl ModelFit {
         let estimated_tps =
             estimate_tps(model, &best_quant_str, system, run_mode, runtime, &config);
 
+        // Record the estimate's inputs so it can be reproduced (issue #292).
+        // Mirrors the path selection in estimate_tps: bandwidth roofline when
+        // the GPU is recognized, per-backend constant otherwise.
+        let estimate_basis = {
+            let gpu_bw = system
+                .gpu_name
+                .as_deref()
+                .and_then(crate::hardware::gpu_memory_bandwidth_gbps);
+            let method = if run_mode == RunMode::CpuOnly {
+                "cpu_constant"
+            } else if gpu_bw.is_some() {
+                "gpu_bandwidth_roofline"
+            } else {
+                "backend_constant"
+            };
+            EstimateBasis {
+                method: method.to_string(),
+                gpu_bandwidth_gbps: (run_mode != RunMode::CpuOnly).then_some(gpu_bw).flatten(),
+                ddr_bandwidth_gbps: (run_mode == RunMode::MoeOffload)
+                    .then(|| ddr_bandwidth_gbps(&config)),
+                efficiency: config.efficiency,
+                assumed_context: estimation_ctx,
+            }
+        };
+
         // Add runtime comparison note on Apple Silicon
         if runtime == InferenceRuntime::Mlx {
             let llamacpp_tps = estimate_tps(
@@ -616,6 +669,7 @@ impl ModelFit {
             fits_with_turboquant,
             effective_context_length: estimation_ctx,
             usable_context,
+            estimate_basis,
         }
     }
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use colored::*;
-use llmfit_core::fit::{FitLevel, ModelFit, RunMode, SortColumn};
+use llmfit_core::fit::{FitLevel, InferenceRuntime, ModelFit, RunMode, SortColumn};
 use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::LlmModel;
 use llmfit_core::plan::PlanEstimate;
@@ -188,6 +188,8 @@ pub fn display_model_detail(fit: &ModelFit) {
     );
     println!("  Baseline Est. Speed: {:.1} tok/s", fit.estimated_tps);
     println!();
+
+    display_estimate_basis(fit);
 
     println!("{}", "Resource Requirements:".bold().underline());
     if let Some(vram) = fit.model.min_vram_gb {
@@ -535,6 +537,59 @@ pub fn display_json_fits_with_llamacpp(specs: &SystemSpecs, fits: &[ModelFit]) {
     );
 }
 
+/// Print how the tok/s estimate was derived and how to verify it locally.
+/// Reproducibility ask from issue #292: no number without its inputs.
+fn display_estimate_basis(fit: &ModelFit) {
+    let basis = &fit.estimate_basis;
+    if basis.method == "unsupported" || fit.estimated_tps <= 0.0 {
+        return;
+    }
+
+    println!("{}", "Estimate Basis:".bold().underline());
+    match basis.method.as_str() {
+        "gpu_bandwidth_roofline" => {
+            let bw = basis.gpu_bandwidth_gbps.unwrap_or(0.0);
+            println!(
+                "  Method: GPU bandwidth roofline — {:.0} GB/s x {:.2} efficiency",
+                bw, basis.efficiency
+            );
+            if let Some(ddr) = basis.ddr_bandwidth_gbps {
+                println!(
+                    "  MoE offload: expert streaming bounded by ~{:.0} GB/s system RAM bandwidth",
+                    ddr
+                );
+            }
+        }
+        "cpu_constant" => {
+            println!("  Method: CPU heuristic constant (no GPU acceleration assumed)");
+        }
+        _ => {
+            println!("  Method: per-backend heuristic constant — GPU not in the bandwidth table,");
+            println!("          so expect a wide error band. Please report your GPU model so we");
+            println!(
+                "          can add real bandwidth data (github.com/AlexsJones/llmfit/issues)."
+            );
+        }
+    }
+    println!(
+        "  Models single-request generation at ctx <= {} tokens; prompt processing",
+        basis.assumed_context
+    );
+    println!("  (prefill/TTFT) is not estimated. Baseline error band is roughly +/-30%.");
+    println!("{}", "  Verify on this machine:".bold());
+    println!(
+        "    llmfit bench \"{}\"    (against a running provider)",
+        fit.model.name
+    );
+    if let Some(bench_cmd) = generate_llamabench_command(fit) {
+        println!(
+            "    {}    (compare the tg128 row; get the path via `llmfit download`)",
+            bench_cmd
+        );
+    }
+    println!();
+}
+
 /// Generate a llama.cpp command string for a model fit.
 fn generate_llamacpp_command(fit: &ModelFit) -> Option<String> {
     if fit.run_mode == RunMode::TensorParallel {
@@ -563,6 +618,30 @@ fn generate_llamacpp_command(fit: &ModelFit) -> Option<String> {
             repo, quant, ngl_args, context, conversation_arg
         )
     })
+}
+
+/// llama-bench invocation that measures the same quantity `estimated_tps`
+/// models: single-request generation throughput (the `tg128` row). Prompt
+/// processing (`pp512`) is deliberately not what llmfit estimates.
+///
+/// Only emitted for pure-GPU and CPU-only runs — offload splits depend on
+/// llama.cpp's layer placement, which llama-bench can't express with a fixed
+/// `-ngl`, so a benchmark there wouldn't be comparable to the estimate.
+fn generate_llamabench_command(fit: &ModelFit) -> Option<String> {
+    if fit.runtime != InferenceRuntime::LlamaCpp {
+        return None;
+    }
+    let ngl = match fit.run_mode {
+        RunMode::Gpu => "99",
+        RunMode::CpuOnly => "0",
+        _ => return None,
+    };
+    // llama-bench needs a local GGUF path (no -hf support); point users at
+    // `llmfit download`, which prints the destination path.
+    Some(format!(
+        "llama-bench -m <path-to-{}-gguf> -ngl {} -p 512 -n 128",
+        fit.best_quant, ngl
+    ))
 }
 
 fn llamacpp_ngl_args(run_mode: RunMode) -> Option<&'static str> {
@@ -741,6 +820,8 @@ fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "capabilities": fit.model.capabilities.iter().map(|c| c.label()).collect::<Vec<_>>(),
         "capability_ids": serde_json::to_value(&fit.model.capabilities).unwrap(),
         "ollama_name": ollama_name_for(&fit.model.name),
+        "estimate_basis": serde_json::to_value(&fit.estimate_basis).unwrap(),
+        "verify_command": generate_llamabench_command(fit),
     })
 }
 
@@ -993,6 +1074,7 @@ mod tests {
             fits_with_turboquant: false,
             effective_context_length: 8_192,
             usable_context: 8_192,
+            estimate_basis: Default::default(),
         }
     }
 

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -3011,6 +3011,7 @@ mod tests {
             fits_with_turboquant: false,
             effective_context_length: 8192,
             usable_context: 8192,
+            estimate_basis: Default::default(),
         }
     }
 

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -4426,6 +4426,7 @@ mod tests {
             fits_with_turboquant: false,
             effective_context_length: 8192,
             usable_context: 8192,
+            estimate_basis: Default::default(),
         }
     }
 


### PR DESCRIPTION
Stacked on #703 (uses the DDR bandwidth resolver). Addresses the reproducibility ask in #292.

## Problem

#292 is the project's deepest open trust wound: *"llmfit shows 30 tok/s but llama.cpp with llmfit's command gives 2"* → *"is this even real 😬?"*. A tok/s number without its inputs can't be verified, only believed or disbelieved.

## Change

Every `ModelFit` now carries an **`EstimateBasis`**: estimation method (`gpu_bandwidth_roofline` / `backend_constant` / `cpu_constant` / `unsupported`), the GPU bandwidth assumed, the DDR bandwidth for MoE offload, the efficiency factor, and the assumed context length.

`llmfit info` renders it:

```
Estimate Basis:
  Method: per-backend heuristic constant — GPU not in the bandwidth table,
          so expect a wide error band. Please report your GPU model so we
          can add real bandwidth data (github.com/AlexsJones/llmfit/issues).
  Models single-request generation at ctx <= 4096 tokens; prompt processing
  (prefill/TTFT) is not estimated. Baseline error band is roughly +/-30%.
  Verify on this machine:
    llmfit bench "unsloth/Qwen3-4B-GGUF"    (against a running provider)
    llama-bench -m <path-to-Q8_0-gguf> -ngl 99 -p 512 -n 128    (compare the tg128 row)
```

Notes on the design:
- The llama-bench line measures **the same quantity the estimate models** (single-request generation, tg128) — the #292 discrepancy came partly from comparing against runs the estimate never claimed to predict.
- llama-bench is only suggested for pure-GPU / CPU-only modes; offload layer splits aren't expressible with a fixed `-ngl`, so we point at `llmfit bench` there.
- Unrecognized GPUs (the Cix ARM chip in #292 would be one) now say so explicitly instead of printing a confident-looking number — and ask for a report so the bandwidth table grows.
- JSON output gains `estimate_basis` + `verify_command` for agents/scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)