### PR TITLE
fix(serve): include per-GPU memory_bandwidth_gbps in /api/v1/system

### DIFF
--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -800,34 +800,7 @@ pub fn display_json_diff_fits(specs: &SystemSpecs, fits: &[ModelFit]) {
 }
 
 fn system_json(specs: &SystemSpecs) -> serde_json::Value {
-    let gpus_json: Vec<serde_json::Value> = specs
-        .gpus
-        .iter()
-        .map(|g| {
-            serde_json::json!({
-                "name": g.name,
-                "vram_gb": g.vram_gb.map(round2),
-                "backend": g.backend.label(),
-                "count": g.count,
-                "unified_memory": g.unified_memory,
-                "memory_bandwidth_gbps": llmfit_core::hardware::gpu_memory_bandwidth_gbps(&g.name),
-            })
-        })
-        .collect();
-
-    serde_json::json!({
-        "total_ram_gb": round2(specs.total_ram_gb),
-        "available_ram_gb": round2(specs.available_ram_gb),
-        "cpu_cores": specs.total_cpu_cores,
-        "cpu_name": specs.cpu_name,
-        "has_gpu": specs.has_gpu,
-        "gpu_vram_gb": specs.gpu_vram_gb.map(round2),
-        "gpu_name": specs.gpu_name,
-        "gpu_count": specs.gpu_count,
-        "unified_memory": specs.unified_memory,
-        "backend": specs.backend.label(),
-        "gpus": gpus_json,
-    })
+    crate::serve_shared::system_json(specs)
 }
 
 fn fit_to_json(fit: &ModelFit) -> serde_json::Value {

--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -1125,6 +1125,9 @@ mod tests {
             let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
             assert!(value.get("node").is_some());
             assert!(value.get("system").is_some());
+            for gpu in value["system"]["gpus"].as_array().unwrap() {
+                assert!(gpu.get("memory_bandwidth_gbps").is_some());
+            }
         });
     }
 

--- a/llmfit-tui/src/serve_shared.rs
+++ b/llmfit-tui/src/serve_shared.rs
@@ -12,6 +12,7 @@ pub fn system_json(specs: &SystemSpecs) -> serde_json::Value {
                 "backend": g.backend.label(),
                 "count": g.count,
                 "unified_memory": g.unified_memory,
+                "memory_bandwidth_gbps": llmfit_core::hardware::gpu_memory_bandwidth_gbps(&g.name),
             })
         })
         .collect();
@@ -104,4 +105,49 @@ pub fn round1(v: f64) -> f64 {
 
 pub fn round2(v: f64) -> f64 {
     (v * 100.0).round() / 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llmfit_core::hardware::{GpuBackend, GpuInfo};
+
+    fn specs_with_gpu(name: &str) -> SystemSpecs {
+        SystemSpecs {
+            total_ram_gb: 32.0,
+            available_ram_gb: 24.0,
+            total_cpu_cores: 8,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: true,
+            gpu_vram_gb: Some(16.0),
+            total_gpu_vram_gb: Some(16.0),
+            gpu_name: Some(name.to_string()),
+            gpu_count: 1,
+            unified_memory: false,
+            backend: GpuBackend::Cuda,
+            gpus: vec![GpuInfo {
+                name: name.to_string(),
+                vram_gb: Some(16.0),
+                backend: GpuBackend::Cuda,
+                count: 1,
+                unified_memory: false,
+            }],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        }
+    }
+
+    #[test]
+    fn system_json_includes_per_gpu_memory_bandwidth() {
+        let json = system_json(&specs_with_gpu("Tesla T4"));
+        assert_eq!(json["gpus"][0]["memory_bandwidth_gbps"], 320.0);
+    }
+
+    #[test]
+    fn system_json_bandwidth_is_null_for_unknown_gpu() {
+        let json = system_json(&specs_with_gpu("Some Unknown GPU"));
+        let gpu = &json["gpus"][0];
+        assert!(gpu.get("memory_bandwidth_gbps").is_some());
+        assert!(gpu["memory_bandwidth_gbps"].is_null());
+    }
 }


### PR DESCRIPTION
Fixes #747

## Problem

`GET /api/v1/system` and `llmfit system --json` disagreed about GPU capability: the CLI reported per-GPU `memory_bandwidth_gbps` but the REST API omitted it. Consumers that treat the API as authoritative (llmfit-dra's sidecar transport) saw GPU bandwidth zero out once the API came up, making every bandwidth-bounded ModelClaim unsatisfiable.

## Root cause

Two drifted copies of `system_json`: the private one in `display.rs` (CLI) gained the field, while `serve_shared::system_json` (used by `/api/v1/system`, the MCP server, and SSE events) never did.

## Fix

- Add `memory_bandwidth_gbps` to `serve_shared::system_json` (also fixes the MCP `get_system_info` tool and SSE system events, which share the serializer).
- Delete the drifted copy in `display.rs` and delegate to `serve_shared::system_json`, so CLI and API can't diverge again.
- Unit tests: known GPU (Tesla T4 → 320.0) and unknown GPU (→ null); plus a presence assertion in the existing `/api/v1/system` route test.

## Verification

Ran `llmfit serve` locally and compared `GET /api/v1/system` with `llmfit system --json` — the per-GPU objects now match field-for-field. All 63 `llmfit` package tests pass; clippy and rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)