### PR TITLE
feat: estimate basis + measured tok/s provenance (#292)

### DIFF
--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -147,6 +147,10 @@ pub fn build_model_fits(
 ) -> Vec<ModelFit> {
     use crate::fit::backend_compatible;
 
+    // Community-measured throughput for this hardware, when the detected GPU
+    // matches a benchmark preset (provenance-weighted estimates).
+    let measured_index = crate::benchmarks::MeasuredTpsIndex::for_specs(specs);
+
     db.get_all_models()
         .iter()
         .filter(|m| backend_compatible(m, specs))
@@ -154,6 +158,9 @@ pub fn build_model_fits(
             let mut fit =
                 ModelFit::analyze_with_forced_runtime(m, specs, context_limit, forced_runtime);
             fit.installed = installed.is_installed(&m.name);
+            fit.measured_tps = measured_index
+                .as_ref()
+                .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
             fit
         })
         .collect()

--- a/llmfit-core/src/benchmarks.rs
+++ b/llmfit-core/src/benchmarks.rs
@@ -367,6 +367,121 @@ pub fn cached_preset_labels() -> Vec<&'static str> {
     labels
 }
 
+// ── Measured throughput lookup (provenance-weighted estimates) ──────
+
+/// A real measured throughput from community benchmark runs on hardware
+/// matching the user's detected system. When present, this is ground truth
+/// and should be displayed with priority over the formula estimate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MeasuredTps {
+    /// Median measured generation throughput (tok/s).
+    pub tok_s: f64,
+    /// Number of community runs behind the median.
+    pub sample_count: u32,
+    /// Hardware preset the runs come from (e.g. "RTX 3090 (24 GB)").
+    pub hardware_label: String,
+}
+
+/// Find the embedded-cache hardware preset matching the detected GPU.
+pub fn cached_preset_for_specs(specs: &SystemSpecs) -> Option<&'static HardwarePreset> {
+    let gpu = specs.gpu_name.as_deref()?.to_lowercase();
+    HardwarePreset::all().iter().find(|p| {
+        p.hardware_name
+            .is_some_and(|hw| gpu.contains(&hw.to_lowercase()))
+    })
+}
+
+/// Prebuilt index of comparable measured runs for the detected hardware.
+/// Build once per fit pass, then O(1) lookups per model.
+pub struct MeasuredTpsIndex {
+    hardware_label: &'static str,
+    /// (model slug, quantization lowercase) -> sorted tok/s samples.
+    samples: std::collections::HashMap<(String, String), Vec<f64>>,
+}
+
+impl MeasuredTpsIndex {
+    /// Build the index from the embedded cache for the preset matching the
+    /// detected GPU. Only rows comparable to `estimated_tps` are indexed:
+    /// single-request generation (batch <= 1), no speculative decoding /
+    /// MTP. Returns None when the GPU has no preset or no rows qualify.
+    pub fn for_specs(specs: &SystemSpecs) -> Option<Self> {
+        let preset = cached_preset_for_specs(specs)?;
+        let resp = cached_leaderboard_for_preset(preset.label)?;
+        Self::from_rows(&resp.rows, preset.label)
+    }
+
+    fn from_rows(rows: &[LeaderboardEntry], hardware_label: &'static str) -> Option<Self> {
+        let mut samples: std::collections::HashMap<(String, String), Vec<f64>> =
+            std::collections::HashMap::new();
+        for row in rows {
+            if row.batch_size.unwrap_or(1) > 1 {
+                continue;
+            }
+            if row
+                .engine_flags
+                .as_ref()
+                .is_some_and(|f| f.spec_decoding.unwrap_or(false) || f.mtp_enabled.unwrap_or(false))
+            {
+                continue;
+            }
+            let Some(tok_s) = row.tok_s_out.filter(|t| *t > 0.5) else {
+                continue;
+            };
+            let hf_id = row.hf_id();
+            let quant = row.quantization();
+            if hf_id.is_empty() || quant.is_empty() {
+                continue;
+            }
+            samples
+                .entry((crate::models::canonical_slug(hf_id), quant.to_lowercase()))
+                .or_default()
+                .push(tok_s);
+        }
+        if samples.is_empty() {
+            return None;
+        }
+        for s in samples.values_mut() {
+            s.sort_by(|a, b| a.partial_cmp(b).expect("tok/s samples are finite"));
+        }
+        Some(Self {
+            hardware_label,
+            samples,
+        })
+    }
+
+    /// Median measured tok/s for this model+quant, if any comparable runs
+    /// exist on the matched hardware.
+    pub fn lookup(&self, model_hf_id: &str, quant: &str) -> Option<MeasuredTps> {
+        let key = (
+            crate::models::canonical_slug(model_hf_id),
+            quant.to_lowercase(),
+        );
+        let s = self.samples.get(&key)?;
+        let n = s.len();
+        let median = if n % 2 == 1 {
+            s[n / 2]
+        } else {
+            (s[n / 2 - 1] + s[n / 2]) / 2.0
+        };
+        Some(MeasuredTps {
+            tok_s: median,
+            sample_count: n as u32,
+            hardware_label: self.hardware_label.to_string(),
+        })
+    }
+}
+
+/// One-shot lookup: median measured tok/s for `model_hf_id` at `quant` on
+/// hardware matching the detected specs. Prefer [`MeasuredTpsIndex`] when
+/// annotating many fits.
+pub fn measured_tps_for(
+    specs: &SystemSpecs,
+    model_hf_id: &str,
+    quant: &str,
+) -> Option<MeasuredTps> {
+    MeasuredTpsIndex::for_specs(specs)?.lookup(model_hf_id, quant)
+}
+
 // ── Fetch functions ──────────────────────────────────────────────────
 
 /// Fetch benchmarks matching the user's hardware.
