### PR TITLE
feat(bench): local store follow-ups — share backlog, dedup PRs, local-measurement overrides + calibration

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -122,7 +122,13 @@ llmfit bench --share
 **Every successful bench run is also saved locally** (under
 `~/.local/share/llmfit/benchmarks/pending/` on Linux; override the location
 with `LLMFIT_BENCH_STORE`), so skipping `--share` never discards data. These
-local results appear at the top of the TUI leaderboard as “you (local)”.
+local results appear at the top of the TUI leaderboard as “you (local)”, and
+they feed back into the fit table: a model you benched shows your measured
+tok/s instead of the estimate, and runs on trustworthy models (≥ 1B params,
+dense) calibrate the formula estimates for **every other model** on the same
+hardware (shown as “Calibrated ×N from your own llmfit bench run(s)” in the
+estimate basis). Runs recorded on a different CPU/GPU configuration are
+ignored.
 Sharing later — `llmfit bench --share` on its own, or the share toggle in the
 TUI — offers to contribute **all** stored benchmarks in a single PR; uploaded
 files move to `.../benchmarks/shared/` so they are kept as history but never

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -109,22 +109,38 @@ service required**:
 # Benchmark every discovered model and open a PR with the results
 llmfit bench --all --share
 
-# Preview the exact JSON payload without contacting GitHub
+# Preview the exact JSON payloads without contacting GitHub
 llmfit bench --all --share --dry-run
 
 # Skip the confirmation prompt (e.g. for automation)
 llmfit bench --all --share --yes
+
+# Upload previously stored local benchmarks without benchmarking again
+llmfit bench --share
 ```
+
+**Every successful bench run is also saved locally** (under
+`~/.local/share/llmfit/benchmarks/pending/` on Linux; override the location
+with `LLMFIT_BENCH_STORE`), so skipping `--share` never discards data. These
+local results appear at the top of the TUI leaderboard as “you (local)”.
+Sharing later — `llmfit bench --share` on its own, or the share toggle in the
+TUI — offers to contribute **all** stored benchmarks in a single PR; uploaded
+files move to `.../benchmarks/shared/` so they are kept as history but never
+submitted twice.
 
 Authentication uses the GitHub **device flow** (the same mechanism
 `gh auth login` uses): llmfit prints a short code and a URL, you approve it in
 your browser once, and the token is cached under `~/.config/llmfit/` for next
 time. If a `GITHUB_TOKEN` or `GH_TOKEN` environment variable is set (or you use
-CI), that token is used automatically and no browser step is needed.
+CI), that token is used automatically and no browser step is needed. With
+`--share`, credentials are resolved and verified **before** any benchmark
+starts, so a missing or expired token fails fast instead of after minutes of
+benching.
 
-`--share` then forks the repo, commits a single result file under
-`llmfit-core/data/community/<hardware>/`, and opens a pull request. Nothing is
-submitted until you confirm, and `--dry-run` never touches the network.
+`--share` then forks the repo, commits one result file per stored submission
+under `llmfit-core/data/community/<hardware>/`, and opens a pull request.
+Nothing is submitted until you confirm, and `--dry-run` never touches the
+network.
 
 > Interactive login requires `LLMFIT_GH_CLIENT_ID` to be set to a registered
 > GitHub OAuth App client id. Until one is configured, use a `GITHUB_TOKEN` /

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -138,9 +138,12 @@ starts, so a missing or expired token fails fast instead of after minutes of
 benching.
 
 `--share` then forks the repo, commits one result file per stored submission
-under `llmfit-core/data/community/<hardware>/`, and opens a pull request.
-Nothing is submitted until you confirm, and `--dry-run` never touches the
-network.
+under `llmfit-core/data/community/<hardware>/`, and opens a pull request — or,
+if you already have an open benchmark PR, **appends the new results to it**
+instead of opening another. Submissions are idempotent: file names mirror your
+local store, so retrying after a partial failure skips anything that already
+landed. Nothing is submitted until you confirm, and `--dry-run` never touches
+the network.
 
 > Interactive login requires `LLMFIT_GH_CLIENT_ID` to be set to a registered
 > GitHub OAuth App client id. Until one is configured, use a `GITHUB_TOKEN` /

--- a/llmfit-core/data/community/README.md
+++ b/llmfit-core/data/community/README.md
@@ -6,11 +6,15 @@ This directory collects benchmark results contributed by llmfit users via:
 llmfit bench --all --share
 ```
 
-`--share` runs a benchmark sweep, shows you the exact JSON payload, asks for
-confirmation, then opens a pull request adding one file here — **without needing
-the `gh` CLI**. Authentication uses the GitHub OAuth *device flow* (the same
-mechanism `gh auth login` uses); a `GITHUB_TOKEN` / `GH_TOKEN` env var is used
-automatically when present (e.g. in CI).
+`--share` runs a benchmark sweep, shows you the exact JSON payloads, asks for
+confirmation, then opens a pull request adding the files here — **without
+needing the `gh` CLI**. Authentication uses the GitHub OAuth *device flow* (the
+same mechanism `gh auth login` uses); a `GITHUB_TOKEN` / `GH_TOKEN` env var is
+used automatically when present (e.g. in CI).
+
+Bench runs made **without** `--share` are kept in a local store on the user's
+machine; a later `llmfit bench --share` (with nothing else to bench) uploads
+that stored backlog in one PR, so declining to share never discards data.
 
 Preview what would be submitted without contacting GitHub:
 
@@ -23,7 +27,7 @@ llmfit bench --all --share --dry-run
 ```
 community/
   <hardware-slug>/
-    <unix-timestamp>-<hash>.json
+    <unix-timestamp>-<hash>-<n>.json
 ```
 
 Files are namespaced by hardware and carry a content hash so concurrent

--- a/llmfit-core/data/community/README.md
+++ b/llmfit-core/data/community/README.md
@@ -27,11 +27,15 @@ llmfit bench --all --share --dry-run
 ```
 community/
   <hardware-slug>/
-    <unix-timestamp>-<hash>-<n>.json
+    <unix-timestamp>-<hash>.json
 ```
 
 Files are namespaced by hardware and carry a content hash so concurrent
-submissions never collide.
+submissions never collide. Each file name mirrors the contributor's local
+store entry, which makes submissions idempotent: if a contributor already has
+an open benchmark PR, new results are appended to it (instead of opening
+another PR), and a retry after a partial failure skips files that already
+landed rather than duplicating them.
 
 ## Format
 

--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -150,6 +150,8 @@ pub fn build_model_fits(
     // Community-measured throughput for this hardware, when the detected GPU
     // matches a benchmark preset (provenance-weighted estimates).
     let measured_index = crate::benchmarks::MeasuredTpsIndex::for_specs(specs);
+    // The user's own `llmfit bench` runs trump community medians.
+    let local_index = crate::share::LocalBenchIndex::load();
 
     db.get_all_models()
         .iter()
@@ -158,9 +160,14 @@ pub fn build_model_fits(
             let mut fit =
                 ModelFit::analyze_with_forced_runtime(m, specs, context_limit, forced_runtime);
             fit.installed = installed.is_installed(&m.name);
-            fit.measured_tps = measured_index
+            fit.measured_tps = local_index
                 .as_ref()
-                .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
+                .and_then(|idx| idx.lookup(&m.name))
+                .or_else(|| {
+                    measured_index
+                        .as_ref()
+                        .and_then(|idx| idx.lookup(&m.name, &fit.best_quant))
+                });
             fit
         })
         .collect()

--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -151,9 +151,10 @@ pub fn build_model_fits(
     // matches a benchmark preset (provenance-weighted estimates).
     let measured_index = crate::benchmarks::MeasuredTpsIndex::for_specs(specs);
     // The user's own `llmfit bench` runs trump community medians.
-    let local_index = crate::share::LocalBenchIndex::load();
+    let local_index = crate::share::LocalBenchIndex::load(specs);
 
-    db.get_all_models()
+    let mut fits: Vec<ModelFit> = db
+        .get_all_models()
         .iter()
         .filter(|m| backend_compatible(m, specs))
         .map(|m| {
@@ -170,5 +171,75 @@ pub fn build_model_fits(
                 });
             fit
         })
-        .collect()
+        .collect();
+    apply_local_calibration(&mut fits);
+    fits
+}
+
+/// Calibrate formula estimates from the user's own benchmark runs.
+///
+/// Anchors are fits whose `measured_tps` came from the local store and whose
+/// catalog entry has a trustworthy size (>= 1B params, dense — MoE and tiny
+/// models don't scale like bandwidth-bound dense generation). The median
+/// measured/estimated ratio, clamped to [0.05, 3.0], scales every row's
+/// estimate and is recorded in `estimate_basis.local_calibration`.
+///
+/// Idempotent: ratios and scaling always derive from the uncalibrated
+/// estimate, so re-applying after a new bench never compounds.
+pub fn apply_local_calibration(fits: &mut [ModelFit]) {
+    use crate::benchmarks::MeasuredSource;
+
+    fn uncalibrated(f: &ModelFit) -> f64 {
+        match f.estimate_basis.local_calibration {
+            Some(c) if c > 0.0 => f.estimated_tps / c,
+            _ => f.estimated_tps,
+        }
+    }
+
+    let mut ratios: Vec<f64> = fits
+        .iter()
+        .filter(|f| f.model.params_b() >= 1.0 && !f.model.is_moe)
+        .filter_map(|f| {
+            let m = f.measured_tps.as_ref()?;
+            if m.source != MeasuredSource::LocalBench {
+                return None;
+            }
+            let est = uncalibrated(f);
+            (est > 0.0 && m.tok_s > 0.0).then(|| m.tok_s / est)
+        })
+        .collect();
+    if ratios.is_empty() {
+        return;
+    }
+    ratios.sort_by(|a, b| a.partial_cmp(b).expect("ratios are finite"));
+    let factor = median(&ratios).clamp(0.05, 3.0);
+
+    for f in fits.iter_mut() {
+        if f.estimated_tps <= 0.0 {
+            continue;
+        }
+        f.estimated_tps = uncalibrated(f) * factor;
+        f.estimate_basis.local_calibration = Some(factor);
+    }
+}
+
+fn median(sorted: &[f64]) -> f64 {
+    let n = sorted.len();
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    }
+}
+
+#[cfg(test)]
+mod calibration_tests {
+    use super::*;
+
+    #[test]
+    fn median_of_sorted() {
+        assert_eq!(median(&[0.1]), 0.1);
+        assert_eq!(median(&[0.1, 0.3]), 0.2);
+        assert_eq!(median(&[0.1, 0.2, 0.9]), 0.2);
+    }
 }

--- a/llmfit-core/src/benchmarks.rs
+++ b/llmfit-core/src/benchmarks.rs
@@ -369,17 +369,33 @@ pub fn cached_preset_labels() -> Vec<&'static str> {
 
 // ── Measured throughput lookup (provenance-weighted estimates) ──────
 
-/// A real measured throughput from community benchmark runs on hardware
-/// matching the user's detected system. When present, this is ground truth
-/// and should be displayed with priority over the formula estimate.
+/// Where a measured throughput came from. The user's own benchmark runs
+/// outrank community medians, which outrank the formula estimate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MeasuredSource {
+    /// Community leaderboard runs on hardware matching the detected GPU.
+    #[default]
+    Community,
+    /// `llmfit bench` runs recorded in this machine's local store.
+    LocalBench,
+}
+
+/// A real measured throughput from benchmark runs — either the community
+/// leaderboard on matching hardware, or the user's own `llmfit bench` runs on
+/// this very machine. When present, this is ground truth and should be
+/// displayed with priority over the formula estimate.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MeasuredTps {
-    /// Median measured generation throughput (tok/s).
+    /// Measured generation throughput (tok/s): community median, or the most
+    /// recent local run.
     pub tok_s: f64,
