### PR TITLE
docs: README top story — benchmark & share

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,7 +17,9 @@
   <a href="https://about.signpath.io"><img src="https://img.shields.io/badge/SignPath-signed-brightgreen?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0id2hpdGUiIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZD0iTTEwLjA2NyA0LjU2N2wtNC43MzQgNC43MzMtMS40LTEuNGExIDEgMCAwIDAtMS40MTQgMS40MTRsMi4xIDIuMWExIDEgMCAwIDAgMS40MTQgMGw1LjQ0LTUuNDRhMSAxIDAgMCAwLTEuNDE0LTEuNDE0eiIvPjwvc3ZnPg==" alt="SignPath で署名済み"></a>
 </p>
 
-> **🎉 [llmfit 1.0 リリース](https://github.com/AlexsJones/llmfit/releases/tag/v1.0.0) — すべての数値が検証可能になったマイルストーンリリース。** マシンのメモリ帯域幅は仮定値ではなく*実測*になりました。あなたの GPU のコミュニティ実測データ（`✓` マーク付き）がある場合は、数式による推定より優先して表示されます。そして、すべての推定値はその根拠を開示します — `llmfit info` で数値の前提条件と、自分のマシンで検証する方法を確認できます。[詳しくはこちら →](https://github.com/AlexsJones/llmfit/discussions/708)
+> **📊 新機能：ベンチマーク＆共有 — あなたのマシンの実測値が、みんなの推定精度を高めます。** `llmfit bench --share` はあなたのハードウェアで実際の tok/s を計測し、PR としてプロジェクトに還元します — `gh` CLI もサードパーティのアカウントも不要です。実行結果はまずローカルに保存され（共有をスキップして、後からまとめてアップロードも可能）、自分の実測値はフィットテーブルの推定値を置き換えます。マージされた提出は次のリリースに同梱され、同一ハードウェアのユーザーはベンチマークを実行する前から実測 `✓` 値と校正済みの推定値を得られます。[共有をはじめる →](docs/cli.md#contributing-benchmarks-bench---share)
+>
+> *これまで：[llmfit 1.0 — すべての数値が検証可能になったリリース →](https://github.com/AlexsJones/llmfit/discussions/708)*
 
 **数百のモデルとプロバイダー。自分のハードウェアで動くものを見つけるコマンドはひとつ。**
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
   <a href="https://about.signpath.io"><img src="https://img.shields.io/badge/SignPath-signed-brightgreen?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0id2hpdGUiIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZD0iTTEwLjA2NyA0LjU2N2wtNC43MzQgNC43MzMtMS40LTEuNGExIDEgMCAwIDAtMS40MTQgMS40MTRsMi4xIDIuMWExIDEgMCAwIDAgMS40MTQgMGw1LjQ0LTUuNDRhMSAxIDAgMCAwLTEuNDE0LTEuNDE0eiIvPjwvc3ZnPg==" alt="Signed with SignPath"></a>
 </p>
 
-> **🎉 [llmfit 1.0 is here](https://github.com/AlexsJones/llmfit/releases/tag/v1.0.0) — the release where the numbers became verifiable.** Your machine's RAM bandwidth is now *measured*, not assumed. Real community benchmarks (marked `✓`) take priority over formula estimates when we have data for your GPU. And every estimate ships its inputs — `llmfit info` shows exactly what the number assumes and how to verify it yourself. [Read the full story →](https://github.com/AlexsJones/llmfit/discussions/708)
+> **📊 New: benchmark & share — real numbers from your machine, better estimates for everyone.** `llmfit bench --share` measures real tok/s on your hardware and contributes it back to the project as a PR — no `gh` CLI, no third-party account. Every run is saved locally first (skip sharing, upload the backlog any time), your own measurements replace estimates in the fit table, and each merged submission ships in the next release: anyone on identical hardware gets measured `✓` numbers and calibrated estimates before they ever run a benchmark. [Get started with sharing →](docs/cli.md#contributing-benchmarks-bench---share)
+>
+> *Previously: [llmfit 1.0 — the release where the numbers became verifiable →](https://github.com/AlexsJones/llmfit/discussions/708)*
 
 **Hundreds of models & providers. One command to find what runs on your hardware.**
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,7 +17,9 @@
   <a href="https://about.signpath.io"><img src="https://img.shields.io/badge/SignPath-signed-brightgreen?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgZmlsbD0id2hpdGUiIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggZD0iTTEwLjA2NyA0LjU2N2wtNC43MzQgNC43MzMtMS40LTEuNGExIDEgMCAwIDAtMS40MTQgMS40MTRsMi4xIDIuMWExIDEgMCAwIDAgMS40MTQgMGw1LjQ0LTUuNDRhMSAxIDAgMCAwLTEuNDE0LTEuNDE0eiIvPjwvc3ZnPg==" alt="Signed with SignPath"></a>
 </p>
 
-> **🎉 [llmfit 1.0 正式发布](https://github.com/AlexsJones/llmfit/releases/tag/v1.0.0) — 让每个数字都可验证的里程碑版本。** 你的内存带宽现在是*实测*的，而非假设值。当我们拥有你的 GPU 的社区实测数据（标记为 `✓`）时，它将优先于公式估算显示。每个估算值都附带其输入参数 — `llmfit info` 会准确展示数字背后的假设，以及如何亲自验证。[阅读完整故事 →](https://github.com/AlexsJones/llmfit/discussions/708)
+> **📊 新功能：基准测试与共享 — 来自你机器的真实数据，让所有人的估算更准确。** `llmfit bench --share` 在你的硬件上实测 tok/s，并以 PR 的形式贡献回项目 — 无需 `gh` CLI，也无需第三方账号。每次测试结果都会先保存在本地（可以暂不共享，之后随时批量上传），你自己的实测值会替换拟合表中的估算值；每条合并的提交都会随下一个版本发布：相同硬件的用户无需自己跑基准测试，就能获得实测 `✓` 数值和校准后的估算。[开始共享 →](docs/cli.md#contributing-benchmarks-bench---share)
+>
+> *此前：[llmfit 1.0 — 让每个数字都可验证的里程碑版本 →](https://github.com/AlexsJones/llmfit/discussions/708)*
 
 **数百种模型与提供商，一条命令即可找出你的硬件能运行哪些模型。**
 


### PR DESCRIPTION
Updates the MOTD banner (EN/中文/日本語) to lead with the benchmark & share feature: bench locally, share as a PR without `gh`, local-first storage, your measurements replacing estimates, and merged submissions shipping to identical hardware in the next release. Links to the getting-started guide at `docs/cli.md#contributing-benchmarks-bench---share`. The 1.0 story stays as a one-line 'previously' link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)