### PR TITLE
feat(bench): ship merged community benchmarks to every user in the next release

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,6 +134,14 @@ TUI — offers to contribute **all** stored benchmarks in a single PR; uploaded
 files move to `.../benchmarks/shared/` so they are kept as history but never
 submitted twice.
 
+**Merged submissions ship in the next release.** Community files are embedded
+into the binary at build time, so anyone on identical hardware (same CPU +
+GPU) sees them on the benchmark page as `llmfit community` rows, gets
+measured ✓ tok/s for those models, and gets calibrated estimates everywhere
+else — a fresh install benefits before its user ever runs a benchmark. Trust
+order everywhere: your own runs > llmfit community on identical hardware >
+localmaxxing medians on matching presets > formula estimate.
+
 Authentication uses the GitHub **device flow** (the same mechanism
 `gh auth login` uses): llmfit prints a short code and a URL, you approve it in
 your browser once, and the token is cached under `~/.config/llmfit/` for next

--- a/llmfit-core/Cargo.toml
+++ b/llmfit-core/Cargo.toml
@@ -23,5 +23,8 @@ sysinfo = "0.39"
 ureq = { version = "3.2", features = ["json"] }
 which = "8.0.2"
 
+[build-dependencies]
+serde_json = "1.0"
+
 [dev-dependencies]
 jsonschema = { version = "0.46", default-features = false }

--- a/llmfit-core/build.rs
+++ b/llmfit-core/build.rs
@@ -1,0 +1,58 @@
+//! Aggregate community benchmark submissions (data/community/<slug>/*.json)
+//! into a single JSON array embedded in the binary. This is what closes the
+//! contribution loop: a submission merged into the repo ships to every user
+//! in the next release, with no CI step or network fetch involved.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-changed=data/community");
+
+    let community_dir = Path::new("data/community");
+    let mut files: Vec<PathBuf> = Vec::new();
+    if let Ok(entries) = fs::read_dir(community_dir) {
+        for entry in entries.flatten() {
+            let slug_dir = entry.path();
+            if !slug_dir.is_dir() {
+                continue; // README.md, schema.json
+            }
+            if let Ok(subs) = fs::read_dir(&slug_dir) {
+                for sub in subs.flatten() {
+                    let p = sub.path();
+                    if p.extension().and_then(|e| e.to_str()) == Some("json") {
+                        files.push(p);
+                    }
+                }
+            }
+        }
+    }
+    // Deterministic embed order regardless of directory iteration order.
+    files.sort();
+
+    let mut payloads: Vec<serde_json::Value> = Vec::new();
+    for f in &files {
+        let Ok(text) = fs::read_to_string(f) else {
+            println!(
+                "cargo:warning=community submission unreadable, skipped: {}",
+                f.display()
+            );
+            continue;
+        };
+        match serde_json::from_str::<serde_json::Value>(&text) {
+            Ok(v) => payloads.push(v),
+            // CI validates submissions on PR; a bad file here should never
+            // happen, but a warning beats breaking every build.
+            Err(e) => println!(
+                "cargo:warning=community submission invalid JSON, skipped: {}: {e}",
+                f.display()
+            ),
+        }
+    }
+
+    let out = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR set by cargo"))
+        .join("community_benchmarks.json");
+    let json = serde_json::to_string(&payloads).expect("serialize community aggregate");
+    fs::write(&out, json).expect("write community aggregate");
+}

--- a/llmfit-core/data/community/README.md
+++ b/llmfit-core/data/community/README.md
@@ -37,6 +37,18 @@ an open benchmark PR, new results are appended to it (instead of opening
 another PR), and a retry after a partial failure skips files that already
 landed rather than duplicating them.
 
+## What happens after merge
+
+Submissions are aggregated by `llmfit-core/build.rs` and **embedded into the
+binary**, so every merged submission ships in the next release. Users on
+identical hardware (same CPU + GPU) then get:
+
+- your runs on their **benchmark page**, attributed `llmfit community`
+- **measured ✓ tok/s** in the fit table for the models you benched
+  (below their own local runs, above localmaxxing medians and estimates)
+- **calibrated estimates** for every other model, anchored on your runs —
+  a fresh install benefits before its user ever benchmarks anything
+
 ## Validation
 
 Every PR touching this directory runs the **Community Benchmarks** workflow

