### PR TITLE
ci: validate community benchmark submissions

### DIFF
--- a/.github/workflows/community-benchmarks.yml
+++ b/.github/workflows/community-benchmarks.yml
@@ -1,0 +1,40 @@
+name: Community Benchmarks
+
+# Validates benchmark submissions contributed via `llmfit bench --share`
+# (PRs adding files under llmfit-core/data/community/): JSON schema
+# conformance, path/naming conventions, and cross-field sanity checks.
+
+'on':
+  pull_request:
+    paths:
+      - 'llmfit-core/data/community/**'
+  push:
+    branches: [main]
+    paths:
+      - 'llmfit-core/data/community/**'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate submissions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install jsonschema
+        run: pip install jsonschema
+
+      # Validates the whole directory, not just changed files: repo-wide
+      # integrity is the invariant, and the directory stays small.
+      - name: Validate community submissions
+        run: python3 scripts/validate_community_benchmarks.py

--- a/llmfit-core/data/community/README.md
+++ b/llmfit-core/data/community/README.md
@@ -37,6 +37,15 @@ an open benchmark PR, new results are appended to it (instead of opening
 another PR), and a retry after a partial failure skips files that already
 landed rather than duplicating them.
 
+## Validation
+
+Every PR touching this directory runs the **Community Benchmarks** workflow
+(`scripts/validate_community_benchmarks.py`): schema conformance against
+[`schema.json`](./schema.json), path/naming conventions, and cross-field
+sanity checks (tps ordering, plausible hardware bounds, submission
+timestamps). Hand-crafted submissions are welcome as long as they pass the
+same checks the generated ones do.
+
 ## Format
 
 Each file conforms to [`schema.json`](./schema.json). Example:

--- a/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1783676393-31f19579.json
+++ b/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1783676393-31f19579.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1783676393,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.0.1"
+  },
+  "hardware": {
+    "hwClass": "UNIFIED",
+    "hardwareName": "Intel Arc Graphics 130V/140V (integrated)",
+    "memTierGb": 32,
+    "vramGb": 30.82,
+    "gpuCount": 1,
+    "unifiedMemory": true,
+    "cpu": "Intel(R) Core(TM) Ultra 7 258V",
+    "cpuCores": 8,
+    "ramGb": 30.82,
+    "os": "linux"
+  },
+  "results": [
+    {
+      "model": "/home/axjns/.cache/llmfit/models/gemma-3.Q8_0.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 3.8,
+      "minTps": 3.68,
+      "maxTps": 3.97,
+      "avgTtftMs": null,
+      "avgTotalMs": 48968.34,
+      "avgOutputTokens": 182.67
+    }
+  ]
+}