@@ -695,4 +810,58 @@ fn urlencoded(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(json: &str) -> LeaderboardEntry {
+        serde_json::from_str(json).expect("valid test row")
+    }
+
+    #[test]
+    fn test_measured_index_median_and_comparability_filters() {
+        let rows = vec![
+            row(
+                r#"{"id":"1","tokSOut":100.0,"model":{"hfId":"unsloth/Qwen3-4B-GGUF"},"engine":{"engineName":"llama.cpp","quantization":"Q4_K_M"}}"#,
+            ),
+            row(
+                r#"{"id":"2","tokSOut":120.0,"model":{"hfId":"unsloth/Qwen3-4B-GGUF"},"engine":{"engineName":"llama.cpp","quantization":"Q4_K_M"}}"#,
+            ),
+            // Batched serving measures a different quantity — excluded.
+            row(
+                r#"{"id":"3","tokSOut":900.0,"batchSize":8,"model":{"hfId":"unsloth/Qwen3-4B-GGUF"},"engine":{"engineName":"vllm","quantization":"Q4_K_M"}}"#,
+            ),
+            // Draft-accelerated runs beat the roofline — excluded.
+            row(
+                r#"{"id":"4","tokSOut":500.0,"engineFlags":{"specDecoding":true},"model":{"hfId":"unsloth/Qwen3-4B-GGUF"},"engine":{"engineName":"llama.cpp","quantization":"Q4_K_M"}}"#,
+            ),
+        ];
+        let idx = MeasuredTpsIndex::from_rows(&rows, "RTX 3090 (24 GB)")
+            .expect("comparable rows should build an index");
+
+        let m = idx
+            .lookup("unsloth/Qwen3-4B-GGUF", "q4_k_m")
+            .expect("quant match is case-insensitive");
+        assert_eq!(
+            m.sample_count, 2,
+            "batched/spec-decoding rows must not count"
+        );
+        assert!((m.tok_s - 110.0).abs() < 1e-9, "median of 100 and 120");
+        assert_eq!(m.hardware_label, "RTX 3090 (24 GB)");
+
+        assert!(
+            idx.lookup("unsloth/Qwen3-4B-GGUF", "Q8_0").is_none(),
+            "different quant must not match"
+        );
+    }
+
+    #[test]
+    fn test_measured_index_none_when_no_comparable_rows() {
+        let rows = vec![row(
+            r#"{"id":"1","tokSOut":900.0,"batchSize":16,"model":{"hfId":"a/b"},"engine":{"engineName":"vllm","quantization":"FP8"}}"#,
+        )];
+        assert!(MeasuredTpsIndex::from_rows(&rows, "A100 (80 GB)").is_none());
+    }
 }

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -206,6 +206,27 @@ pub struct ScoreComponents {
     pub context: f64,
 }
 