--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -147,11 +147,12 @@ pub fn build_model_fits(
 ) -> Vec<ModelFit> {
     use crate::fit::backend_compatible;
 
-    // Community-measured throughput for this hardware, when the detected GPU
-    // matches a benchmark preset (provenance-weighted estimates).
-    let measured_index = crate::benchmarks::MeasuredTpsIndex::for_specs(specs);
-    // The user's own `llmfit bench` runs trump community medians.
+    // Measured-throughput sources, most trustworthy first: the user's own
+    // runs on this machine, llmfit community submissions recorded on
+    // identical hardware, then localmaxxing medians on matching presets.
     let local_index = crate::share::LocalBenchIndex::load(specs);
+    let community_index = crate::benchmarks::CommunityBenchIndex::for_specs(specs);
+    let measured_index = crate::benchmarks::MeasuredTpsIndex::for_specs(specs);
 
     let mut fits: Vec<ModelFit> = db
         .get_all_models()
@@ -164,6 +165,7 @@ pub fn build_model_fits(
             fit.measured_tps = local_index
                 .as_ref()
                 .and_then(|idx| idx.lookup(&m.name))
+                .or_else(|| community_index.as_ref().and_then(|idx| idx.lookup(&m.name)))
                 .or_else(|| {
                     measured_index
                         .as_ref()
@@ -176,13 +178,16 @@ pub fn build_model_fits(
     fits
 }
 
-/// Calibrate formula estimates from the user's own benchmark runs.
+/// Calibrate formula estimates from benchmark runs made on this exact
+/// hardware: the user's own local runs, plus llmfit community submissions
+/// recorded on an identical configuration (so a fresh install benefits the
+/// moment anyone contributed on the same machine class).
 ///
-/// Anchors are fits whose `measured_tps` came from the local store and whose
-/// catalog entry has a trustworthy size (>= 1B params, dense — MoE and tiny
-/// models don't scale like bandwidth-bound dense generation). The median
-/// measured/estimated ratio, clamped to [0.05, 3.0], scales every row's
-/// estimate and is recorded in `estimate_basis.local_calibration`.
+/// Anchors must map to a catalog entry with a trustworthy size (>= 1B
+/// params, dense — MoE and tiny models don't scale like bandwidth-bound
+/// dense generation). The median measured/estimated ratio, clamped to
+/// [0.05, 3.0], scales every row's estimate and is recorded in
+/// `estimate_basis.local_calibration`.
 ///
 /// Idempotent: ratios and scaling always derive from the uncalibrated
 /// estimate, so re-applying after a new bench never compounds.
@@ -201,7 +206,10 @@ pub fn apply_local_calibration(fits: &mut [ModelFit]) {
         .filter(|f| f.model.params_b() >= 1.0 && !f.model.is_moe)
         .filter_map(|f| {
             let m = f.measured_tps.as_ref()?;
-            if m.source != MeasuredSource::LocalBench {
+            if !matches!(
+                m.source,
+                MeasuredSource::LocalBench | MeasuredSource::CommunityLlmfit
+            ) {
                 return None;
             }
             let est = uncalibrated(f);

--- a/llmfit-core/src/benchmarks.rs
+++ b/llmfit-core/src/benchmarks.rs
@@ -13,6 +13,11 @@ const BASE_URL: &str = "https://localmaxxing.com/api";
 // Embedded benchmark cache — scraped by scripts/scrape_benchmarks.py
 const BENCHMARK_CACHE_JSON: &str = include_str!("../data/benchmark_cache.json");
 
+// Community submissions contributed via `llmfit bench --share`, aggregated
+// from data/community/ by build.rs. Merged submission → next release ships it.
+const COMMUNITY_BENCH_JSON: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/community_benchmarks.json"));
+
 // ── Response types ───────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -369,14 +374,19 @@ pub fn cached_preset_labels() -> Vec<&'static str> {
 
 // ── Measured throughput lookup (provenance-weighted estimates) ──────
 
-/// Where a measured throughput came from. The user's own benchmark runs
-/// outrank community medians, which outrank the formula estimate.
+/// Where a measured throughput came from. Priority when annotating fits:
+/// your own runs on this machine, then llmfit community submissions recorded
+/// on identical hardware, then localmaxxing medians on matching presets —
+/// all of which outrank the formula estimate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum MeasuredSource {
-    /// Community leaderboard runs on hardware matching the detected GPU.
+    /// localmaxxing.com leaderboard runs on hardware matching the detected GPU.
     #[default]
     Community,
+    /// `llmfit bench --share` submissions merged into the llmfit repo,
+    /// recorded on hardware identical to this machine's.
+    CommunityLlmfit,
     /// `llmfit bench` runs recorded in this machine's local store.
     LocalBench,
 }
@@ -497,6 +507,117 @@ pub fn measured_tps_for(
     quant: &str,
 ) -> Option<MeasuredTps> {
     MeasuredTpsIndex::for_specs(specs)?.lookup(model_hf_id, quant)
+}
+
+// ── Embedded llmfit community submissions ───────────────────────────
+
+/// All community benchmark submissions embedded at build time (see
+/// build.rs). Each element is a full submission payload conforming to
+/// `data/community/schema.json`.
+pub fn community_submissions() -> &'static [serde_json::Value] {
+    static CACHE: OnceLock<Vec<serde_json::Value>> = OnceLock::new();
+    CACHE.get_or_init(|| serde_json::from_str(COMMUNITY_BENCH_JSON).unwrap_or_default())
+}
+
+/// Whether a submission's recorded `hardware` object matches `specs` (same
+/// CPU and GPU name). Shared by the local store and the embedded community
+/// data: measurements only transfer between identical configurations.
+pub fn hardware_payload_matches(hw: &serde_json::Value, specs: &SystemSpecs) -> bool {
+    let cpu_ok = hw["cpu"]
+        .as_str()
+        .is_some_and(|c| c.eq_ignore_ascii_case(&specs.cpu_name));
+    let gpu_ok = match (&specs.gpu_name, hw["hardwareName"].as_str()) {
+        (Some(now), Some(then)) => now.eq_ignore_ascii_case(then),
+        (None, None) => true,
+        _ => false,
+    };
+    cpu_ok && gpu_ok
+}
+
+/// One benchmark result from a community submission, for leaderboard display.
+#[derive(Debug, Clone)]
+pub struct CommunityResult {
+    pub model: String,
+    pub provider: String,
+    pub avg_tps: f64,
+    pub ttft_ms: Option<f64>,
+}
+
+/// Community results recorded on hardware matching `specs`, newest
+/// submission first.
+pub fn community_results_for_specs(specs: &SystemSpecs) -> Vec<CommunityResult> {
+    let mut subs: Vec<&serde_json::Value> = community_submissions()
+        .iter()
+        .filter(|s| hardware_payload_matches(&s["hardware"], specs))
+        .collect();
+    subs.sort_by_key(|s| std::cmp::Reverse(s["submittedAtUnix"].as_u64().unwrap_or(0)));
+
+    let mut out = Vec::new();
+    for s in subs {
+        for r in s["results"]
+            .as_array()
+            .map(|v| v.as_slice())
+            .unwrap_or_default()
+        {
+            let Some(tps) = r["avgTps"].as_f64().filter(|t| *t > 0.0) else {
+                continue;
+            };
+            out.push(CommunityResult {
+                model: r["model"].as_str().unwrap_or("?").to_string(),
+                provider: r["provider"].as_str().unwrap_or("").to_string(),
+                avg_tps: tps,
+                ttft_ms: r["avgTtftMs"].as_f64(),
+            });
+        }
+    }
+    out
+}
+
+/// Index of embedded community submissions recorded on hardware identical to
+/// the detected machine, for annotating fit rows. Sits between the user's
+/// own local runs and localmaxxing preset medians in trust order — and gives
+/// a fresh install measured numbers (and calibration anchors) from day one
+/// when someone already contributed on the same hardware.
+pub struct CommunityBenchIndex {
+    /// (provider model tag, tok/s), newest submission first.
+    entries: Vec<(String, f64)>,
+}
+
+impl CommunityBenchIndex {
+    pub fn for_specs(specs: &SystemSpecs) -> Option<Self> {
+        let entries: Vec<(String, f64)> = community_results_for_specs(specs)
+            .into_iter()
+            .map(|r| (r.model, r.avg_tps))
+            .collect();
+        (!entries.is_empty()).then_some(Self { entries })
+    }
+
+    /// Median community-measured tok/s for a catalog model, resolved through
+    /// the same tag-matching heuristics as installed detection.
+    pub fn lookup(&self, model_hf_name: &str) -> Option<MeasuredTps> {
+        let mut matches: Vec<f64> = self
+            .entries
+            .iter()
+            .filter(|(tag, _)| crate::providers::tag_matches_model(tag, model_hf_name))
+            .map(|(_, tps)| *tps)
+            .collect();
+        if matches.is_empty() {
+            return None;
+        }
+        matches.sort_by(|a, b| a.partial_cmp(b).expect("tok/s values are finite"));
+        let n = matches.len();
+        let median = if n % 2 == 1 {
+            matches[n / 2]
+        } else {
+            (matches[n / 2 - 1] + matches[n / 2]) / 2.0
+        };
+        Some(MeasuredTps {
+            tok_s: median,
+            sample_count: n as u32,
+            hardware_label: "identical hardware".to_string(),
+            source: MeasuredSource::CommunityLlmfit,
+        })
+    }
 }
 
 // ── Fetch functions ──────────────────────────────────────────────────
@@ -835,6 +956,83 @@ mod tests {
 
     fn row(json: &str) -> LeaderboardEntry {
         serde_json::from_str(json).expect("valid test row")
+    }
+
+    fn specs(cpu: &str, gpu: Option<&str>) -> SystemSpecs {
+        SystemSpecs {
+            total_ram_gb: 32.0,
+            available_ram_gb: 24.0,
+            total_cpu_cores: 8,
+            cpu_name: cpu.to_string(),
+            has_gpu: gpu.is_some(),
+            gpu_vram_gb: None,
+            total_gpu_vram_gb: None,
+            gpu_name: gpu.map(str::to_string),
+            gpu_count: u32::from(gpu.is_some()),
+            unified_memory: false,
+            backend: GpuBackend::CpuX86,
+            gpus: vec![],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        }
+    }
+
+    #[test]
+    fn community_embed_parses_and_is_seeded() {
+        let subs = community_submissions();
+        // data/community/ ships with at least the first genuine submission;
+        // this breaks if build.rs stops aggregating it into the binary.
+        assert!(!subs.is_empty(), "embedded community aggregate is empty");
+        for s in subs {
+            assert_eq!(s["schemaVersion"], 1, "unexpected submission shape");
+            assert!(s["results"].as_array().is_some_and(|r| !r.is_empty()));
+            assert!(s["hardware"]["cpu"].is_string());
+        }
+    }
+
+    #[test]
+    fn community_results_filter_by_hardware() {
+        // The seeded submission was recorded on this exact configuration.
+        let seeded = specs(
+            "Intel(R) Core(TM) Ultra 7 258V",
+            Some("Intel Arc Graphics 130V/140V (integrated)"),
+        );
+        let rows = community_results_for_specs(&seeded);
+        assert!(!rows.is_empty());
+        assert!(rows.iter().all(|r| r.avg_tps > 0.0));
+
+        // A different machine gets nothing.
+        let other = specs("AMD Ryzen 9 7950X", Some("NVIDIA GeForce RTX 4090"));
+        assert!(community_results_for_specs(&other).is_empty());
+    }
+
+    #[test]
+    fn hardware_payload_matching_rules() {
+        use serde_json::json;
+        let hw = json!({"cpu": "Test CPU", "hardwareName": "Test GPU"});
+        assert!(hardware_payload_matches(
+            &hw,
+            &specs("Test CPU", Some("Test GPU"))
+        ));
+        assert!(hardware_payload_matches(
+            &hw,
+            &specs("test cpu", Some("test gpu"))
+        ));
+        assert!(!hardware_payload_matches(&hw, &specs("Test CPU", None)));
+        assert!(!hardware_payload_matches(
+            &hw,
+            &specs("Other CPU", Some("Test GPU"))
+        ));
+
+        let cpu_only = json!({"cpu": "Test CPU", "hardwareName": null});
+        assert!(hardware_payload_matches(
+            &cpu_only,
+            &specs("Test CPU", None)
+        ));
+        assert!(!hardware_payload_matches(
+            &cpu_only,
+            &specs("Test CPU", Some("Test GPU"))
+        ));
     }
 
     #[test]

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -247,16 +247,7 @@ impl StoredBenchmark {
     /// and GPU). Measurements from a previous machine configuration must not
     /// override or calibrate estimates for the current one.
     pub fn matches_hardware(&self, specs: &SystemSpecs) -> bool {
-        let hw = &self.payload["hardware"];
-        let cpu_ok = hw["cpu"]
-            .as_str()
-            .is_some_and(|c| c.eq_ignore_ascii_case(&specs.cpu_name));
-        let gpu_ok = match (&specs.gpu_name, hw["hardwareName"].as_str()) {
-            (Some(now), Some(then)) => now.eq_ignore_ascii_case(then),
-            (None, None) => true,
-            _ => false,
-        };
-        cpu_ok && gpu_ok
+        crate::benchmarks::hardware_payload_matches(&self.payload["hardware"], specs)
     }
 
     /// One line per benchmark result: `model via provider — N tok/s`.

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -150,7 +150,8 @@ pub fn display_model_fits(fits: &[ModelFit]) {
     );
     if fits.iter().any(|f| f.measured_tps.is_some()) {
         println!(
-            "  ✓ = measured by the community on hardware matching yours (localmaxxing.com), not an estimate."
+            "  ✓ = measured, not estimated: your own benchmarks, llmfit community submissions \
+             on identical hardware, or localmaxxing.com data for matching hardware."
         );
     }
 }
@@ -563,6 +564,17 @@ fn display_estimate_basis(fit: &ModelFit) {
                 );
                 println!("  Your measurement — trust this over the formula estimate below.");
             }
+            llmfit_core::benchmarks::MeasuredSource::CommunityLlmfit => {
+                println!("{}", "Measured on Identical Hardware:".bold().underline());
+                println!(
+                    "  {:.1} tok/s median across {} llmfit community submission(s) \
+                     (`llmfit bench --share`)",
+                    m.tok_s, m.sample_count
+                );
+                println!(
+                    "  Real runs on your exact hardware — trust this over the estimate below."
+                );
+            }
             llmfit_core::benchmarks::MeasuredSource::Community => {
                 println!("{}", "Measured on Matching Hardware:".bold().underline());
                 println!(
@@ -578,7 +590,8 @@ fn display_estimate_basis(fit: &ModelFit) {
     println!("{}", "Estimate Basis:".bold().underline());
     if let Some(c) = basis.local_calibration {
         println!(
-            "  Calibrated x{:.2} from your own `llmfit bench` run(s) on this machine",
+            "  Calibrated x{:.2} from benchmark run(s) on this exact hardware \
+             (yours and/or the llmfit community's)",
             c
         );
     }

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1175,9 +1175,11 @@ impl App {
             .count();
 
         // Only analyze models that can actually run on this hardware.
-        let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&specs);
-        // The user's own `llmfit bench` runs trump community medians.
+        // Measured sources, most trustworthy first: your own runs, llmfit
+        // community submissions on identical hardware, localmaxxing presets.
         let local_index = llmfit_core::share::LocalBenchIndex::load(&specs);
+        let community_index = llmfit_core::benchmarks::CommunityBenchIndex::for_specs(&specs);
+        let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&specs);
         let mut all_fits: Vec<ModelFit> = db
             .get_all_models()
             .iter()
@@ -1188,6 +1190,7 @@ impl App {
                 fit.measured_tps = local_index
                     .as_ref()
                     .and_then(|idx| idx.lookup(&m.name))
+                    .or_else(|| community_index.as_ref().and_then(|idx| idx.lookup(&m.name)))
                     .or_else(|| {
                         measured_index
                             .as_ref()
@@ -2518,18 +2521,59 @@ impl App {
         llmfit_core::analysis::apply_local_calibration(&mut self.all_fits);
     }
 
-    /// Rebuild the "your local results" rows pinned at the top of the
-    /// leaderboard: stored submissions (pending and already shared) rendered
-    /// as `local:`-prefixed entries attributed to "you". Skipped while
-    /// browsing a hardware preset other than this machine.
+    /// Rebuild the rows pinned at the top of the leaderboard: your stored
+    /// runs (`local:` ids, "you (local)/(shared)") and llmfit community
+    /// submissions recorded on identical hardware (`community:` ids,
+    /// "llmfit community"). Skipped while browsing a hardware preset other
+    /// than this machine.
     pub fn merge_local_bench_rows(&mut self) {
         use llmfit_core::benchmarks::{
             LeaderboardEngine, LeaderboardEntry, LeaderboardModel, LeaderboardUser,
         };
 
-        self.bench_entries.retain(|e| !e.id.starts_with("local:"));
+        self.bench_entries
+            .retain(|e| !e.id.starts_with("local:") && !e.id.starts_with("community:"));
         if self.bench_hw_label.is_some() {
             return;
+        }
+
+        fn pinned_row(
+            id: String,
+            who: &str,
+            model: &str,
+            provider: &str,
+            tps: Option<f64>,
+            ttft: Option<f64>,
+        ) -> LeaderboardEntry {
+            LeaderboardEntry {
+                id,
+                tok_s_out: tps,
+                tok_s_total: None,
+                ttft_ms: ttft,
+                context_length: None,
+                batch_size: None,
+                peak_vram_gb: None,
+                notes: None,
+                model: Some(LeaderboardModel {
+                    hf_id: model.to_string(),
+                    display_name: None,
+                    family: None,
+                    params: None,
+                    is_mo_e: None,
+                }),
+                hardware: None,
+                engine: Some(LeaderboardEngine {
+                    engine_name: provider.to_string(),
+                    engine_version: None,
+                    quantization: String::new(),
+                    backend: None,
+                }),
+                engine_flags: None,
+                user: Some(LeaderboardUser {
+                    username: Some(who.to_string()),
+                    verified: None,
+                }),
+            }
         }
 
         let mut local: Vec<LeaderboardEntry> = Vec::new();
@@ -2543,43 +2587,45 @@ impl App {
                     continue;
                 };
                 for (i, r) in results.iter().enumerate() {
-                    local.push(LeaderboardEntry {
-                        id: format!("local:{}:{i}", s.path.display()),
-                        tok_s_out: r["avgTps"].as_f64(),
-                        tok_s_total: None,
-                        ttft_ms: r["avgTtftMs"].as_f64(),
-                        context_length: None,
-                        batch_size: None,
-                        peak_vram_gb: None,
-                        notes: None,
-                        model: Some(LeaderboardModel {
-                            hf_id: r["model"].as_str().unwrap_or("?").to_string(),
-                            display_name: None,
-                            family: None,
-                            params: None,
-                            is_mo_e: None,
-                        }),
-                        hardware: None,
-                        engine: Some(LeaderboardEngine {
-                            engine_name: r["provider"].as_str().unwrap_or("").to_string(),
-                            engine_version: None,
-                            quantization: String::new(),
-                            backend: None,
-                        }),
-                        engine_flags: None,
-                        user: Some(LeaderboardUser {
-                            username: Some((*who).to_string()),
-                            verified: None,
-                        }),
-                    });
+                    local.push(pinned_row(
+                        format!("local:{}:{i}", s.path.display()),
+                        who,
+                        r["model"].as_str().unwrap_or("?"),
+                        r["provider"].as_str().unwrap_or(""),
+                        r["avgTps"].as_f64(),
+                        r["avgTtftMs"].as_f64(),
+                    ));
                 }
             }
         }
+        // Newest first, pinned above the fetched leaderboard.
+        local.reverse();
+
+        // Embedded community submissions on identical hardware — below your
+        // own rows. Your shared runs also live in the embedded data, so skip
+        // community entries that duplicate a local row (same model + tok/s).
+        let is_dup = |model: &str, tps: f64, rows: &[LeaderboardEntry]| {
+            rows.iter()
+                .any(|e| e.hf_id() == model && e.tok_s_out.is_some_and(|t| (t - tps).abs() < 0.005))
+        };
+        let community = llmfit_core::benchmarks::community_results_for_specs(&self.specs);
+        for (i, r) in community.iter().enumerate() {
+            if is_dup(&r.model, r.avg_tps, &local) {
+                continue;
+            }
+            local.push(pinned_row(
+                format!("community:{i}"),
+                "llmfit community",
+                &r.model,
+                &r.provider,
+                Some(r.avg_tps),
+                r.ttft_ms,
+            ));
+        }
+
         if local.is_empty() {
             return;
         }
-        // Newest first, pinned above the fetched leaderboard.
-        local.reverse();
         local.append(&mut self.bench_entries);
         self.bench_entries = local;
         if self.bench_cursor >= self.bench_entries.len() {

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -4405,11 +4405,19 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
         .iter()
         .filter(|e| e.id.starts_with("local:"))
         .count();
-    let counts = if local_count > 0 {
-        format!("  ({} results, {} yours)", app.bench_total, local_count)
-    } else {
-        format!("  ({} results)", app.bench_total)
-    };
+    let community_count = app
+        .bench_entries
+        .iter()
+        .filter(|e| e.id.starts_with("community:"))
+        .count();
+    let mut counts = format!("  ({} results", app.bench_total);
+    if local_count > 0 {
+        counts.push_str(&format!(", {} yours", local_count));
+    }
+    if community_count > 0 {
+        counts.push_str(&format!(", {} llmfit community", community_count));
+    }
+    counts.push(')');
     let mut summary_spans = vec![
         Span::styled("  Hardware: ", Style::default().fg(tc.muted)),
         Span::styled(&hw_desc, Style::default().fg(tc.fg).bold()),
@@ -4489,6 +4497,7 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
                 .unwrap_or_default();
 
             let is_local = entry.id.starts_with("local:");
+            let is_community = entry.id.starts_with("community:");
             let verified_marker = if entry.verified() { " *" } else { "" };
             let user = format!("{}{}", entry.username(), verified_marker);
 
@@ -4513,6 +4522,10 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
                 if is_local {
                     // Your own stored results, pinned above the fetched board.
                     Cell::from(user).style(Style::default().fg(tc.accent))
+                } else if is_community {
+                    // Repo-contributed runs on identical hardware, shipped
+                    // inside this build.
+                    Cell::from(user).style(Style::default().fg(tc.info))
                 } else {
                     Cell::from(user)
                 },


### PR DESCRIPTION
Closes the read side of the contribution loop (#710). Until now, merged community submissions under `llmfit-core/data/community/` were write-only — nothing surfaced them.

## How it works

- **Embed at build time**: new `llmfit-core/build.rs` aggregates `data/community/**/*.json` into a JSON array embedded in the binary. Merged submission → next release ships it, deterministically, no CI step or network fetch.
- **Benchmark page**: on hardware identical to a submission's (CPU + GPU fingerprint), its runs appear as `llmfit community` rows (distinct color), pinned below your own `you (local)/(shared)` rows and deduped against them.
- **Fit table**: a new `CommunityBenchIndex` supplies measured ✓ tok/s, slotted into the trust order — **your runs > llmfit community on identical hardware > localmaxxing medians > formula estimate** — with a new `MeasuredSource::CommunityLlmfit` keeping provenance visible everywhere ('Measured on Identical Hardware' in the estimate detail).
- **Calibration**: community anchors count alongside local ones, so a **fresh install gets corrected estimates before its user ever benchmarks anything**.

## Verified

- Simulated fresh machine (temp community submission for `llama3.1:8b` @ 4.0 tok/s + empty local store): fit table shows 4.0 measured (`community_llmfit`) and every other estimate calibrated ×0.37
- Seeded real submission (Arc 140V, 3.8 tok/s) flows build.rs → binary → parse, covered by new unit tests (embed shape, hardware fingerprint filtering, matching rules)
- 510 tests green, fmt/clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)