### PR TITLE
fix(providers): show LM Studio/Docker Desktop as installed when idle

### DIFF
--- a/llmfit-core/src/doctor.rs
+++ b/llmfit-core/src/doctor.rs
@@ -216,6 +216,20 @@ pub fn collect_diagnostics(version: &str) -> String {
     );
     section(&mut report, "npu-smi info", &capture("npu-smi", &["info"]));
 
+    // Provider applications that are detected by install location rather
+    // than a live API probe (#731) — lets "installed but not running"
+    // reports carry the evidence.
+    section(
+        &mut report,
+        "Provider app installs",
+        &format!(
+            "LM Studio installed: {}\nDocker Desktop installed: {}\nollama on PATH: {}",
+            crate::providers::lmstudio_app_installed(),
+            crate::providers::docker_desktop_installed(),
+            crate::providers::command_exists("ollama"),
+        ),
+    );
+
     report
 }
 

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -3,7 +3,7 @@
 //! Each provider can list locally installed models and pull new ones.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
 // Provider trait
@@ -1629,6 +1629,49 @@ fn is_docker_desktop_running() -> bool {
         .unwrap_or(false)
 }
 
+/// Check whether the Docker Desktop application is installed, regardless of
+/// whether it is currently running (#731). The Model Runner API probe only
+/// succeeds while Docker Desktop is up, so this is what lets the UI say
+/// "installed (not running)" instead of "not detected".
+pub fn docker_desktop_installed() -> bool {
+    docker_desktop_install_candidates(
+        std::env::var("ProgramFiles").ok().as_deref(),
+        dirs::home_dir().as_deref(),
+    )
+    .iter()
+    .any(|p| p.exists())
+}
+
+/// Filesystem locations that identify a Docker Desktop (or docker-model
+/// plugin) install. Pure so tests can cover the per-OS layouts; `exists()`
+/// checks happen in [`docker_desktop_installed`].
+fn docker_desktop_install_candidates(
+    program_files: Option<&str>,
+    home: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(pf) = program_files {
+        let docker = Path::new(pf).join("Docker").join("Docker");
+        // Classic layout, and the frontend/ layout used by newer releases
+        // (e.g. C:\Program Files\Docker\Docker\frontend\Docker Desktop.exe).
+        candidates.push(docker.join("Docker Desktop.exe"));
+        candidates.push(docker.join("frontend").join("Docker Desktop.exe"));
+        candidates.push(Path::new(pf).join("Docker").join("cli-plugins"));
+    }
+    candidates.push(PathBuf::from("/Applications/Docker.app"));
+    candidates.push(PathBuf::from("/opt/docker-desktop"));
+    if let Some(home) = home {
+        candidates.push(home.join("Applications").join("Docker.app"));
+        candidates.push(home.join(".docker").join("desktop"));
+        // Standalone Model Runner plugin (docker-model), installable
+        // without Docker Desktop on Docker CE.
+        let plugins = home.join(".docker").join("cli-plugins");
+        candidates.push(plugins.join("docker-model"));
+        candidates.push(plugins.join("docker-model.exe"));
+    }
+    candidates
+}
+
 fn normalize_docker_mr_host(raw: &str) -> Option<String> {
     let host = raw.trim();
     if host.is_empty() {
@@ -1807,6 +1850,54 @@ impl ModelProvider for DockerModelRunnerProvider {
 pub struct LmStudioProvider {
     base_url: String,
     api_key: Option<String>,
+}
+
+/// Check whether the LM Studio application is installed, regardless of
+/// whether its local server is running (#731). LM Studio's REST API is off
+/// until the user starts the server (or `lms server start`), so the HTTP
+/// probe alone reports installed-but-idle copies as missing.
+pub fn lmstudio_app_installed() -> bool {
+    if command_exists("lms") {
+        return true;
+    }
+    lmstudio_install_candidates(
+        std::env::var("ProgramFiles").ok().as_deref(),
+        std::env::var("LOCALAPPDATA").ok().as_deref(),
+        dirs::home_dir().as_deref(),
+    )
+    .iter()
+    .any(|p| p.exists())
+}
+
+/// Filesystem locations that identify an LM Studio install. Pure so tests
+/// can cover the per-OS layouts; `exists()` checks happen in
+/// [`lmstudio_app_installed`].
+fn lmstudio_install_candidates(
+    program_files: Option<&str>,
+    local_app_data: Option<&str>,
+    home: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    // Windows per-machine install (e.g. C:\Program Files\LM Studio\LM Studio.exe).
+    if let Some(pf) = program_files {
+        candidates.push(Path::new(pf).join("LM Studio").join("LM Studio.exe"));
+    }
+    // Windows per-user install (the installer default).
+    if let Some(lad) = local_app_data {
+        candidates.push(
+            Path::new(lad)
+                .join("Programs")
+                .join("LM Studio")
+                .join("LM Studio.exe"),
+        );
+    }
+    candidates.push(PathBuf::from("/Applications/LM Studio.app"));
+    if let Some(home) = home {
+        candidates.push(home.join("Applications").join("LM Studio.app"));
+        // ~/.lmstudio is created on first run on every OS (models, lms CLI).
+        candidates.push(home.join(".lmstudio"));
+    }
+    candidates
 }
 
 fn normalize_lmstudio_host(raw: &str) -> Option<String> {
@@ -3613,6 +3704,70 @@ pub fn tag_matches_model(tag: &str, hf_name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Install layouts from issue #731 (Windows, LM Studio + Docker Desktop
+    // installed but their servers not running) must be recognized. Expected
+    // paths are built with join() so separators stay portable across the
+    // 3-OS CI matrix.
+    #[test]
+    fn test_lmstudio_install_candidates_windows_layouts() {
+        let pf = Path::new(r"C:\Program Files");
+        let lad = Path::new(r"C:\Users\ben\AppData\Local");
+        let home = Path::new(r"C:\Users\ben");
+        let candidates = lmstudio_install_candidates(pf.to_str(), lad.to_str(), Some(home));
+        // Reporter's per-machine install.
+        assert!(candidates.contains(&pf.join("LM Studio").join("LM Studio.exe")));
+        // Installer's per-user default.
+        assert!(candidates.contains(&lad.join("Programs").join("LM Studio").join("LM Studio.exe")));
+        // First-run data dir (any OS).
+        assert!(candidates.contains(&home.join(".lmstudio")));
+    }
+
+    #[test]
+    fn test_lmstudio_install_candidates_unix_layouts() {
+        let home = Path::new("/home/ben");
+        let candidates = lmstudio_install_candidates(None, None, Some(home));
+        assert!(candidates.contains(&PathBuf::from("/Applications/LM Studio.app")));
+        assert!(candidates.contains(&home.join("Applications").join("LM Studio.app")));
+        assert!(candidates.contains(&home.join(".lmstudio")));
+    }
+
+    #[test]
+    fn test_docker_desktop_install_candidates_windows_layouts() {
+        let pf = Path::new(r"C:\Program Files");
+        let home = Path::new(r"C:\Users\ben");
+        let candidates = docker_desktop_install_candidates(pf.to_str(), Some(home));
+        let docker = pf.join("Docker").join("Docker");
+        // Classic exe location.
+        assert!(candidates.contains(&docker.join("Docker Desktop.exe")));
+        // Reporter's frontend\ layout from newer Docker Desktop releases.
+        assert!(candidates.contains(&docker.join("frontend").join("Docker Desktop.exe")));
+        assert!(
+            candidates.contains(
+                &home
+                    .join(".docker")
+                    .join("cli-plugins")
+                    .join("docker-model.exe")
+            )
+        );
+    }
+
+    #[test]
+    fn test_docker_desktop_install_candidates_unix_layouts() {
+        let home = Path::new("/home/ben");
+        let candidates = docker_desktop_install_candidates(None, Some(home));
+        assert!(candidates.contains(&PathBuf::from("/Applications/Docker.app")));
+        assert!(candidates.contains(&PathBuf::from("/opt/docker-desktop")));
+        assert!(candidates.contains(&home.join(".docker").join("desktop")));
+        assert!(
+            candidates.contains(
+                &home
+                    .join(".docker")
+                    .join("cli-plugins")
+                    .join("docker-model")
+            )
+        );
+    }
 
     #[test]
     fn test_hf_name_to_mlx_candidates() {

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -87,11 +87,13 @@ pub enum ProviderDetectionMsg {
     },
     DockerMr {
         available: bool,
+        app_installed: bool,
         installed: HashSet<String>,
         installed_count: usize,
     },
     LmStudio {
         available: bool,
+        app_installed: bool,
         installed: HashSet<String>,
         installed_count: usize,
     },
@@ -905,8 +907,10 @@ pub struct App {
     pub llamacpp_detection_hint: String,
     llamacpp: LlamaCppProvider,
     pub docker_mr_available: bool,
+    pub docker_desktop_installed: bool,
     docker_mr: DockerModelRunnerProvider,
     pub lmstudio_available: bool,
+    pub lmstudio_app_installed: bool,
     lmstudio: LmStudioProvider,
     pub vllm_available: bool,
     vllm: VllmProvider,
@@ -1102,8 +1106,10 @@ impl App {
         let mlx_available = false;
         let docker_mr = DockerModelRunnerProvider::new();
         let docker_mr_available = false;
+        let docker_desktop_installed = false;
         let lmstudio = LmStudioProvider::new();
         let lmstudio_available = false;
+        let lmstudio_app_installed = false;
         let vllm = VllmProvider::new();
         let vllm_available = false;
         let ramalama = RamaLamaProvider::new();
@@ -1145,8 +1151,12 @@ impl App {
             thread::spawn(move || {
                 let docker_mr = DockerModelRunnerProvider::new();
                 let (available, installed, installed_count) = docker_mr.detect_with_installed();
+                // Distinguish "not installed" from "installed but Docker
+                // Desktop isn't running" (#731).
+                let app_installed = available || llmfit_core::providers::docker_desktop_installed();
                 let _ = tx.send(ProviderDetectionMsg::DockerMr {
                     available,
+                    app_installed,
                     installed,
                     installed_count,
                 });
@@ -1157,8 +1167,12 @@ impl App {
             thread::spawn(move || {
                 let lmstudio = LmStudioProvider::new();
                 let (available, installed, installed_count) = lmstudio.detect_with_installed();
+                // Distinguish "not installed" from "installed but the local
+                // server isn't running" (#731).
+                let app_installed = available || llmfit_core::providers::lmstudio_app_installed();
                 let _ = tx.send(ProviderDetectionMsg::LmStudio {
                     available,
+                    app_installed,
                     installed,
                     installed_count,
                 });
@@ -1438,8 +1452,10 @@ impl App {
             llamacpp_detection_hint,
             llamacpp,
             docker_mr_available,
+            docker_desktop_installed,
             docker_mr,
             lmstudio_available,
+            lmstudio_app_installed,
             lmstudio,
             vllm_available,
             vllm,
@@ -4557,19 +4573,23 @@ impl App {
                         }
                         ProviderDetectionMsg::DockerMr {
                             available,
+                            app_installed,
                             installed,
                             installed_count,
                         } => {
                             self.docker_mr_available = available;
+                            self.docker_desktop_installed = app_installed;
                             self.installed.docker_mr = installed;
                             self.installed.docker_mr_count = installed_count;
                         }
                         ProviderDetectionMsg::LmStudio {
                             available,
+                            app_installed,
                             installed,
                             installed_count,
                         } => {
                             self.lmstudio_available = available;
+                            self.lmstudio_app_installed = app_installed;
                             self.installed.lmstudio = installed;
                             self.installed.lmstudio_count = installed_count;
                         }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -137,11 +137,15 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
 
     let ollama_info = if app.ollama_available {
         format!("Ollama: ✓ ({} installed)", app.installed.ollama_count)
+    } else if app.ollama_binary_available {
+        "Ollama: installed (not running)".to_string()
     } else {
         "Ollama: ✗".to_string()
     };
     let ollama_color = if app.ollama_available {
         tc.good
+    } else if app.ollama_binary_available {
+        tc.warning
     } else {
         tc.muted
     };
@@ -182,22 +186,30 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
 
     let docker_mr_info = if app.docker_mr_available {
         format!("Docker: ✓ ({} models)", app.installed.docker_mr_count)
+    } else if app.docker_desktop_installed {
+        "Docker: installed (not running)".to_string()
     } else {
         "Docker: ✗".to_string()
     };
     let docker_mr_color = if app.docker_mr_available {
         tc.good
+    } else if app.docker_desktop_installed {
+        tc.warning
     } else {
         tc.muted
     };
 
     let lmstudio_info = if app.lmstudio_available {
         format!("LM Studio: ✓ ({} models)", app.installed.lmstudio_count)
+    } else if app.lmstudio_app_installed {
+        "LM Studio: installed (server off)".to_string()
     } else {
         "LM Studio: ✗".to_string()
     };
     let lmstudio_color = if app.lmstudio_available {
         tc.good
+    } else if app.lmstudio_app_installed {
+        tc.warning
     } else {
         tc.muted
     };


### PR DESCRIPTION
Fixes #731

## Problem

LM Studio and Docker Model Runner were detected only by probing their local HTTP APIs (`127.0.0.1:1234`, `localhost:12434`). Those servers are only up while LM Studio's local server / Docker Desktop is actually running, so installed-but-idle copies showed as "not detected" — exactly the reporter's setup (`C:\Program Files\LM Studio\LM Studio.exe`, `C:\Program Files\Docker\Docker\frontend\Docker Desktop.exe`).

## Fix

- **Install-location detection in llmfit-core** (`lmstudio_app_installed()`, `docker_desktop_installed()`): pure, unit-tested candidate builders covering Windows per-machine and per-user exe paths (including Docker Desktop's newer `frontend\` layout from the report), macOS app bundles, `/opt/docker-desktop`, `~/.lmstudio`, `~/.docker/desktop`, the `lms` CLI, and the standalone `docker-model` CLI plugin.
- **TUI provider bar three-state display**: running (green ✓ with model count) → installed but not running (warning color, "installed (not running)" / "installed (server off)") → not found (muted ✗). Same idiom the MLX/llama.cpp "cached" states already use.
- **Ollama consistency**: the header now uses the already-tracked `binary_available` signal the same way instead of showing ✗ for an installed-but-stopped Ollama.
- **`llmfit doctor`** gains a "Provider app installs" section so future reports of this bug class carry the evidence.

Download/pull flows are unchanged — they still require the respective API to be up.

## Testing

- Unit tests for the per-OS candidate layouts (join-built paths, portable across the 3-OS CI matrix), including the reporter's two exact install paths.
- Verified live: `llmfit doctor` reports false/false on a machine without the apps and true/true with install markers present; TUI header capture with simulated installs shows `Docker: installed (not running)` and `LM Studio: installed (server off)`, and `Ollama: installed (not running)` for a stopped Ollama.
- `cargo test -p llmfit-core -p llmfit` green; fmt clean; no new clippy warnings (23 pre-existing before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)