### PR TITLE
fix(serve): include per-GPU memory_bandwidth_gbps in /api/v1/system

### DIFF
--- a/API.md
+++ b/API.md
@@ -97,16 +97,29 @@ Example response shape:
     "available_ram_gb": 41.08,
     "cpu_cores": 14,
     "cpu_name": "Intel(R) Core(TM) Ultra 7 165U",
-    "has_gpu": false,
-    "gpu_vram_gb": null,
-    "gpu_name": null,
-    "gpu_count": 0,
+    "has_gpu": true,
+    "gpu_vram_gb": 16.0,
+    "gpu_name": "Tesla T4",
+    "gpu_count": 1,
     "unified_memory": false,
-    "backend": "CPU (x86)",
-    "gpus": []
+    "backend": "CUDA",
+    "gpus": [
+      {
+        "name": "Tesla T4",
+        "vram_gb": 16.0,
+        "backend": "CUDA",
+        "count": 1,
+        "unified_memory": false,
+        "memory_bandwidth_gbps": 320.0
+      }
+    ]
   }
 }
 ```
+
+`memory_bandwidth_gbps` is `null` when the model isn't in the bandwidth
+table — consumers sizing fit bounds from it (e.g. llmfit-dra) should treat
+missing as unknown, not zero.
 
 ---
 

--- a/llmfit-tui/src/serve_shared.rs
+++ b/llmfit-tui/src/serve_shared.rs
@@ -12,6 +12,7 @@ pub fn system_json(specs: &SystemSpecs) -> serde_json::Value {
                 "backend": g.backend.label(),
                 "count": g.count,
                 "unified_memory": g.unified_memory,
+                "memory_bandwidth_gbps": llmfit_core::hardware::gpu_memory_bandwidth_gbps(&g.name),
             })
         })
         .collect();
@@ -104,4 +105,28 @@ pub fn round1(v: f64) -> f64 {
 
 pub fn round2(v: f64) -> f64 {
     (v * 100.0).round() / 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llmfit_core::hardware::{GpuBackend, GpuInfo};
+
+    // The REST /api/v1/system consumers (llmfit-dra) size fit bounds from
+    // per-GPU bandwidth; the field silently going missing zeroes GPU
+    // bandwidth in their inventory (AlexsJones/llmfit#747).
+    #[test]
+    fn system_json_includes_per_gpu_memory_bandwidth() {
+        let mut specs = SystemSpecs::detect();
+        specs.gpus = vec![GpuInfo {
+            name: "Tesla T4".to_string(),
+            vram_gb: Some(16.0),
+            backend: GpuBackend::Cuda,
+            count: 1,
+            unified_memory: false,
+        }];
+
+        let value = system_json(&specs);
+        assert_eq!(value["gpus"][0]["memory_bandwidth_gbps"], 320.0);
+    }
 }


### PR DESCRIPTION
`llmfit system --json` (display.rs) includes `memory_bandwidth_gbps` per GPU; the shared REST serializer (`serve_shared::system_json`, used by `/api/v1/system` and the MCP server) never got the field. Downstream, llmfit-dra prefers the API transport once the sidecar is up and zeroes GPU bandwidth in its DRA inventory — making every bandwidth-bounded ModelClaim unsatisfiable (observed live on a Tesla T4: 320 GB/s → gone; see sympozium-ai/llmfit-dra#38).

One-line fix using the same `hardware::gpu_memory_bandwidth_gbps` lookup the CLI path uses, plus a regression test asserting the field survives serialization (T4 → 320.0).

`cargo test -p llmfit serve` green, `cargo fmt --check` clean.

Fixes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)