### PR TITLE
feat: bench --share — contribute benchmarks as PRs without the gh CLI (RFC #710)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,7 @@ dependencies = [
 name = "llmfit-core"
 version = "1.0.1"
 dependencies = [
+ "base64 0.22.1",
  "dirs",
  "http",
  "jsonschema",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,7 +98,10 @@ python3 scripts/test_api.py --base-url http://127.0.0.1:8787
 ### Contributing benchmarks (`bench --share`)
 
 `llmfit bench` measures inference performance against a running provider
-(Ollama, vLLM, or MLX). Add `--share` to contribute your results back to the
+(Ollama, vLLM, MLX, or llama-server). llama-server is auto-detected on port
+8080 via its `/props` endpoint (override with `LLAMA_SERVER_HOST` for a full
+URL, or `LLAMA_SERVER_PORT`), or select it explicitly with
+`--provider llamacpp`. Add `--share` to contribute your results back to the
 project as a pull request — **no `gh` CLI and no account on a third-party
 service required**:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,6 +95,38 @@ python3 scripts/test_api.py --spawn
 python3 scripts/test_api.py --base-url http://127.0.0.1:8787
 ```
 
+### Contributing benchmarks (`bench --share`)
+
+`llmfit bench` measures inference performance against a running provider
+(Ollama, vLLM, or MLX). Add `--share` to contribute your results back to the
+project as a pull request — **no `gh` CLI and no account on a third-party
+service required**:
+
+```sh
+# Benchmark every discovered model and open a PR with the results
+llmfit bench --all --share
+
+# Preview the exact JSON payload without contacting GitHub
+llmfit bench --all --share --dry-run
+
+# Skip the confirmation prompt (e.g. for automation)
+llmfit bench --all --share --yes
+```
+
+Authentication uses the GitHub **device flow** (the same mechanism
+`gh auth login` uses): llmfit prints a short code and a URL, you approve it in
+your browser once, and the token is cached under `~/.config/llmfit/` for next
+time. If a `GITHUB_TOKEN` or `GH_TOKEN` environment variable is set (or you use
+CI), that token is used automatically and no browser step is needed.
+
+`--share` then forks the repo, commits a single result file under
+`llmfit-core/data/community/<hardware>/`, and opens a pull request. Nothing is
+submitted until you confirm, and `--dry-run` never touches the network.
+
+> Interactive login requires `LLMFIT_GH_CLIENT_ID` to be set to a registered
+> GitHub OAuth App client id. Until one is configured, use a `GITHUB_TOKEN` /
+> `GH_TOKEN` with `public_repo` scope.
+
 ### Hardware overrides
 
 Hardware autodetection can fail on some systems (e.g. broken `nvidia-smi`, VMs, passthrough setups), or you may want to evaluate model fit against different target hardware. Use `--memory`, `--ram`, and `--cpu-cores` to override detected values:

--- a/llmfit-core/Cargo.toml
+++ b/llmfit-core/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["llm", "hardware", "inference", "models", "gpu"]
 categories = ["hardware-support"]
 
 [dependencies]
+base64 = "0.22"
 dirs = "6.0"
 http = "1"
 regex = "1"

--- a/llmfit-core/data/community/README.md
+++ b/llmfit-core/data/community/README.md
@@ -1,0 +1,70 @@
+# Community benchmarks
+
+This directory collects benchmark results contributed by llmfit users via:
+
+```sh
+llmfit bench --all --share
+```
+
+`--share` runs a benchmark sweep, shows you the exact JSON payload, asks for
+confirmation, then opens a pull request adding one file here — **without needing
+the `gh` CLI**. Authentication uses the GitHub OAuth *device flow* (the same
+mechanism `gh auth login` uses); a `GITHUB_TOKEN` / `GH_TOKEN` env var is used
+automatically when present (e.g. in CI).
+
+Preview what would be submitted without contacting GitHub:
+
+```sh
+llmfit bench --all --share --dry-run
+```
+
+## Layout
+
+```
+community/
+  <hardware-slug>/
+    <unix-timestamp>-<hash>.json
+```
+
+Files are namespaced by hardware and carry a content hash so concurrent
+submissions never collide.
+
+## Format
+
+Each file conforms to [`schema.json`](./schema.json). Example:
+
+```json
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1752127200,
+  "tool": { "name": "llmfit", "version": "1.0.0" },
+  "hardware": {
+    "hwClass": "DISCRETE_GPU",
+    "hardwareName": "NVIDIA GeForce RTX 4090",
+    "memTierGb": 24,
+    "vramGb": 24.0,
+    "gpuCount": 1,
+    "unifiedMemory": false,
+    "cpu": "AMD Ryzen 9 7950X",
+    "cpuCores": 32,
+    "ramGb": 64.0,
+    "os": "linux"
+  },
+  "results": [
+    {
+      "model": "llama3.1:8b",
+      "provider": "ollama",
+      "numRuns": 3,
+      "avgTps": 128.4,
+      "minTps": 121.0,
+      "maxTps": 133.7,
+      "avgTtftMs": 41.2,
+      "avgTotalMs": 812.5,
+      "avgOutputTokens": 104.0
+    }
+  ]
+}
+```
+
+Submissions are validated against the schema and sanity-checked (measurements
+within physical limits for the reported hardware) before merge.

--- a/llmfit-core/data/community/schema.json
+++ b/llmfit-core/data/community/schema.json
@@ -43,7 +43,7 @@
         "required": ["model", "provider", "numRuns", "avgTps", "minTps", "maxTps", "avgTotalMs", "avgOutputTokens"],
         "properties": {
           "model": { "type": "string", "minLength": 1 },
-          "provider": { "type": "string", "enum": ["ollama", "vllm", "mlx"] },
+          "provider": { "type": "string", "enum": ["ollama", "vllm", "mlx", "llamacpp"] },
           "numRuns": { "type": "integer", "minimum": 1 },
           "avgTps": { "type": "number", "minimum": 0, "maximum": 100000 },
           "minTps": { "type": "number", "minimum": 0, "maximum": 100000 },

--- a/llmfit-core/data/community/schema.json
+++ b/llmfit-core/data/community/schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://llmfit.dev/schemas/community-benchmark.json",
+  "title": "llmfit community benchmark submission",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "submittedAtUnix", "tool", "hardware", "results"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "const": 1 },
+    "submittedAtUnix": { "type": "integer", "minimum": 0 },
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    },
+    "hardware": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hwClass", "gpuCount", "unifiedMemory", "cpu", "cpuCores", "ramGb", "os"],
+      "properties": {
+        "hwClass": { "type": "string", "enum": ["DISCRETE_GPU", "UNIFIED", "CPU_ONLY"] },
+        "hardwareName": { "type": ["string", "null"] },
+        "memTierGb": { "type": ["integer", "null"], "minimum": 0 },
+        "vramGb": { "type": ["number", "null"], "minimum": 0 },
+        "gpuCount": { "type": "integer", "minimum": 0 },
+        "unifiedMemory": { "type": "boolean" },
+        "cpu": { "type": "string" },
+        "cpuCores": { "type": "integer", "minimum": 1 },
+        "ramGb": { "type": "number", "minimum": 0 },
+        "os": { "type": "string", "enum": ["linux", "macos", "windows"] }
+      }
+    },
+    "results": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["model", "provider", "numRuns", "avgTps", "minTps", "maxTps", "avgTotalMs", "avgOutputTokens"],
+        "properties": {
+          "model": { "type": "string", "minLength": 1 },
+          "provider": { "type": "string", "enum": ["ollama", "vllm", "mlx"] },
+          "numRuns": { "type": "integer", "minimum": 1 },
+          "avgTps": { "type": "number", "minimum": 0, "maximum": 100000 },
+          "minTps": { "type": "number", "minimum": 0, "maximum": 100000 },
+          "maxTps": { "type": "number", "minimum": 0, "maximum": 100000 },
+          "avgTtftMs": { "type": ["number", "null"], "minimum": 0 },
+          "avgTotalMs": { "type": "number", "minimum": 0 },
+          "avgOutputTokens": { "type": "number", "minimum": 0 }
+        }
+      }
+    }
+  }
+}

--- a/llmfit-core/src/bench.rs
+++ b/llmfit-core/src/bench.rs
@@ -339,6 +339,32 @@ pub enum BenchTarget {
     Ollama { url: String, model: String },
     VLlm { url: String, model: String },
     Mlx { url: String, model: String },
+    LlamaCpp { url: String, model: String },
+}
+
+/// Base URL for a running llama-server instance.
+/// `LLAMA_SERVER_HOST` (full URL) wins; otherwise localhost with
+/// `LLAMA_SERVER_PORT` (default 8080, llama-server's own default).
+pub fn llamacpp_url() -> String {
+    if let Ok(host) = std::env::var("LLAMA_SERVER_HOST")
+        && !host.trim().is_empty()
+    {
+        return host.trim().trim_end_matches('/').to_string();
+    }
+    let port = std::env::var("LLAMA_SERVER_PORT").unwrap_or_else(|_| "8080".to_string());
+    format!("http://localhost:{}", port)
+}
+
+/// Positively identify a llama-server instance via its `/props` endpoint.
+/// llama.cpp serves it; MLX and vLLM return 404, which disambiguates
+/// llama-server from `mlx_lm.server` on the shared default port 8080.
+pub fn probe_llamacpp(base_url: &str) -> bool {
+    ureq::get(&format!("{}/props", base_url.trim_end_matches('/')))
+        .config()
+        .timeout_global(Some(Duration::from_secs(2)))
+        .build()
+        .call()
+        .is_ok()
 }
 
 /// Auto-detect available providers and pick the best one to benchmark.
@@ -370,6 +396,18 @@ pub fn auto_detect_target(model_hint: Option<&str>) -> Result<BenchTarget, Strin
         });
     }
 
+    // Check llama-server before MLX: both default to port 8080, but only
+    // llama.cpp answers /props, so it can be identified positively.
+    let llama_url = llamacpp_url();
+    if probe_llamacpp(&llama_url)
+        && let Ok(model_name) = detect_openai_model(&llama_url, model_hint)
+    {
+        return Ok(BenchTarget::LlamaCpp {
+            url: llama_url,
+            model: model_name,
+        });
+    }
+
     // Check MLX
     let mlx_url =
         std::env::var("MLX_LM_HOST").unwrap_or_else(|_| "http://localhost:8080".to_string());
@@ -387,7 +425,7 @@ pub fn auto_detect_target(model_hint: Option<&str>) -> Result<BenchTarget, Strin
         });
     }
 
-    Err("No inference provider found. Start Ollama, vLLM, or MLX first.".to_string())
+    Err("No inference provider found. Start Ollama, vLLM, MLX, or llama-server first.".to_string())
 }
 
 /// Discover all available models across all providers.
@@ -418,10 +456,26 @@ pub fn discover_all_targets() -> Vec<BenchTarget> {
         }
     }
 
-    // Check MLX
+    // Check llama-server before MLX: both default to port 8080, but only
+    // llama.cpp answers /props, so it can be identified positively.
+    let llama_url = llamacpp_url();
+    let llamacpp_found = probe_llamacpp(&llama_url);
+    if llamacpp_found && let Ok(models) = list_openai_models(&llama_url) {
+        for model in models {
+            targets.push(BenchTarget::LlamaCpp {
+                url: llama_url.clone(),
+                model,
+            });
+        }
+    }
+
+    // Check MLX (skip if the llama-server probe already claimed this URL,
+    // e.g. both on the default port 8080)
     let mlx_url =
         std::env::var("MLX_LM_HOST").unwrap_or_else(|_| "http://localhost:8080".to_string());
-    if let Ok(models) = list_openai_models(&mlx_url) {
+    if !(llamacpp_found && mlx_url.trim_end_matches('/') == llama_url)
+        && let Ok(models) = list_openai_models(&mlx_url)
+    {
         for model in models {
             targets.push(BenchTarget::Mlx {
                 url: mlx_url.clone(),

--- a/llmfit-core/src/lib.rs
+++ b/llmfit-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod models;
 pub mod plan;
 pub mod providers;
 pub mod quality;
+pub mod share;
 pub mod task_bench;
 pub mod update;
 

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -2501,7 +2501,7 @@ fn docker_mr_installed_matches(installed_name: &str, candidate: &str) -> bool {
 
 /// Strip quantization suffix from a GGUF file stem.
 /// "llama-3.1-8b-instruct-q4_k_m" → "llama-3.1-8b-instruct"
-fn strip_gguf_quant_suffix(stem: &str) -> Option<String> {
+pub fn strip_gguf_quant_suffix(stem: &str) -> Option<String> {
     let quant_patterns = [
         "-q8_0", "-q6_k", "-q6_k_l", "-q5_k_m", "-q5_k_s", "-q4_k_m", "-q4_k_s", "-q4_0",
         "-q3_k_m", "-q3_k_s", "-q2_k", "-iq4_xs", "-iq3_m", "-iq2_m", "-iq1_m", "-f16", "-f32",

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -4094,10 +4094,22 @@ mod tests {
             .iter()
             .map(|s| s.to_string())
             .collect();
-        assert!(is_model_installed_llamacpp("tiny-random/gemma-3", &installed));
-        assert!(!is_model_installed_llamacpp("google/gemma-3-27b-it", &installed));
-        assert!(!is_model_installed_llamacpp("google/gemma-3-4b-it", &installed));
-        assert!(!is_model_installed_llamacpp("unsloth/gemma-3-270m-it", &installed));
+        assert!(is_model_installed_llamacpp(
+            "tiny-random/gemma-3",
+            &installed
+        ));
+        assert!(!is_model_installed_llamacpp(
+            "google/gemma-3-27b-it",
+            &installed
+        ));
+        assert!(!is_model_installed_llamacpp(
+            "google/gemma-3-4b-it",
+            &installed
+        ));
+        assert!(!is_model_installed_llamacpp(
+            "unsloth/gemma-3-270m-it",
+            &installed
+        ));
     }
 
     // ── gguf_pull_tag ────────────────────────────────────────────────

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -2689,21 +2689,25 @@ pub fn is_model_installed_llamacpp(hf_name: &str, installed: &HashSet<String>) -
         .unwrap_or(hf_name)
         .to_lowercase();
 
-    // Direct match on model name stem
+    // Direct match on model name stem. The installed set already contains
+    // both raw file stems and quant-suffix-stripped bases (see
+    // `installed_models_counted`), so exact lookups cover files like
+    // "qwen2.5-7b-instruct-q4_k_m.gguf" matched against the plain repo name.
     if installed.contains(&repo) {
         return true;
     }
 
-    // Check with common suffixes stripped
+    // Also accept a match with common variant suffixes stripped.
+    //
+    // Deliberately no substring matching here: a single "gemma-3.gguf" on
+    // disk must not mark every gemma-3-* model in the database as installed
+    // (`repo.contains("gemma-3")` is true for all of them).
     let stripped = repo
         .replace("-instruct", "")
         .replace("-chat", "")
         .replace("-hf", "")
         .replace("-it", "");
-
-    installed.iter().any(|name| {
-        name.contains(&repo) || name.contains(&stripped) || repo.contains(name.as_str())
-    })
+    installed.contains(&stripped)
 }
 
 /// Given an HF model name, return the best GGUF repo to pull from.
@@ -4078,6 +4082,22 @@ mod tests {
             "meta-llama/Llama-3.1-8B-Instruct",
             &installed
         ));
+    }
+
+    #[test]
+    fn test_is_model_installed_llamacpp_no_family_false_positives() {
+        // A single "gemma-3.Q8_0.gguf" on disk yields these stems — it must
+        // mark ONLY repos actually named "gemma-3" as installed, not the
+        // whole gemma-3 family (regression: substring matching ticked every
+        // gemma-3-* model in the table).
+        let installed: HashSet<String> = ["gemma-3.q8_0", "gemma-3"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(is_model_installed_llamacpp("tiny-random/gemma-3", &installed));
+        assert!(!is_model_installed_llamacpp("google/gemma-3-27b-it", &installed));
+        assert!(!is_model_installed_llamacpp("google/gemma-3-4b-it", &installed));
+        assert!(!is_model_installed_llamacpp("unsloth/gemma-3-270m-it", &installed));
     }
 
     // ── gguf_pull_tag ────────────────────────────────────────────────

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -299,10 +299,7 @@ pub fn submit_results(
     let path = format!("{SUBMISSION_DIR}/{slug}/{}-{hash}.json", now_unix());
     let message = format!(
         "data: community benchmark ({} on {})",
-        results
-            .first()
-            .map(|r| r.model.as_str())
-            .unwrap_or("model"),
+        results.first().map(|r| r.model.as_str()).unwrap_or("model"),
         slug
     );
     put_file(token, &login, &branch, &path, &json, &message)?;
@@ -517,12 +514,7 @@ fn device_flow(client_id: &str) -> Result<String, String> {
 /// Issue an authenticated GitHub API request. Returns `(status, body)` where
 /// `body` is parsed JSON (or `Value::Null` when there is none). Non-2xx statuses
 /// are returned rather than raised so callers can react to them.
-fn api(
-    method: &str,
-    url: &str,
-    token: &str,
-    body: Option<&Value>,
-) -> Result<(u16, Value), String> {
+fn api(method: &str, url: &str, token: &str, body: Option<&Value>) -> Result<(u16, Value), String> {
     let auth = format!("Bearer {token}");
     let resp = match method {
         "GET" => ureq::get(url)
@@ -612,7 +604,8 @@ fn ensure_fork(token: &str, login: &str) -> Result<(), String> {
 }
 
 fn upstream_head_sha(token: &str) -> Result<String, String> {
-    let url = format!("{API}/repos/{UPSTREAM_OWNER}/{UPSTREAM_REPO}/git/ref/heads/{UPSTREAM_BRANCH}");
+    let url =
+        format!("{API}/repos/{UPSTREAM_OWNER}/{UPSTREAM_REPO}/git/ref/heads/{UPSTREAM_BRANCH}");
     let (status, body) = api("GET", &url, token, None)?;
     if !(200..300).contains(&status) {
         return Err(api_error(status, &body));
@@ -786,8 +779,8 @@ mod tests {
         );
         let value = serde_json::to_value(&submission).unwrap();
 
-        let schema_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("data/community/schema.json");
+        let schema_path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("data/community/schema.json");
         let schema: Value =
             serde_json::from_str(&std::fs::read_to_string(&schema_path).unwrap()).unwrap();
         let validator = jsonschema::validator_for(&schema).unwrap();

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -266,16 +266,35 @@ pub fn share_results(
     }
 
     let token = resolve_token()?;
-    let login = whoami(&token)?;
-    eprintln!("  Authenticated as {login}.");
+    let pr_url = submit_results(results, specs, &token)?;
+    Ok(Some(pr_url))
+}
 
-    ensure_fork(&token, &login)?;
-    let base_sha = upstream_head_sha(&token)?;
+/// Non-interactive core of the share flow: fork the repo, commit the result
+/// file to a new branch, and open a pull request using an already-resolved
+/// token. Never prompts or reads stdin, so it is safe to call from a worker
+/// thread while a TUI owns the terminal. Returns the PR URL.
+pub fn submit_results(
+    results: &[BenchResult],
+    specs: &SystemSpecs,
+    token: &str,
+) -> Result<String, String> {
+    if results.is_empty() {
+        return Err("no benchmark results to share".to_string());
+    }
+    let submission = build_submission(results, specs);
+    let json =
+        serde_json::to_string_pretty(&submission).map_err(|e| format!("serialize failed: {e}"))?;
+
+    let login = whoami(token)?;
+
+    ensure_fork(token, &login)?;
+    let base_sha = upstream_head_sha(token)?;
 
     let slug = hardware_slug(specs);
     let hash = short_hash(&json);
     let branch = format!("bench/{slug}-{hash}");
-    create_branch(&token, &login, &branch, &base_sha)?;
+    create_branch(token, &login, &branch, &base_sha)?;
 
     let path = format!("{SUBMISSION_DIR}/{slug}/{}-{hash}.json", now_unix());
     let message = format!(
@@ -286,10 +305,9 @@ pub fn share_results(
             .unwrap_or("model"),
         slug
     );
-    put_file(&token, &login, &branch, &path, &json, &message)?;
+    put_file(token, &login, &branch, &path, &json, &message)?;
 
-    let pr_url = open_pr(&token, &login, &branch, results, &slug)?;
-    Ok(Some(pr_url))
+    open_pr(token, &login, &branch, results, &slug)
 }
 
 fn confirm(prompt: &str) -> Result<bool, String> {
@@ -307,30 +325,47 @@ fn confirm(prompt: &str) -> Result<bool, String> {
 // Authentication
 // ---------------------------------------------------------------------------
 
-/// Resolve a GitHub token: env var, then cached token, then interactive device flow.
-fn resolve_token() -> Result<String, String> {
+/// Resolve a GitHub token without any user interaction: env vars, then the
+/// cached token from a previous device-flow login. Returns `None` when an
+/// interactive login would be required.
+pub fn resolve_token_noninteractive() -> Option<String> {
     for var in ["GITHUB_TOKEN", "GH_TOKEN"] {
         if let Some(t) = std::env::var(var)
             .ok()
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
         {
-            return Ok(t);
+            return Some(t);
         }
     }
-    if let Some(t) = read_cached_token() {
+    read_cached_token()
+}
+
+/// The OAuth App client id for the device flow, or `None` when only the
+/// unregistered placeholder is available (interactive login not possible).
+pub fn oauth_client_id() -> Option<String> {
+    let id = std::env::var("LLMFIT_GH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
+    (id != DEFAULT_CLIENT_ID).then_some(id)
+}
+
+/// Persist a token obtained via the device flow for future runs.
+pub fn cache_token(token: &str) -> Result<(), String> {
+    write_cached_token(token)
+}
+
+/// Resolve a GitHub token: env var, then cached token, then interactive device flow.
+fn resolve_token() -> Result<String, String> {
+    if let Some(t) = resolve_token_noninteractive() {
         return Ok(t);
     }
-    let client_id =
-        std::env::var("LLMFIT_GH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
-    if client_id == DEFAULT_CLIENT_ID {
+    let Some(client_id) = oauth_client_id() else {
         return Err(
             "no GitHub token found. Set GITHUB_TOKEN (or GH_TOKEN), or set \
              LLMFIT_GH_CLIENT_ID to a registered OAuth App client id to enable \
              interactive login."
                 .to_string(),
         );
-    }
+    };
     let token = device_flow(&client_id)?;
     if let Err(e) = write_cached_token(&token) {
         eprintln!("  Warning: could not cache token: {e}");
@@ -363,9 +398,31 @@ fn write_cached_token(token: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Run the GitHub OAuth device flow, blocking until the user authorizes or the
-/// code expires. Returns the access token.
-fn device_flow(client_id: &str) -> Result<String, String> {
+/// A started device-flow authorization: show `user_code` / `verification_uri`
+/// to the user, then call [`device_flow_poll`] every `interval` seconds.
+pub struct DeviceAuth {
+    pub user_code: String,
+    pub verification_uri: String,
+    pub device_code: String,
+    /// Minimum seconds to wait between polls.
+    pub interval: u64,
+}
+
+/// Outcome of a single device-flow poll.
+pub enum DevicePoll {
+    /// Authorized; carries the access token.
+    Token(String),
+    /// User has not authorized yet — poll again after `interval`.
+    Pending,
+    /// Server asked to slow down — add ~5s to the interval and poll again.
+    SlowDown,
+    /// Terminal failure (expired, denied, or protocol error).
+    Failed(String),
+}
+
+/// Begin the GitHub OAuth device flow: request a user code for the given
+/// OAuth App client id.
+pub fn device_flow_start(client_id: &str) -> Result<DeviceAuth, String> {
     let resp = ureq::post("https://github.com/login/device/code")
         .config()
         .http_status_as_error(false)
@@ -379,56 +436,76 @@ fn device_flow(client_id: &str) -> Result<String, String> {
         .read_json()
         .map_err(|e| format!("device code parse failed: {e}"))?;
 
-    let device_code = v["device_code"]
-        .as_str()
-        .ok_or("device flow: missing device_code")?
-        .to_string();
-    let user_code = v["user_code"].as_str().unwrap_or("").to_string();
-    let verification_uri = v["verification_uri"]
-        .as_str()
-        .unwrap_or("https://github.com/login/device")
-        .to_string();
-    let mut interval = v["interval"].as_u64().unwrap_or(5).max(1);
+    Ok(DeviceAuth {
+        device_code: v["device_code"]
+            .as_str()
+            .ok_or("device flow: missing device_code")?
+            .to_string(),
+        user_code: v["user_code"].as_str().unwrap_or("").to_string(),
+        verification_uri: v["verification_uri"]
+            .as_str()
+            .unwrap_or("https://github.com/login/device")
+            .to_string(),
+        interval: v["interval"].as_u64().unwrap_or(5).max(1),
+    })
+}
+
+/// Poll the device flow once. The caller owns the pacing (sleep `interval`
+/// seconds between calls), which lets a TUI keep its event loop responsive.
+pub fn device_flow_poll(client_id: &str, device_code: &str) -> Result<DevicePoll, String> {
+    let resp = ureq::post("https://github.com/login/oauth/access_token")
+        .config()
+        .http_status_as_error(false)
+        .build()
+        .header("Accept", "application/json")
+        .header("User-Agent", USER_AGENT)
+        .send_json(json!({
+            "client_id": client_id,
+            "device_code": device_code,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        }))
+        .map_err(|e| format!("token poll failed: {e}"))?;
+    let v: Value = resp
+        .into_body()
+        .read_json()
+        .map_err(|e| format!("token poll parse failed: {e}"))?;
+
+    if let Some(tok) = v["access_token"].as_str() {
+        return Ok(DevicePoll::Token(tok.to_string()));
+    }
+    Ok(match v["error"].as_str() {
+        Some("authorization_pending") => DevicePoll::Pending,
+        Some("slow_down") => DevicePoll::SlowDown,
+        Some("expired_token") => {
+            DevicePoll::Failed("device code expired before authorization".into())
+        }
+        Some("access_denied") => DevicePoll::Failed("authorization was denied".into()),
+        Some(other) => DevicePoll::Failed(format!("authorization failed: {other}")),
+        None => DevicePoll::Failed("unexpected response while polling for token".into()),
+    })
+}
+
+/// Run the GitHub OAuth device flow, blocking until the user authorizes or the
+/// code expires. Returns the access token. (CLI path; prints to stderr.)
+fn device_flow(client_id: &str) -> Result<String, String> {
+    let auth = device_flow_start(client_id)?;
+    let mut interval = auth.interval;
 
     eprintln!("\n  To authorize llmfit to open a pull request on your behalf:\n");
-    eprintln!("    1. Open {verification_uri}");
-    eprintln!("    2. Enter code: {user_code}\n");
+    eprintln!("    1. Open {}", auth.verification_uri);
+    eprintln!("    2. Enter code: {}\n", auth.user_code);
     eprintln!("  Waiting for authorization (Ctrl-C to cancel)...");
 
     loop {
         std::thread::sleep(Duration::from_secs(interval + 1));
-        let resp = ureq::post("https://github.com/login/oauth/access_token")
-            .config()
-            .http_status_as_error(false)
-            .build()
-            .header("Accept", "application/json")
-            .header("User-Agent", USER_AGENT)
-            .send_json(json!({
-                "client_id": client_id,
-                "device_code": device_code,
-                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-            }))
-            .map_err(|e| format!("token poll failed: {e}"))?;
-        let v: Value = resp
-            .into_body()
-            .read_json()
-            .map_err(|e| format!("token poll parse failed: {e}"))?;
-
-        if let Some(tok) = v["access_token"].as_str() {
-            return Ok(tok.to_string());
-        }
-        match v["error"].as_str() {
-            Some("authorization_pending") => continue,
-            Some("slow_down") => {
+        match device_flow_poll(client_id, &auth.device_code)? {
+            DevicePoll::Token(tok) => return Ok(tok),
+            DevicePoll::Pending => continue,
+            DevicePoll::SlowDown => {
                 interval += 5;
                 continue;
             }
-            Some("expired_token") => {
-                return Err("device code expired before authorization; run --share again".into());
-            }
-            Some("access_denied") => return Err("authorization was denied".into()),
-            Some(other) => return Err(format!("authorization failed: {other}")),
-            None => return Err("unexpected response while polling for token".into()),
+            DevicePoll::Failed(e) => return Err(e),
         }
     }
 }
@@ -513,7 +590,6 @@ fn ensure_fork(token: &str, login: &str) -> Result<(), String> {
         return Ok(());
     }
 
-    eprintln!("  Creating fork of {UPSTREAM_OWNER}/{UPSTREAM_REPO}...");
     let (status, body) = api(
         "POST",
         &format!("{API}/repos/{UPSTREAM_OWNER}/{UPSTREAM_REPO}/forks"),

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -1,0 +1,718 @@
+//! Contribute benchmark results back to the project as a GitHub pull request.
+//!
+//! No `gh` CLI and no server are required. Authentication uses the GitHub OAuth
+//! **device flow** — the same mechanism `gh auth login` uses — with a public
+//! client id, so nothing secret ships in the binary. The fork / commit / open-PR
+//! steps then go through the GitHub REST API via `ureq` (already a dependency).
+//!
+//! A `GITHUB_TOKEN` / `GH_TOKEN` env var, or a token cached from a previous
+//! device-flow login, short-circuits the interactive step — which also makes
+//! `--share` usable from CI.
+//!
+//! All human-facing output goes to stderr so it never corrupts `bench --json`
+//! output on stdout.
+
+use crate::bench::BenchResult;
+use crate::hardware::SystemSpecs;
+use base64::Engine;
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::io::Write;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const UPSTREAM_OWNER: &str = "AlexsJones";
+const UPSTREAM_REPO: &str = "llmfit";
+const UPSTREAM_BRANCH: &str = "main";
+const SUBMISSION_DIR: &str = "llmfit-core/data/community";
+const SCHEMA_VERSION: u32 = 1;
+const USER_AGENT: &str = concat!("llmfit/", env!("CARGO_PKG_VERSION"));
+const API: &str = "https://api.github.com";
+
+/// Public OAuth App client id used for the device flow. This is **not** a
+/// secret (device flow requires no client secret) and is safe to ship. Until
+/// the real OAuth App is registered, override it with the `LLMFIT_GH_CLIENT_ID`
+/// environment variable.
+const DEFAULT_CLIENT_ID: &str = "REPLACE_WITH_OAUTH_APP_CLIENT_ID";
+
+/// Options controlling a `bench --share` invocation.
+pub struct ShareOptions {
+    /// Print the payload that would be submitted and exit without contacting GitHub.
+    pub dry_run: bool,
+    /// Skip the interactive confirmation prompt (assume "yes").
+    pub assume_yes: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Submission payload
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Submission {
+    schema_version: u32,
+    submitted_at_unix: u64,
+    tool: ToolInfo,
+    hardware: HwPayload,
+    results: Vec<ResultPayload>,
+}
+
+#[derive(Serialize)]
+struct ToolInfo {
+    name: &'static str,
+    version: &'static str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HwPayload {
+    hw_class: &'static str,
+    hardware_name: Option<String>,
+    mem_tier_gb: Option<u32>,
+    vram_gb: Option<f64>,
+    gpu_count: u32,
+    unified_memory: bool,
+    cpu: String,
+    cpu_cores: usize,
+    ram_gb: f64,
+    os: &'static str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ResultPayload {
+    model: String,
+    provider: String,
+    num_runs: usize,
+    avg_tps: f64,
+    min_tps: f64,
+    max_tps: f64,
+    avg_ttft_ms: Option<f64>,
+    avg_total_ms: f64,
+    avg_output_tokens: f64,
+}
+
+fn os_name() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "linux"
+    }
+}
+
+/// Round a memory size to the nearest common tier (matches the leaderboard's
+/// coarse buckets so submissions group cleanly).
+fn nearest_mem_tier(gb: f64) -> u32 {
+    const TIERS: [u32; 12] = [8, 12, 16, 24, 32, 48, 64, 80, 96, 128, 192, 256];
+    let mut best = 0u32;
+    let mut best_d = f64::MAX;
+    for &t in &TIERS {
+        let d = (gb - t as f64).abs();
+        if d < best_d {
+            best_d = d;
+            best = t;
+        }
+    }
+    best
+}
+
+fn build_submission(results: &[BenchResult], specs: &SystemSpecs) -> Submission {
+    let hw_class = if specs.unified_memory {
+        "UNIFIED"
+    } else if specs.has_gpu {
+        "DISCRETE_GPU"
+    } else {
+        "CPU_ONLY"
+    };
+
+    let mem_tier_gb = if let Some(vram) = specs.total_gpu_vram_gb {
+        let t = nearest_mem_tier(vram);
+        (t > 0).then_some(t)
+    } else if specs.unified_memory {
+        let t = nearest_mem_tier(specs.total_ram_gb);
+        (t > 0).then_some(t)
+    } else {
+        None
+    };
+
+    let results = results
+        .iter()
+        .map(|r| ResultPayload {
+            model: r.model.clone(),
+            provider: r.provider.clone(),
+            num_runs: r.summary.num_runs,
+            avg_tps: round2(r.summary.avg_tps),
+            min_tps: round2(r.summary.min_tps),
+            max_tps: round2(r.summary.max_tps),
+            avg_ttft_ms: r.summary.avg_ttft_ms.map(round2),
+            avg_total_ms: round2(r.summary.avg_total_ms),
+            avg_output_tokens: round2(r.summary.avg_output_tokens),
+        })
+        .collect();
+
+    Submission {
+        schema_version: SCHEMA_VERSION,
+        submitted_at_unix: now_unix(),
+        tool: ToolInfo {
+            name: "llmfit",
+            version: env!("CARGO_PKG_VERSION"),
+        },
+        hardware: HwPayload {
+            hw_class,
+            hardware_name: specs.gpu_name.clone(),
+            mem_tier_gb,
+            vram_gb: specs.total_gpu_vram_gb.map(round2),
+            gpu_count: specs.gpu_count,
+            unified_memory: specs.unified_memory,
+            cpu: specs.cpu_name.clone(),
+            cpu_cores: specs.total_cpu_cores,
+            ram_gb: round2(specs.total_ram_gb),
+            os: os_name(),
+        },
+        results,
+    }
+}
+
+fn round2(v: f64) -> f64 {
+    (v * 100.0).round() / 100.0
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Slug identifying the hardware, used for the branch name and submission path.
+fn hardware_slug(specs: &SystemSpecs) -> String {
+    let raw = specs
+        .gpu_name
+        .clone()
+        .unwrap_or_else(|| format!("cpu-{}", specs.cpu_name));
+    let mut slug: String = raw
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    while slug.contains("--") {
+        slug = slug.replace("--", "-");
+    }
+    let slug = slug.trim_matches('-').to_string();
+    if slug.is_empty() {
+        "unknown".to_string()
+    } else {
+        slug
+    }
+}
+
+/// Short stable hash of the payload, for a unique branch/file name without
+/// relying on a random source.
+fn short_hash(s: &str) -> String {
+    // FNV-1a 64-bit.
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    // Mix in the wall clock so repeated identical runs still differ.
+    h ^= now_unix();
+    h = h.wrapping_mul(0x100000001b3);
+    format!("{:08x}", (h & 0xffff_ffff) as u32)
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/// Build the submission, confirm with the user, then fork the repo, commit the
+/// result file to a new branch, and open a pull request.
+///
+/// Returns `Ok(Some(pr_url))` on success, `Ok(None)` if the user cancelled or
+/// `--dry-run` was set, and `Err(_)` on failure.
+pub fn share_results(
+    results: &[BenchResult],
+    specs: &SystemSpecs,
+    opts: &ShareOptions,
+) -> Result<Option<String>, String> {
+    if results.is_empty() {
+        return Err("no benchmark results to share".to_string());
+    }
+
+    let submission = build_submission(results, specs);
+    let json =
+        serde_json::to_string_pretty(&submission).map_err(|e| format!("serialize failed: {e}"))?;
+
+    eprintln!("\n  The following benchmark data would be contributed:\n");
+    for line in json.lines() {
+        eprintln!("    {line}");
+    }
+
+    if opts.dry_run {
+        eprintln!("\n  --dry-run: nothing was submitted.");
+        return Ok(None);
+    }
+
+    if !opts.assume_yes {
+        let prompt = format!(
+            "\n  Contribute {} result(s) as a PR to {UPSTREAM_OWNER}/{UPSTREAM_REPO}?",
+            results.len()
+        );
+        if !confirm(&prompt)? {
+            eprintln!("  Cancelled.");
+            return Ok(None);
+        }
+    }
+
+    let token = resolve_token()?;
+    let login = whoami(&token)?;
+    eprintln!("  Authenticated as {login}.");
+
+    ensure_fork(&token, &login)?;
+    let base_sha = upstream_head_sha(&token)?;
+
+    let slug = hardware_slug(specs);
+    let hash = short_hash(&json);
+    let branch = format!("bench/{slug}-{hash}");
+    create_branch(&token, &login, &branch, &base_sha)?;
+
+    let path = format!("{SUBMISSION_DIR}/{slug}/{}-{hash}.json", now_unix());
+    let message = format!(
+        "data: community benchmark ({} on {})",
+        results
+            .first()
+            .map(|r| r.model.as_str())
+            .unwrap_or("model"),
+        slug
+    );
+    put_file(&token, &login, &branch, &path, &json, &message)?;
+
+    let pr_url = open_pr(&token, &login, &branch, results, &slug)?;
+    Ok(Some(pr_url))
+}
+
+fn confirm(prompt: &str) -> Result<bool, String> {
+    eprint!("{prompt} [y/N] ");
+    std::io::stderr().flush().ok();
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .map_err(|e| format!("failed to read input: {e}"))?;
+    let a = line.trim().to_lowercase();
+    Ok(a == "y" || a == "yes")
+}
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+/// Resolve a GitHub token: env var, then cached token, then interactive device flow.
+fn resolve_token() -> Result<String, String> {
+    for var in ["GITHUB_TOKEN", "GH_TOKEN"] {
+        if let Some(t) = std::env::var(var)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+        {
+            return Ok(t);
+        }
+    }
+    if let Some(t) = read_cached_token() {
+        return Ok(t);
+    }
+    let client_id =
+        std::env::var("LLMFIT_GH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
+    if client_id == DEFAULT_CLIENT_ID {
+        return Err(
+            "no GitHub token found. Set GITHUB_TOKEN (or GH_TOKEN), or set \
+             LLMFIT_GH_CLIENT_ID to a registered OAuth App client id to enable \
+             interactive login."
+                .to_string(),
+        );
+    }
+    let token = device_flow(&client_id)?;
+    if let Err(e) = write_cached_token(&token) {
+        eprintln!("  Warning: could not cache token: {e}");
+    }
+    Ok(token)
+}
+
+fn token_path() -> Option<std::path::PathBuf> {
+    Some(dirs::config_dir()?.join("llmfit").join("github_token"))
+}
+
+fn read_cached_token() -> Option<String> {
+    let p = token_path()?;
+    let t = std::fs::read_to_string(p).ok()?;
+    let t = t.trim().to_string();
+    (!t.is_empty()).then_some(t)
+}
+
+fn write_cached_token(token: &str) -> Result<(), String> {
+    let p = token_path().ok_or("no config directory")?;
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&p, token).map_err(|e| e.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+/// Run the GitHub OAuth device flow, blocking until the user authorizes or the
+/// code expires. Returns the access token.
+fn device_flow(client_id: &str) -> Result<String, String> {
+    let resp = ureq::post("https://github.com/login/device/code")
+        .config()
+        .http_status_as_error(false)
+        .build()
+        .header("Accept", "application/json")
+        .header("User-Agent", USER_AGENT)
+        .send_json(json!({ "client_id": client_id, "scope": "public_repo" }))
+        .map_err(|e| format!("device code request failed: {e}"))?;
+    let v: Value = resp
+        .into_body()
+        .read_json()
+        .map_err(|e| format!("device code parse failed: {e}"))?;
+
+    let device_code = v["device_code"]
+        .as_str()
+        .ok_or("device flow: missing device_code")?
+        .to_string();
+    let user_code = v["user_code"].as_str().unwrap_or("").to_string();
+    let verification_uri = v["verification_uri"]
+        .as_str()
+        .unwrap_or("https://github.com/login/device")
+        .to_string();
+    let mut interval = v["interval"].as_u64().unwrap_or(5).max(1);
+
+    eprintln!("\n  To authorize llmfit to open a pull request on your behalf:\n");
+    eprintln!("    1. Open {verification_uri}");
+    eprintln!("    2. Enter code: {user_code}\n");
+    eprintln!("  Waiting for authorization (Ctrl-C to cancel)...");
+
+    loop {
+        std::thread::sleep(Duration::from_secs(interval + 1));
+        let resp = ureq::post("https://github.com/login/oauth/access_token")
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .header("Accept", "application/json")
+            .header("User-Agent", USER_AGENT)
+            .send_json(json!({
+                "client_id": client_id,
+                "device_code": device_code,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            }))
+            .map_err(|e| format!("token poll failed: {e}"))?;
+        let v: Value = resp
+            .into_body()
+            .read_json()
+            .map_err(|e| format!("token poll parse failed: {e}"))?;
+
+        if let Some(tok) = v["access_token"].as_str() {
+            return Ok(tok.to_string());
+        }
+        match v["error"].as_str() {
+            Some("authorization_pending") => continue,
+            Some("slow_down") => {
+                interval += 5;
+                continue;
+            }
+            Some("expired_token") => {
+                return Err("device code expired before authorization; run --share again".into());
+            }
+            Some("access_denied") => return Err("authorization was denied".into()),
+            Some(other) => return Err(format!("authorization failed: {other}")),
+            None => return Err("unexpected response while polling for token".into()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub REST API helpers
+// ---------------------------------------------------------------------------
+
+/// Issue an authenticated GitHub API request. Returns `(status, body)` where
+/// `body` is parsed JSON (or `Value::Null` when there is none). Non-2xx statuses
+/// are returned rather than raised so callers can react to them.
+fn api(
+    method: &str,
+    url: &str,
+    token: &str,
+    body: Option<&Value>,
+) -> Result<(u16, Value), String> {
+    let auth = format!("Bearer {token}");
+    let resp = match method {
+        "GET" => ureq::get(url)
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .header("Authorization", &auth)
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", USER_AGENT)
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .call(),
+        "POST" => ureq::post(url)
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .header("Authorization", &auth)
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", USER_AGENT)
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send_json(body.unwrap_or(&json!({}))),
+        "PUT" => ureq::put(url)
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .header("Authorization", &auth)
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", USER_AGENT)
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send_json(body.unwrap_or(&json!({}))),
+        _ => return Err(format!("unsupported method {method}")),
+    }
+    .map_err(|e| format!("{method} {url} failed: {e}"))?;
+
+    let status = resp.status().as_u16();
+    let val: Value = resp.into_body().read_json().unwrap_or(Value::Null);
+    Ok((status, val))
+}
+
+/// Extract a human-readable error message from a GitHub error body.
+fn api_error(status: u16, body: &Value) -> String {
+    let msg = body["message"].as_str().unwrap_or("unknown error");
+    format!("GitHub API returned {status}: {msg}")
+}
+
+fn whoami(token: &str) -> Result<String, String> {
+    let (status, body) = api("GET", &format!("{API}/user"), token, None)?;
+    if status == 401 {
+        return Err("GitHub token is invalid or expired (401)".into());
+    }
+    if !(200..300).contains(&status) {
+        return Err(api_error(status, &body));
+    }
+    body["login"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| "could not determine GitHub username".into())
+}
+
+/// Ensure the authenticated user has a fork of the upstream repo, creating one
+/// if needed and waiting until it is queryable.
+fn ensure_fork(token: &str, login: &str) -> Result<(), String> {
+    let fork_url = format!("{API}/repos/{login}/{UPSTREAM_REPO}");
+    let (status, _) = api("GET", &fork_url, token, None)?;
+    if status == 200 {
+        return Ok(());
+    }
+
+    eprintln!("  Creating fork of {UPSTREAM_OWNER}/{UPSTREAM_REPO}...");
+    let (status, body) = api(
+        "POST",
+        &format!("{API}/repos/{UPSTREAM_OWNER}/{UPSTREAM_REPO}/forks"),
+        token,
+        None,
+    )?;
+    if !(200..300).contains(&status) {
+        return Err(api_error(status, &body));
+    }
+
+    // Forking is asynchronous; poll until the fork responds.
+    for _ in 0..15 {
+        std::thread::sleep(Duration::from_secs(2));
+        let (status, _) = api("GET", &fork_url, token, None)?;
+        if status == 200 {
+            return Ok(());
+        }
+    }
+    Err("fork was not ready after waiting; try --share again shortly".into())
+}
+
+fn upstream_head_sha(token: &str) -> Result<String, String> {
+    let url = format!("{API}/repos/{UPSTREAM_OWNER}/{UPSTREAM_REPO}/git/ref/heads/{UPSTREAM_BRANCH}");
+    let (status, body) = api("GET", &url, token, None)?;
+    if !(200..300).contains(&status) {
+        return Err(api_error(status, &body));
+    }
+    body["object"]["sha"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| "could not read upstream head sha".into())
+}
+
+fn create_branch(token: &str, login: &str, branch: &str, sha: &str) -> Result<(), String> {
+    let url = format!("{API}/repos/{login}/{UPSTREAM_REPO}/git/refs");
+    let body = json!({ "ref": format!("refs/heads/{branch}"), "sha": sha });
+    let (status, body) = api("POST", &url, token, Some(&body))?;
+    // 201 created; 422 typically means the ref already exists — acceptable.
+    if status == 201 || status == 422 {
+        return Ok(());
+    }
+    Err(api_error(status, &body))
+}
+
+fn put_file(
+    token: &str,
+    login: &str,
+    branch: &str,
+    path: &str,
+    content: &str,
+    message: &str,
+) -> Result<(), String> {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(content);
+    let url = format!("{API}/repos/{login}/{UPSTREAM_REPO}/contents/{path}");
+    let body = json!({
+        "message": message,
+        "content": encoded,
+        "branch": branch,
+    });
+    let (status, body) = api("PUT", &url, token, Some(&body))?;
+    if !(200..300).contains(&status) {
+        return Err(api_error(status, &body));
+    }
+    Ok(())
+}
+
+fn open_pr(
+    token: &str,
+    login: &str,
+    branch: &str,
+    results: &[BenchResult],
+    slug: &str,
+) -> Result<String, String> {
+    let title = format!("bench: community results for {slug}");
+    let mut body = String::from(
+        "Automated benchmark contribution from `llmfit bench --share`.\n\n\
+         | Model | Provider | Avg TPS | Avg TTFT (ms) |\n\
+         | --- | --- | --- | --- |\n",
+    );
+    for r in results {
+        let ttft = r
+            .summary
+            .avg_ttft_ms
+            .map(|v| format!("{v:.1}"))
+            .unwrap_or_else(|| "—".to_string());
+        body.push_str(&format!(
+            "| {} | {} | {:.1} | {} |\n",
+            r.model, r.provider, r.summary.avg_tps, ttft
+        ));
+    }
+    body.push_str("\n_Submitted without the `gh` CLI via the GitHub device flow._\n");
+
+    let url = format!("{API}/repos/{UPSTREAM_OWNER}/{UPSTREAM_REPO}/pulls");
+    let payload = json!({
+        "title": title,
+        "head": format!("{login}:{branch}"),
+        "base": UPSTREAM_BRANCH,
+        "body": body,
+    });
+    let (status, resp) = api("POST", &url, token, Some(&payload))?;
+    if !(200..300).contains(&status) {
+        return Err(api_error(status, &resp));
+    }
+    resp["html_url"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| "pull request created but no URL returned".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mem_tier_rounds_to_nearest() {
+        assert_eq!(nearest_mem_tier(23.9), 24);
+        assert_eq!(nearest_mem_tier(31.0), 32);
+        assert_eq!(nearest_mem_tier(7.5), 8);
+    }
+
+    fn specs_with_gpu(name: &str) -> SystemSpecs {
+        SystemSpecs {
+            total_ram_gb: 32.0,
+            available_ram_gb: 24.0,
+            total_cpu_cores: 8,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: true,
+            gpu_vram_gb: Some(24.0),
+            total_gpu_vram_gb: Some(24.0),
+            gpu_name: Some(name.to_string()),
+            gpu_count: 1,
+            unified_memory: false,
+            backend: crate::hardware::GpuBackend::Cuda,
+            gpus: vec![],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        }
+    }
+
+    #[test]
+    fn slug_is_filename_safe() {
+        let specs = specs_with_gpu("NVIDIA RTX 4090!!");
+        let slug = hardware_slug(&specs);
+        assert!(slug.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
+        assert!(!slug.contains("--"));
+        assert!(!slug.starts_with('-') && !slug.ends_with('-'));
+        assert_eq!(slug, "nvidia-rtx-4090");
+    }
+
+    #[test]
+    fn short_hash_is_hex() {
+        let h = short_hash("{\"a\":1}");
+        assert_eq!(h.len(), 8);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn submission_matches_published_schema() {
+        use crate::bench::{BenchResult, BenchSummary};
+
+        let result = BenchResult {
+            model: "llama3.1:8b".to_string(),
+            provider: "ollama".to_string(),
+            runs: vec![],
+            summary: BenchSummary {
+                num_runs: 3,
+                avg_ttft_ms: Some(41.234),
+                avg_tps: 128.44,
+                min_tps: 121.0,
+                max_tps: 133.7,
+                avg_total_ms: 812.5,
+                avg_output_tokens: 104.0,
+            },
+        };
+
+        let submission = build_submission(&[result], &specs_with_gpu("NVIDIA GeForce RTX 4090"));
+        let value = serde_json::to_value(&submission).unwrap();
+
+        let schema_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("data/community/schema.json");
+        let schema: Value =
+            serde_json::from_str(&std::fs::read_to_string(&schema_path).unwrap()).unwrap();
+        let validator = jsonschema::validator_for(&schema).unwrap();
+
+        let errors: Vec<String> = validator
+            .iter_errors(&value)
+            .map(|e| format!("  [{}] {}", e.instance_path(), e))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "generated submission violates schema:\n{}\npayload:\n{}",
+            errors.join("\n"),
+            serde_json::to_string_pretty(&value).unwrap()
+        );
+
+        // camelCase field names must survive serialization.
+        assert_eq!(value["schemaVersion"], 1);
+        assert_eq!(value["hardware"]["hwClass"], "DISCRETE_GPU");
+        assert_eq!(value["hardware"]["memTierGb"], 24);
+        assert_eq!(value["results"][0]["avgTps"], 128.44);
+    }
+}

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -688,8 +688,26 @@ mod tests {
                 avg_output_tokens: 104.0,
             },
         };
+        // llama-server results are labeled "llamacpp" — must be schema-valid too.
+        let llamacpp_result = BenchResult {
+            model: "qwen2.5-7b-q4_k_m".to_string(),
+            provider: "llamacpp".to_string(),
+            runs: vec![],
+            summary: BenchSummary {
+                num_runs: 3,
+                avg_ttft_ms: None,
+                avg_tps: 42.5,
+                min_tps: 40.0,
+                max_tps: 45.0,
+                avg_total_ms: 2400.0,
+                avg_output_tokens: 100.0,
+            },
+        };
 
-        let submission = build_submission(&[result], &specs_with_gpu("NVIDIA GeForce RTX 4090"));
+        let submission = build_submission(
+            &[result, llamacpp_result],
+            &specs_with_gpu("NVIDIA GeForce RTX 4090"),
+        );
         let value = serde_json::to_value(&submission).unwrap();
 
         let schema_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -2050,7 +2050,9 @@ fn run_bench(
     if all {
         let targets = bench::discover_all_targets();
         if targets.is_empty() {
-            eprintln!("No providers or models found. Start Ollama, vLLM, MLX, or llama-server first.");
+            eprintln!(
+                "No providers or models found. Start Ollama, vLLM, MLX, or llama-server first."
+            );
             std::process::exit(1);
         }
 
@@ -2355,7 +2357,9 @@ fn run_quality_bench(
     let targets: Vec<bench::BenchTarget> = if all {
         let all_targets = bench::discover_all_targets();
         if all_targets.is_empty() {
-            eprintln!("No providers or models found. Start Ollama, vLLM, MLX, or llama-server first.");
+            eprintln!(
+                "No providers or models found. Start Ollama, vLLM, MLX, or llama-server first."
+            );
             std::process::exit(1);
         }
         if skip_patterns.is_empty() {
@@ -3007,8 +3011,7 @@ fn main() {
                 yes,
             } => {
                 // No model/flags → launch bench TUI view
-                let is_bare =
-                    model.is_none() && !all && !json && !quality && !routing && !share;
+                let is_bare = model.is_none() && !all && !json && !quality && !routing && !share;
                 if is_bare {
                     if let Err(e) = run_tui_bench(&overrides, context_limit, cli.api_key) {
                         eprintln!("Error running bench TUI: {}", e);
@@ -3031,7 +3034,9 @@ fn main() {
                         dry_run,
                         assume_yes: yes,
                     });
-                    run_bench(model, &provider, url, runs, all, json, share_opts, &overrides);
+                    run_bench(
+                        model, &provider, url, runs, all, json, share_opts, &overrides,
+                    );
                 }
             }
         }

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -785,7 +785,7 @@ AGENT USAGE:
         /// Model name to benchmark (auto-detects provider if omitted)
         model: Option<String>,
 
-        /// Provider to benchmark (auto, ollama, vllm, mlx)
+        /// Provider to benchmark (auto, ollama, vllm, mlx, llamacpp)
         #[arg(long, default_value = "auto")]
         provider: String,
 
@@ -2017,6 +2017,7 @@ fn target_info(target: &bench::BenchTarget) -> (&str, &str, &str) {
         bench::BenchTarget::Ollama { url, model } => ("Ollama", url.as_str(), model.as_str()),
         bench::BenchTarget::VLlm { url, model } => ("vLLM", url.as_str(), model.as_str()),
         bench::BenchTarget::Mlx { url, model } => ("MLX", url.as_str(), model.as_str()),
+        bench::BenchTarget::LlamaCpp { url, model } => ("llama.cpp", url.as_str(), model.as_str()),
     }
 }
 
@@ -2049,7 +2050,7 @@ fn run_bench(
     if all {
         let targets = bench::discover_all_targets();
         if targets.is_empty() {
-            eprintln!("No providers or models found. Start Ollama, vLLM, or MLX first.");
+            eprintln!("No providers or models found. Start Ollama, vLLM, MLX, or llama-server first.");
             std::process::exit(1);
         }
 
@@ -2088,6 +2089,9 @@ fn run_bench(
                 }
                 bench::BenchTarget::Mlx { url, model } => {
                     bench::bench_openai_compat(url, model, "mlx", runs, &progress)
+                }
+                bench::BenchTarget::LlamaCpp { url, model } => {
+                    bench::bench_openai_compat(url, model, "llamacpp", runs, &progress)
                 }
             };
 
@@ -2176,6 +2180,28 @@ fn run_bench(
                 model: model_name,
             }
         }
+        "llamacpp" | "llama.cpp" | "llama-server" => {
+            let url = url_override.clone().unwrap_or_else(bench::llamacpp_url);
+            match bench::detect_model_from_url(&url, model.as_deref()) {
+                Ok(model_name) => bench::BenchTarget::LlamaCpp {
+                    url,
+                    model: model_name,
+                },
+                Err(_) => {
+                    let model_name = model.unwrap_or_else(|| {
+                        eprintln!(
+                            "Error: could not detect model from llama-server at {}. Use --model",
+                            url
+                        );
+                        std::process::exit(1);
+                    });
+                    bench::BenchTarget::LlamaCpp {
+                        url,
+                        model: model_name,
+                    }
+                }
+            }
+        }
         _ => match bench::auto_detect_target(model.as_deref()) {
             Ok(t) => t,
             Err(e) => {
@@ -2208,6 +2234,9 @@ fn run_bench(
         }
         bench::BenchTarget::Mlx { url, model } => {
             bench::bench_openai_compat(url, model, "mlx", runs, &progress)
+        }
+        bench::BenchTarget::LlamaCpp { url, model } => {
+            bench::bench_openai_compat(url, model, "llamacpp", runs, &progress)
         }
     };
 
@@ -2326,7 +2355,7 @@ fn run_quality_bench(
     let targets: Vec<bench::BenchTarget> = if all {
         let all_targets = bench::discover_all_targets();
         if all_targets.is_empty() {
-            eprintln!("No providers or models found. Start Ollama, vLLM, or MLX first.");
+            eprintln!("No providers or models found. Start Ollama, vLLM, MLX, or llama-server first.");
             std::process::exit(1);
         }
         if skip_patterns.is_empty() {
@@ -2396,6 +2425,28 @@ fn run_quality_bench(
                     model: model_name,
                 }
             }
+            "llamacpp" | "llama.cpp" | "llama-server" => {
+                let url = url_override.clone().unwrap_or_else(bench::llamacpp_url);
+                match bench::detect_model_from_url(&url, model.as_deref()) {
+                    Ok(model_name) => bench::BenchTarget::LlamaCpp {
+                        url,
+                        model: model_name,
+                    },
+                    Err(_) => {
+                        let model_name = model.unwrap_or_else(|| {
+                            eprintln!(
+                                "Error: could not detect model from llama-server at {}. Use --model",
+                                url
+                            );
+                            std::process::exit(1);
+                        });
+                        bench::BenchTarget::LlamaCpp {
+                            url,
+                            model: model_name,
+                        }
+                    }
+                }
+            }
             _ => match bench::auto_detect_target(model.as_deref()) {
                 Ok(t) => t,
                 Err(e) => {
@@ -2434,7 +2485,9 @@ fn run_quality_bench(
             bench::BenchTarget::Ollama { url, model } => {
                 quality::bench_quality_ollama(url, model, &config, rf)
             }
-            bench::BenchTarget::VLlm { url, model } | bench::BenchTarget::Mlx { url, model } => {
+            bench::BenchTarget::VLlm { url, model }
+            | bench::BenchTarget::Mlx { url, model }
+            | bench::BenchTarget::LlamaCpp { url, model } => {
                 quality::bench_quality_openai_compat(url, model, provider_name, &config, rf)
             }
         };

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -23,6 +23,7 @@ use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::ModelDatabase;
 use llmfit_core::plan::{PlanRequest, estimate_model_plan, resolve_model_selector};
 use llmfit_core::quality;
+use llmfit_core::share;
 
 fn parse_positive_usize(value: &str) -> Result<usize, String> {
     let parsed = value
@@ -823,6 +824,19 @@ AGENT USAGE:
         /// Skip specific models by name substring (comma-separated)
         #[arg(long)]
         skip: Option<String>,
+
+        /// Contribute results back to the project as a GitHub pull request
+        /// (no `gh` CLI required; authenticates via the GitHub device flow)
+        #[arg(long)]
+        share: bool,
+
+        /// With --share, print the submission payload and exit without contacting GitHub
+        #[arg(long)]
+        dry_run: bool,
+
+        /// With --share, skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
     },
 }
 
@@ -2018,6 +2032,7 @@ fn truncate_str(s: &str, max: usize) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_bench(
     model: Option<String>,
     provider: &str,
@@ -2025,6 +2040,8 @@ fn run_bench(
     runs: u32,
     all: bool,
     json: bool,
+    share_opts: Option<share::ShareOptions>,
+    overrides: &HardwareOverrides,
 ) {
     let runs = runs as usize;
 
@@ -2098,6 +2115,9 @@ fn run_bench(
                 "results": results,
             });
             println!("{}", serde_json::to_string_pretty(&json_out).unwrap());
+        }
+        if let Some(opts) = share_opts {
+            share_bench_results(&results, overrides, opts);
         }
         return;
     }
@@ -2203,9 +2223,33 @@ fn run_bench(
             } else {
                 r.display();
             }
+            if let Some(opts) = share_opts {
+                share_bench_results(std::slice::from_ref(&r), overrides, opts);
+            }
         }
         Err(e) => {
             eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Detect hardware and contribute benchmark results upstream via `share`.
+fn share_bench_results(
+    results: &[bench::BenchResult],
+    overrides: &HardwareOverrides,
+    opts: share::ShareOptions,
+) {
+    if results.is_empty() {
+        eprintln!("  Nothing to share: no successful benchmark results.");
+        return;
+    }
+    let specs = detect_specs(overrides);
+    match share::share_results(results, &specs, &opts) {
+        Ok(Some(url)) => println!("\n  Pull request opened: {url}"),
+        Ok(None) => {}
+        Err(e) => {
+            eprintln!("  Share failed: {e}");
             std::process::exit(1);
         }
     }
@@ -2905,9 +2949,13 @@ fn main() {
                 roles,
                 quality_config,
                 skip,
+                share,
+                dry_run,
+                yes,
             } => {
                 // No model/flags → launch bench TUI view
-                let is_bare = model.is_none() && !all && !json && !quality && !routing;
+                let is_bare =
+                    model.is_none() && !all && !json && !quality && !routing && !share;
                 if is_bare {
                     if let Err(e) = run_tui_bench(&overrides, context_limit, cli.api_key) {
                         eprintln!("Error running bench TUI: {}", e);
@@ -2926,7 +2974,11 @@ fn main() {
                         skip,
                     );
                 } else {
-                    run_bench(model, &provider, url, runs, all, json);
+                    let share_opts = share.then_some(share::ShareOptions {
+                        dry_run,
+                        assume_yes: yes,
+                    });
+                    run_bench(model, &provider, url, runs, all, json, share_opts, &overrides);
                 }
             }
         }

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -123,6 +123,7 @@ pub enum InputMode {
     DownloadManager,
     FilterPopup,
     Benchmarks,
+    BenchOffer,
 }
 
 /// Fields in the Filter Popup modal.
@@ -316,6 +317,254 @@ pub enum BenchMsg {
     },
     ModelDone(quality::ModelQualityResult),
     AllDone,
+}
+
+/// Messages sent from the bench-offer worker thread (benchmark of the
+/// selected model, plus the optional share-as-PR flow) to the UI.
+pub enum BenchOfferMsg {
+    Progress(String),
+    /// GitHub device-flow authorization needed: show code + URL in the modal.
+    AuthCode {
+        user_code: String,
+        verification_uri: String,
+    },
+    Done {
+        summary: String,
+        pr_url: Option<String>,
+        /// Set when the bench succeeded but the share step failed/was skipped.
+        share_note: Option<String>,
+    },
+    Error(String),
+}
+
+/// UI state of the bench-offer modal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BenchOfferState {
+    /// Waiting for the user to confirm, toggle share, or dismiss.
+    Offer,
+    /// Worker thread is benchmarking (and possibly sharing).
+    Running,
+    /// Finished — summary (and PR URL, if shared) is displayed.
+    Done,
+    /// Failed — error message is displayed.
+    Error,
+}
+
+/// Match a running provider's model tag against an HF-style model name,
+/// reusing the same heuristics as the installed-column detection.
+///
+/// Two deliberately separate passes: Ollama-style candidate matching runs
+/// only against the verbatim id, while file paths reported by llama-server
+/// (".../gemma-3.Q8_0.gguf") get exact stem matching only — feeding a bare
+/// stem into the Ollama candidate heuristics would match whole families.
+fn bench_target_matches(target_model: &str, hf_name: &str) -> bool {
+    let lower = target_model.to_lowercase();
+
+    let mut tag_set = HashSet::new();
+    tag_set.insert(lower.clone());
+    if llmfit_core::providers::is_model_installed(hf_name, &tag_set) {
+        return true;
+    }
+
+    let stem = lower
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(&lower)
+        .trim_end_matches(".gguf")
+        .to_string();
+    let mut stem_set = HashSet::new();
+    if let Some(base) = llmfit_core::providers::strip_gguf_quant_suffix(&stem) {
+        stem_set.insert(base);
+    }
+    stem_set.insert(stem);
+    llmfit_core::providers::is_model_installed_llamacpp(hf_name, &stem_set)
+}
+
+/// Body of the bench-offer worker thread: find the selected model on a running
+/// provider, benchmark it, and optionally share the result as a PR. All
+/// user-visible output goes through `tx` — never stdout/stderr (the TUI owns
+/// the terminal).
+fn bench_offer_worker(
+    tx: &mpsc::Sender<BenchOfferMsg>,
+    model_name: &str,
+    share: bool,
+    specs: &SystemSpecs,
+) {
+    use llmfit_core::bench::{self, BenchTarget};
+    use llmfit_core::share;
+
+    let targets = bench::discover_all_targets();
+    let target = targets.into_iter().find(|t| {
+        let model = match t {
+            BenchTarget::Ollama { model, .. }
+            | BenchTarget::VLlm { model, .. }
+            | BenchTarget::Mlx { model, .. }
+            | BenchTarget::LlamaCpp { model, .. } => model,
+        };
+        bench_target_matches(model, model_name)
+    });
+    let Some(target) = target else {
+        let _ = tx.send(BenchOfferMsg::Error(format!(
+            "{} is installed but not served by any running provider",
+            model_name
+        )));
+        return;
+    };
+
+    const RUNS: usize = 3;
+    let (provider, url, tag) = match &target {
+        BenchTarget::Ollama { url, model } => ("ollama", url, model),
+        BenchTarget::VLlm { url, model } => ("vllm", url, model),
+        BenchTarget::Mlx { url, model } => ("mlx", url, model),
+        BenchTarget::LlamaCpp { url, model } => ("llamacpp", url, model),
+    };
+
+    // llama-server reports file paths as model ids — display just the stem.
+    let display_tag = tag
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(tag)
+        .trim_end_matches(".gguf")
+        .to_string();
+
+    let progress_tx = tx.clone();
+    let tag_for_progress = display_tag.clone();
+    let on_progress = move |i: usize, total: usize| {
+        let msg = if i == 0 {
+            format!("Warming up {}...", tag_for_progress)
+        } else {
+            format!("Benchmarking {} — run {}/{}", tag_for_progress, i, total)
+        };
+        let _ = progress_tx.send(BenchOfferMsg::Progress(msg));
+    };
+
+    let result = match &target {
+        BenchTarget::Ollama { url: u, model } => bench::bench_ollama(u, model, RUNS, &on_progress),
+        BenchTarget::VLlm { url: u, model } => {
+            bench::bench_openai_compat(u, model, "vllm", RUNS, &on_progress)
+        }
+        BenchTarget::Mlx { url: u, model } => {
+            bench::bench_openai_compat(u, model, "mlx", RUNS, &on_progress)
+        }
+        BenchTarget::LlamaCpp { url: u, model } => {
+            bench::bench_openai_compat(u, model, "llamacpp", RUNS, &on_progress)
+        }
+    };
+
+    let result = match result {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = tx.send(BenchOfferMsg::Error(format!(
+                "benchmark via {} at {} failed: {}",
+                provider, url, e
+            )));
+            return;
+        }
+    };
+
+    let ttft = result
+        .summary
+        .avg_ttft_ms
+        .map(|v| format!("{:.0} ms TTFT, ", v))
+        .unwrap_or_default();
+    let summary = format!(
+        "{}: {:.1} tok/s avg ({:.1}–{:.1}), {}{} runs via {}",
+        display_tag,
+        result.summary.avg_tps,
+        result.summary.min_tps,
+        result.summary.max_tps,
+        ttft,
+        result.summary.num_runs,
+        provider,
+    );
+
+    if !share {
+        let _ = tx.send(BenchOfferMsg::Done {
+            summary,
+            pr_url: None,
+            share_note: None,
+        });
+        return;
+    }
+
+    // Share flow: cached/env token first, then interactive device flow with
+    // the code rendered inside the modal.
+    let _ = tx.send(BenchOfferMsg::Progress("Sharing with llmfit...".into()));
+    let token = match share::resolve_token_noninteractive() {
+        Some(t) => t,
+        None => {
+            let Some(client_id) = share::oauth_client_id() else {
+                let _ = tx.send(BenchOfferMsg::Done {
+                    summary,
+                    pr_url: None,
+                    share_note: Some(
+                        "Share skipped: no GitHub token. Set GITHUB_TOKEN or run \
+                         `llmfit bench --share` once to log in."
+                            .into(),
+                    ),
+                });
+                return;
+            };
+            let auth = match share::device_flow_start(&client_id) {
+                Ok(a) => a,
+                Err(e) => {
+                    let _ = tx.send(BenchOfferMsg::Done {
+                        summary,
+                        pr_url: None,
+                        share_note: Some(format!("Share skipped: {}", e)),
+                    });
+                    return;
+                }
+            };
+            let _ = tx.send(BenchOfferMsg::AuthCode {
+                user_code: auth.user_code.clone(),
+                verification_uri: auth.verification_uri.clone(),
+            });
+            let mut interval = auth.interval;
+            loop {
+                thread::sleep(std::time::Duration::from_secs(interval + 1));
+                match share::device_flow_poll(&client_id, &auth.device_code) {
+                    Ok(share::DevicePoll::Token(t)) => {
+                        let _ = share::cache_token(&t);
+                        break t;
+                    }
+                    Ok(share::DevicePoll::Pending) => continue,
+                    Ok(share::DevicePoll::SlowDown) => {
+                        interval += 5;
+                        continue;
+                    }
+                    Ok(share::DevicePoll::Failed(e)) | Err(e) => {
+                        let _ = tx.send(BenchOfferMsg::Done {
+                            summary,
+                            pr_url: None,
+                            share_note: Some(format!("Share skipped: {}", e)),
+                        });
+                        return;
+                    }
+                }
+            }
+        }
+    };
+
+    let _ = tx.send(BenchOfferMsg::Progress(
+        "Opening pull request on GitHub...".into(),
+    ));
+    match share::submit_results(std::slice::from_ref(&result), specs, &token) {
+        Ok(pr_url) => {
+            let _ = tx.send(BenchOfferMsg::Done {
+                summary,
+                pr_url: Some(pr_url),
+                share_note: None,
+            });
+        }
+        Err(e) => {
+            let _ = tx.send(BenchOfferMsg::Done {
+                summary,
+                pr_url: None,
+                share_note: Some(format!("Share failed: {}", e)),
+            });
+        }
+    }
 }
 
 /// Per-model bench status for the live dashboard rows.
@@ -756,6 +1005,22 @@ pub struct App {
     pub bench_tests_done: usize,
     pub bench_tests_total: usize,
     bench_rx: Option<mpsc::Receiver<BenchMsg>>,
+
+    // Bench-offer modal (benchmark the selected model, optionally share as PR)
+    pub bench_offer_state: BenchOfferState,
+    pub bench_offer_share: bool,
+    /// HF-style name of the model being offered for benchmark.
+    pub bench_offer_model: String,
+    /// Providers that have the model installed (display names).
+    pub bench_offer_providers: Vec<&'static str>,
+    pub bench_offer_progress: String,
+    /// Device-flow authorization prompt: (user_code, verification_uri).
+    pub bench_offer_auth: Option<(String, String)>,
+    pub bench_offer_summary: Option<String>,
+    pub bench_offer_pr_url: Option<String>,
+    pub bench_offer_share_note: Option<String>,
+    pub bench_offer_error: Option<String>,
+    bench_offer_rx: Option<mpsc::Receiver<BenchOfferMsg>>,
 
     // Background provider detection
     provider_detection_rx: mpsc::Receiver<ProviderDetectionMsg>,
@@ -1200,6 +1465,18 @@ impl App {
             bench_tests_done: 0,
             bench_tests_total: 0,
             bench_rx: None,
+            // Bench-offer modal
+            bench_offer_state: BenchOfferState::Offer,
+            bench_offer_share: false,
+            bench_offer_model: String::new(),
+            bench_offer_providers: Vec::new(),
+            bench_offer_progress: String::new(),
+            bench_offer_auth: None,
+            bench_offer_summary: None,
+            bench_offer_pr_url: None,
+            bench_offer_share_note: None,
+            bench_offer_error: None,
+            bench_offer_rx: None,
             provider_detection_rx,
             providers_loading: true,
         };
@@ -2031,6 +2308,28 @@ impl App {
         self.bench_cursor = 0;
         self.bench_scroll = 0;
 
+        // If the selected model is installed and a provider has it, offer to
+        // benchmark it (with optional share-as-PR) before showing the board.
+        if self.bench_offer_rx.is_none()
+            && let Some(fit) = self.selected_fit()
+            && fit.installed
+        {
+            let name = fit.model.name.clone();
+            let providers = self.installed.installed_providers(&name);
+            if !providers.is_empty() {
+                self.bench_offer_state = BenchOfferState::Offer;
+                self.bench_offer_model = name;
+                self.bench_offer_providers = providers;
+                self.bench_offer_progress = String::new();
+                self.bench_offer_auth = None;
+                self.bench_offer_summary = None;
+                self.bench_offer_pr_url = None;
+                self.bench_offer_share_note = None;
+                self.bench_offer_error = None;
+                self.input_mode = InputMode::BenchOffer;
+            }
+        }
+
         // Fetch if we don't have data yet
         if self.bench_entries.is_empty() && !self.bench_loading {
             self.fetch_benchmarks();
@@ -2040,6 +2339,79 @@ impl App {
     pub fn close_benchmarks(&mut self) {
         self.show_benchmarks = false;
         self.input_mode = InputMode::Normal;
+    }
+
+    /// Toggle the "share with llmfit" checkbox in the bench-offer modal.
+    pub fn bench_offer_toggle_share(&mut self) {
+        self.bench_offer_share = !self.bench_offer_share;
+    }
+
+    /// Dismiss the bench-offer modal and drop into the leaderboard view. A
+    /// still-running worker is detached: its receiver is dropped and its sends
+    /// fail silently.
+    pub fn bench_offer_dismiss(&mut self) {
+        self.bench_offer_rx = None;
+        self.bench_offer_state = BenchOfferState::Offer;
+        self.input_mode = InputMode::Benchmarks;
+    }
+
+    /// Start the bench(+share) worker for the offered model.
+    pub fn bench_offer_confirm(&mut self) {
+        if self.bench_offer_state != BenchOfferState::Offer {
+            return;
+        }
+        let model_name = self.bench_offer_model.clone();
+        let share = self.bench_offer_share;
+        // Share real hardware, never simulated specs.
+        let specs = self.real_specs.clone();
+
+        let (tx, rx) = mpsc::channel::<BenchOfferMsg>();
+        self.bench_offer_rx = Some(rx);
+        self.bench_offer_state = BenchOfferState::Running;
+        self.bench_offer_progress = "Detecting providers...".to_string();
+
+        thread::spawn(move || {
+            bench_offer_worker(&tx, &model_name, share, &specs);
+        });
+    }
+
+    /// Drain bench-offer worker messages (called every frame, non-blocking).
+    pub fn tick_bench_offer(&mut self) {
+        let mut finished = false;
+        if let Some(rx) = &self.bench_offer_rx {
+            while let Ok(msg) = rx.try_recv() {
+                match msg {
+                    BenchOfferMsg::Progress(s) => self.bench_offer_progress = s,
+                    BenchOfferMsg::AuthCode {
+                        user_code,
+                        verification_uri,
+                    } => {
+                        self.bench_offer_auth = Some((user_code, verification_uri));
+                    }
+                    BenchOfferMsg::Done {
+                        summary,
+                        pr_url,
+                        share_note,
+                    } => {
+                        self.bench_offer_state = BenchOfferState::Done;
+                        self.bench_offer_summary = Some(summary);
+                        self.bench_offer_pr_url = pr_url;
+                        self.bench_offer_share_note = share_note;
+                        self.bench_offer_auth = None;
+                        finished = true;
+                    }
+                    BenchOfferMsg::Error(e) => {
+                        self.bench_offer_state = BenchOfferState::Error;
+                        self.bench_offer_error = Some(e);
+                        self.bench_offer_auth = None;
+                        finished = true;
+                    }
+                }
+            }
+        }
+        if finished {
+            self.bench_offer_rx = None;
+        }
     }
 
     pub fn fetch_benchmarks(&mut self) {
@@ -4668,5 +5040,82 @@ mod tests {
         app.search_input('z');
         assert!(app.filtered_fits.is_empty());
         assert_eq!(app.selected_row, 0);
+    }
+
+    /// Build an app with one installed model, primed so open_benchmarks
+    /// skips the network fetch (bench_loading = true).
+    fn app_with_installed_model(installed: bool) -> App {
+        let mut app = test_app();
+        let mut fit = test_fit("test/llama-3.1-8b", FitLevel::Perfect, 90.0);
+        fit.installed = installed;
+        app.all_fits = vec![fit];
+        app.filtered_fits = vec![0];
+        app.selected_row = 0;
+        if installed {
+            app.installed.ollama.insert("test/llama-3.1-8b".to_string());
+        }
+        app.bench_loading = true; // skip leaderboard fetch in tests
+        app
+    }
+
+    #[test]
+    fn open_benchmarks_offers_bench_for_installed_model() {
+        let mut app = app_with_installed_model(true);
+        app.open_benchmarks();
+        assert_eq!(app.input_mode, InputMode::BenchOffer);
+        assert_eq!(app.bench_offer_state, BenchOfferState::Offer);
+        assert_eq!(app.bench_offer_model, "test/llama-3.1-8b");
+        assert_eq!(app.bench_offer_providers, vec!["Ollama"]);
+        assert!(app.show_benchmarks);
+    }
+
+    #[test]
+    fn open_benchmarks_skips_offer_for_uninstalled_model() {
+        let mut app = app_with_installed_model(false);
+        app.open_benchmarks();
+        assert_eq!(app.input_mode, InputMode::Benchmarks);
+    }
+
+    #[test]
+    fn bench_offer_share_toggle_and_dismiss() {
+        let mut app = app_with_installed_model(true);
+        app.open_benchmarks();
+        assert!(!app.bench_offer_share);
+        app.bench_offer_toggle_share();
+        assert!(app.bench_offer_share);
+        app.bench_offer_toggle_share();
+        assert!(!app.bench_offer_share);
+
+        // Dismiss drops into the leaderboard view, not back to Normal.
+        app.bench_offer_dismiss();
+        assert_eq!(app.input_mode, InputMode::Benchmarks);
+        assert!(app.show_benchmarks);
+    }
+
+    #[test]
+    fn bench_target_matching_reuses_installed_heuristics() {
+        // Exact HF name (as MLX/vLLM report it)
+        assert!(bench_target_matches(
+            "meta-llama/Llama-3.1-8B-Instruct",
+            "meta-llama/Llama-3.1-8B-Instruct"
+        ));
+        // Real Ollama tag resolved through the mapping table
+        assert!(bench_target_matches("llama3.1:8b", "test/llama-3.1-8b"));
+        // Variant tag reported by `ollama list` (quant suffix)
+        assert!(bench_target_matches(
+            "llama3.1:8b-instruct-q4_K_M",
+            "test/llama-3.1-8b"
+        ));
+        // llama-server style: model id is a file path with quant suffix
+        assert!(bench_target_matches(
+            "/home/user/.cache/llmfit/models/gemma-3.Q8_0.gguf",
+            "tiny-random/gemma-3"
+        ));
+        // Unrelated models must not match
+        assert!(!bench_target_matches("qwen2.5:7b", "test/llama-3.1-8b"));
+        assert!(!bench_target_matches(
+            "/home/user/.cache/llmfit/models/gemma-3.Q8_0.gguf",
+            "google/gemma-3-27b-it"
+        ));
     }
 }

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -5,9 +5,10 @@ use crate::tui_app::{App, InputMode};
 
 /// Poll for and handle events. Returns true if an event was processed.
 pub fn handle_events(app: &mut App) -> std::io::Result<bool> {
-    // Always tick the pull progress and live-bench worker messages (non-blocking)
+    // Always tick the pull progress and worker messages (non-blocking)
     app.tick_pull();
     app.tick_bench();
+    app.tick_bench_offer();
 
     if event::poll(Duration::from_millis(50))?
         && let Event::Key(key) = event::read()?
@@ -37,6 +38,7 @@ pub fn handle_events(app: &mut App) -> std::io::Result<bool> {
             InputMode::DownloadManager => handle_download_manager_mode(app, key),
             InputMode::FilterPopup => handle_filter_popup_mode(app, key),
             InputMode::Benchmarks => handle_benchmarks_mode(app, key),
+            InputMode::BenchOffer => handle_bench_offer_mode(app, key),
         }
         return Ok(true);
     }
@@ -702,6 +704,28 @@ fn handle_filter_popup_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Char(c) if c.is_ascii_digit() || c == '.' => app.filter_input(c),
 
         _ => {}
+    }
+}
+
+fn handle_bench_offer_mode(app: &mut App, key: KeyEvent) {
+    use crate::tui_app::BenchOfferState;
+    match app.bench_offer_state {
+        BenchOfferState::Offer => match key.code {
+            KeyCode::Enter => app.bench_offer_confirm(),
+            KeyCode::Char(' ') | KeyCode::Char('s') => app.bench_offer_toggle_share(),
+            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('n') => app.bench_offer_dismiss(),
+            _ => {}
+        },
+        // While running, Esc detaches the worker and drops to the leaderboard.
+        BenchOfferState::Running => {
+            if key.code == KeyCode::Esc {
+                app.bench_offer_dismiss();
+            }
+        }
+        BenchOfferState::Done | BenchOfferState::Error => match key.code {
+            KeyCode::Enter | KeyCode::Esc | KeyCode::Char('q') => app.bench_offer_dismiss(),
+            _ => {}
+        },
     }
 }
 

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -12,9 +12,9 @@ use ratatui::{
 use crate::download_history::DownloadResult;
 use crate::theme::ThemeColors;
 use crate::tui_app::{
-    AdvConfigField, App, AvailabilityFilter, BenchViewMode, DL_DOCKER, DL_LLAMACPP, DL_LMSTUDIO,
-    DL_OLLAMA, DL_VLLM, DownloadCapability, DownloadManagerFocus, DownloadProvider, FitFilter,
-    InputMode, PlanField, SimulationField,
+    AdvConfigField, App, AvailabilityFilter, BenchOfferState, BenchViewMode, DL_DOCKER,
+    DL_LLAMACPP, DL_LMSTUDIO, DL_OLLAMA, DL_VLLM, DownloadCapability, DownloadManagerFocus,
+    DownloadProvider, FitFilter, InputMode, PlanField, SimulationField,
 };
 use llmfit_core::fit::{FitLevel, ModelFit, SortColumn};
 use llmfit_core::hardware::is_running_in_wsl;
@@ -92,6 +92,8 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_advanced_config_popup(frame, app, &tc);
     } else if app.input_mode == InputMode::FilterPopup {
         draw_filter_popup(frame, app, &tc);
+    } else if app.input_mode == InputMode::BenchOffer {
+        draw_bench_offer_popup(frame, app, &tc);
     }
 }
 
@@ -412,7 +414,8 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         | InputMode::AdvancedConfig
         | InputMode::DownloadManager
         | InputMode::FilterPopup
-        | InputMode::Benchmarks => Style::default().fg(tc.muted),
+        | InputMode::Benchmarks
+        | InputMode::BenchOffer => Style::default().fg(tc.muted),
     };
 
     let search_inner_width = chunks[0].width.saturating_sub(2) as usize;
@@ -3048,6 +3051,10 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             " ↑/k:up  ↓/j:down  H:change GPU  r:refresh  b/q/Esc:close".to_string(),
             "COMMUNITY LEADERBOARD".to_string(),
         ),
+        InputMode::BenchOffer => (
+            " Enter:run  Space:share toggle  Esc:skip".to_string(),
+            "BENCHMARK".to_string(),
+        ),
     }
 }
 
@@ -3369,6 +3376,135 @@ fn draw_params_bucket_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         );
 
     let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, popup_area);
+}
+
+fn draw_bench_offer_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
+    let area = frame.area();
+
+    let popup_width = 64.min(area.width.saturating_sub(4));
+    let popup_height = 14.min(area.height.saturating_sub(4));
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    frame.render_widget(Clear, popup_area);
+
+    let mut lines: Vec<Line> = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Model:    ", Style::default().fg(tc.muted)),
+            Span::styled(
+                app.bench_offer_model.clone(),
+                Style::default().fg(tc.fg).add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Provider: ", Style::default().fg(tc.muted)),
+            Span::styled(
+                app.bench_offer_providers.join(", "),
+                Style::default().fg(tc.fg),
+            ),
+        ]),
+        Line::from(""),
+    ];
+
+    match app.bench_offer_state {
+        BenchOfferState::Offer => {
+            let (mark, mark_style) = if app.bench_offer_share {
+                ("[x]", Style::default().fg(tc.good).add_modifier(Modifier::BOLD))
+            } else {
+                ("[ ]", Style::default().fg(tc.muted))
+            };
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {mark} "), mark_style),
+                Span::styled("Share with llmfit ", Style::default().fg(tc.fg)),
+                Span::styled(
+                    "(opens a PR with your results)",
+                    Style::default().fg(tc.muted),
+                ),
+            ]));
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  [Enter] Run   [Space] Toggle share   [Esc] Skip",
+                Style::default().fg(tc.muted),
+            )));
+        }
+        BenchOfferState::Running => {
+            lines.push(Line::from(Span::styled(
+                format!("  {}", app.bench_offer_progress),
+                Style::default().fg(tc.info),
+            )));
+            if let Some((code, url)) = &app.bench_offer_auth {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    "  Authorize on GitHub to share:",
+                    Style::default().fg(tc.fg),
+                )));
+                lines.push(Line::from(vec![
+                    Span::styled("    Open ", Style::default().fg(tc.muted)),
+                    Span::styled(url.clone(), Style::default().fg(tc.accent)),
+                    Span::styled("  and enter code ", Style::default().fg(tc.muted)),
+                    Span::styled(
+                        code.clone(),
+                        Style::default().fg(tc.accent).add_modifier(Modifier::BOLD),
+                    ),
+                ]));
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  [Esc] Continue in background",
+                Style::default().fg(tc.muted),
+            )));
+        }
+        BenchOfferState::Done => {
+            if let Some(summary) = &app.bench_offer_summary {
+                lines.push(Line::from(Span::styled(
+                    format!("  {}", summary),
+                    Style::default().fg(tc.good),
+                )));
+            }
+            if let Some(url) = &app.bench_offer_pr_url {
+                lines.push(Line::from(vec![
+                    Span::styled("  PR opened: ", Style::default().fg(tc.fg)),
+                    Span::styled(url.clone(), Style::default().fg(tc.accent)),
+                ]));
+            }
+            if let Some(note) = &app.bench_offer_share_note {
+                lines.push(Line::from(Span::styled(
+                    format!("  {}", note),
+                    Style::default().fg(tc.warning),
+                )));
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  [Enter] Continue to leaderboard",
+                Style::default().fg(tc.muted),
+            )));
+        }
+        BenchOfferState::Error => {
+            if let Some(e) = &app.bench_offer_error {
+                lines.push(Line::from(Span::styled(
+                    format!("  {}", e),
+                    Style::default().fg(tc.error),
+                )));
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  [Enter] Continue to leaderboard",
+                Style::default().fg(tc.muted),
+            )));
+        }
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(tc.border))
+        .title(Span::styled(
+            " Benchmark this model ",
+            Style::default().fg(tc.title).add_modifier(Modifier::BOLD),
+        ));
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
     frame.render_widget(paragraph, popup_area);
 }
 

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -3412,7 +3412,10 @@ fn draw_bench_offer_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
     match app.bench_offer_state {
         BenchOfferState::Offer => {
             let (mark, mark_style) = if app.bench_offer_share {
-                ("[x]", Style::default().fg(tc.good).add_modifier(Modifier::BOLD))
+                (
+                    "[x]",
+                    Style::default().fg(tc.good).add_modifier(Modifier::BOLD),
+                )
             } else {
                 ("[ ]", Style::default().fg(tc.muted))
             };
@@ -3504,7 +3507,9 @@ fn draw_bench_offer_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
             " Benchmark this model ",
             Style::default().fg(tc.title).add_modifier(Modifier::BOLD),
         ));
-    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, popup_area);
 }
 

--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -1104,20 +1104,91 @@ def _model_gguf_repo_candidates(repo_id: str) -> list[tuple[str, str]]:
     return candidates
 
 
-def check_gguf_repo_exists(repo_id: str) -> bool:
-    """Check if a HuggingFace repo exists and has GGUF files."""
+def _base_models_from_tags(tags: list) -> list[str]:
+    """Extract base-model repo ids from HF tags.
+
+    Quant repos carry tags like `base_model:tomaszki/gemma-3` and
+    `base_model:quantized:tomaszki/gemma-3` — the repo id is always the
+    segment after the last colon.
+    """
+    return [
+        t.rsplit(":", 1)[-1].lower()
+        for t in tags
+        if isinstance(t, str) and t.startswith("base_model:")
+    ]
+
+
+_REPO_PARAMS_CACHE: dict[str, int | None] = {}
+_MIRROR_PARAMS_TOLERANCE = 0.30
+
+
+def _repo_total_params(repo_id: str) -> int | None:
+    """Total parameter count of a repo from its safetensors metadata."""
+    if repo_id in _REPO_PARAMS_CACHE:
+        return _REPO_PARAMS_CACHE[repo_id]
+    url = f"{HF_API}/{repo_id}"
+    req = urllib.request.Request(url, headers=_auth_headers())
+    total = None
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            info = json.loads(resp.read().decode())
+            st = info.get("safetensors") or {}
+            raw = st.get("total")
+            total = int(raw) if raw else None
+    except Exception:
+        pass
+    _REPO_PARAMS_CACHE[repo_id] = total
+    return total
+
+
+def check_gguf_repo_exists(
+    repo_id: str,
+    source_repo_id: str | None = None,
+    source_params: int | None = None,
+) -> bool:
+    """Check that a HuggingFace repo exists, has GGUF files, and — when the
+    repo declares `base_model` tags — was actually quantized from
+    `source_repo_id`.
+
+    Candidate repo names are built from the bare model name only, so different
+    orgs' models with the same name (e.g. `tiny-random/gemma-3` vs
+    `tomaszki/gemma-3`) would otherwise be linked to the wrong quant.
+
+    A base_model mismatch is still accepted when the declared base has ~the
+    same parameter count as the source model (`source_params`): that's a
+    mirror/re-upload of the same weights (e.g. unsloth re-uploads pointing at
+    the canonical upstream). Repos without base_model tags are accepted as
+    before (unverifiable).
+    """
     url = f"{HF_API}/{repo_id}"
     req = urllib.request.Request(url, headers=_auth_headers())
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             info = json.loads(resp.read().decode())
             tags = info.get("tags", [])
-            return "gguf" in tags
+            if "gguf" not in tags:
+                return False
+            if source_repo_id:
+                bases = _base_models_from_tags(tags)
+                if bases and source_repo_id.lower() not in bases:
+                    if not source_params:
+                        return False
+                    base_params = next(
+                        (p for p in (_repo_total_params(b) for b in bases) if p),
+                        None,
+                    )
+                    if not base_params:
+                        return False
+                    ratio = base_params / source_params
+                    return abs(ratio - 1.0) <= _MIRROR_PARAMS_TOLERANCE
+            return True
     except Exception:
         return False
 
 
-def _resolve_gguf_sources(repo_id: str) -> tuple[list[dict], list[tuple[str, bool]]]:
+def _resolve_gguf_sources(
+    repo_id: str, source_params: int | None = None
+) -> tuple[list[dict], list[tuple[str, bool]]]:
     """Resolve GGUF sources for a single model repo.
 
     Returns (sources, checks) where checks is [(candidate_repo, exists), ...].
@@ -1125,7 +1196,9 @@ def _resolve_gguf_sources(repo_id: str) -> tuple[list[dict], list[tuple[str, boo
     sources: list[dict] = []
     checks: list[tuple[str, bool]] = []
     for provider, candidate_repo in _model_gguf_repo_candidates(repo_id):
-        exists = check_gguf_repo_exists(candidate_repo)
+        exists = check_gguf_repo_exists(
+            candidate_repo, source_repo_id=repo_id, source_params=source_params
+        )
         checks.append((candidate_repo, exists))
         if exists:
             sources.append({"repo": candidate_repo, "provider": provider})
@@ -1145,7 +1218,7 @@ def enrich_gguf_sources(models: list[dict], threads: int = 1) -> int:
     total = len(models)
     from datetime import datetime, timezone
 
-    to_check: list[tuple[int, str]] = []
+    to_check: list[tuple[int, str, int | None]] = []
 
     for i, model in enumerate(models, 1):
         repo_id = model["name"]
@@ -1159,7 +1232,7 @@ def enrich_gguf_sources(models: list[dict], threads: int = 1) -> int:
             sources = cache[repo_id]["sources"]
             cache_hits += 1
         else:
-            to_check.append((i, repo_id))
+            to_check.append((i, repo_id, model.get("parameters_raw")))
             continue
 
         if sources:
@@ -1179,8 +1252,8 @@ def enrich_gguf_sources(models: list[dict], threads: int = 1) -> int:
                 enriched += 1
 
         if threads <= 1:
-            for idx, repo_id in to_check:
-                sources, checks = _resolve_gguf_sources(repo_id)
+            for idx, repo_id, params_raw in to_check:
+                sources, checks = _resolve_gguf_sources(repo_id, params_raw)
                 print(f"  [{idx}/{total}] {repo_id}")
                 for candidate_repo, exists in checks:
                     mark = "✓" if exists else "✗"
@@ -1191,8 +1264,8 @@ def enrich_gguf_sources(models: list[dict], threads: int = 1) -> int:
             print(f"  Using {threads} threads for GGUF source checks")
             future_to_meta: dict[concurrent.futures.Future, tuple[int, str]] = {}
             with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
-                for idx, repo_id in to_check:
-                    future = executor.submit(_resolve_gguf_sources, repo_id)
+                for idx, repo_id, params_raw in to_check:
+                    future = executor.submit(_resolve_gguf_sources, repo_id, params_raw)
                     future_to_meta[future] = (idx, repo_id)
 
                 for future in concurrent.futures.as_completed(future_to_meta):


### PR DESCRIPTION
Implements the `bench --share` RFC from discussion #710, plus the fixes uncovered while building it.

## What's in here

### 1. `llmfit bench --share` (CLI)
Run a benchmark and contribute the results back to this repo as a PR — **no `gh` CLI, no server**:

```sh
llmfit bench --all --share            # bench everything, confirm, open a PR
llmfit bench --all --share --dry-run  # print the exact JSON payloads, touch nothing
llmfit bench --all --share --yes      # skip the confirmation prompt (CI)
llmfit bench --share                  # upload previously stored local benchmarks
```

- Auth via the **GitHub OAuth device flow** (the same mechanism `gh auth login` uses): one-time code + browser approval, token cached under `~/.config/llmfit/`. `GITHUB_TOKEN`/`GH_TOKEN` short-circuits it entirely.
- Fork → branch → commit → PR all through the GitHub REST API over `ureq` (already a dependency).
- Results land under `llmfit-core/data/community/<hardware-slug>/` — schema + README scaffolded, and generated payloads are schema-validated in unit tests.

### 2. Local benchmark store — bench now, share later
Every successful bench run is **always saved locally** as a ready-to-upload, schema-valid submission payload (`~/.local/share/llmfit/benchmarks/pending/`, overridable with `LLMFIT_BENCH_STORE`), so declining to share never discards data:

- Sharing — `--share` or the TUI toggle — offers to contribute **all** stored local benchmarks in a single PR ("this run + N stored"). Uploaded files move to `benchmarks/shared/`: kept as history, never submitted twice. A failed or cancelled upload leaves everything pending, so a network hiccup can't lose a run.
- Bare `llmfit bench --share` uploads the stored backlog without benchmarking again.
- **Credential pre-flight**: with `--share`, the GitHub token is resolved and *validated against the API* before any benchmark starts — a missing or expired token fails in seconds, not after a 10-minute sweep. Stale cached tokens are discarded and re-acquired via the device flow; an explicit invalid `GITHUB_TOKEN` is a hard error.
- Local results render **pinned at the top of the TUI leaderboard** as `you (local)` / `you (shared)` — including offline (the full-page fetch error now only shows when there are no rows at all, which also un-breaks the embedded-cache fallback that the error screen used to mask).
- **No duplicate submissions**: if you already have an open benchmark PR upstream, new results are **appended to it** instead of opening one PR per bench run. Upstream file names mirror the local store entry, so a retry after a partial failure (including a failed pending→shared move) skips files that already landed — GitHub's 422-on-existing-path is the idempotency check. `submit_stored` returns a `SubmitOutcome` and the CLI/TUI report "opened" / "added to existing PR" / "already contributed" distinctly.
- **Local runs override the estimated tok/s in the main table**: fit rows consult the local store first — your own measurement outranks community medians, which outrank the formula estimate (rendered via the existing ✓-marked `measured_tps` path, refreshed live after an in-TUI bench). Motivating case: a local `gemma-3.Q8_0.gguf` maps to the `tiny-random/gemma-3` catalog stub whose formula estimate says 880 tok/s while the actually-served 2.5B model measures 3.8 tok/s.
- **Local runs calibrate all other estimates for this machine**: benched fits on trustworthy catalog models (≥ 1B params, dense) act as anchors; the median measured/estimated ratio (clamped to [0.05, 3.0]) scales every row's formula estimate, recorded in `estimate_basis.local_calibration` and shown in the estimate-basis detail. Idempotent application; runs from a different CPU/GPU configuration are ignored (hardware fingerprint check, which also gates the exact-model override).
- **Catalog hygiene**: 100 CI/test-stub entries purged from `hf_models.json` (`tiny-random/*`, `tiny-dummy`, `ci-random-*`, `test-*`/`testing-*` repos) — randomly initialized micro-models whose names shadow real families and poison installed-detection, estimates, and (if benched) shared data. The scraper now skips them at discovery and scrape time so they can't return.

### 3. TUI integration
Pressing `b` now offers to benchmark the selected model first (when it's installed **and** served by a running provider), with a **"Share with llmfit"** toggle that routes through the same PR flow. Benchmark + share run on a worker thread; the device-flow code/URL renders inside the modal (now *before* the bench, as part of the credential pre-flight). Missing credentials are flagged in the modal up front, and the run downgrades to save-locally instead of failing. Verified end-to-end against a live llama-server.

### 4. llama-server as a first-class bench provider
Previously a llama-server was either missed or silently mislabeled `mlx` (shared default port 8080) — which would have polluted shared data. Now positively identified via `/props`, labeled `llamacpp`, configurable via `LLAMA_SERVER_HOST`/`LLAMA_SERVER_PORT`, selectable with `--provider llamacpp`.

### 5. Installed-detection fix
A single `gemma-3.Q8_0.gguf` on disk marked **every** gemma-3-family model as installed (bidirectional substring matching). Now exact stem matching, with regression tests.

### 6. GGUF source provenance fix
`gguf_sources` links were matched by bare model name only, so e.g. `tiny-random/gemma-3` (9M test stub) linked to a quant of `tomaszki/gemma-3` (2.5B) — users downloaded 2.5 GB while llmfit predicted 0.0 GB disk. The scraper now verifies the quant's `base_model` tag (with a ±30% parameter-count tolerance so mirrors/re-uploads stay linked). All 1,656 existing links audited against the HF API: 19 wrong-model links removed, 295 mirror links preserved.

## Testing before merge

- [ ] **Register a GitHub OAuth App** (device flow enabled, `public_repo` scope) and set the client id in `share.rs` (`DEFAULT_CLIENT_ID`) — until then interactive login is gated and `--share` needs `GITHUB_TOKEN`/`GH_TOKEN`
- [ ] `llmfit bench --all --share --dry-run` against a real provider
- [ ] TUI: select an installed model → `b` → Enter (bench), Space (share toggle)
- [ ] End-to-end share with a token: verify the PR lands under `llmfit-core/data/community/`
- [ ] Bench without `--share`, confirm the result is stored under the local `benchmarks/pending/` dir and appears on the TUI leaderboard as `you (local)`, then `llmfit bench --share` uploads it and it flips to `you (shared)`
- [ ] With an expired/garbage `GITHUB_TOKEN`, `llmfit bench <model> --share` must fail **before** benchmarking

Follow-up (separate PR): CI validation for incoming `community/` submissions (schema + hardware sanity checks), auto-merge policy.

Closes the build-out phase of #710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
