### PR TITLE
feat(tui): filter by installed models in the Filter modal

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -134,6 +134,7 @@ pub enum FilterPopupField {
     MemPctMax,
     SortDirection,
     FitFilter,
+    Availability,
 }
 
 impl FilterPopupField {
@@ -144,18 +145,20 @@ impl FilterPopupField {
             Self::MemPctMin => Self::MemPctMax,
             Self::MemPctMax => Self::SortDirection,
             Self::SortDirection => Self::FitFilter,
-            Self::FitFilter => Self::ParamsMin,
+            Self::FitFilter => Self::Availability,
+            Self::Availability => Self::ParamsMin,
         }
     }
 
     pub fn prev(self) -> Self {
         match self {
-            Self::ParamsMin => Self::FitFilter,
+            Self::ParamsMin => Self::Availability,
             Self::ParamsMax => Self::ParamsMin,
             Self::MemPctMin => Self::ParamsMax,
             Self::MemPctMax => Self::MemPctMin,
             Self::SortDirection => Self::MemPctMax,
             Self::FitFilter => Self::SortDirection,
+            Self::Availability => Self::FitFilter,
         }
     }
 }
@@ -169,6 +172,7 @@ struct FilterSnapshot {
     mem_pct_max: String,
     sort_ascending: bool,
     fit_filter: FitFilter,
+    availability_filter: AvailabilityFilter,
 }
 
 /// Fields in the Advanced Configuration modal.
@@ -3065,6 +3069,7 @@ impl App {
             mem_pct_max: self.filter_mem_pct_max_input.clone(),
             sort_ascending: self.sort_ascending,
             fit_filter: self.fit_filter,
+            availability_filter: self.availability_filter,
         });
         self.filter_field = FilterPopupField::ParamsMin;
         self.filter_cursor_position = self.filter_params_min_input.len();
@@ -3080,6 +3085,7 @@ impl App {
             self.filter_mem_pct_max_input = snap.mem_pct_max;
             self.sort_ascending = snap.sort_ascending;
             self.fit_filter = snap.fit_filter;
+            self.availability_filter = snap.availability_filter;
         }
         self.input_mode = InputMode::Normal;
     }
@@ -3147,7 +3153,9 @@ impl App {
             FilterPopupField::ParamsMax => self.filter_params_max_input.len(),
             FilterPopupField::MemPctMin => self.filter_mem_pct_min_input.len(),
             FilterPopupField::MemPctMax => self.filter_mem_pct_max_input.len(),
-            FilterPopupField::SortDirection | FilterPopupField::FitFilter => 0,
+            FilterPopupField::SortDirection
+            | FilterPopupField::FitFilter
+            | FilterPopupField::Availability => 0,
         }
     }
 
