### PR TITLE
bench: community results for intel-arc-graphics-130v-140v-integrated

### DIFF
--- a/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1783676393-792a24b6-0.json
+++ b/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1783676393-792a24b6-0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) Ultra 7 258V",
+    "cpuCores": 8,
+    "gpuCount": 1,
+    "hardwareName": "Intel Arc Graphics 130V/140V (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 30.82,
+    "unifiedMemory": true,
+    "vramGb": 30.82
+  },
+  "results": [
+    {
+      "avgOutputTokens": 182.67,
+      "avgTotalMs": 48968.34,
+      "avgTps": 3.8,
+      "avgTtftMs": null,
+      "maxTps": 3.97,
+      "minTps": 3.68,
+      "model": "/home/axjns/.cache/llmfit/models/gemma-3.Q8_0.gguf",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1783676393,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.0.1"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| /home/axjns/.cache/llmfit/models/gemma-3.Q8_0.gguf | llamacpp | 3.8 | — |

_Submitted without the `gh` CLI via the GitHub device flow._
