### PR TITLE
feat: surface community-measured tok/s when hardware matches benchmark data

### DIFF
--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -147,6 +147,10 @@ pub fn build_model_fits(
 ) -> Vec<ModelFit> {
     use crate::fit::backend_compatible;
 
+    // Community-measured throughput for this hardware, when the detected GPU
+    // matches a benchmark preset (provenance-weighted estimates).
+    let measured_index = crate::benchmarks::MeasuredTpsIndex::for_specs(specs);
+
     db.get_all_models()
         .iter()
         .filter(|m| backend_compatible(m, specs))
@@ -154,6 +158,9 @@ pub fn build_model_fits(
             let mut fit =
                 ModelFit::analyze_with_forced_runtime(m, specs, context_limit, forced_runtime);
             fit.installed = installed.is_installed(&m.name);
+            fit.measured_tps = measured_index
+                .as_ref()
+                .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
             fit
         })
         .collect()

--- a/llmfit-core/src/benchmarks.rs
+++ b/llmfit-core/src/benchmarks.rs
@@ -367,6 +367,121 @@ pub fn cached_preset_labels() -> Vec<&'static str> {
     labels
 }
 
+// ── Measured throughput lookup (provenance-weighted estimates) ──────
+
+/// A real measured throughput from community benchmark runs on hardware
+/// matching the user's detected system. When present, this is ground truth
+/// and should be displayed with priority over the formula estimate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MeasuredTps {
+    /// Median measured generation throughput (tok/s).
+    pub tok_s: f64,
+    /// Number of community runs behind the median.
+    pub sample_count: u32,
+    /// Hardware preset the runs come from (e.g. "RTX 3090 (24 GB)").
+    pub hardware_label: String,
+}
+
+/// Find the embedded-cache hardware preset matching the detected GPU.
+pub fn cached_preset_for_specs(specs: &SystemSpecs) -> Option<&'static HardwarePreset> {
+    let gpu = specs.gpu_name.as_deref()?.to_lowercase();
+    HardwarePreset::all().iter().find(|p| {
+        p.hardware_name
+            .is_some_and(|hw| gpu.contains(&hw.to_lowercase()))
+    })
+}
+
+/// Prebuilt index of comparable measured runs for the detected hardware.
+/// Build once per fit pass, then O(1) lookups per model.
+pub struct MeasuredTpsIndex {
+    hardware_label: &'static str,
+    /// (model slug, quantization lowercase) -> sorted tok/s samples.
+    samples: std::collections::HashMap<(String, String), Vec<f64>>,
+}
+
+impl MeasuredTpsIndex {
+    /// Build the index from the embedded cache for the preset matching the
+    /// detected GPU. Only rows comparable to `estimated_tps` are indexed:
+    /// single-request generation (batch <= 1), no speculative decoding /
+    /// MTP. Returns None when the GPU has no preset or no rows qualify.
+    pub fn for_specs(specs: &SystemSpecs) -> Option<Self> {
+        let preset = cached_preset_for_specs(specs)?;
+        let resp = cached_leaderboard_for_preset(preset.label)?;
+        Self::from_rows(&resp.rows, preset.label)
+    }
+
+    fn from_rows(rows: &[LeaderboardEntry], hardware_label: &'static str) -> Option<Self> {
+        let mut samples: std::collections::HashMap<(String, String), Vec<f64>> =
+            std::collections::HashMap::new();
+        for row in rows {
+            if row.batch_size.unwrap_or(1) > 1 {
+                continue;
+            }
+            if row
+                .engine_flags
+                .as_ref()
+                .is_some_and(|f| f.spec_decoding.unwrap_or(false) || f.mtp_enabled.unwrap_or(false))
+            {
+                continue;
+            }
+            let Some(tok_s) = row.tok_s_out.filter(|t| *t > 0.5) else {
+                continue;
+            };
+            let hf_id = row.hf_id();
+            let quant = row.quantization();
+            if hf_id.is_empty() || quant.is_empty() {
+                continue;
+            }
+            samples
+                .entry((crate::models::canonical_slug(hf_id), quant.to_lowercase()))
+                .or_default()
+                .push(tok_s);
+        }
+        if samples.is_empty() {
+            return None;
+        }
+        for s in samples.values_mut() {
+            s.sort_by(|a, b| a.partial_cmp(b).expect("tok/s samples are finite"));
+        }
+        Some(Self {
+            hardware_label,
+            samples,
+        })
+    }
+
+    /// Median measured tok/s for this model+quant, if any comparable runs
+    /// exist on the matched hardware.
+    pub fn lookup(&self, model_hf_id: &str, quant: &str) -> Option<MeasuredTps> {
+        let key = (
+            crate::models::canonical_slug(model_hf_id),
+            quant.to_lowercase(),
+        );
+        let s = self.samples.get(&key)?;
+        let n = s.len();
+        let median = if n % 2 == 1 {
+            s[n / 2]
+        } else {
+            (s[n / 2 - 1] + s[n / 2]) / 2.0
+        };
+        Some(MeasuredTps {
+            tok_s: median,
+            sample_count: n as u32,
+            hardware_label: self.hardware_label.to_string(),
+        })
+    }
+}
+
+/// One-shot lookup: median measured tok/s for `model_hf_id` at `quant` on
+/// hardware matching the detected specs. Prefer [`MeasuredTpsIndex`] when
+/// annotating many fits.
+pub fn measured_tps_for(
+    specs: &SystemSpecs,
+    model_hf_id: &str,
+    quant: &str,
+) -> Option<MeasuredTps> {
+    MeasuredTpsIndex::for_specs(specs)?.lookup(model_hf_id, quant)
+}
+
 // ── Fetch functions ──────────────────────────────────────────────────
 
 /// Fetch benchmarks matching the user's hardware.
