### PR TITLE
fix: match Unsloth `-UD` dynamic GGUFs to catalog models

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -2803,7 +2803,14 @@ pub fn strip_gguf_quant_suffix(stem: &str) -> Option<String> {
     ];
     for pat in &quant_patterns {
         if let Some(pos) = stem.rfind(pat) {
-            return Some(stem[..pos].to_string());
+            let base = &stem[..pos];
+            // Unsloth "Dynamic" GGUFs embed a `-ud` marker between the model
+            // name and the quant (e.g. `qwen3.6-35b-a3b-ud-q4_k_m`). It is not
+            // part of the canonical model name, so strip it too — otherwise the
+            // stem never reduces to the catalog id and the file reads as neither
+            // installed nor served.
+            let base = base.strip_suffix("-ud").unwrap_or(base);
+            return Some(base.to_string());
         }
     }
     None
@@ -4397,6 +4404,48 @@ mod tests {
         assert!(is_model_installed_llamacpp(
             "meta-llama/Llama-3.1-8B-Instruct",
             &installed
+        ));
+    }
+
+    #[test]
+    fn test_strip_gguf_quant_suffix_unsloth_ud_marker() {
+        // Unsloth "Dynamic" GGUFs carry a `-ud` marker before the quant; it
+        // must be stripped alongside the quant so the stem reduces to the
+        // canonical model name.
+        assert_eq!(
+            strip_gguf_quant_suffix("qwen3.6-35b-a3b-ud-q4_k_m").as_deref(),
+            Some("qwen3.6-35b-a3b")
+        );
+        // Non-Unsloth files are unaffected.
+        assert_eq!(
+            strip_gguf_quant_suffix("qwen2.5-7b-instruct-q4_k_m").as_deref(),
+            Some("qwen2.5-7b-instruct")
+        );
+    }
+
+    #[test]
+    fn test_is_model_installed_llamacpp_unsloth_ud() {
+        // `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf` on disk yields these set entries
+        // (see `installed_models_counted`) and must mark the catalog model as
+        // installed despite the embedded `-ud` marker.
+        let installed: HashSet<String> = ["qwen3.6-35b-a3b-ud-q4_k_m", "qwen3.6-35b-a3b"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(is_model_installed_llamacpp(
+            "Qwen/Qwen3.6-35B-A3B",
+            &installed
+        ));
+    }
+
+    #[test]
+    fn test_tag_matches_model_unsloth_ud_gguf() {
+        // End-to-end: a llama-server serving an Unsloth UD GGUF reports the
+        // file name as the model id; it must match the catalog HF name so the
+        // model is benchmarkable (regression: `-ud` broke the exact stem match).
+        assert!(tag_matches_model(
+            "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+            "Qwen/Qwen3.6-35B-A3B"
         ));
     }
 


### PR DESCRIPTION
## Problem

A model actively served by `llama-server` (or present on disk) read as **neither served nor installed** when it was an Unsloth "Dynamic" GGUF:

- Benchmarking failed with *"…is installed but not served by any running provider"*
- The installed column / detail panel omitted it

## Root cause

Unsloth Dynamic GGUFs embed a `-UD` marker between the model name and the quant suffix, e.g.:

```
Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
```

`strip_gguf_quant_suffix()` only removed the quant token (`-q4_k_m`), leaving the stem as `qwen3.6-35b-a3b-ud`. That never equals the catalog id `qwen3.6-35b-a3b`, and llama-server file ids are matched by **exact stem equality** (substring matching is deliberately avoided to prevent whole-family false positives). So the match silently failed.

## Fix

Strip a trailing `-ud` marker alongside the quant so the stem reduces to the canonical model name. A single helper (`strip_gguf_quant_suffix`) feeds both consumers, so this fixes:

- `tag_matches_model` → benchmark-target detection
- `is_model_installed_llamacpp` (via `installed_models_counted`) → installed/served column and detail panel

Non-Unsloth files are unaffected. Change is confined to model-name matching.

## Tests

Added regression coverage at all three levels:
- `test_strip_gguf_quant_suffix_unsloth_ud_marker` — the helper
- `test_is_model_installed_llamacpp_unsloth_ud` — installed-set detection
- `test_tag_matches_model_unsloth_ud_gguf` — end-to-end match against the real `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf` / `Qwen/Qwen3.6-35B-A3B` pair

Full `llmfit-core` lib suite passes (460 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)