-    /// Number of community runs behind the median.
+    /// Number of runs behind the value.
     pub sample_count: u32,
-    /// Hardware preset the runs come from (e.g. "RTX 3090 (24 GB)").
+    /// Hardware the runs come from (e.g. "RTX 3090 (24 GB)" or "this machine").
     pub hardware_label: String,
+    #[serde(default)]
+    pub source: MeasuredSource,
 }
 
 /// Find the embedded-cache hardware preset matching the detected GPU.
@@ -467,6 +483,7 @@ impl MeasuredTpsIndex {
             tok_s: median,
             sample_count: n as u32,
             hardware_label: self.hardware_label.to_string(),
+            source: MeasuredSource::Community,
         })
     }
 }

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -225,6 +225,11 @@ pub struct EstimateBasis {
     /// The estimate models single-request *generation* throughput at this
     /// context length. Prompt processing (prefill/TTFT) is not estimated.
     pub assumed_context: u32,
+    /// Correction factor derived from the user's own `llmfit bench` runs on
+    /// this machine (median measured/estimated across trustworthy anchors),
+    /// already applied to `estimated_tps`. `None` when no local runs matched.
+    #[serde(default)]
+    pub local_calibration: Option<f64>,
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -586,6 +591,7 @@ impl ModelFit {
                     .then(|| ddr_bandwidth_gbps(&config)),
                 efficiency: config.efficiency,
                 assumed_context: estimation_ctx,
+                local_calibration: None,
             }
         };
 

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -3278,6 +3278,37 @@ pub fn ollama_pull_tag(hf_name: &str) -> Option<String> {
     lookup_ollama_tag(hf_name).map(|s| s.to_string())
 }
 
+/// Match a running provider's model tag (an Ollama-style id, or a GGUF file
+/// path/stem as reported by llama-server) against an HF-style model name,
+/// reusing the installed-column heuristics.
+///
+/// Two deliberately separate passes: Ollama-style candidate matching runs
+/// only against the verbatim id, while file paths (".../gemma-3.Q8_0.gguf")
+/// get exact stem matching only — feeding a bare stem into the Ollama
+/// candidate heuristics would match whole families.
+pub fn tag_matches_model(tag: &str, hf_name: &str) -> bool {
+    let lower = tag.to_lowercase();
+
+    let mut tag_set = HashSet::new();
+    tag_set.insert(lower.clone());
+    if is_model_installed(hf_name, &tag_set) {
+        return true;
+    }
+
+    let stem = lower
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(&lower)
+        .trim_end_matches(".gguf")
+        .to_string();
+    let mut stem_set = HashSet::new();
+    if let Some(base) = strip_gguf_quant_suffix(&stem) {
+        stem_set.insert(base);
+    }
+    stem_set.insert(stem);
+    is_model_installed_llamacpp(hf_name, &stem_set)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -342,6 +342,54 @@ pub fn mark_shared(stored: &[StoredBenchmark]) {
     }
 }
 