+/// The inputs behind `estimated_tps`, exposed so users can see exactly what
+/// the estimate assumes and reproduce it locally (issue #292).
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct EstimateBasis {
+    /// `"gpu_bandwidth_roofline"` — derived from the GPU's memory bandwidth;
+    /// `"backend_constant"` — GPU not in the bandwidth table, per-backend
+    /// heuristic constant used; `"cpu_constant"` — CPU-only path;
+    /// `"unsupported"` — no estimate produced.
+    pub method: String,
+    /// GPU memory bandwidth assumed (GB/s), when the roofline path was used.
+    pub gpu_bandwidth_gbps: Option<f64>,
+    /// System RAM bandwidth assumed for MoE expert streaming (GB/s);
+    /// only set for MoE-offload runs.
+    pub ddr_bandwidth_gbps: Option<f64>,
+    /// Efficiency factor applied to raw bandwidth (default 0.55).
+    pub efficiency: f64,
+    /// The estimate models single-request *generation* throughput at this
+    /// context length. Prompt processing (prefill/TTFT) is not estimated.
+    pub assumed_context: u32,
+}
+
 #[derive(Clone, serde::Serialize)]
 pub struct ModelFit {
     pub model: LlmModel,
@@ -230,6 +251,9 @@ pub struct ModelFit {
     /// A "Perfect" fit with an 8k usable context out of a 262k window is a
     /// very different proposition for coding work (issue #621).
     pub usable_context: u32,
+    /// What the tok/s estimate assumes — method, bandwidths, efficiency —
+    /// so the number can be reproduced and verified (issue #292).
+    pub estimate_basis: EstimateBasis,
 }
 
 impl ModelFit {
@@ -334,6 +358,10 @@ impl ModelFit {
                 fits_with_turboquant: false,
                 effective_context_length: estimation_ctx,
                 usable_context: 0,
+                estimate_basis: EstimateBasis {
+                    method: "unsupported".to_string(),
+                    ..EstimateBasis::default()
+                },
             };
         }
 
@@ -530,6 +558,31 @@ impl ModelFit {
         let estimated_tps =
             estimate_tps(model, &best_quant_str, system, run_mode, runtime, &config);
 
+        // Record the estimate's inputs so it can be reproduced (issue #292).
+        // Mirrors the path selection in estimate_tps: bandwidth roofline when
+        // the GPU is recognized, per-backend constant otherwise.
+        let estimate_basis = {
+            let gpu_bw = system
+                .gpu_name
+                .as_deref()
+                .and_then(crate::hardware::gpu_memory_bandwidth_gbps);
+            let method = if run_mode == RunMode::CpuOnly {
+                "cpu_constant"
+            } else if gpu_bw.is_some() {
+                "gpu_bandwidth_roofline"
+            } else {
+                "backend_constant"
+            };
+            EstimateBasis {
+                method: method.to_string(),
+                gpu_bandwidth_gbps: (run_mode != RunMode::CpuOnly).then_some(gpu_bw).flatten(),
+                ddr_bandwidth_gbps: (run_mode == RunMode::MoeOffload)
+                    .then(|| ddr_bandwidth_gbps(&config)),
+                efficiency: config.efficiency,
+                assumed_context: estimation_ctx,
+            }
+        };
+
         // Add runtime comparison note on Apple Silicon
         if runtime == InferenceRuntime::Mlx {
             let llamacpp_tps = estimate_tps(
@@ -616,6 +669,7 @@ impl ModelFit {
             fits_with_turboquant,
             effective_context_length: estimation_ctx,
             usable_context,
+            estimate_basis,
         }
     }
 

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -254,6 +254,11 @@ pub struct ModelFit {
     /// What the tok/s estimate assumes — method, bandwidths, efficiency —
     /// so the number can be reproduced and verified (issue #292).
     pub estimate_basis: EstimateBasis,
+    /// Community-measured throughput on hardware matching this system
+    /// (localmaxxing.com data), when available. Ground truth, displayed
+    /// with priority over `estimated_tps`. Set after analysis, like
+    /// `installed`.
+    pub measured_tps: Option<crate::benchmarks::MeasuredTps>,
 }
 
 impl ModelFit {
@@ -362,6 +367,7 @@ impl ModelFit {
                     method: "unsupported".to_string(),
                     ..EstimateBasis::default()
                 },
+                measured_tps: None,
             };
         }
 
@@ -670,6 +676,7 @@ impl ModelFit {
             effective_context_length: estimation_ctx,
             usable_context,
             estimate_basis,
+            measured_tps: None, // set later, like `installed`
         }
     }
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -125,7 +125,10 @@ pub fn display_model_fits(fits: &[ModelFit]) {
                 provider: fit.model.provider.clone(),
                 size: fit.model.parameter_count.clone(),
                 score: format!("{:.0}", fit.score),
-                tps: format!("{:.1}", fit.estimated_tps),
+                tps: match &fit.measured_tps {
+                    Some(m) => format!("{:.1} ✓", m.tok_s),
+                    None => format!("{:.1}", fit.estimated_tps),
+                },
                 quant: fit.best_quant.clone(),
                 runtime: fit.runtime_text().to_string(),
                 mode: fit.run_mode_text().to_string(),
@@ -145,6 +148,11 @@ pub fn display_model_fits(fits: &[ModelFit]) {
     println!(
         "  Note: tok/s values are baseline estimates; real runtime depends on engine/runtime."
     );
+    if fits.iter().any(|f| f.measured_tps.is_some()) {
+        println!(
+            "  ✓ = measured by the community on hardware matching yours (localmaxxing.com), not an estimate."
+        );
+    }
 }
 
 pub fn display_model_detail(fit: &ModelFit) {
@@ -545,6 +553,16 @@ fn display_estimate_basis(fit: &ModelFit) {
         return;
     }
 
+    if let Some(m) = &fit.measured_tps {
+        println!("{}", "Measured on Matching Hardware:".bold().underline());
+        println!(
+            "  {:.1} tok/s median across {} community run(s) on {} (localmaxxing.com)",
+            m.tok_s, m.sample_count, m.hardware_label
+        );
+        println!("  Real user data — trust this over the formula estimate below.");
+        println!();
+    }
+
     println!("{}", "Estimate Basis:".bold().underline());
     match basis.method.as_str() {
         "gpu_bandwidth_roofline" => {
@@ -822,6 +840,7 @@ fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "ollama_name": ollama_name_for(&fit.model.name),
         "estimate_basis": serde_json::to_value(&fit.estimate_basis).unwrap(),
         "verify_command": generate_llamabench_command(fit),
+        "measured_tps": serde_json::to_value(&fit.measured_tps).unwrap(),
     })
 }
 
@@ -1075,6 +1094,7 @@ mod tests {
             effective_context_length: 8_192,
             usable_context: 8_192,
             estimate_basis: Default::default(),
+            measured_tps: None,
         }
     }
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use colored::*;
-use llmfit_core::fit::{FitLevel, ModelFit, RunMode, SortColumn};
+use llmfit_core::fit::{FitLevel, InferenceRuntime, ModelFit, RunMode, SortColumn};
 use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::LlmModel;
 use llmfit_core::plan::PlanEstimate;
@@ -188,6 +188,8 @@ pub fn display_model_detail(fit: &ModelFit) {
     );
     println!("  Baseline Est. Speed: {:.1} tok/s", fit.estimated_tps);
     println!();
+
+    display_estimate_basis(fit);
 
     println!("{}", "Resource Requirements:".bold().underline());
     if let Some(vram) = fit.model.min_vram_gb {
@@ -535,6 +537,59 @@ pub fn display_json_fits_with_llamacpp(specs: &SystemSpecs, fits: &[ModelFit]) {
     );
 }
 
+/// Print how the tok/s estimate was derived and how to verify it locally.
+/// Reproducibility ask from issue #292: no number without its inputs.
+fn display_estimate_basis(fit: &ModelFit) {
+    let basis = &fit.estimate_basis;
+    if basis.method == "unsupported" || fit.estimated_tps <= 0.0 {
+        return;
+    }
+
+    println!("{}", "Estimate Basis:".bold().underline());
+    match basis.method.as_str() {
+        "gpu_bandwidth_roofline" => {
+            let bw = basis.gpu_bandwidth_gbps.unwrap_or(0.0);
+            println!(
+                "  Method: GPU bandwidth roofline — {:.0} GB/s x {:.2} efficiency",
+                bw, basis.efficiency
+            );
+            if let Some(ddr) = basis.ddr_bandwidth_gbps {
+                println!(
+                    "  MoE offload: expert streaming bounded by ~{:.0} GB/s system RAM bandwidth",
+                    ddr
+                );
+            }
+        }
+        "cpu_constant" => {
+            println!("  Method: CPU heuristic constant (no GPU acceleration assumed)");
+        }
+        _ => {
+            println!("  Method: per-backend heuristic constant — GPU not in the bandwidth table,");
+            println!("          so expect a wide error band. Please report your GPU model so we");
+            println!(
+                "          can add real bandwidth data (github.com/AlexsJones/llmfit/issues)."
+            );
+        }
+    }
+    println!(
+        "  Models single-request generation at ctx <= {} tokens; prompt processing",
+        basis.assumed_context
+    );
+    println!("  (prefill/TTFT) is not estimated. Baseline error band is roughly +/-30%.");
+    println!("{}", "  Verify on this machine:".bold());
+    println!(
+        "    llmfit bench \"{}\"    (against a running provider)",
+        fit.model.name
+    );
+    if let Some(bench_cmd) = generate_llamabench_command(fit) {
+        println!(
+            "    {}    (compare the tg128 row; get the path via `llmfit download`)",
+            bench_cmd
+        );
+    }
+    println!();
+}
+
 /// Generate a llama.cpp command string for a model fit.
 fn generate_llamacpp_command(fit: &ModelFit) -> Option<String> {
     if fit.run_mode == RunMode::TensorParallel {
@@ -563,6 +618,30 @@ fn generate_llamacpp_command(fit: &ModelFit) -> Option<String> {
             repo, quant, ngl_args, context, conversation_arg
         )
     })
+}
+
+/// llama-bench invocation that measures the same quantity `estimated_tps`
+/// models: single-request generation throughput (the `tg128` row). Prompt
+/// processing (`pp512`) is deliberately not what llmfit estimates.
+///
+/// Only emitted for pure-GPU and CPU-only runs — offload splits depend on
+/// llama.cpp's layer placement, which llama-bench can't express with a fixed
+/// `-ngl`, so a benchmark there wouldn't be comparable to the estimate.
+fn generate_llamabench_command(fit: &ModelFit) -> Option<String> {
+    if fit.runtime != InferenceRuntime::LlamaCpp {
+        return None;
+    }
+    let ngl = match fit.run_mode {
+        RunMode::Gpu => "99",
+        RunMode::CpuOnly => "0",
+        _ => return None,
+    };
+    // llama-bench needs a local GGUF path (no -hf support); point users at
+    // `llmfit download`, which prints the destination path.
+    Some(format!(
+        "llama-bench -m <path-to-{}-gguf> -ngl {} -p 512 -n 128",
+        fit.best_quant, ngl
+    ))
 }
 
 fn llamacpp_ngl_args(run_mode: RunMode) -> Option<&'static str> {