@@ -695,4 +810,58 @@ fn urlencoded(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(json: &str) -> LeaderboardEntry {
+        serde_json::from_str(json).expect("valid test row")
+    }
+
+    #[test]
+    fn test_measured_index_median_and_comparability_filters() {
+        let rows = vec![
+            row(
+                r#"{"id":"1","tokSOut":100.0,"model":{"hfId":"unsloth/Qwen3-4B-GGUF"},"engine":{"engineName":"llama.cpp","quantization":"Q4_K_M"}}"#,
+            ),
+            row(
+                r#"{"id":"2","tokSOut":120.0,"model":{"hfId":"unsloth/Qwen3-4B-GGUF"},"engine":{"engineName":"llama.cpp","quantization":"Q4_K_M"}}"#,
+            ),
+            // Batched serving measures a different quantity — excluded.
+            row(
+                r#"{"id":"3","tokSOut":900.0,"batchSize":8,"model":{"hfId":"unsloth/Qwen3-4B-GGUF"},"engine":{"engineName":"vllm","quantization":"Q4_K_M"}}"#,
+            ),
+            // Draft-accelerated runs beat the roofline — excluded.
+            row(
+                r#"{"id":"4","tokSOut":500.0,"engineFlags":{"specDecoding":true},"model":{"hfId":"unsloth/Qwen3-4B-GGUF"},"engine":{"engineName":"llama.cpp","quantization":"Q4_K_M"}}"#,
+            ),
+        ];
+        let idx = MeasuredTpsIndex::from_rows(&rows, "RTX 3090 (24 GB)")
+            .expect("comparable rows should build an index");
+
+        let m = idx
+            .lookup("unsloth/Qwen3-4B-GGUF", "q4_k_m")
+            .expect("quant match is case-insensitive");
+        assert_eq!(
+            m.sample_count, 2,
+            "batched/spec-decoding rows must not count"
+        );
+        assert!((m.tok_s - 110.0).abs() < 1e-9, "median of 100 and 120");
+        assert_eq!(m.hardware_label, "RTX 3090 (24 GB)");
+
+        assert!(
+            idx.lookup("unsloth/Qwen3-4B-GGUF", "Q8_0").is_none(),
+            "different quant must not match"
+        );
+    }
+
+    #[test]
+    fn test_measured_index_none_when_no_comparable_rows() {
+        let rows = vec![row(
+            r#"{"id":"1","tokSOut":900.0,"batchSize":16,"model":{"hfId":"a/b"},"engine":{"engineName":"vllm","quantization":"FP8"}}"#,
+        )];
+        assert!(MeasuredTpsIndex::from_rows(&rows, "A100 (80 GB)").is_none());
+    }
 }

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -254,6 +254,11 @@ pub struct ModelFit {
     /// What the tok/s estimate assumes — method, bandwidths, efficiency —
     /// so the number can be reproduced and verified (issue #292).
     pub estimate_basis: EstimateBasis,
+    /// Community-measured throughput on hardware matching this system
+    /// (localmaxxing.com data), when available. Ground truth, displayed
+    /// with priority over `estimated_tps`. Set after analysis, like
+    /// `installed`.
+    pub measured_tps: Option<crate::benchmarks::MeasuredTps>,
 }
 
 impl ModelFit {
@@ -362,6 +367,7 @@ impl ModelFit {
                     method: "unsupported".to_string(),
                     ..EstimateBasis::default()
                 },
+                measured_tps: None,
             };
         }
 
