### PR TITLE
Correct MiniMax M2.7 context window

### DIFF
--- a/scripts/scrape_hf_models.py
+++ b/scripts/scrape_hf_models.py
@@ -2278,7 +2278,7 @@ def main():
             "provider": "MiniMax", "parameter_count": "230B",
             "parameters_raw": 230000000000,
             "min_ram_gb": 128.6, "recommended_ram_gb": 214.4, "min_vram_gb": 117.9,
-            "quantization": "Q4_K_M", "context_length": 131072,
+            "quantization": "Q4_K_M", "context_length": 204800,
             "use_case": "Previous flagship with enhanced reasoning and coding",
             "pipeline_tag": "text-generation", "architecture": "minimax",
             "is_moe": True, "num_experts": 32, "active_experts": 2,


### PR DESCRIPTION
## Summary
- Corrects the MiniMax M2.7 context window from 131,072 to 204,800 in the scraper fallback.
- Keeps the generated model catalog entry in sync.

Follow-up to #702.

## Verification
- Confirmed the 204,800-token value through HTTP request captures of the official API documentation and model configuration.
- `python3 -m json.tool llmfit-core/data/hf_models.json`
- `python3 -m py_compile scripts/scrape_hf_models.py`
- `cargo test -p llmfit-core`
- `git diff --check`
