### PR TITLE
fix: name AMD unified APUs when rocm-smi reports "N/A", gate junk shares

### DIFF
--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -188,6 +188,13 @@ impl SystemSpecs {
             if let Some(idx) = amd_idx {
                 gpus[idx].unified_memory = true;
                 gpus[idx].vram_gb = Some(apu_pool_gb);
+                // When detection could only produce a generic name (e.g. rocm-smi
+                // reported "N/A"), use the APU model instead — it names the iGPU
+                // (e.g. "AMD Ryzen AI MAX+ 395 w/ Radeon 8060S"), giving a stable
+                // hardware identity for the leaderboard.
+                if is_generic_amd_gpu_name(&gpus[idx].name) {
+                    gpus[idx].name = format!("{cpu_name} (integrated)");
+                }
             } else {
                 // No AMD GPU found via other methods; create one.
                 gpus.push(GpuInfo {
@@ -674,10 +681,18 @@ impl SystemSpecs {
             let lower = line.to_lowercase();
             if lower.contains("card series")
                 && line.contains(':')
-                && let Some(name) = line.rsplit(':').next().map(|n| n.trim().to_string())
-                && !name.is_empty()
+                && let Some(raw) = line.rsplit(':').next().map(|n| n.trim().to_string())
+                && !raw.is_empty()
             {
-                block.push(name);
+                // rocm-smi reports "N/A" when it cannot read the marketing name
+                // (e.g. libdrm_amdgpu.so missing on Strix Halo APUs). Keep the
+                // slot aligned but record it as a generic AMD GPU so callers can
+                // fall back to a real name (lspci / the APU model) downstream.
+                block.push(if is_placeholder_gpu_name(&raw) {
+                    "AMD GPU".to_string()
+                } else {
+                    raw
+                });
             } else if lower.contains("gfx version")
                 && line.contains(':')
                 && let Some(gfx) = line.rsplit(':').next().map(|g| g.trim().to_string())
@@ -735,7 +750,7 @@ impl SystemSpecs {
             }
             let slice_end = end.min(line.len());
             let name = line[start..slice_end].trim().to_string();
-            out.push(if name.is_empty() {
+            out.push(if name.is_empty() || is_placeholder_gpu_name(&name) {
                 "AMD GPU".to_string()
             } else {
                 name
@@ -2091,6 +2106,27 @@ fn detect_running_in_wsl() -> bool {
 ///  - Ryzen AI 9 / 7 / 5 (Strix Point, Krackan Point): configurable shared
 ///    memory, users can allocate most of system RAM to GPU via BIOS.
 /// All Ryzen AI APUs have integrated Radeon GPUs that share system memory.
+/// Placeholder GPU-name tokens that mean detection failed to read a real
+/// marketing name (rocm-smi prints "N/A" when it can't load libdrm). These
+/// must never be used as an actual GPU identity.
+fn is_placeholder_gpu_name(name: &str) -> bool {
+    let lower = name.trim().to_lowercase();
+    matches!(
+        lower.as_str(),
+        "" | "n/a" | "na" | "n-a" | "n\\a" | "unknown" | "none" | "null" | "-"
+    )
+}
+
+/// Whether a GPU name is too generic to identify the specific model, so a more
+/// descriptive fallback (e.g. the APU model string) should be preferred.
+fn is_generic_amd_gpu_name(name: &str) -> bool {
+    let lower = name.trim().to_lowercase();
+    matches!(
+        lower.as_str(),
+        "amd gpu" | "radeon graphics" | "amd radeon graphics"
+    )
+}
+
 fn is_amd_unified_memory_apu(cpu_name: &str) -> bool {
     let lower = cpu_name.to_lowercase();
     // Only "Ryzen AI MAX" / "Ryzen AI MAX+" APUs have a large unified memory
@@ -3975,6 +4011,39 @@ GPU[0]          : VRAM Total Used Memory (B): 200000";
         assert_eq!(gpus.len(), 1);
         assert_eq!(gpus[0].name, "AMD GPU");
         assert!(gpus[0].vram_gb.unwrap() > 31.0);
+    }
+
+    // Strix Halo (AMD Ryzen AI MAX+) with libdrm_amdgpu.so missing: rocm-smi
+    // reports `Card Series: N/A` for the marketing name. That "N/A" must not
+    // become the GPU identity — it falls back to a generic "AMD GPU" so the
+    // APU-unify step (and, ultimately, the leaderboard) can name it properly.
+    #[test]
+    fn test_parse_rocm_smi_na_product_name_falls_back() {
+        let vram_text = "\
+GPU[0]          : VRAM Total Memory (B): 68719476736
+GPU[0]          : VRAM Total Used Memory (B): 53637746688";
+        let product_text = "\
+GPU[0]          : Card Series:            N/A
+GPU[0]          : Card Model:             0x1586
+GPU[0]          : Card SKU:               STRXLGEN
+GPU[0]          : GFX Version:            gfx1151";
+
+        let gpus = SystemSpecs::parse_rocm_smi_output(vram_text, Some(product_text));
+
+        assert_eq!(gpus.len(), 1);
+        assert_eq!(gpus[0].name, "AMD GPU", "N/A must not be used as a name");
+        assert!(gpus[0].vram_gb.unwrap() > 63.0);
+    }
+
+    #[test]
+    fn test_is_placeholder_and_generic_amd_gpu_name() {
+        assert!(super::is_placeholder_gpu_name("N/A"));
+        assert!(super::is_placeholder_gpu_name(" n/a "));
+        assert!(super::is_placeholder_gpu_name("unknown"));
+        assert!(!super::is_placeholder_gpu_name("Radeon 8060S"));
+        assert!(super::is_generic_amd_gpu_name("AMD GPU"));
+        assert!(super::is_generic_amd_gpu_name("Radeon Graphics"));
+        assert!(!super::is_generic_amd_gpu_name("AMD Radeon RX 7900 XTX"));
     }
 
     // Newer rocm-smi emits a tabular layout instead of one line per field.

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -194,6 +194,28 @@ fn now_unix() -> u64 {
         .unwrap_or(0)
 }
 
+/// Whether a hardware-identity string is a placeholder emitted when detection
+/// failed (e.g. a GPU reported as "N/A" because ROCm/libdrm couldn't name it).
+fn is_placeholder_identity(s: &str) -> bool {
+    let t = s.trim().to_lowercase();
+    t.is_empty() || matches!(t.as_str(), "n/a" | "na" | "n-a" | "unknown" | "none" | "null" | "-")
+}
+
+/// Whether a stored submission identifies its hardware well enough to be a
+/// useful community contribution. The leaderboard buckets results by hardware
+/// identity — GPU/accelerator name for GPU machines, CPU for CPU-only ones — so
+/// a placeholder identity produces a meaningless bucket and must not be shared.
+fn hardware_is_identifiable(payload: &Value) -> bool {
+    let hw = &payload["hardware"];
+    match hw["hwClass"].as_str().unwrap_or("") {
+        "DISCRETE_GPU" | "UNIFIED" => {
+            !is_placeholder_identity(hw["hardwareName"].as_str().unwrap_or(""))
+        }
+        // CPU-only machines are identified by their CPU (see `payload_slug`).
+        _ => !is_placeholder_identity(hw["cpu"].as_str().unwrap_or("")),
+    }
+}
+
 /// Slug identifying the hardware of a stored submission payload, used for the
 /// branch name and submission path.
 fn payload_slug(payload: &Value) -> String {
@@ -238,6 +260,7 @@ fn short_hash(s: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// A submission payload recorded in the local benchmark store.
+#[derive(Clone)]
 pub struct StoredBenchmark {
     pub path: PathBuf,
     pub payload: Value,
@@ -494,6 +517,26 @@ pub fn submit_stored(stored: &[StoredBenchmark], token: &str) -> Result<SubmitOu
     if stored.is_empty() {
         return Err("no benchmark results to share".to_string());
     }
+
+    // Never contribute a result whose hardware could not be identified: the
+    // community leaderboard groups submissions by hardware, so a placeholder
+    // identity (e.g. a GPU reported as "N/A" when ROCm/libdrm can't name it) is
+    // noise. Keep such results local rather than polluting the board.
+    let stored: Vec<StoredBenchmark> = stored
+        .iter()
+        .filter(|s| hardware_is_identifiable(&s.payload))
+        .cloned()
+        .collect();
+    if stored.is_empty() {
+        return Err(
+            "not submitting: your hardware could not be identified (GPU/accelerator \
+             name reported as \"N/A\"). The community leaderboard groups results by \
+             hardware, so an unidentified machine can't be contributed. Your results \
+             remain stored locally."
+                .to_string(),
+        );
+    }
+    let stored = stored.as_slice();
 
     let now = now_unix();
     let files = prepare_files(stored, now)?;
@@ -1083,6 +1126,32 @@ mod tests {
         assert_eq!(nearest_mem_tier(23.9), 24);
         assert_eq!(nearest_mem_tier(31.0), 32);
         assert_eq!(nearest_mem_tier(7.5), 8);
+    }
+
+    #[test]
+    fn hardware_identifiable_rejects_placeholder_gpu() {
+        // The exact shape that produced the meaningless `bench/n-a-…` PR: a GPU
+        // machine whose accelerator name could not be read.
+        let na = json!({
+            "hardware": { "hwClass": "DISCRETE_GPU", "hardwareName": "N/A", "cpu": "AMD Ryzen" }
+        });
+        assert!(!hardware_is_identifiable(&na));
+
+        // A real GPU name is fine.
+        let good = json!({
+            "hardware": { "hwClass": "UNIFIED", "hardwareName": "Apple M3 Max", "cpu": "Apple M3 Max" }
+        });
+        assert!(hardware_is_identifiable(&good));
+
+        // CPU-only machines are identified by their CPU.
+        let cpu_only = json!({
+            "hardware": { "hwClass": "CPU_ONLY", "hardwareName": null, "cpu": "Intel Core i9-14900K" }
+        });
+        assert!(hardware_is_identifiable(&cpu_only));
+        let cpu_unknown = json!({
+            "hardware": { "hwClass": "CPU_ONLY", "hardwareName": null, "cpu": "unknown" }
+        });
+        assert!(!hardware_is_identifiable(&cpu_unknown));
     }
 
     fn specs_with_gpu(name: &str) -> SystemSpecs {

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -198,7 +198,11 @@ fn now_unix() -> u64 {
 /// failed (e.g. a GPU reported as "N/A" because ROCm/libdrm couldn't name it).
 fn is_placeholder_identity(s: &str) -> bool {
     let t = s.trim().to_lowercase();
-    t.is_empty() || matches!(t.as_str(), "n/a" | "na" | "n-a" | "unknown" | "none" | "null" | "-")
+    t.is_empty()
+        || matches!(
+            t.as_str(),
+            "n/a" | "na" | "n-a" | "unknown" | "none" | "null" | "-"
+        )
 }
 
 /// Whether a stored submission identifies its hardware well enough to be a


### PR DESCRIPTION
## Problem

On an AMD Ryzen AI MAX+ 395 (Strix Halo) box, `llmfit bench --share` opened a meaningless PR titled *"community results for n-a"* on branch `bench/n-a-…`, with `Provider: llamacpp` but hardware **`hardwareName: "N/A"`**.

Root cause: `libdrm_amdgpu.so` is missing, so `rocm-smi --showproductname` reports:

```
GPU[0] : Card Series:   N/A
GPU[0] : Card SKU:      STRXLGEN
GPU[0] : GFX Version:   gfx1151
```

llmfit took that `"N/A"` **literally** as the GPU name. That one value cascaded into three failures:

1. **Junk leaderboard identity** — `hardwareName: "N/A"` → the `bench/n-a-…` branch/PR.
2. **Wrong memory class** — the APU-unify step (`hardware.rs`) matches a GPU whose name contains `"amd"`/`"radeon"` to flag unified memory. `"N/A"` matches neither, so this APU (correctly recognised by `is_amd_unified_memory_apu`) was classed **`DISCRETE_GPU`**, recording the 64 GB *shared* pool as dedicated VRAM.
3. **Recurring noise** — every future run on such a machine would contribute unusable results.

This affects **any AMD unified/APU system where `rocm-smi` can't read the marketing name** — likely common on Strix Halo.

## Fix

**Detection (`hardware.rs`)**
- Treat rocm-smi `"N/A"`/empty product names as a generic `"AMD GPU"` instead of a literal identity (both block and tabular parse paths).
- On a recognised unified APU, upgrade a *generic* GPU name to the APU model — e.g. `"AMD Ryzen AI MAX+ 395 w/ Radeon 8060S (integrated)"`. The CPU string already names the iGPU, so this yields a stable identity **and** lets the APU-unify step set `unified_memory=true`.

**Sharing (`share.rs`)**
- `submit_stored` now refuses to contribute a result whose hardware is still a placeholder (GPU name `"N/A"` on a GPU machine, or an unknown CPU on CPU-only). The board groups by hardware, so an unidentified machine is noise — results stay stored locally with a clear message.

Together: real hardware now contributes correctly; truly-unidentified machines are held back rather than blocked-forever.

## Verification

Ran `SystemSpecs::detect()` on the actual Strix Halo box:

| | Before | After |
|---|---|---|
| `gpu_name` | `"N/A"` | `"AMD RYZEN AI MAX+ 395 w/ Radeon 8060S (integrated)"` |
| `unified_memory` | `false` | `true` |
| class | `DISCRETE_GPU` | `UNIFIED` |

Tests: 3 added (`test_parse_rocm_smi_na_product_name_falls_back`, `test_is_placeholder_and_generic_amd_gpu_name`, `hardware_identifiable_rejects_placeholder_gpu`); full `llmfit-core` lib suite passes (463).

🤖 Generated with [Claude Code](https://claude.com/claude-code)