### PR TITLE
ci(docker): lowercase image name for digest push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,8 +36,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - name: Prepare platform slug
-        run: echo "PLATFORM_PAIR=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_ENV"
+      - name: Prepare platform slug and lowercase image name
+        run: |
+          echo "PLATFORM_PAIR=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -89,6 +91,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
Follow-up to #750: `github.repository` is mixed-case and OCI repo names must be lowercase. `metadata-action` handled this implicitly in the old flow; the push-by-digest output and `imagetools create` use the raw env var, so both platform builds failed at export with `invalid reference format`. Lowercase `IMAGE_NAME` at job start in both jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)