@@ -741,6 +820,8 @@ fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "capabilities": fit.model.capabilities.iter().map(|c| c.label()).collect::<Vec<_>>(),
         "capability_ids": serde_json::to_value(&fit.model.capabilities).unwrap(),
         "ollama_name": ollama_name_for(&fit.model.name),
+        "estimate_basis": serde_json::to_value(&fit.estimate_basis).unwrap(),
+        "verify_command": generate_llamabench_command(fit),
     })
 }
 
@@ -993,6 +1074,7 @@ mod tests {
             fits_with_turboquant: false,
             effective_context_length: 8_192,
             usable_context: 8_192,
+            estimate_basis: Default::default(),
         }
     }
 

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -2735,7 +2735,13 @@ fn main() {
                     }
                 };
 
-                let fit = ModelFit::analyze_with_context_limit(&models[idx], &specs, context_limit);
+                let mut fit =
+                    ModelFit::analyze_with_context_limit(&models[idx], &specs, context_limit);
+                fit.measured_tps = llmfit_core::benchmarks::measured_tps_for(
+                    &specs,
+                    &fit.model.name,
+                    &fit.best_quant,
+                );
                 if cli.json {
                     display::display_json_fits(&specs, &[fit]);
                 } else {
@@ -3012,6 +3018,7 @@ mod tests {
             effective_context_length: 8192,
             usable_context: 8192,
             estimate_basis: Default::default(),
+            measured_tps: None,
         }
     }
 

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -3011,6 +3011,7 @@ mod tests {
             fits_with_turboquant: false,
             effective_context_length: 8192,
             usable_context: 8192,
+            estimate_basis: Default::default(),
         }
     }
 

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -869,6 +869,7 @@ impl App {
             .count();
 
         // Only analyze models that can actually run on this hardware.
+        let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&specs);
         let mut all_fits: Vec<ModelFit> = db
             .get_all_models()
             .iter()
