### PR TITLE
feat(llmfit-web): make API base URL configurable via VITE_API_BASE

### DIFF
--- a/llmfit-web/.env.example
+++ b/llmfit-web/.env.example
@@ -1,0 +1,13 @@
+# Base URL for the llmfit backend API (the `llmfit serve` axum server).
+#
+# Leave empty (or omit) to use same-origin requests. This keeps the Vite dev
+# proxy (`npm run dev` -> http://127.0.0.1:8787) and any deployment where the
+# frontend is served from the same origin as the API working unchanged.
+#
+# Set this to point the frontend at a self-hosted backend, e.g.:
+#   - a machine on your LAN:  http://192.168.1.50:8787
+#   - a cloudflared/ngrok tunnel URL:  https://llmfit-xyz.trycloudflare.com
+#   - a cloud-hosted backend:  https://llmfit.example.com
+#
+# Trailing slashes are stripped automatically. Requires a rebuild.
+VITE_API_BASE=

--- a/llmfit-web/README.md
+++ b/llmfit-web/README.md
@@ -18,3 +18,19 @@ npm run build
 ```
 
 Build output is written to `llmfit-web/dist` and embedded into `llmfit serve` at compile time.
+
+## Pointing at a self-hosted backend
+
+By default the frontend talks to the same origin (the Vite dev proxy forwards
+`/api` to `http://127.0.0.1:8787`). To point the built frontend at a remote
+`llmfit serve` instance (LAN IP, tunnel URL, or cloud backend), set `VITE_API_BASE`
+before building:
+
+```sh
+# copy and edit .env.example -> .env
+echo 'VITE_API_BASE=https://llmfit-xyz.trycloudflare.com' > .env
+npm run build
+```
+
+`VITE_API_BASE` accepts a bare origin (trailing slashes are trimmed). The value
+is baked into the bundle at build time, so rebuild after changing it.

--- a/llmfit-web/src/api.js
+++ b/llmfit-web/src/api.js
@@ -8,6 +8,15 @@ export const DEFAULT_FILTERS = {
   limit: '50'
 };
 
+// Base URL for the backend API. Defaults to same-origin (''), which keeps the
+// Vite dev proxy and same-origin deployments working unchanged. Set VITE_API_BASE
+// (e.g. https://my-host:8787) to point the frontend at a self-hosted backend.
+const API_BASE = (import.meta.env.VITE_API_BASE || '').replace(/\/+$/, '');
+
+function apiUrl(path) {
+  return `${API_BASE}${path}`;
+}
+
 function trimOrEmpty(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
@@ -121,29 +130,29 @@ async function parseJsonOrThrow(response) {
 export async function fetchSystemInfo(simulation = {}, signal) {
   const query = appendSimulationParams(new URLSearchParams(), simulation).toString();
   const path = query ? `/api/v1/system?${query}` : '/api/v1/system';
-  const response = await fetch(path, { signal });
+  const response = await fetch(apiUrl(path), { signal });
   return parseJsonOrThrow(response);
 }
 
 export async function fetchModels(filters, simulation = {}, signal) {
   const query = buildModelsQuery(filters, simulation);
   const path = query ? `/api/v1/models?${query}` : '/api/v1/models';
-  const response = await fetch(path, { signal });
+  const response = await fetch(apiUrl(path), { signal });
   return parseJsonOrThrow(response);
 }
 
 export async function fetchRuntimes(signal) {
-  const response = await fetch('/api/v1/runtimes', { signal });
+  const response = await fetch(apiUrl('/api/v1/runtimes'), { signal });
   return parseJsonOrThrow(response);
 }
 
 export async function fetchInstalled(signal) {
-  const response = await fetch('/api/v1/installed', { signal });
+  const response = await fetch(apiUrl('/api/v1/installed'), { signal });
   return parseJsonOrThrow(response);
 }
 
 export async function startDownload(model, runtime, signal) {
-  const response = await fetch('/api/v1/download', {
+  const response = await fetch(apiUrl('/api/v1/download'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ model, runtime }),
@@ -153,7 +162,7 @@ export async function startDownload(model, runtime, signal) {
 }
 
 export async function fetchDownloadStatus(id, signal) {
-  const response = await fetch(`/api/v1/download/${encodeURIComponent(id)}/status`, { signal });
+  const response = await fetch(apiUrl(`/api/v1/download/${encodeURIComponent(id)}/status`), { signal });
   return parseJsonOrThrow(response);
 }
 
@@ -177,7 +186,7 @@ export async function fetchPlanEstimate(
     body.cpu_cores = Math.trunc(cpuCores);
   }
 
-  const response = await fetch('/api/v1/plan', {
+  const response = await fetch(apiUrl('/api/v1/plan'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
Make the `llmfit-web` frontend's API base URL configurable so it can be deployed independently and pointed at a self-hosted `llmfit serve` backend.

Closes #745

## Changes
- `src/api.js`: add `API_BASE` from `import.meta.env.VITE_API_BASE` (trailing slashes trimmed) and an `apiUrl()` helper; all 7 `fetch` calls now route through it. Empty default preserves same-origin behavior (dev proxy / embedded build unchanged).
- `.env.example`: documents `VITE_API_BASE` with LAN / tunnel / cloud examples.
- `README.md`: documents the self-hosted backend workflow.

## Usage
```sh
echo 'VITE_API_BASE=https://llmfit-xyz.trycloudflare.com' > .env
npm run build
```

## Verification
- `npm test` — 14 passed
- `npm run build` — succeeds