@@ -3157,7 +3165,9 @@ impl App {
             FilterPopupField::ParamsMax => &mut self.filter_params_max_input,
             FilterPopupField::MemPctMin => &mut self.filter_mem_pct_min_input,
             FilterPopupField::MemPctMax => &mut self.filter_mem_pct_max_input,
-            FilterPopupField::SortDirection | FilterPopupField::FitFilter => {
+            FilterPopupField::SortDirection
+            | FilterPopupField::FitFilter
+            | FilterPopupField::Availability => {
                 unreachable!("no text input for toggle fields")
             }
         }
@@ -3187,6 +3197,10 @@ impl App {
 
     pub fn cycle_filter_fit(&mut self) {
         self.fit_filter = self.fit_filter.next();
+    }
+
+    pub fn cycle_filter_availability(&mut self) {
+        self.availability_filter = self.availability_filter.next();
     }
 
     pub fn apply_filter_popup(&mut self) {

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -680,6 +680,7 @@ fn handle_filter_popup_mode(app: &mut App, key: KeyEvent) {
                 app.filter_field,
                 crate::tui_app::FilterPopupField::SortDirection
                     | crate::tui_app::FilterPopupField::FitFilter
+                    | crate::tui_app::FilterPopupField::Availability
             ) {
                 return;
             }
@@ -696,6 +697,13 @@ fn handle_filter_popup_mode(app: &mut App, key: KeyEvent) {
         // Fit filter cycling
         KeyCode::Char(' ') if app.filter_field == crate::tui_app::FilterPopupField::FitFilter => {
             app.cycle_filter_fit()
+        }
+
+        // Availability filter cycling (All / GGUF Avail / Installed)
+        KeyCode::Char(' ')
+            if app.filter_field == crate::tui_app::FilterPopupField::Availability =>
+        {
+            app.cycle_filter_availability()
         }
 
         // Numeric input

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -4435,11 +4435,11 @@ fn draw_bench_hw_picker(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 }
 
 fn draw_filter_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
-    use crate::tui_app::{FilterPopupField, FitFilter};
+    use crate::tui_app::{AvailabilityFilter, FilterPopupField, FitFilter};
 
     let area = frame.area();
     let popup_width = 56u16.min(area.width.saturating_sub(4));
-    let popup_height = 18u16.min(area.height.saturating_sub(4));
+    let popup_height = 21u16.min(area.height.saturating_sub(4));
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
@@ -4590,6 +4590,33 @@ fn draw_filter_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         Span::styled(format!(" {:>12}", app.fit_filter.label()), fit_val_style),
     ]));
 
+    lines.push(Line::from(""));
+
+    // Availability Filter (installed / GGUF-available)
+    lines.push(Line::from(Span::styled(
+        "  Availability:",
+        Style::default().fg(tc.accent).bold(),
+    )));
+
+    let is_avail = app.filter_field == FilterPopupField::Availability;
+    let avail_color = match app.availability_filter {
+        AvailabilityFilter::All => tc.fg,
+        AvailabilityFilter::HasGguf => tc.info,
+        AvailabilityFilter::Installed => tc.good,
+    };
+    let avail_val_style = if is_avail {
+        Style::default().fg(avail_color).bg(tc.highlight_bg)
+    } else {
+        Style::default().fg(avail_color)
+    };
+    lines.push(Line::from(vec![
+        Span::styled("    Show:", label_style(is_avail)),
+        Span::styled(
+            format!(" {:>12}", app.availability_filter.label()),
+            avail_val_style,
+        ),
+    ]));
+
     // Footer
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
@@ -4605,7 +4632,8 @@ fn draw_filter_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
     //  0: "Parameters (B):"    1: Min  2: Max  3: (blank)
     //  4: "Memory Usage (%):"  5: Min  6: Max  7: (blank)
     //  8: "Sort:"              9: Direction     10: (blank)
-    // 11: "Fit Filter:"       12: Fit
+    // 11: "Fit Filter:"       12: Fit           13: (blank)
+    // 14: "Availability:"     15: Show
     let field_row: u16 = match app.filter_field {
         FilterPopupField::ParamsMin => 1,
         FilterPopupField::ParamsMax => 2,
@@ -4613,6 +4641,7 @@ fn draw_filter_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
         FilterPopupField::MemPctMax => 6,
         FilterPopupField::SortDirection => 9,
         FilterPopupField::FitFilter => 12,
+        FilterPopupField::Availability => 15,
     };
 
     // "    Min: " / "    Max: " = 9 chars label


### PR DESCRIPTION
## Summary

Adds an **Availability** field to the Filter modal (`F`) so you can filter the leaderboard to installed models (or GGUF-available models) without leaving the modal.

The `AvailabilityFilter` (All / GGUF Avail / Installed) already existed and was wired into `apply_filters`, but was only reachable via the top-bar `a` shortcut. This surfaces it alongside the range/sort/fit filters.

## How to use

Press `F` → Tab to **Availability** → `Space` to cycle `All → GGUF Avail → Installed` → `Enter` to apply. `Esc` cancels. The selection stays in sync with the existing `a` shortcut and persists to `~/.config/llmfit/filters.json`.

## Changes

- Add `Availability` variant to `FilterPopupField` (tab order + toggle input arms)
- Snapshot `availability_filter` in `FilterSnapshot` so `Esc` restores it
- Add `cycle_filter_availability()` + a Space-to-cycle key handler in `handle_filter_popup_mode`
- Render a color-coded Availability section in `draw_filter_popup` (Installed=green, GGUF=info, All=fg); bump popup height and cursor row map

Reuses the existing `apply_filters` availability branch and persistence — no changes to filtering logic or the saved config format.

## Testing

- `cargo build -p llmfit` — clean (only pre-existing warnings)
- `cargo test -p llmfit --test cli_smoke` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)