@@ -876,6 +877,9 @@ impl App {
             .map(|m| {
                 let mut fit = ModelFit::analyze_with_context_limit(m, &specs, context_limit);
                 fit.installed = installed.is_installed(&m.name);
+                fit.measured_tps = measured_index
+                    .as_ref()
+                    .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
                 fit
             })
             .collect();
@@ -2924,6 +2928,7 @@ impl App {
             .filter(|m| !backend_compatible(m, &self.specs))
             .count();
 
+        let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&self.specs);
         self.all_fits = db
             .get_all_models()
             .iter()
@@ -2932,6 +2937,9 @@ impl App {
                 let mut fit =
                     ModelFit::analyze_with_context_limit(m, &self.specs, self.context_limit);
                 fit.installed = self.installed.is_installed(&m.name);
+                fit.measured_tps = measured_index
+                    .as_ref()
+                    .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
                 fit
             })
             .collect();
@@ -3360,6 +3368,7 @@ impl App {
             .filter(|m| !backend_compatible(m, &self.specs))
             .count();
 
+        let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&self.specs);
         self.all_fits = db
             .get_all_models()
             .iter()
@@ -3368,6 +3377,9 @@ impl App {
                 let mut fit =
                     ModelFit::analyze_with_config(m, &self.specs, self.calc_config.clone());
                 fit.installed = self.installed.is_installed(&m.name);
+                fit.measured_tps = measured_index
+                    .as_ref()
+                    .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
                 fit
             })
             .collect();