+/// Index of the user's own benchmark runs (pending and shared), used to
+/// annotate fit rows: a throughput measured on THIS machine is ground truth
+/// and takes priority over community medians and formula estimates.
+pub struct LocalBenchIndex {
+    /// (provider model tag, tok/s), newest run first.
+    entries: Vec<(String, f64)>,
+}
+
+impl LocalBenchIndex {
+    /// Load every stored benchmark result. Returns `None` when the store is
+    /// empty so callers can skip per-model lookups entirely.
+    pub fn load() -> Option<Self> {
+        let mut entries: Vec<(String, f64)> = Vec::new();
+        for s in shared_benchmarks().into_iter().chain(pending_benchmarks()) {
+            let Some(results) = s.payload["results"].as_array() else {
+                continue;
+            };
+            for r in results {
+                if let (Some(model), Some(tps)) = (r["model"].as_str(), r["avgTps"].as_f64())
+                    && tps > 0.0
+                {
+                    entries.push((model.to_string(), tps));
+                }
+            }
+        }
+        // Store reads are oldest-first; prefer the newest measurement.
+        entries.reverse();
+        (!entries.is_empty()).then_some(Self { entries })
+    }
+
+    /// Most recent locally measured tok/s for a catalog model, if any stored
+    /// run's provider tag matches it.
+    pub fn lookup(&self, model_hf_name: &str) -> Option<crate::benchmarks::MeasuredTps> {
+        let matches: Vec<f64> = self
+            .entries
+            .iter()
+            .filter(|(tag, _)| crate::providers::tag_matches_model(tag, model_hf_name))
+            .map(|(_, tps)| *tps)
+            .collect();
+        Some(crate::benchmarks::MeasuredTps {
+            tok_s: *matches.first()?,
+            sample_count: matches.len() as u32,
+            hardware_label: "this machine".to_string(),
+            source: crate::benchmarks::MeasuredSource::LocalBench,
+        })
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Orchestration
 // ---------------------------------------------------------------------------
@@ -1148,7 +1196,23 @@ mod tests {
         );
         assert!(shared_benchmarks().is_empty());
 
+        // The local index resolves the stored run for the matching catalog
+        // model (ollama tag "llama3.1:8b" ↔ HF-style name) and outranks
+        // nothing else: unknown models get no local measurement.
+        let idx = LocalBenchIndex::load().expect("store has one run");
+        let m = idx.lookup("test/llama-3.1-8b").expect("tag should match");
+        assert_eq!(m.tok_s, 128.44);
+        assert_eq!(m.sample_count, 1);
+        assert_eq!(m.source, crate::benchmarks::MeasuredSource::LocalBench);
+        assert!(idx.lookup("test/qwen2.5-7b").is_none());
+
         mark_shared(&pending);
+        // Shared runs still count as local measurements.
+        assert!(
+            LocalBenchIndex::load()
+                .and_then(|i| i.lookup("test/llama-3.1-8b"))
+                .is_some()
+        );
         assert!(pending_benchmarks().is_empty());
         let shared = shared_benchmarks();
         assert_eq!(shared.len(), 1);

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -1,5 +1,11 @@
 //! Contribute benchmark results back to the project as a GitHub pull request.
 //!
+//! Every successful bench run is first recorded in a **local store** as a
+//! ready-to-upload submission payload (see [`store_local`]). Sharing — now or
+//! any time later — uploads everything still pending in a single PR, after
+//! which the files move to `shared/` so they remain as local history but are
+//! never sent twice. Declining to share therefore never discards data.
+//!
 //! No `gh` CLI and no server are required. Authentication uses the GitHub OAuth
 //! **device flow** — the same mechanism `gh auth login` uses — with a public
 //! client id, so nothing secret ships in the binary. The fork / commit / open-PR
@@ -7,7 +13,8 @@
 //!
 //! A `GITHUB_TOKEN` / `GH_TOKEN` env var, or a token cached from a previous
 //! device-flow login, short-circuits the interactive step — which also makes
-//! `--share` usable from CI.
+//! `--share` usable from CI. Credentials are resolved and verified *before*
+//! benchmarks run ([`preflight_auth`]) so a bad token is caught up front.
 //!
 //! All human-facing output goes to stderr so it never corrupts `bench --json`
 //! output on stdout.
@@ -18,6 +25,7 @@ use base64::Engine;
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::io::Write;
+use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const UPSTREAM_OWNER: &str = "AlexsJones";
@@ -185,12 +193,14 @@ fn now_unix() -> u64 {
         .unwrap_or(0)
 }
 
-/// Slug identifying the hardware, used for the branch name and submission path.
-fn hardware_slug(specs: &SystemSpecs) -> String {
-    let raw = specs
-        .gpu_name
-        .clone()
-        .unwrap_or_else(|| format!("cpu-{}", specs.cpu_name));
+/// Slug identifying the hardware of a stored submission payload, used for the
+/// branch name and submission path.
+fn payload_slug(payload: &Value) -> String {
+    let hw = &payload["hardware"];
+    let raw = hw["hardwareName"]
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("cpu-{}", hw["cpu"].as_str().unwrap_or("unknown")));
     let mut slug: String = raw
         .to_lowercase()
         .chars()
@@ -223,88 +233,220 @@ fn short_hash(s: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// Orchestration
+// Local benchmark store
 // ---------------------------------------------------------------------------
 
-/// Build the submission, confirm with the user, then fork the repo, commit the
-/// result file to a new branch, and open a pull request.
-///
-/// Returns `Ok(Some(pr_url))` on success, `Ok(None)` if the user cancelled or
-/// `--dry-run` was set, and `Err(_)` on failure.
-pub fn share_results(
-    results: &[BenchResult],
-    specs: &SystemSpecs,
-    opts: &ShareOptions,
-) -> Result<Option<String>, String> {
-    if results.is_empty() {
-        return Err("no benchmark results to share".to_string());
-    }
+/// A submission payload recorded in the local benchmark store.
+pub struct StoredBenchmark {
+    pub path: PathBuf,
+    pub payload: Value,
+}
 
+impl StoredBenchmark {
+    /// One line per benchmark result: `model via provider — N tok/s`.
+    pub fn result_lines(&self) -> Vec<String> {
+        let Some(results) = self.payload["results"].as_array() else {
+            return Vec::new();
+        };
+        results
+            .iter()
+            .map(|r| {
+                format!(
+                    "{} via {} — {:.1} tok/s",
+                    r["model"].as_str().unwrap_or("?"),
+                    r["provider"].as_str().unwrap_or("?"),
+                    r["avgTps"].as_f64().unwrap_or(0.0),
+                )
+            })
+            .collect()
+    }
+}
+
+/// Root of the local store. Overridable with `LLMFIT_BENCH_STORE` (useful for
+/// tests and for keeping the store on a shared volume).
+fn store_root() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("LLMFIT_BENCH_STORE")
+        && !dir.trim().is_empty()
+    {
+        return Some(PathBuf::from(dir));
+    }
+    Some(dirs::data_local_dir()?.join("llmfit").join("benchmarks"))
+}
+
+fn read_store(subdir: &str) -> Vec<StoredBenchmark> {
+    let Some(dir) = store_root().map(|r| r.join(subdir)) else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<StoredBenchmark> = entries
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                return None;
+            }
+            let payload: Value =
+                serde_json::from_str(&std::fs::read_to_string(&path).ok()?).ok()?;
+            Some(StoredBenchmark { path, payload })
+        })
+        .collect();
+    // Filenames start with the unix timestamp, so path order is record order.
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    out
+}
+
+/// Record benchmark results locally as a ready-to-upload submission payload.
+/// Returns the path of the stored file.
+pub fn store_local(results: &[BenchResult], specs: &SystemSpecs) -> Result<PathBuf, String> {
+    if results.is_empty() {
+        return Err("no benchmark results to store".to_string());
+    }
     let submission = build_submission(results, specs);
     let json =
         serde_json::to_string_pretty(&submission).map_err(|e| format!("serialize failed: {e}"))?;
+    let dir = store_root()
+        .ok_or("no local data directory")?
+        .join("pending");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    let path = dir.join(format!("{}-{}.json", now_unix(), short_hash(&json)));
+    std::fs::write(&path, json).map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(path)
+}
 
-    eprintln!("\n  The following benchmark data would be contributed:\n");
-    for line in json.lines() {
-        eprintln!("    {line}");
+/// Stored benchmarks not yet contributed upstream, oldest first.
+pub fn pending_benchmarks() -> Vec<StoredBenchmark> {
+    read_store("pending")
+}
+
+/// Stored benchmarks already contributed upstream, oldest first.
+pub fn shared_benchmarks() -> Vec<StoredBenchmark> {
+    read_store("shared")
+}
+
+/// Move uploaded submissions from `pending/` to `shared/` so they remain as
+/// local history but are never uploaded twice. Best-effort: a file that cannot
+/// be moved stays pending (worst case a duplicate submission, never data loss).
+pub fn mark_shared(stored: &[StoredBenchmark]) {
+    let Some(dir) = store_root().map(|r| r.join("shared")) else {
+        return;
+    };
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    for s in stored {
+        if let Some(name) = s.path.file_name() {
+            let _ = std::fs::rename(&s.path, dir.join(name));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/// Share everything in the local pending store as a single pull request.
+/// Interactive CLI flow: lists the stored submissions, confirms with the
+/// user, then uploads and marks them shared. Pass a pre-validated `token`
+/// (from [`preflight_auth`]) to skip credential resolution here.
+///
+/// Returns `Ok(Some(pr_url))` on success, `Ok(None)` if the user cancelled or
+/// `--dry-run` was set, and `Err(_)` on failure.
+pub fn share_all_pending(
+    opts: &ShareOptions,
+    token: Option<String>,
+) -> Result<Option<String>, String> {
+    let stored = pending_benchmarks();
+    if stored.is_empty() {
+        return Err(
+            "no local benchmarks are stored yet. Run `llmfit bench <model>` or \
+             `llmfit bench --all` first."
+                .to_string(),
+        );
+    }
+
+    eprintln!("\n  The following stored benchmark data would be contributed:\n");
+    for s in &stored {
+        for line in s.result_lines() {
+            eprintln!("    - {line}");
+        }
     }
 
     if opts.dry_run {
+        for s in &stored {
+            if let Ok(json) = serde_json::to_string_pretty(&s.payload) {
+                eprintln!("\n  --- {} ---", s.path.display());
+                for line in json.lines() {
+                    eprintln!("    {line}");
+                }
+            }
+        }
         eprintln!("\n  --dry-run: nothing was submitted.");
         return Ok(None);
     }
 
     if !opts.assume_yes {
         let prompt = format!(
-            "\n  Contribute {} result(s) as a PR to {UPSTREAM_OWNER}/{UPSTREAM_REPO}?",
-            results.len()
+            "\n  Share all {} local benchmark submission(s) as a PR to \
+             {UPSTREAM_OWNER}/{UPSTREAM_REPO}?",
+            stored.len()
         );
         if !confirm(&prompt)? {
-            eprintln!("  Cancelled.");
+            eprintln!("  Cancelled — results remain stored locally.");
             return Ok(None);
         }
     }
 
-    let token = resolve_token()?;
-    let pr_url = submit_results(results, specs, &token)?;
+    let token = match token {
+        Some(t) => t,
+        None => preflight_auth()?,
+    };
+    let pr_url = submit_stored(&stored, &token)?;
+    mark_shared(&stored);
     Ok(Some(pr_url))
 }
 
-/// Non-interactive core of the share flow: fork the repo, commit the result
-/// file to a new branch, and open a pull request using an already-resolved
-/// token. Never prompts or reads stdin, so it is safe to call from a worker
-/// thread while a TUI owns the terminal. Returns the PR URL.
-pub fn submit_results(
-    results: &[BenchResult],
-    specs: &SystemSpecs,
-    token: &str,
-) -> Result<String, String> {
-    if results.is_empty() {
+/// Non-interactive core of the share flow: fork the repo, commit each stored
+/// submission to one new branch, and open a single pull request using an
+/// already-resolved token. Never prompts or reads stdin, so it is safe to
+/// call from a worker thread while a TUI owns the terminal. Returns the PR
+/// URL; the caller is responsible for [`mark_shared`] afterwards.
+pub fn submit_stored(stored: &[StoredBenchmark], token: &str) -> Result<String, String> {
+    if stored.is_empty() {
         return Err("no benchmark results to share".to_string());
     }
-    let submission = build_submission(results, specs);
-    let json =
-        serde_json::to_string_pretty(&submission).map_err(|e| format!("serialize failed: {e}"))?;
+
+    // Re-stamp the submission time: stored files may be days old.
+    let now = now_unix();
+    let files: Vec<(String, String)> = stored
+        .iter()
+        .map(|s| {
+            let mut payload = s.payload.clone();
+            payload["submittedAtUnix"] = json!(now);
+            let json = serde_json::to_string_pretty(&payload)
+                .map_err(|e| format!("serialize failed: {e}"))?;
+            Ok((payload_slug(&payload), json))
+        })
+        .collect::<Result<_, String>>()?;
 
     let login = whoami(token)?;
-
     ensure_fork(token, &login)?;
     let base_sha = upstream_head_sha(token)?;
 
-    let slug = hardware_slug(specs);
-    let hash = short_hash(&json);
+    let all_json: String = files.iter().map(|(_, j)| j.as_str()).collect();
+    let hash = short_hash(&all_json);
+    let slug = files[0].0.clone();
     let branch = format!("bench/{slug}-{hash}");
     create_branch(token, &login, &branch, &base_sha)?;
 
-    let path = format!("{SUBMISSION_DIR}/{slug}/{}-{hash}.json", now_unix());
-    let message = format!(
-        "data: community benchmark ({} on {})",
-        results.first().map(|r| r.model.as_str()).unwrap_or("model"),
-        slug
-    );
-    put_file(token, &login, &branch, &path, &json, &message)?;
+    for (i, (file_slug, json)) in files.iter().enumerate() {
+        let path = format!("{SUBMISSION_DIR}/{file_slug}/{now}-{hash}-{i}.json");
+        let message = format!("data: community benchmark ({file_slug})");
+        put_file(token, &login, &branch, &path, json, &message)?;
+    }
 
-    open_pr(token, &login, &branch, results, &slug)
+    open_pr(token, &login, &branch, stored, &slug)
 }
 
 fn confirm(prompt: &str) -> Result<bool, String> {
@@ -322,38 +464,90 @@ fn confirm(prompt: &str) -> Result<bool, String> {
 // Authentication
 // ---------------------------------------------------------------------------
 
+/// Where a non-interactively resolved token came from. An invalid env token
+/// is a hard error (the user set it explicitly); an invalid cached token is
+/// silently discarded and re-acquired via the device flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenSource {
+    /// `GITHUB_TOKEN` / `GH_TOKEN` environment variable.
+    Env,
+    /// Token cached by a previous device-flow login.
+    Cache,
+}
+
 /// Resolve a GitHub token without any user interaction: env vars, then the
 /// cached token from a previous device-flow login. Returns `None` when an
 /// interactive login would be required.
 pub fn resolve_token_noninteractive() -> Option<String> {
+    resolve_token_noninteractive_with_source().map(|(t, _)| t)
+}
+
+/// [`resolve_token_noninteractive`], also reporting where the token came from.
+pub fn resolve_token_noninteractive_with_source() -> Option<(String, TokenSource)> {
     for var in ["GITHUB_TOKEN", "GH_TOKEN"] {
         if let Some(t) = std::env::var(var)
             .ok()
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
         {
-            return Some(t);
+            return Some((t, TokenSource::Env));
         }
     }
-    read_cached_token()
+    read_cached_token().map(|t| (t, TokenSource::Cache))
 }
 
-/// The OAuth App client id for the device flow, or `None` when only the
-/// unregistered placeholder is available (interactive login not possible).
-pub fn oauth_client_id() -> Option<String> {
-    let id = std::env::var("LLMFIT_GH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
-    (id != DEFAULT_CLIENT_ID).then_some(id)
+/// Check a token against the GitHub API. `Ok(Some(login))` means the token is
+/// valid, `Ok(None)` means GitHub rejected it (invalid/expired), `Err` means
+/// the request itself failed (network, rate limit, ...).
+pub fn validate_token(token: &str) -> Result<Option<String>, String> {
+    let (status, body) = api("GET", &format!("{API}/user"), token, None)?;
+    if status == 401 {
+        return Ok(None);
+    }
+    if !(200..300).contains(&status) {
+        return Err(api_error(status, &body));
+    }
+    Ok(Some(
+        body["login"]
+            .as_str()
+            .ok_or("could not determine GitHub username")?
+            .to_string(),
+    ))
 }
 
-/// Persist a token obtained via the device flow for future runs.
-pub fn cache_token(token: &str) -> Result<(), String> {
-    write_cached_token(token)
+/// Drop the cached device-flow token (e.g. after GitHub reports it expired).
+pub fn clear_cached_token() {
+    if let Some(p) = token_path() {
+        let _ = std::fs::remove_file(p);
+    }
 }
 
-/// Resolve a GitHub token: env var, then cached token, then interactive device flow.
-fn resolve_token() -> Result<String, String> {
-    if let Some(t) = resolve_token_noninteractive() {
-        return Ok(t);
+/// Resolve *and verify* GitHub credentials, intended to run **before** any
+/// benchmarks so a missing or expired token is caught up front rather than
+/// after minutes of benching. Falls back to the interactive device flow when
+/// possible. Prints progress to stderr (CLI flow).
+pub fn preflight_auth() -> Result<String, String> {
+    if let Some((token, source)) = resolve_token_noninteractive_with_source() {
+        match validate_token(&token) {
+            Ok(Some(login)) => {
+                eprintln!("  GitHub: authenticated as {login}");
+                return Ok(token);
+            }
+            Ok(None) => match source {
+                TokenSource::Env => {
+                    return Err(
+                        "the GITHUB_TOKEN/GH_TOKEN environment variable holds an invalid \
+                         or expired token"
+                            .to_string(),
+                    );
+                }
+                TokenSource::Cache => {
+                    eprintln!("  GitHub: cached login has expired — starting a new login");
+                    clear_cached_token();
+                }
+            },
+            Err(e) => return Err(format!("could not verify GitHub credentials: {e}")),
+        }
     }
     let Some(client_id) = oauth_client_id() else {
         return Err(
@@ -368,6 +562,18 @@ fn resolve_token() -> Result<String, String> {
         eprintln!("  Warning: could not cache token: {e}");
     }
     Ok(token)
+}
+
+/// The OAuth App client id for the device flow, or `None` when only the
+/// unregistered placeholder is available (interactive login not possible).
+pub fn oauth_client_id() -> Option<String> {
+    let id = std::env::var("LLMFIT_GH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
+    (id != DEFAULT_CLIENT_ID).then_some(id)
+}
+
+/// Persist a token obtained via the device flow for future runs.
+pub fn cache_token(token: &str) -> Result<(), String> {
+    write_cached_token(token)
 }
 
 fn token_path() -> Option<std::path::PathBuf> {
@@ -560,17 +766,7 @@ fn api_error(status: u16, body: &Value) -> String {
 }
 
 fn whoami(token: &str) -> Result<String, String> {
-    let (status, body) = api("GET", &format!("{API}/user"), token, None)?;
-    if status == 401 {
-        return Err("GitHub token is invalid or expired (401)".into());
-    }
-    if !(200..300).contains(&status) {
-        return Err(api_error(status, &body));
-    }
-    body["login"]
-        .as_str()
-        .map(str::to_string)
-        .ok_or_else(|| "could not determine GitHub username".into())
+    validate_token(token)?.ok_or_else(|| "GitHub token is invalid or expired (401)".into())
 }
 
 /// Ensure the authenticated user has a fork of the upstream repo, creating one
@@ -653,7 +849,7 @@ fn open_pr(
     token: &str,
     login: &str,
     branch: &str,
-    results: &[BenchResult],
+    stored: &[StoredBenchmark],
     slug: &str,
 ) -> Result<String, String> {
     let title = format!("bench: community results for {slug}");
@@ -662,16 +858,21 @@ fn open_pr(
          | Model | Provider | Avg TPS | Avg TTFT (ms) |\n\
          | --- | --- | --- | --- |\n",
     );
-    for r in results {
-        let ttft = r
-            .summary
-            .avg_ttft_ms
-            .map(|v| format!("{v:.1}"))
-            .unwrap_or_else(|| "—".to_string());
-        body.push_str(&format!(
-            "| {} | {} | {:.1} | {} |\n",
-            r.model, r.provider, r.summary.avg_tps, ttft
-        ));
+    for s in stored {
+        let results = s.payload["results"].as_array();
+        for r in results.map(|v| v.as_slice()).unwrap_or_default() {
+            let ttft = r["avgTtftMs"]
+                .as_f64()
+                .map(|v| format!("{v:.1}"))
+                .unwrap_or_else(|| "—".to_string());
+            body.push_str(&format!(
+                "| {} | {} | {:.1} | {} |\n",
+                r["model"].as_str().unwrap_or("?"),
+                r["provider"].as_str().unwrap_or("?"),
+                r["avgTps"].as_f64().unwrap_or(0.0),
+                ttft
+            ));
+        }
     }
     body.push_str("\n_Submitted without the `gh` CLI via the GitHub device flow._\n");
 
@@ -722,14 +923,71 @@ mod tests {
         }
     }
 
+    fn sample_result() -> BenchResult {
+        use crate::bench::BenchSummary;
+        BenchResult {
+            model: "llama3.1:8b".to_string(),
+            provider: "ollama".to_string(),
+            runs: vec![],
+            summary: BenchSummary {
+                num_runs: 3,
+                avg_ttft_ms: Some(41.2),
+                avg_tps: 128.44,
+                min_tps: 121.0,
+                max_tps: 133.7,
+                avg_total_ms: 812.5,
+                avg_output_tokens: 104.0,
+            },
+        }
+    }
+
     #[test]
     fn slug_is_filename_safe() {
-        let specs = specs_with_gpu("NVIDIA RTX 4090!!");
-        let slug = hardware_slug(&specs);
+        let submission = build_submission(&[sample_result()], &specs_with_gpu("NVIDIA RTX 4090!!"));
+        let payload = serde_json::to_value(&submission).unwrap();
+        let slug = payload_slug(&payload);
         assert!(slug.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
         assert!(!slug.contains("--"));
         assert!(!slug.starts_with('-') && !slug.ends_with('-'));
         assert_eq!(slug, "nvidia-rtx-4090");
+
+        // No GPU name → falls back to a cpu-derived slug.
+        let mut cpu_only = specs_with_gpu("unused");
+        cpu_only.gpu_name = None;
+        let payload =
+            serde_json::to_value(build_submission(&[sample_result()], &cpu_only)).unwrap();
+        assert_eq!(payload_slug(&payload), "cpu-test-cpu");
+    }
+
+    #[test]
+    fn local_store_roundtrip() {
+        // LLMFIT_BENCH_STORE scopes the store to a temp dir. Env vars are
+        // process-global, so this is the only test that may touch the store.
+        let dir = std::env::temp_dir().join(format!("llmfit-store-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        unsafe { std::env::set_var("LLMFIT_BENCH_STORE", &dir) };
+
+        let specs = specs_with_gpu("NVIDIA GeForce RTX 4090");
+        let path = store_local(&[sample_result()], &specs).unwrap();
+        assert!(path.starts_with(dir.join("pending")));
+
+        let pending = pending_benchmarks();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].payload["schemaVersion"], 1);
+        assert_eq!(
+            pending[0].result_lines(),
+            vec!["llama3.1:8b via ollama — 128.4 tok/s".to_string()]
+        );
+        assert!(shared_benchmarks().is_empty());
+
+        mark_shared(&pending);
+        assert!(pending_benchmarks().is_empty());
+        let shared = shared_benchmarks();
+        assert_eq!(shared.len(), 1);
+        assert_eq!(shared[0].payload["results"][0]["avgTps"], 128.44);
+
+        unsafe { std::env::remove_var("LLMFIT_BENCH_STORE") };
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -243,6 +243,22 @@ pub struct StoredBenchmark {
 }
 
 impl StoredBenchmark {
+    /// Whether this run was recorded on hardware matching `specs` (same CPU
+    /// and GPU). Measurements from a previous machine configuration must not
+    /// override or calibrate estimates for the current one.
+    pub fn matches_hardware(&self, specs: &SystemSpecs) -> bool {
+        let hw = &self.payload["hardware"];
+        let cpu_ok = hw["cpu"]
+            .as_str()
+            .is_some_and(|c| c.eq_ignore_ascii_case(&specs.cpu_name));
+        let gpu_ok = match (&specs.gpu_name, hw["hardwareName"].as_str()) {
+            (Some(now), Some(then)) => now.eq_ignore_ascii_case(then),
+            (None, None) => true,
+            _ => false,
+        };
+        cpu_ok && gpu_ok
+    }
+
     /// One line per benchmark result: `model via provider — N tok/s`.
     pub fn result_lines(&self) -> Vec<String> {
         let Some(results) = self.payload["results"].as_array() else {
@@ -351,11 +367,15 @@ pub struct LocalBenchIndex {
 }
 
 impl LocalBenchIndex {
-    /// Load every stored benchmark result. Returns `None` when the store is
-    /// empty so callers can skip per-model lookups entirely.
-    pub fn load() -> Option<Self> {
+    /// Load every stored benchmark result recorded on hardware matching
+    /// `specs`. Returns `None` when nothing qualifies so callers can skip
+    /// per-model lookups entirely.
+    pub fn load(specs: &SystemSpecs) -> Option<Self> {
         let mut entries: Vec<(String, f64)> = Vec::new();
         for s in shared_benchmarks().into_iter().chain(pending_benchmarks()) {
+            if !s.matches_hardware(specs) {
+                continue;
+            }
             let Some(results) = s.payload["results"].as_array() else {
                 continue;
             };
@@ -1199,17 +1219,23 @@ mod tests {
         // The local index resolves the stored run for the matching catalog
         // model (ollama tag "llama3.1:8b" ↔ HF-style name) and outranks
         // nothing else: unknown models get no local measurement.
-        let idx = LocalBenchIndex::load().expect("store has one run");
+        let idx = LocalBenchIndex::load(&specs).expect("store has one run");
         let m = idx.lookup("test/llama-3.1-8b").expect("tag should match");
         assert_eq!(m.tok_s, 128.44);
         assert_eq!(m.sample_count, 1);
         assert_eq!(m.source, crate::benchmarks::MeasuredSource::LocalBench);
         assert!(idx.lookup("test/qwen2.5-7b").is_none());
 
+        // Runs recorded on different hardware never leak into the index.
+        let other_gpu = specs_with_gpu("NVIDIA GeForce RTX 3060");
+        assert!(LocalBenchIndex::load(&other_gpu).is_none());
+        assert!(!pending[0].matches_hardware(&other_gpu));
+        assert!(pending[0].matches_hardware(&specs));
+
         mark_shared(&pending);
         // Shared runs still count as local measurements.
         assert!(
-            LocalBenchIndex::load()
+            LocalBenchIndex::load(&specs)
                 .and_then(|i| i.lookup("test/llama-3.1-8b"))
                 .is_some()
         );

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -351,12 +351,12 @@ pub fn mark_shared(stored: &[StoredBenchmark]) {
 /// user, then uploads and marks them shared. Pass a pre-validated `token`
 /// (from [`preflight_auth`]) to skip credential resolution here.
 ///
-/// Returns `Ok(Some(pr_url))` on success, `Ok(None)` if the user cancelled or
-/// `--dry-run` was set, and `Err(_)` on failure.
+/// Returns `Ok(Some(outcome))` on success, `Ok(None)` if the user cancelled
+/// or `--dry-run` was set, and `Err(_)` on failure.
 pub fn share_all_pending(
     opts: &ShareOptions,
     token: Option<String>,
-) -> Result<Option<String>, String> {
+) -> Result<Option<SubmitOutcome>, String> {
     let stored = pending_benchmarks();
     if stored.is_empty() {
         return Err(
@@ -402,51 +402,132 @@ pub fn share_all_pending(
         Some(t) => t,
         None => preflight_auth()?,
     };
-    let pr_url = submit_stored(&stored, &token)?;
+    let outcome = submit_stored(&stored, &token)?;
     mark_shared(&stored);
-    Ok(Some(pr_url))
+    Ok(Some(outcome))
 }
 
-/// Non-interactive core of the share flow: fork the repo, commit each stored
-/// submission to one new branch, and open a single pull request using an
-/// already-resolved token. Never prompts or reads stdin, so it is safe to
-/// call from a worker thread while a TUI owns the terminal. Returns the PR
-/// URL; the caller is responsible for [`mark_shared`] afterwards.
-pub fn submit_stored(stored: &[StoredBenchmark], token: &str) -> Result<String, String> {
+/// Outcome of uploading stored submissions.
+pub struct SubmitOutcome {
+    /// PR that now contains the results — an already-open bench PR when one
+    /// existed, otherwise a newly opened one. `None` when every file had
+    /// already been submitted upstream and there was nothing to open a PR for.
+    pub pr_url: Option<String>,
+    /// Results were appended to an existing open PR instead of a new one.
+    pub reused_existing_pr: bool,
+    /// Files actually uploaded this time.
+    pub uploaded: usize,
+    /// Files skipped because a submission with the same name already exists
+    /// upstream (e.g. a retry after a partially failed share).
+    pub skipped: usize,
+}
+
+/// Non-interactive core of the share flow, safe to call from a worker thread
+/// while a TUI owns the terminal (never prompts or reads stdin). Forks the
+/// repo, then either **appends** the stored submissions to the user's
+/// already-open benchmark PR (avoiding one PR per bench run) or commits them
+/// to a new branch and opens one. Upstream file names mirror the local store
+/// names, so re-submitting after a partial failure skips what already landed
+/// instead of duplicating it. The caller is responsible for [`mark_shared`]
+/// afterwards.
+pub fn submit_stored(stored: &[StoredBenchmark], token: &str) -> Result<SubmitOutcome, String> {
     if stored.is_empty() {
         return Err("no benchmark results to share".to_string());
     }
 
-    // Re-stamp the submission time: stored files may be days old.
     let now = now_unix();
-    let files: Vec<(String, String)> = stored
-        .iter()
-        .map(|s| {
-            let mut payload = s.payload.clone();
-            payload["submittedAtUnix"] = json!(now);
-            let json = serde_json::to_string_pretty(&payload)
-                .map_err(|e| format!("serialize failed: {e}"))?;
-            Ok((payload_slug(&payload), json))
-        })
-        .collect::<Result<_, String>>()?;
+    let files = prepare_files(stored, now)?;
 
     let login = whoami(token)?;
     ensure_fork(token, &login)?;
-    let base_sha = upstream_head_sha(token)?;
 
-    let all_json: String = files.iter().map(|(_, j)| j.as_str()).collect();
+    // A lookup failure only means we open a fresh PR — never a lost result —
+    // so it is deliberately soft.
+    if let Some((branch, pr_url)) = find_open_bench_pr(token, &login).unwrap_or(None) {
+        let (uploaded, skipped) = put_files(token, &login, &branch, &files)?;
+        return Ok(SubmitOutcome {
+            pr_url: Some(pr_url),
+            reused_existing_pr: true,
+            uploaded,
+            skipped,
+        });
+    }
+
+    let base_sha = upstream_head_sha(token)?;
+    let all_json: String = files.iter().map(|(_, _, j)| j.as_str()).collect();
     let hash = short_hash(&all_json);
     let slug = files[0].0.clone();
     let branch = format!("bench/{slug}-{hash}");
     create_branch(token, &login, &branch, &base_sha)?;
 
-    for (i, (file_slug, json)) in files.iter().enumerate() {
-        let path = format!("{SUBMISSION_DIR}/{file_slug}/{now}-{hash}-{i}.json");
-        let message = format!("data: community benchmark ({file_slug})");
-        put_file(token, &login, &branch, &path, json, &message)?;
+    let (uploaded, skipped) = put_files(token, &login, &branch, &files)?;
+    if uploaded == 0 {
+        // Everything was already upstream (e.g. an earlier PR merged but the
+        // local move to shared/ failed). No diff — GitHub would reject a PR.
+        return Ok(SubmitOutcome {
+            pr_url: None,
+            reused_existing_pr: false,
+            uploaded,
+            skipped,
+        });
     }
 
-    open_pr(token, &login, &branch, stored, &slug)
+    let pr_url = open_pr(token, &login, &branch, stored, &slug)?;
+    Ok(SubmitOutcome {
+        pr_url: Some(pr_url),
+        reused_existing_pr: false,
+        uploaded,
+        skipped,
+    })
+}
+
+/// Build the upload set as `(hardware slug, file name, payload json)` per
+/// stored submission, re-stamping the submission time (stored files may be
+/// days old). Upstream file names reuse the local store name (record
+/// timestamp + content hash): stable across retries, so a re-upload of the
+/// same stored result targets the same path and is skipped, not duplicated.
+fn prepare_files(
+    stored: &[StoredBenchmark],
+    now: u64,
+) -> Result<Vec<(String, String, String)>, String> {
+    stored
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let mut payload = s.payload.clone();
+            payload["submittedAtUnix"] = json!(now);
+            let json = serde_json::to_string_pretty(&payload)
+                .map_err(|e| format!("serialize failed: {e}"))?;
+            let name = s
+                .path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("{now}-{i}.json"));
+            Ok((payload_slug(&payload), name, json))
+        })
+        .collect()
+}
+
+/// Commit each prepared file to `branch`, returning `(uploaded, skipped)`
+/// where skipped counts files that already existed upstream.
+fn put_files(
+    token: &str,
+    login: &str,
+    branch: &str,
+    files: &[(String, String, String)],
+) -> Result<(usize, usize), String> {
+    let (mut uploaded, mut skipped) = (0usize, 0usize);
+    for (slug, name, json) in files {
+        let path = format!("{SUBMISSION_DIR}/{slug}/{name}");
+        let message = format!("data: community benchmark ({slug})");
+        if put_file(token, login, branch, &path, json, &message)? {
+            uploaded += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+    Ok((uploaded, skipped))
 }
 
 fn confirm(prompt: &str) -> Result<bool, String> {
@@ -823,6 +904,11 @@ fn create_branch(token: &str, login: &str, branch: &str, sha: &str) -> Result<()
     Err(api_error(status, &body))
 }
 
+/// Create `path` on `branch`. Returns `Ok(true)` when the file was written,
+/// `Ok(false)` when it already exists there — creating over an existing path
+/// makes GitHub answer 422 `"sha" wasn't supplied`, which for our
+/// content-hash-named submissions means this exact result already landed in
+/// an earlier attempt.
 fn put_file(
     token: &str,
     login: &str,
@@ -830,7 +916,7 @@ fn put_file(
     path: &str,
     content: &str,
     message: &str,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let encoded = base64::engine::general_purpose::STANDARD.encode(content);
     let url = format!("{API}/repos/{login}/{UPSTREAM_REPO}/contents/{path}");
     let body = json!({
@@ -839,10 +925,40 @@ fn put_file(
         "branch": branch,
     });
     let (status, body) = api("PUT", &url, token, Some(&body))?;
+    if status == 422 && body["message"].as_str().is_some_and(|m| m.contains("sha")) {
+        return Ok(false);
+    }
     if !(200..300).contains(&status) {
         return Err(api_error(status, &body));
     }
-    Ok(())
+    Ok(true)
+}
+
+/// First open upstream PR whose head is one of this user's `bench/…`
+/// branches, as `(branch, html_url)`.
+fn find_open_bench_pr(token: &str, login: &str) -> Result<Option<(String, String)>, String> {
+    let url = format!("{API}/repos/{UPSTREAM_OWNER}/{UPSTREAM_REPO}/pulls?state=open&per_page=100");
+    let (status, body) = api("GET", &url, token, None)?;
+    if !(200..300).contains(&status) {
+        return Err(api_error(status, &body));
+    }
+    Ok(open_bench_pr_in(&body, login))
+}
+
+/// Pure matcher over a GitHub pull-list response: this user's first open
+/// `bench/…` PR, if any.
+fn open_bench_pr_in(prs: &Value, login: &str) -> Option<(String, String)> {
+    let prefix = format!("{login}:bench/");
+    prs.as_array()?.iter().find_map(|pr| {
+        let label = pr["head"]["label"].as_str()?;
+        if !label.starts_with(&prefix) {
+            return None;
+        }
+        Some((
+            pr["head"]["ref"].as_str()?.to_string(),
+            pr["html_url"].as_str()?.to_string(),
+        ))
+    })
 }
 
 fn open_pr(
@@ -957,6 +1073,58 @@ mod tests {
         let payload =
             serde_json::to_value(build_submission(&[sample_result()], &cpu_only)).unwrap();
         assert_eq!(payload_slug(&payload), "cpu-test-cpu");
+    }
+
+    #[test]
+    fn open_bench_pr_matcher_picks_own_bench_branch_only() {
+        let prs = json!([
+            // Someone else's bench PR — must not match.
+            {"head": {"label": "otheruser:bench/rtx-4090-aaaa", "ref": "bench/rtx-4090-aaaa"},
+             "html_url": "https://github.com/AlexsJones/llmfit/pull/1"},
+            // Our PR but not a bench branch — must not match.
+            {"head": {"label": "me:fix/typo", "ref": "fix/typo"},
+             "html_url": "https://github.com/AlexsJones/llmfit/pull/2"},
+            // Ours — match.
+            {"head": {"label": "me:bench/rtx-4090-bbbb", "ref": "bench/rtx-4090-bbbb"},
+             "html_url": "https://github.com/AlexsJones/llmfit/pull/3"},
+        ]);
+        assert_eq!(
+            open_bench_pr_in(&prs, "me"),
+            Some((
+                "bench/rtx-4090-bbbb".to_string(),
+                "https://github.com/AlexsJones/llmfit/pull/3".to_string()
+            ))
+        );
+        assert_eq!(open_bench_pr_in(&prs, "nobody"), None);
+        assert_eq!(open_bench_pr_in(&json!([]), "me"), None);
+        assert_eq!(
+            open_bench_pr_in(&json!({"message": "rate limited"}), "me"),
+            None
+        );
+    }
+
+    #[test]
+    fn prepare_files_restamps_and_keeps_stable_names() {
+        let submission = build_submission(
+            &[sample_result()],
+            &specs_with_gpu("NVIDIA GeForce RTX 4090"),
+        );
+        let stored = StoredBenchmark {
+            path: PathBuf::from("/store/pending/1752100000-abcd1234.json"),
+            payload: serde_json::to_value(&submission).unwrap(),
+        };
+
+        let files = prepare_files(std::slice::from_ref(&stored), 9_999_999_999).unwrap();
+        assert_eq!(files.len(), 1);
+        let (slug, name, json) = &files[0];
+        assert_eq!(slug, "nvidia-geforce-rtx-4090");
+        // Upstream name mirrors the local store file, so retries are idempotent.
+        assert_eq!(name, "1752100000-abcd1234.json");
+        let payload: Value = serde_json::from_str(json).unwrap();
+        assert_eq!(payload["submittedAtUnix"], 9_999_999_999u64);
+        // Identical input at the same submit time → identical prepared file.
+        let again = prepare_files(std::slice::from_ref(&stored), 9_999_999_999).unwrap();
+        assert_eq!(&again[0].2, json);
     }
 
     #[test]

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -554,12 +554,24 @@ fn display_estimate_basis(fit: &ModelFit) {
     }
 
     if let Some(m) = &fit.measured_tps {
-        println!("{}", "Measured on Matching Hardware:".bold().underline());
-        println!(
-            "  {:.1} tok/s median across {} community run(s) on {} (localmaxxing.com)",
-            m.tok_s, m.sample_count, m.hardware_label
-        );
-        println!("  Real user data — trust this over the formula estimate below.");
+        match m.source {
+            llmfit_core::benchmarks::MeasuredSource::LocalBench => {
+                println!("{}", "Measured on This Machine:".bold().underline());
+                println!(
+                    "  {:.1} tok/s from your own `llmfit bench` run(s) ({} stored)",
+                    m.tok_s, m.sample_count
+                );
+                println!("  Your measurement — trust this over the formula estimate below.");
+            }
+            llmfit_core::benchmarks::MeasuredSource::Community => {
+                println!("{}", "Measured on Matching Hardware:".bold().underline());
+                println!(
+                    "  {:.1} tok/s median across {} community run(s) on {} (localmaxxing.com)",
+                    m.tok_s, m.sample_count, m.hardware_label
+                );
+                println!("  Real user data — trust this over the formula estimate below.");
+            }
+        }
         println!();
     }
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -576,6 +576,12 @@ fn display_estimate_basis(fit: &ModelFit) {
     }
 
     println!("{}", "Estimate Basis:".bold().underline());
+    if let Some(c) = basis.local_calibration {
+        println!(
+            "  Calibrated x{:.2} from your own `llmfit bench` run(s) on this machine",
+            c
+        );
+    }
     match basis.method.as_str() {
         "gpu_bandwidth_roofline" => {
             let bw = basis.gpu_bandwidth_gbps.unwrap_or(0.0);

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -826,7 +826,9 @@ AGENT USAGE:
         skip: Option<String>,
 
         /// Contribute results back to the project as a GitHub pull request
-        /// (no `gh` CLI required; authenticates via the GitHub device flow)
+        /// (no `gh` CLI required; authenticates via the GitHub device flow).
+        /// Shares all locally stored benchmarks; alone (no model, no --all)
+        /// it uploads the stored backlog without benchmarking
         #[arg(long)]
         share: bool,
 
@@ -2046,6 +2048,19 @@ fn run_bench(
 ) {
     let runs = runs as usize;
 
+    // With --share, resolve and verify GitHub credentials up front so a
+    // missing or expired token surfaces before minutes of benchmarking.
+    let share_token = match &share_opts {
+        Some(opts) if !opts.dry_run => match share::preflight_auth() {
+            Ok(t) => Some(t),
+            Err(e) => {
+                eprintln!("Error: --share: {e}");
+                std::process::exit(1);
+            }
+        },
+        _ => None,
+    };
+
     // --all mode: discover and bench every available model
     if all {
         let targets = bench::discover_all_targets();
@@ -2122,8 +2137,9 @@ fn run_bench(
             });
             println!("{}", serde_json::to_string_pretty(&json_out).unwrap());
         }
+        store_bench_results(&results, overrides, share_opts.is_none());
         if let Some(opts) = share_opts {
-            share_bench_results(&results, overrides, opts);
+            share_pending_cli(&opts, share_token);
         }
         return;
     }
@@ -2254,8 +2270,9 @@ fn run_bench(
             } else {
                 r.display();
             }
+            store_bench_results(std::slice::from_ref(&r), overrides, share_opts.is_none());
             if let Some(opts) = share_opts {
-                share_bench_results(std::slice::from_ref(&r), overrides, opts);
+                share_pending_cli(&opts, share_token);
             }
         }
         Err(e) => {
@@ -2265,22 +2282,39 @@ fn run_bench(
     }
 }
 
-/// Detect hardware and contribute benchmark results upstream via `share`.
-fn share_bench_results(
-    results: &[bench::BenchResult],
-    overrides: &HardwareOverrides,
-    opts: share::ShareOptions,
-) {
+/// Record successful benchmark results in the local store. With `hint`, tells
+/// the user where they went and how to contribute them later.
+fn store_bench_results(results: &[bench::BenchResult], overrides: &HardwareOverrides, hint: bool) {
     if results.is_empty() {
-        eprintln!("  Nothing to share: no successful benchmark results.");
         return;
     }
     let specs = detect_specs(overrides);
-    match share::share_results(results, &specs, &opts) {
+    match share::store_local(results, &specs) {
+        Ok(_) => {
+            if hint {
+                let pending = share::pending_benchmarks().len();
+                eprintln!(
+                    "\n  Results saved locally ({pending} submission(s) pending). \
+                     Contribute them any time with `llmfit bench --share`."
+                );
+            }
+        }
+        Err(e) => eprintln!("  Warning: could not save results locally: {e}"),
+    }
+}
+
+/// Contribute everything in the local pending store as a single PR.
+fn share_pending_cli(opts: &share::ShareOptions, token: Option<String>) {
+    match share::share_all_pending(opts, token) {
         Ok(Some(url)) => println!("\n  Pull request opened: {url}"),
         Ok(None) => {}
         Err(e) => {
             eprintln!("  Share failed: {e}");
+            if !share::pending_benchmarks().is_empty() {
+                eprintln!(
+                    "  Your results remain stored locally; retry with `llmfit bench --share`."
+                );
+            }
             std::process::exit(1);
         }
     }
@@ -3028,6 +3062,16 @@ fn main() {
                         roles,
                         quality_config,
                         skip,
+                    );
+                } else if share && model.is_none() && !all && provider == "auto" && url.is_none() {
+                    // `llmfit bench --share` with nothing to bench: contribute
+                    // previously stored local benchmarks.
+                    share_pending_cli(
+                        &share::ShareOptions {
+                            dry_run,
+                            assume_yes: yes,
+                        },
+                        None,
                     );
                 } else {
                     let share_opts = share.then_some(share::ShareOptions {

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -2306,7 +2306,24 @@ fn store_bench_results(results: &[bench::BenchResult], overrides: &HardwareOverr
 /// Contribute everything in the local pending store as a single PR.
 fn share_pending_cli(opts: &share::ShareOptions, token: Option<String>) {
     match share::share_all_pending(opts, token) {
-        Ok(Some(url)) => println!("\n  Pull request opened: {url}"),
+        Ok(Some(outcome)) => {
+            if outcome.skipped > 0 {
+                eprintln!(
+                    "\n  {} previously submitted result(s) were skipped.",
+                    outcome.skipped
+                );
+            }
+            match (&outcome.pr_url, outcome.reused_existing_pr) {
+                (Some(url), true) => println!(
+                    "\n  Added {} submission(s) to your open pull request: {url}",
+                    outcome.uploaded
+                ),
+                (Some(url), false) => println!("\n  Pull request opened: {url}"),
+                (None, _) => println!(
+                    "\n  All stored results were already contributed upstream — nothing new to submit."
+                ),
+            }
+        }
         Ok(None) => {}
         Err(e) => {
             eprintln!("  Share failed: {e}");

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -532,12 +532,28 @@ fn bench_offer_worker(
         stored.len()
     )));
     match share::submit_stored(&stored, &token) {
-        Ok(pr_url) => {
+        Ok(outcome) => {
             share::mark_shared(&stored);
+            let mut notes: Vec<String> = Vec::new();
+            if outcome.reused_existing_pr {
+                notes.push(format!(
+                    "Added {} result(s) to your open benchmark PR.",
+                    outcome.uploaded
+                ));
+            }
+            if outcome.skipped > 0 {
+                notes.push(format!(
+                    "{} previously submitted result(s) skipped.",
+                    outcome.skipped
+                ));
+            }
+            if outcome.pr_url.is_none() {
+                notes.push("All results were already contributed upstream.".to_string());
+            }
             let _ = tx.send(BenchOfferMsg::Done {
                 summary,
-                pr_url: Some(pr_url),
-                share_note: None,
+                pr_url: outcome.pr_url,
+                share_note: (!notes.is_empty()).then(|| notes.join(" ")),
             });
         }
         Err(e) => {

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -427,6 +427,26 @@ fn bench_offer_worker(
         .trim_end_matches(".gguf")
         .to_string();
 
+    // Resolve and verify GitHub credentials BEFORE the benchmark runs, so a
+    // missing or expired token (or the device-flow prompt) surfaces while the
+    // user is still watching — not after minutes of benching. A credential
+    // problem never aborts the bench: it downgrades to save-locally.
+    let mut share_note: Option<String> = None;
+    let share_token: Option<String> = if share {
+        let _ = tx.send(BenchOfferMsg::Progress(
+            "Checking GitHub credentials...".into(),
+        ));
+        match tui_share_auth(tx) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                share_note = Some(format!("Share skipped: {e}"));
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let progress_tx = tx.clone();
     let tag_for_progress = display_tag.clone();
     let on_progress = move |i: usize, total: usize| {
@@ -478,79 +498,42 @@ fn bench_offer_worker(
         provider,
     );
 
-    if !share {
+    // Always record the run locally; sharing (now or later) uploads from the
+    // pending store, so declining to share never discards the result.
+    let store_err = share::store_local(std::slice::from_ref(&result), specs).err();
+
+    let Some(token) = share_token else {
+        let mut note = share_note.unwrap_or_default();
+        if !note.is_empty() {
+            note.push(' ');
+        }
+        match store_err {
+            None => {
+                let pending = share::pending_benchmarks().len();
+                note.push_str(&format!(
+                    "Saved locally ({pending} pending) — share any time with \
+                     `llmfit bench --share`."
+                ));
+            }
+            Some(e) => note.push_str(&format!("Warning: could not save result locally: {e}")),
+        }
         let _ = tx.send(BenchOfferMsg::Done {
             summary,
             pr_url: None,
-            share_note: None,
+            share_note: Some(note),
         });
         return;
-    }
-
-    // Share flow: cached/env token first, then interactive device flow with
-    // the code rendered inside the modal.
-    let _ = tx.send(BenchOfferMsg::Progress("Sharing with llmfit...".into()));
-    let token = match share::resolve_token_noninteractive() {
-        Some(t) => t,
-        None => {
-            let Some(client_id) = share::oauth_client_id() else {
-                let _ = tx.send(BenchOfferMsg::Done {
-                    summary,
-                    pr_url: None,
-                    share_note: Some(
-                        "Share skipped: no GitHub token. Set GITHUB_TOKEN or run \
-                         `llmfit bench --share` once to log in."
-                            .into(),
-                    ),
-                });
-                return;
-            };
-            let auth = match share::device_flow_start(&client_id) {
-                Ok(a) => a,
-                Err(e) => {
-                    let _ = tx.send(BenchOfferMsg::Done {
-                        summary,
-                        pr_url: None,
-                        share_note: Some(format!("Share skipped: {}", e)),
-                    });
-                    return;
-                }
-            };
-            let _ = tx.send(BenchOfferMsg::AuthCode {
-                user_code: auth.user_code.clone(),
-                verification_uri: auth.verification_uri.clone(),
-            });
-            let mut interval = auth.interval;
-            loop {
-                thread::sleep(std::time::Duration::from_secs(interval + 1));
-                match share::device_flow_poll(&client_id, &auth.device_code) {
-                    Ok(share::DevicePoll::Token(t)) => {
-                        let _ = share::cache_token(&t);
-                        break t;
-                    }
-                    Ok(share::DevicePoll::Pending) => continue,
-                    Ok(share::DevicePoll::SlowDown) => {
-                        interval += 5;
-                        continue;
-                    }
-                    Ok(share::DevicePoll::Failed(e)) | Err(e) => {
-                        let _ = tx.send(BenchOfferMsg::Done {
-                            summary,
-                            pr_url: None,
-                            share_note: Some(format!("Share skipped: {}", e)),
-                        });
-                        return;
-                    }
-                }
-            }
-        }
     };
 
-    let _ = tx.send(BenchOfferMsg::Progress(
-        "Opening pull request on GitHub...".into(),
-    ));
-    match share::submit_results(std::slice::from_ref(&result), specs, &token) {
+    // Upload the entire pending store: this run plus anything stored earlier.
+    let stored = share::pending_benchmarks();
+    let _ = tx.send(BenchOfferMsg::Progress(format!(
+        "Opening pull request on GitHub ({} submission(s))...",
+        stored.len()
+    )));
+    match share::submit_stored(&stored, &token) {
         Ok(pr_url) => {
+            share::mark_shared(&stored);
             let _ = tx.send(BenchOfferMsg::Done {
                 summary,
                 pr_url: Some(pr_url),
@@ -561,8 +544,59 @@ fn bench_offer_worker(
             let _ = tx.send(BenchOfferMsg::Done {
                 summary,
                 pr_url: None,
-                share_note: Some(format!("Share failed: {}", e)),
+                share_note: Some(format!(
+                    "Share failed: {e}. Results remain stored locally — retry with \
+                     `llmfit bench --share`."
+                )),
             });
+        }
+    }
+}
+
+/// Resolve a *validated* GitHub token for the TUI share flow: env or cached
+/// token (verified against the API), falling back to the device flow with the
+/// code rendered inside the modal. Runs before the benchmark so credential
+/// problems surface immediately.
+fn tui_share_auth(tx: &mpsc::Sender<BenchOfferMsg>) -> Result<String, String> {
+    use llmfit_core::share;
+
+    if let Some((token, source)) = share::resolve_token_noninteractive_with_source() {
+        match share::validate_token(&token) {
+            Ok(Some(_login)) => return Ok(token),
+            Ok(None) => match source {
+                share::TokenSource::Env => {
+                    return Err("GITHUB_TOKEN/GH_TOKEN is invalid or expired.".into());
+                }
+                // Stale cached login — drop it and fall through to a fresh
+                // device-flow authorization.
+                share::TokenSource::Cache => share::clear_cached_token(),
+            },
+            Err(e) => return Err(format!("could not reach GitHub: {e}.")),
+        }
+    }
+
+    let Some(client_id) = share::oauth_client_id() else {
+        return Err("no GitHub token. Set GITHUB_TOKEN or GH_TOKEN.".into());
+    };
+    let auth = share::device_flow_start(&client_id)?;
+    let _ = tx.send(BenchOfferMsg::AuthCode {
+        user_code: auth.user_code.clone(),
+        verification_uri: auth.verification_uri.clone(),
+    });
+    let mut interval = auth.interval;
+    loop {
+        thread::sleep(std::time::Duration::from_secs(interval + 1));
+        match share::device_flow_poll(&client_id, &auth.device_code) {
+            Ok(share::DevicePoll::Token(t)) => {
+                let _ = share::cache_token(&t);
+                return Ok(t);
+            }
+            Ok(share::DevicePoll::Pending) => continue,
+            Ok(share::DevicePoll::SlowDown) => {
+                interval += 5;
+                continue;
+            }
+            Ok(share::DevicePoll::Failed(e)) | Err(e) => return Err(e),
         }
     }
 }
@@ -1009,6 +1043,12 @@ pub struct App {
     // Bench-offer modal (benchmark the selected model, optionally share as PR)
     pub bench_offer_state: BenchOfferState,
     pub bench_offer_share: bool,
+    /// Locally stored submissions that a share would also upload.
+    pub bench_offer_pending: usize,
+    /// Why sharing cannot work right now (no token and no OAuth client id);
+    /// `None` when sharing is possible. Checked when the modal opens so the
+    /// user learns about missing credentials before benchmarking.
+    pub bench_offer_share_unavailable: Option<String>,
     /// HF-style name of the model being offered for benchmark.
     pub bench_offer_model: String,
     /// Providers that have the model installed (display names).
@@ -1468,6 +1508,8 @@ impl App {
             // Bench-offer modal
             bench_offer_state: BenchOfferState::Offer,
             bench_offer_share: false,
+            bench_offer_pending: 0,
+            bench_offer_share_unavailable: None,
             bench_offer_model: String::new(),
             bench_offer_providers: Vec::new(),
             bench_offer_progress: String::new(),
@@ -2320,6 +2362,17 @@ impl App {
                 self.bench_offer_state = BenchOfferState::Offer;
                 self.bench_offer_model = name;
                 self.bench_offer_providers = providers;
+                self.bench_offer_pending = llmfit_core::share::pending_benchmarks().len();
+                // Cheap offline check (env var + cached-token file) so the
+                // modal can flag missing credentials before a bench starts.
+                self.bench_offer_share_unavailable =
+                    if llmfit_core::share::resolve_token_noninteractive().is_some()
+                        || llmfit_core::share::oauth_client_id().is_some()
+                    {
+                        None
+                    } else {
+                        Some("no GitHub credentials (set GITHUB_TOKEN)".to_string())
+                    };
                 self.bench_offer_progress = String::new();
                 self.bench_offer_auth = None;
                 self.bench_offer_summary = None;
@@ -2330,9 +2383,16 @@ impl App {
             }
         }
 
-        // Fetch if we don't have data yet
-        if self.bench_entries.is_empty() && !self.bench_loading {
+        // Fetch if we have no server data yet (pinned local rows don't count)
+        let has_server_rows = self
+            .bench_entries
+            .iter()
+            .any(|e| !e.id.starts_with("local:"));
+        if !has_server_rows && !self.bench_loading {
             self.fetch_benchmarks();
+        } else {
+            // Cached board — still refresh the pinned local rows.
+            self.merge_local_bench_rows();
         }
     }
 
@@ -2342,7 +2402,12 @@ impl App {
     }
 
     /// Toggle the "share with llmfit" checkbox in the bench-offer modal.
+    /// A no-op when sharing is unavailable (the modal shows why).
     pub fn bench_offer_toggle_share(&mut self) {
+        if self.bench_offer_share_unavailable.is_some() {
+            self.bench_offer_share = false;
+            return;
+        }
         self.bench_offer_share = !self.bench_offer_share;
     }
 
@@ -2381,7 +2446,12 @@ impl App {
         if let Some(rx) = &self.bench_offer_rx {
             while let Ok(msg) = rx.try_recv() {
                 match msg {
-                    BenchOfferMsg::Progress(s) => self.bench_offer_progress = s,
+                    BenchOfferMsg::Progress(s) => {
+                        // Any progress after the auth prompt means the device
+                        // flow completed — stop showing the code.
+                        self.bench_offer_auth = None;
+                        self.bench_offer_progress = s;
+                    }
                     BenchOfferMsg::AuthCode {
                         user_code,
                         verification_uri,
@@ -2411,6 +2481,78 @@ impl App {
         }
         if finished {
             self.bench_offer_rx = None;
+            // The worker stored (and possibly shared) a new local result —
+            // refresh the local rows pinned to the leaderboard behind the modal.
+            self.merge_local_bench_rows();
+        }
+    }
+
+    /// Rebuild the "your local results" rows pinned at the top of the
+    /// leaderboard: stored submissions (pending and already shared) rendered
+    /// as `local:`-prefixed entries attributed to "you". Skipped while
+    /// browsing a hardware preset other than this machine.
+    pub fn merge_local_bench_rows(&mut self) {
+        use llmfit_core::benchmarks::{
+            LeaderboardEngine, LeaderboardEntry, LeaderboardModel, LeaderboardUser,
+        };
+
+        self.bench_entries.retain(|e| !e.id.starts_with("local:"));
+        if self.bench_hw_label.is_some() {
+            return;
+        }
+
+        let mut local: Vec<LeaderboardEntry> = Vec::new();
+        let stores = [
+            ("you (local)", llmfit_core::share::pending_benchmarks()),
+            ("you (shared)", llmfit_core::share::shared_benchmarks()),
+        ];
+        for (who, stored) in &stores {
+            for s in stored {
+                let Some(results) = s.payload["results"].as_array() else {
+                    continue;
+                };
+                for (i, r) in results.iter().enumerate() {
+                    local.push(LeaderboardEntry {
+                        id: format!("local:{}:{i}", s.path.display()),
+                        tok_s_out: r["avgTps"].as_f64(),
+                        tok_s_total: None,
+                        ttft_ms: r["avgTtftMs"].as_f64(),
+                        context_length: None,
+                        batch_size: None,
+                        peak_vram_gb: None,
+                        notes: None,
+                        model: Some(LeaderboardModel {
+                            hf_id: r["model"].as_str().unwrap_or("?").to_string(),
+                            display_name: None,
+                            family: None,
+                            params: None,
+                            is_mo_e: None,
+                        }),
+                        hardware: None,
+                        engine: Some(LeaderboardEngine {
+                            engine_name: r["provider"].as_str().unwrap_or("").to_string(),
+                            engine_version: None,
+                            quantization: String::new(),
+                            backend: None,
+                        }),
+                        engine_flags: None,
+                        user: Some(LeaderboardUser {
+                            username: Some((*who).to_string()),
+                            verified: None,
+                        }),
+                    });
+                }
+            }
+        }
+        if local.is_empty() {
+            return;
+        }
+        // Newest first, pinned above the fetched leaderboard.
+        local.reverse();
+        local.append(&mut self.bench_entries);
+        self.bench_entries = local;
+        if self.bench_cursor >= self.bench_entries.len() {
+            self.bench_cursor = self.bench_entries.len().saturating_sub(1);
         }
     }
 
@@ -2438,6 +2580,8 @@ impl App {
                 }
             }
         }
+        // Local results render even when the API is unreachable.
+        self.merge_local_bench_rows();
     }
 
     pub fn bench_move_up(&mut self) {
@@ -2540,6 +2684,7 @@ impl App {
                     }
                 }
             }
+            self.merge_local_bench_rows();
         }
 
         self.bench_cursor = 0;

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1173,7 +1173,7 @@ impl App {
         // Only analyze models that can actually run on this hardware.
         let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&specs);
         // The user's own `llmfit bench` runs trump community medians.
-        let local_index = llmfit_core::share::LocalBenchIndex::load();
+        let local_index = llmfit_core::share::LocalBenchIndex::load(&specs);
         let mut all_fits: Vec<ModelFit> = db
             .get_all_models()
             .iter()
@@ -1192,6 +1192,9 @@ impl App {
                 fit
             })
             .collect();
+
+        // Calibrate formula estimates from the user's own benchmark runs.
+        llmfit_core::analysis::apply_local_calibration(&mut all_fits);
 
         // Sort by fit level then RAM usage
         all_fits = llmfit_core::fit::rank_models_by_fit(all_fits);
@@ -2496,16 +2499,19 @@ impl App {
     /// Re-annotate fit rows with the latest local benchmark measurements so
     /// the main table's tok/s column reflects a just-finished bench without a
     /// restart. Only upgrades rows a local run matches; community-measured
-    /// values elsewhere are left alone.
+    /// values elsewhere are left alone. Estimate calibration is then
+    /// recomputed (idempotently) from the updated anchors.
     pub fn refresh_local_measured_tps(&mut self) {
-        let Some(idx) = llmfit_core::share::LocalBenchIndex::load() else {
-            return;
-        };
-        for fit in &mut self.all_fits {
-            if let Some(m) = idx.lookup(&fit.model.name) {
-                fit.measured_tps = Some(m);
+        // Same specs the fits were built with: under simulated hardware the
+        // stored runs won't match, so simulated estimates stay untouched.
+        if let Some(idx) = llmfit_core::share::LocalBenchIndex::load(&self.specs) {
+            for fit in &mut self.all_fits {
+                if let Some(m) = idx.lookup(&fit.model.name) {
+                    fit.measured_tps = Some(m);
+                }
             }
         }
+        llmfit_core::analysis::apply_local_calibration(&mut self.all_fits);
     }
 
     /// Rebuild the "your local results" rows pinned at the top of the

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -358,26 +358,7 @@ pub enum BenchOfferState {
 /// (".../gemma-3.Q8_0.gguf") get exact stem matching only — feeding a bare
 /// stem into the Ollama candidate heuristics would match whole families.
 fn bench_target_matches(target_model: &str, hf_name: &str) -> bool {
-    let lower = target_model.to_lowercase();
-
-    let mut tag_set = HashSet::new();
-    tag_set.insert(lower.clone());
-    if llmfit_core::providers::is_model_installed(hf_name, &tag_set) {
-        return true;
-    }
-
-    let stem = lower
-        .rsplit(['/', '\\'])
-        .next()
-        .unwrap_or(&lower)
-        .trim_end_matches(".gguf")
-        .to_string();
-    let mut stem_set = HashSet::new();
-    if let Some(base) = llmfit_core::providers::strip_gguf_quant_suffix(&stem) {
-        stem_set.insert(base);
-    }
-    stem_set.insert(stem);
-    llmfit_core::providers::is_model_installed_llamacpp(hf_name, &stem_set)
+    llmfit_core::providers::tag_matches_model(target_model, hf_name)
 }
 
 /// Body of the bench-offer worker thread: find the selected model on a running
@@ -1191,6 +1172,8 @@ impl App {
 
         // Only analyze models that can actually run on this hardware.
         let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&specs);
+        // The user's own `llmfit bench` runs trump community medians.
+        let local_index = llmfit_core::share::LocalBenchIndex::load();
         let mut all_fits: Vec<ModelFit> = db
             .get_all_models()
             .iter()
@@ -1198,9 +1181,14 @@ impl App {
             .map(|m| {
                 let mut fit = ModelFit::analyze_with_context_limit(m, &specs, context_limit);
                 fit.installed = installed.is_installed(&m.name);
-                fit.measured_tps = measured_index
+                fit.measured_tps = local_index
                     .as_ref()
-                    .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
+                    .and_then(|idx| idx.lookup(&m.name))
+                    .or_else(|| {
+                        measured_index
+                            .as_ref()
+                            .and_then(|idx| idx.lookup(&m.name, &fit.best_quant))
+                    });
                 fit
             })
             .collect();
@@ -2498,8 +2486,25 @@ impl App {
         if finished {
             self.bench_offer_rx = None;
             // The worker stored (and possibly shared) a new local result —
-            // refresh the local rows pinned to the leaderboard behind the modal.
+            // refresh the local rows pinned to the leaderboard behind the
+            // modal and the measured tok/s shown in the main table.
             self.merge_local_bench_rows();
+            self.refresh_local_measured_tps();
+        }
+    }
+
+    /// Re-annotate fit rows with the latest local benchmark measurements so
+    /// the main table's tok/s column reflects a just-finished bench without a
+    /// restart. Only upgrades rows a local run matches; community-measured
+    /// values elsewhere are left alone.
+    pub fn refresh_local_measured_tps(&mut self) {
+        let Some(idx) = llmfit_core::share::LocalBenchIndex::load() else {
+            return;
+        };
+        for fit in &mut self.all_fits {
+            if let Some(m) = idx.lookup(&fit.model.name) {
+                fit.measured_tps = Some(m);
+            }
         }
     }
 

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -3495,7 +3495,7 @@ fn draw_bench_offer_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
             }
             if let Some(url) = &app.bench_offer_pr_url {
                 lines.push(Line::from(vec![
-                    Span::styled("  PR opened: ", Style::default().fg(tc.fg)),
+                    Span::styled("  Results PR: ", Style::default().fg(tc.fg)),
                     Span::styled(url.clone(), Style::default().fg(tc.accent)),
                 ]));
             }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -3411,22 +3411,48 @@ fn draw_bench_offer_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
 
     match app.bench_offer_state {
         BenchOfferState::Offer => {
-            let (mark, mark_style) = if app.bench_offer_share {
-                (
-                    "[x]",
-                    Style::default().fg(tc.good).add_modifier(Modifier::BOLD),
-                )
-            } else {
-                ("[ ]", Style::default().fg(tc.muted))
-            };
-            lines.push(Line::from(vec![
-                Span::styled(format!("  {mark} "), mark_style),
-                Span::styled("Share with llmfit ", Style::default().fg(tc.fg)),
-                Span::styled(
-                    "(opens a PR with your results)",
+            if let Some(reason) = &app.bench_offer_share_unavailable {
+                lines.push(Line::from(vec![
+                    Span::styled("  [-] ", Style::default().fg(tc.muted)),
+                    Span::styled("Share with llmfit ", Style::default().fg(tc.muted)),
+                    Span::styled(
+                        format!("(unavailable: {reason})"),
+                        Style::default().fg(tc.warning),
+                    ),
+                ]));
+                lines.push(Line::from(Span::styled(
+                    "      Results are saved locally for sharing later",
                     Style::default().fg(tc.muted),
-                ),
-            ]));
+                )));
+            } else {
+                let (mark, mark_style) = if app.bench_offer_share {
+                    (
+                        "[x]",
+                        Style::default().fg(tc.good).add_modifier(Modifier::BOLD),
+                    )
+                } else {
+                    ("[ ]", Style::default().fg(tc.muted))
+                };
+                let desc = if app.bench_offer_pending > 0 {
+                    format!(
+                        "(one PR: this run + {} stored local result(s))",
+                        app.bench_offer_pending
+                    )
+                } else {
+                    "(opens a PR with your results)".to_string()
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(format!("  {mark} "), mark_style),
+                    Span::styled("Share with llmfit ", Style::default().fg(tc.fg)),
+                    Span::styled(desc, Style::default().fg(tc.muted)),
+                ]));
+                if !app.bench_offer_share {
+                    lines.push(Line::from(Span::styled(
+                        "      Off: results are saved locally for sharing later",
+                        Style::default().fg(tc.muted),
+                    )));
+                }
+            }
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 "  [Enter] Run   [Space] Toggle share   [Esc] Skip",
@@ -4321,7 +4347,11 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
         return;
     }
 
-    if let Some(ref err) = app.bench_error {
+    // Full-page error only when there is nothing to show — cached data and
+    // locally stored results still render, with the error in the summary line.
+    if let Some(ref err) = app.bench_error
+        && app.bench_entries.is_empty()
+    {
         let err_text = Paragraph::new(vec![
             Line::from(Span::styled(
                 "  Failed to fetch benchmarks:",
@@ -4370,15 +4400,29 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
             .unwrap_or(&app.specs.cpu_name)
             .to_string()
     };
-    let summary = Line::from(vec![
+    let local_count = app
+        .bench_entries
+        .iter()
+        .filter(|e| e.id.starts_with("local:"))
+        .count();
+    let counts = if local_count > 0 {
+        format!("  ({} results, {} yours)", app.bench_total, local_count)
+    } else {
+        format!("  ({} results)", app.bench_total)
+    };
+    let mut summary_spans = vec![
         Span::styled("  Hardware: ", Style::default().fg(tc.muted)),
         Span::styled(&hw_desc, Style::default().fg(tc.fg).bold()),
-        Span::styled(
-            format!("  ({} results)", app.bench_total),
-            Style::default().fg(tc.muted),
-        ),
+        Span::styled(counts, Style::default().fg(tc.muted)),
         Span::styled("  H:change GPU", Style::default().fg(tc.accent)),
-    ]);
+    ];
+    if let Some(ref err) = app.bench_error {
+        summary_spans.push(Span::styled(
+            format!("  ⚠ {}", err),
+            Style::default().fg(tc.warning),
+        ));
+    }
+    let summary = Line::from(summary_spans);
 
     // Table header
     let header_cells = [
@@ -4444,6 +4488,7 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
                 .map(|v| format!("{}", v))
                 .unwrap_or_default();
 
+            let is_local = entry.id.starts_with("local:");
             let verified_marker = if entry.verified() { " *" } else { "" };
             let user = format!("{}{}", entry.username(), verified_marker);
 
@@ -4465,7 +4510,12 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
                 Cell::from(ttft),
                 Cell::from(vram),
                 Cell::from(ctx),
-                Cell::from(user),
+                if is_local {
+                    // Your own stored results, pinned above the fetched board.
+                    Cell::from(user).style(Style::default().fg(tc.accent))
+                } else {
+                    Cell::from(user)
+                },
             ])
             .style(style)
         })

--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -15,6 +15,7 @@ import argparse
 import concurrent.futures
 import json
 import os
+import re
 import sys
 import time
 import urllib.request
@@ -923,6 +924,9 @@ def _detect_format_from_name(repo_id: str) -> tuple[str, str]:
 
 def scrape_model(repo_id: str) -> dict | None:
     """Scrape a single model and return an LlmModel-compatible dict."""
+    if is_test_stub(repo_id):
+        print(f"  ⚠ Skipping test stub {repo_id}", file=sys.stderr)
+        return None
     info = fetch_model_info(repo_id)
     if not info:
         return None
@@ -1305,6 +1309,20 @@ SKIP_ORGS = {
     "trl-internal-testing",   # Test fixtures
 }
 
+# Markers of CI/test-stub repos: randomly initialized micro-models that look
+# like real model families by name (e.g. `tiny-random/gemma-3` is 9M params).
+# They poison installed-detection and throughput estimates, so they never
+# belong in the catalog regardless of download counts.
+TEST_STUB_MARKERS = ("tiny-random", "tiny-dummy", "-random-init", "ci-random-")
+
+
+def is_test_stub(repo_id: str) -> bool:
+    rid = repo_id.lower()
+    if any(marker in rid for marker in TEST_STUB_MARKERS):
+        return True
+    name = rid.split("/")[-1]
+    return name.startswith(("test-", "testing-", "test_")) or bool(re.match(r"^test\d", name))
+
 # Sort strategies to query — results are merged and deduplicated.
 # Each strategy surfaces models that the others might miss.
 DISCOVER_SORT_STRATEGIES = [
@@ -1408,6 +1426,10 @@ def _process_listing(
         stats["skip_org"] += 1
         return None
 
+    if is_test_stub(repo_id):
+        stats["skip_test_stub"] += 1
+        return None
+
     downloads_raw = m.get("downloads")
     downloads = downloads_raw or 0
     if downloads < min_downloads and (require_downloads_floor or downloads_raw is not None):
@@ -1491,6 +1513,7 @@ def discover_trending_models(limit: int = 30, min_downloads: int = 10000) -> lis
         "skip_curated": 0,
         "skip_duplicate": 0,
         "skip_org": 0,
+        "skip_test_stub": 0,
         "skip_downloads": 0,
         "skip_tags": 0,
         "skip_no_params": 0,


### PR DESCRIPTION
Follow-ups to #712 that landed on the branch after it was merged this morning (4 commits, 10:33–11:07).

## What's in here

### 1. Local benchmark store — bench now, share later
Every successful bench run is saved locally as a ready-to-upload, schema-valid submission payload (`~/.local/share/llmfit/benchmarks/pending/`, `LLMFIT_BENCH_STORE` to override). Sharing uploads the **whole pending store** in one PR; uploaded files move to `shared/` (kept as history, never re-sent). Bare `llmfit bench --share` uploads the backlog without benchmarking. A failed upload leaves everything pending — a network hiccup can't lose a run.

### 2. Credential pre-flight
With share enabled, the GitHub token is resolved **and validated against the API** before any benchmark starts: CLI fails in seconds on a missing/expired token; the TUI runs the device flow up front and downgrades to save-locally with a note. Stale cached tokens are discarded and re-acquired; an invalid explicit `GITHUB_TOKEN` is a hard error.

### 3. No duplicate submissions
An already-open `bench/*` PR is reused (results appended) instead of opening one PR per run. Upstream file names mirror the local store entry, so retries after partial failures are idempotent (GitHub's 422-on-existing-path is the check). `submit_stored` returns a `SubmitOutcome`; CLI/TUI report opened / appended / already-contributed distinctly.

### 4. Local results in the UI
Stored runs render pinned at the top of the TUI leaderboard as `you (local)` / `you (shared)` — including when the API is unreachable (full-page fetch error now only shows when there are no rows, which also un-breaks the embedded-cache fallback).

### 5. Local runs override the estimated tok/s
Fit rows consult the local store first: your measurement outranks community medians, which outrank the formula estimate (existing ✓-marked `measured_tps` path; refreshes live after an in-TUI bench). Gated by a hardware fingerprint so runs from a previous machine configuration don't leak.

### 6. Estimate calibration from your own benchmarks
Anchored on locally-benched real catalog models (≥ 1B params, dense): the median measured/estimated ratio (clamped to [0.05, 3.0]) scales every row's estimate, recorded in `estimate_basis.local_calibration` and shown in the estimate-basis detail. Idempotent application.

### 7. Catalog hygiene: 100 test stubs purged
`tiny-random/*`, `tiny-dummy`, `ci-random-*`, `test-*`/`testing-*` repos removed from `hf_models.json`, and the scraper now skips them at discovery + scrape time. Root cause of the motivating bug: a local `gemma-3.Q8_0.gguf` matched the `tiny-random/gemma-3` stub (9M params) and produced an 880 tok/s estimate for a 2.5B model that measures 3.8 tok/s.

## Testing
- 508 tests pass (`cargo test -p llmfit-core -p llmfit`); fmt/clippy clean
- Verified live: store→dry-run→confirm flows, fail-fast preflight, local rows on the leaderboard, 3.8 tok/s override on the real store, calibration factor ×0.37 from a synthetic anchor, zero stub rows post-purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
