### PR TITLE
feat(share): ship the registered OAuth App client id — interactive login enabled

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -159,9 +159,11 @@ local store, so retrying after a partial failure skips anything that already
 landed. Nothing is submitted until you confirm, and `--dry-run` never touches
 the network.
 
-> Interactive login requires `LLMFIT_GH_CLIENT_ID` to be set to a registered
-> GitHub OAuth App client id. Until one is configured, use a `GITHUB_TOKEN` /
-> `GH_TOKEN` with `public_repo` scope.
+> Interactive login ships enabled — the public OAuth App client id is baked
+> into the binary (the device flow needs no client secret, so this is safe by
+> design). `LLMFIT_GH_CLIENT_ID` overrides it (e.g. when running a fork
+> against your own OAuth App); set it to an empty string to disable
+> interactive login entirely and rely on `GITHUB_TOKEN` / `GH_TOKEN`.
 
 ### Hardware overrides
 

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -36,11 +36,12 @@ const SCHEMA_VERSION: u32 = 1;
 const USER_AGENT: &str = concat!("llmfit/", env!("CARGO_PKG_VERSION"));
 const API: &str = "https://api.github.com";
 
-/// Public OAuth App client id used for the device flow. This is **not** a
-/// secret (device flow requires no client secret) and is safe to ship. Until
-/// the real OAuth App is registered, override it with the `LLMFIT_GH_CLIENT_ID`
-/// environment variable.
-const DEFAULT_CLIENT_ID: &str = "REPLACE_WITH_OAUTH_APP_CLIENT_ID";
+/// Public OAuth App client id used for the device flow (the "llmfit" OAuth
+/// App, device flow enabled). This is **not** a secret — the device flow
+/// requires no client secret, so shipping it in the binary is by design.
+/// Override with the `LLMFIT_GH_CLIENT_ID` environment variable (e.g. when
+/// running a fork against a different OAuth App).
+const DEFAULT_CLIENT_ID: &str = "Ov23lirCd460lRfnbKyK";
 
 /// Options controlling a `bench --share` invocation.
 pub struct ShareOptions {
@@ -704,11 +705,16 @@ pub fn preflight_auth() -> Result<String, String> {
     Ok(token)
 }
 
-/// The OAuth App client id for the device flow, or `None` when only the
-/// unregistered placeholder is available (interactive login not possible).
+/// The OAuth App client id for the device flow: the `LLMFIT_GH_CLIENT_ID`
+/// env override when set, otherwise the shipped default. `None` only when
+/// the override is explicitly set to an empty string (opt-out of
+/// interactive login, e.g. in restricted CI).
 pub fn oauth_client_id() -> Option<String> {
-    let id = std::env::var("LLMFIT_GH_CLIENT_ID").unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string());
-    (id != DEFAULT_CLIENT_ID).then_some(id)
+    let id = std::env::var("LLMFIT_GH_CLIENT_ID")
+        .unwrap_or_else(|_| DEFAULT_CLIENT_ID.to_string())
+        .trim()
+        .to_string();
+    (!id.is_empty()).then_some(id)
 }
 
 /// Persist a token obtained via the device flow for future runs.


### PR DESCRIPTION
Completes the last item from #712's checklist: the llmfit OAuth App is registered (device flow enabled) and its public client id ships as `DEFAULT_CLIENT_ID`.

- `oauth_client_id()` no longer treats the default as an unregistered placeholder — the shipped id is used unless `LLMFIT_GH_CLIENT_ID` overrides it; an explicitly empty override disables interactive login (for restricted CI)
- Not a secret: the device flow requires no client secret, so a public client id in the binary is by design (same model as `gh` itself)
- docs/cli.md gating note replaced accordingly

**Verified live**: with no `GITHUB_TOKEN`/`GH_TOKEN`, no cached token, and no env override, `llmfit bench --share` walks straight into the device flow and presents a real GitHub code. Also verified the registration itself via a raw device-code request.

From the next release, sharing benchmarks needs zero setup: run, approve once in the browser, done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)