### PR TITLE
chore: release-please — patch bumps by default (next release 1.1.1)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
       "tag-separator": "",
       "include-v-in-tag": true,
       "changelog-path": "CHANGELOG.md",
-      "versioning": "default",
+      "versioning": "always-bump-patch",
       "extra-files": [
         {
           "type": "toml",


### PR DESCRIPTION
Per Alex: slow the version cadence now that 1.1.0 is out. `versioning: always-bump-patch` makes every release-please release a patch bump (1.1.1, 1.1.2, …) regardless of commit types; minor/major become deliberate calls via a `Release-As:` footer (the same mechanism used to cut 1.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)