@@ -670,6 +676,7 @@ impl ModelFit {
             effective_context_length: estimation_ctx,
             usable_context,
             estimate_basis,
+            measured_tps: None, // set later, like `installed`
         }
     }
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -125,7 +125,10 @@ pub fn display_model_fits(fits: &[ModelFit]) {
                 provider: fit.model.provider.clone(),
                 size: fit.model.parameter_count.clone(),
                 score: format!("{:.0}", fit.score),
-                tps: format!("{:.1}", fit.estimated_tps),
+                tps: match &fit.measured_tps {
+                    Some(m) => format!("{:.1} ✓", m.tok_s),
+                    None => format!("{:.1}", fit.estimated_tps),
+                },
                 quant: fit.best_quant.clone(),
                 runtime: fit.runtime_text().to_string(),
                 mode: fit.run_mode_text().to_string(),
@@ -145,6 +148,11 @@ pub fn display_model_fits(fits: &[ModelFit]) {
     println!(
         "  Note: tok/s values are baseline estimates; real runtime depends on engine/runtime."
     );
+    if fits.iter().any(|f| f.measured_tps.is_some()) {
+        println!(
+            "  ✓ = measured by the community on hardware matching yours (localmaxxing.com), not an estimate."
+        );
+    }
 }
 
 pub fn display_model_detail(fit: &ModelFit) {
@@ -545,6 +553,16 @@ fn display_estimate_basis(fit: &ModelFit) {
         return;
     }
 
+    if let Some(m) = &fit.measured_tps {
+        println!("{}", "Measured on Matching Hardware:".bold().underline());
+        println!(
+            "  {:.1} tok/s median across {} community run(s) on {} (localmaxxing.com)",
+            m.tok_s, m.sample_count, m.hardware_label
+        );
+        println!("  Real user data — trust this over the formula estimate below.");
+        println!();
+    }
+
     println!("{}", "Estimate Basis:".bold().underline());
     match basis.method.as_str() {
         "gpu_bandwidth_roofline" => {
@@ -822,6 +840,7 @@ fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "ollama_name": ollama_name_for(&fit.model.name),
         "estimate_basis": serde_json::to_value(&fit.estimate_basis).unwrap(),
         "verify_command": generate_llamabench_command(fit),
+        "measured_tps": serde_json::to_value(&fit.measured_tps).unwrap(),
     })
 }
 
@@ -1075,6 +1094,7 @@ mod tests {
             effective_context_length: 8_192,
             usable_context: 8_192,
             estimate_basis: Default::default(),
+            measured_tps: None,
         }
     }
 

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -2735,7 +2735,13 @@ fn main() {
                     }
                 };
 
-                let fit = ModelFit::analyze_with_context_limit(&models[idx], &specs, context_limit);
+                let mut fit =
+                    ModelFit::analyze_with_context_limit(&models[idx], &specs, context_limit);
+                fit.measured_tps = llmfit_core::benchmarks::measured_tps_for(
+                    &specs,
+                    &fit.model.name,
+                    &fit.best_quant,
+                );
                 if cli.json {
                     display::display_json_fits(&specs, &[fit]);
                 } else {
@@ -3012,6 +3018,7 @@ mod tests {
             effective_context_length: 8192,
             usable_context: 8192,
             estimate_basis: Default::default(),
+            measured_tps: None,
         }
     }
 

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -869,6 +869,7 @@ impl App {
             .count();
 
         // Only analyze models that can actually run on this hardware.
+        let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&specs);
         let mut all_fits: Vec<ModelFit> = db
             .get_all_models()
             .iter()