--- a/scripts/validate_community_benchmarks.py
+++ b/scripts/validate_community_benchmarks.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Validate community benchmark submissions (llmfit-core/data/community/).
+
+Run by CI on every PR touching the community data directory, and runnable
+locally:
+
+    python3 scripts/validate_community_benchmarks.py            # all files
+    python3 scripts/validate_community_benchmarks.py FILE...    # specific files
+
+Checks, per file:
+  1. Path conventions — `community/<hardware-slug>/<timestamp>-<hash>.json`
+     with a lowercase alphanumeric-dash slug (what `llmfit bench --share`
+     generates; anything else is hand-crafted and gets a closer look).
+  2. Size cap — a submission is a few KB; anything large is not a benchmark.
+  3. Valid JSON that conforms to community/schema.json (draft-07).
+  4. Cross-field sanity the schema cannot express: minTps <= avgTps <= maxTps,
+     plausible hardware bounds, and a submission timestamp that is neither
+     before the feature existed nor in the future.
+
+Exit code 0 when every file passes; 1 with one line per problem otherwise.
+
+Requires: jsonschema (`pip install jsonschema`).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+import jsonschema
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMMUNITY_DIR = REPO_ROOT / "llmfit-core" / "data" / "community"
+SCHEMA_PATH = COMMUNITY_DIR / "schema.json"
+
+MAX_FILE_BYTES = 64 * 1024
+MAX_RESULTS_PER_FILE = 100
+
+# `bench --share` names files after the local store entry: unix timestamp +
+# 8-hex content hash (an optional -<n> suffix appeared in early builds).
+FILENAME_RE = re.compile(r"^\d{9,12}-[0-9a-f]{8}(-\d+)?\.json$")
+SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# The share feature shipped in July 2026; nothing genuine predates it.
+MIN_SUBMITTED_AT = 1_782_864_000  # 2026-07-01 00:00:00 UTC
+FUTURE_SLACK_SECS = 24 * 3600
+
+# Upper bounds that the schema leaves open. Generous on purpose: these catch
+# nonsense (a 4 TB GPU, a million-core CPU), not exotic-but-real hardware.
+MAX_RAM_GB = 8192
+MAX_VRAM_GB = 2048
+MAX_CPU_CORES = 1024
+MAX_GPU_COUNT = 64
+
+
+def check_file(path: Path, validator: jsonschema.Draft7Validator) -> list[str]:
+    problems: list[str] = []
+    rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+
+    def bad(msg: str) -> None:
+        problems.append(f"{rel}: {msg}")
+
+    # 1. Path conventions.
+    if path.parent.parent != COMMUNITY_DIR:
+        bad("must live directly under community/<hardware-slug>/")
+    else:
+        slug = path.parent.name
+        if not SLUG_RE.match(slug):
+            bad(f"hardware slug {slug!r} must be lowercase alphanumeric-dash")
+    if not FILENAME_RE.match(path.name):
+        bad(f"file name {path.name!r} must match <unix-timestamp>-<hash>.json")
+
+    # 2. Size cap.
+    size = path.stat().st_size
+    if size > MAX_FILE_BYTES:
+        bad(f"file is {size} bytes (cap {MAX_FILE_BYTES}); not a benchmark submission")
+        return problems
+
+    # 3. JSON + schema.
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        bad(f"not valid JSON: {e}")
+        return problems
+    schema_errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.path))
+    for err in schema_errors:
+        where = "/".join(str(p) for p in err.path) or "(root)"
+        bad(f"schema violation at {where}: {err.message}")
+    if schema_errors:
+        return problems
+
+    # 4. Cross-field sanity.
+    submitted = payload["submittedAtUnix"]
+    if submitted < MIN_SUBMITTED_AT:
+        bad(f"submittedAtUnix {submitted} predates the share feature (min {MIN_SUBMITTED_AT})")
+    if submitted > time.time() + FUTURE_SLACK_SECS:
+        bad(f"submittedAtUnix {submitted} is in the future")
+
+    hw = payload["hardware"]
+    if hw["ramGb"] > MAX_RAM_GB:
+        bad(f"ramGb {hw['ramGb']} exceeds sanity cap {MAX_RAM_GB}")
+    if (hw.get("vramGb") or 0) > MAX_VRAM_GB:
+        bad(f"vramGb {hw['vramGb']} exceeds sanity cap {MAX_VRAM_GB}")
+    if hw["cpuCores"] > MAX_CPU_CORES:
+        bad(f"cpuCores {hw['cpuCores']} exceeds sanity cap {MAX_CPU_CORES}")
+    if hw["gpuCount"] > MAX_GPU_COUNT:
+        bad(f"gpuCount {hw['gpuCount']} exceeds sanity cap {MAX_GPU_COUNT}")
+
+    results = payload["results"]
+    if len(results) > MAX_RESULTS_PER_FILE:
+        bad(f"{len(results)} results in one submission (cap {MAX_RESULTS_PER_FILE})")
+    for i, r in enumerate(results):
+        if not r["minTps"] <= r["avgTps"] <= r["maxTps"]:
+            bad(
+                f"results[{i}] ({r['model']}): tps ordering violated "
+                f"(min {r['minTps']}, avg {r['avgTps']}, max {r['maxTps']})"
+            )
+        if r["avgTps"] <= 0:
+            bad(f"results[{i}] ({r['model']}): avgTps must be positive")
+
+    return problems
+
+
+def main() -> int:
+    if len(sys.argv) > 1:
+        files = [Path(a).resolve() for a in sys.argv[1:]]
+    else:
+        files = sorted(
+            p for p in COMMUNITY_DIR.rglob("*.json") if p != SCHEMA_PATH
+        )
+
+    if not files:
+        print("no community submissions to validate")
+        return 0
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft7Validator.check_schema(schema)
+    validator = jsonschema.Draft7Validator(schema)
+
+    problems: list[str] = []
+    for f in files:
+        if not f.exists():
+            # A PR that deletes/moves a file passes paths of removed entries.
+            continue
+        problems.extend(check_file(f, validator))
+
+    if problems:
+        print(f"❌ {len(problems)} problem(s) across {len(files)} file(s):")
+        for p in problems:
+            print(f"  {p}")
+        return 1
+    print(f"✅ {len(files)} community submission(s) valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the CI-validation follow-up named in #712.

## What it does

New **Community Benchmarks** workflow runs on any PR touching `llmfit-core/data/community/` (and on push to main), executing `scripts/validate_community_benchmarks.py`:

- **Schema**: every submission validates against `community/schema.json` (draft-07)
- **Conventions**: `community/<hardware-slug>/<unix-timestamp>-<hash>.json` — lowercase slug, generated-style file names
- **Size caps**: 64 KB/file, ≤ 100 results/file
- **Cross-field sanity** the schema can't express: `minTps ≤ avgTps ≤ maxTps`, positive throughput, plausible hardware bounds (RAM ≤ 8 TB, VRAM ≤ 2 TB, ≤ 1024 cores, ≤ 64 GPUs), and submission timestamps within the feature's lifetime (post 2026-07-01, not in the future)

Whole-directory validation on every touch, so repo-wide integrity is the invariant.

## Seed data

Includes the first genuine community submission (Intel Arc 140V / Core Ultra 7 258V, gemma-3 Q8 via llama-server, 3.8 tok/s — previously attempted in #713/#716), which makes this PR exercise its own workflow.

## Tested

- Real submission passes; empty directory passes
- Six failure modes verified locally with precise per-file messages: bad slug, bad file name, stale timestamp, tps-ordering violation, two schema violations (invalid os / provider enum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)