@@ -4427,6 +4439,7 @@ mod tests {
             effective_context_length: 8192,
             usable_context: 8192,
             estimate_basis: Default::default(),
+            measured_tps: None,
         }
     }
 

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -4426,6 +4426,7 @@ mod tests {
             fits_with_turboquant: false,
             effective_context_length: 8192,
             usable_context: 8192,
+            estimate_basis: Default::default(),
         }
     }
 

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -809,14 +809,20 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
                 tc.score_low
             };
 
-            #[allow(clippy::if_same_then_else)]
-            let tps_text = if fit.estimated_tps >= 100.0 {
-                format!("{:.0}", fit.estimated_tps)
-            } else if fit.estimated_tps >= 10.0 {
-                format!("{:.1}", fit.estimated_tps)
-            } else {
-                format!("{:.1}", fit.estimated_tps)
+            // Community-measured tok/s (marked ✓) takes priority over the
+            // formula estimate when matching hardware data exists.
+            let (tps_value, tps_measured) = match &fit.measured_tps {
+                Some(m) => (m.tok_s, true),
+                None => (fit.estimated_tps, false),
             };
+            let mut tps_text = if tps_value >= 100.0 {
+                format!("{:.0}", tps_value)
+            } else {
+                format!("{:.1}", tps_value)
+            };
+            if tps_measured {
+                tps_text.push('✓');
+            }
 
             let is_pulling = app.pull_active.is_some()
                 && app.pull_model_name.as_deref() == Some(&fit.model.name);


### PR DESCRIPTION
Now carries **both** remaining pieces of the estimate-trust work: the original #704 estimate-basis commit *and* #706 (measured tok/s provenance), which was merged into this branch. Synced with main (post-#703/#705); full workspace suite green locally (432 core tests).

## What lands when this merges

**Estimate Basis (#292 reproducibility):**
- Every `ModelFit` records what its tok/s estimate assumed: method (`gpu_bandwidth_roofline` / `backend_constant` / `cpu_constant`), GPU bandwidth, DDR bandwidth (MoE offload), efficiency factor, assumed context.
- `llmfit info` prints it plus verification commands: `llmfit bench "<model>"` and a `llama-bench -p 512 -n 128` recipe (tg128 measures the same quantity the estimate models).
- Unrecognized GPUs are labeled honestly ("expect a wide error band — please report your GPU") instead of printing a confident-looking number.
- JSON gains `estimate_basis` + `verify_command`.

**Measured provenance (from #706):**
- `MeasuredTpsIndex` built from the embedded localmaxxing cache when the detected GPU matches a preset; comparability filters match the calibration test (batch ≤ 1, no spec-decoding/MTP, same quant).
- CLI/TUI fit tables show the measured median marked `✓` with an explanatory footnote; `llmfit info` gains a "Measured on Matching Hardware" section; JSON gains `measured_tps`.

Both features are described in discussion #708 — merging this makes that announcement fully backed by main.

Earlier CI failure on this PR was a runner infrastructure flake (DNS failure installing the Rust toolchain), not a test failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)