@@ -876,6 +877,9 @@ impl App {
             .map(|m| {
                 let mut fit = ModelFit::analyze_with_context_limit(m, &specs, context_limit);
                 fit.installed = installed.is_installed(&m.name);
+                fit.measured_tps = measured_index
+                    .as_ref()
+                    .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
                 fit
             })
             .collect();
@@ -2924,6 +2928,7 @@ impl App {
             .filter(|m| !backend_compatible(m, &self.specs))
             .count();
 
+        let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&self.specs);
         self.all_fits = db
             .get_all_models()
             .iter()
@@ -2932,6 +2937,9 @@ impl App {
                 let mut fit =
                     ModelFit::analyze_with_context_limit(m, &self.specs, self.context_limit);
                 fit.installed = self.installed.is_installed(&m.name);
+                fit.measured_tps = measured_index
+                    .as_ref()
+                    .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
                 fit
             })
             .collect();
@@ -3360,6 +3368,7 @@ impl App {
             .filter(|m| !backend_compatible(m, &self.specs))
             .count();
 
+        let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&self.specs);
         self.all_fits = db
             .get_all_models()
             .iter()
@@ -3368,6 +3377,9 @@ impl App {
                 let mut fit =
                     ModelFit::analyze_with_config(m, &self.specs, self.calc_config.clone());
                 fit.installed = self.installed.is_installed(&m.name);
+                fit.measured_tps = measured_index
+                    .as_ref()
+                    .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
                 fit
             })
             .collect();
@@ -4427,6 +4439,7 @@ mod tests {
             effective_context_length: 8192,
             usable_context: 8192,
             estimate_basis: Default::default(),
+            measured_tps: None,
         }
     }
 

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -809,14 +809,20 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
                 tc.score_low
             };
 
-            #[allow(clippy::if_same_then_else)]
-            let tps_text = if fit.estimated_tps >= 100.0 {
-                format!("{:.0}", fit.estimated_tps)
-            } else if fit.estimated_tps >= 10.0 {
-                format!("{:.1}", fit.estimated_tps)
-            } else {
-                format!("{:.1}", fit.estimated_tps)
+            // Community-measured tok/s (marked ✓) takes priority over the
+            // formula estimate when matching hardware data exists.
+            let (tps_value, tps_measured) = match &fit.measured_tps {
+                Some(m) => (m.tok_s, true),
+                None => (fit.estimated_tps, false),
             };
+            let mut tps_text = if tps_value >= 100.0 {
+                format!("{:.0}", tps_value)
+            } else {
+                format!("{:.1}", tps_value)
+            };
+            if tps_measured {
+                tps_text.push('✓');
+            }
 
             let is_pulling = app.pull_active.is_some()
                 && app.pull_model_name.as_deref() == Some(&fit.model.name);


### PR DESCRIPTION
Stacked on #704. Third piece of the estimate-trust work (#703 → #704 → this).

## Problem

The embedded localmaxxing benchmark cache contains *real measured tok/s* for popular hardware (RTX 3090/4090/5090, A100, M-series, ...), but the main fit table never used it — users with exactly that hardware still saw a formula estimate, with no indication that ground truth existed. Community feedback is blunt about which of the two they trust.

## Change

When the detected GPU matches a benchmark preset, measured data takes display priority:

- **`MeasuredTpsIndex`** (core): built once per fit pass from the embedded cache. Comparability filters match the calibration test: batch ≤ 1, no speculative decoding/MTP, same quant. Median + sample count + hardware label.
- **`ModelFit.measured_tps`**: populated post-analysis (same pattern as `installed`) in `build_model_fits`, both TUI fit passes, and `info`.
- **CLI/TUI tables**: measured value shown with a `✓` marker; footnote explains it's community-measured on matching hardware, not an estimate.
- **`llmfit info`**: new "Measured on Matching Hardware" section above the Estimate Basis, e.g.:

  ```
  Measured on Matching Hardware:
    152.0 tok/s median across 8 community run(s) on RTX 3090 (24 GB) (localmaxxing.com)
    Real user data — trust this over the formula estimate below.
  ```
- **JSON**: `measured_tps` field (`{tok_s, sample_count, hardware_label}` or `null`).

Estimates remain untouched underneath — this changes provenance and presentation, not the estimator. Unit tests cover median selection, comparability filters, quant case-insensitivity, and the empty-index case.

Verification note: my dev machine's iGPU matches no preset, so the ✓ path is exercised by unit tests rather than a live table here — review screenshots from a 3090/4090 owner welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)