### PR TITLE
bench: add RTX 2080 community benchmark (Qwen3-30B-A3B, MoE offload)

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784193317-d01967fb.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784193317-d01967fb.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784193317,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.0.0"
+  },
+  "hardware": {
+    "hwClass": "DISCRETE_GPU",
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "memTierGb": 8,
+    "vramGb": 8.0,
+    "gpuCount": 1,
+    "unifiedMemory": false,
+    "cpu": "Intel(R) Core(TM) i9-10900X CPU @ 3.70GHz",
+    "cpuCores": 20,
+    "ramGb": 62.49,
+    "os": "linux"
+  },
+  "results": [
+    {
+      "model": "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 33.72,
+      "minTps": 32.86,
+      "maxTps": 34.81,
+      "avgTtftMs": null,
+      "avgTotalMs": 4432.16,
+      "avgOutputTokens": 150.67
+    }
+  ]
+}


### PR DESCRIPTION
Community benchmark for the NVIDIA GeForce RTX 2080 (8 GB) + i9-10900X, following the hand-crafted path documented in `community/README.md` (the v1.0.0 release binary predates `bench --share`, #712).

Numbers come from `llmfit bench --runs 3` (v1.0.0) against a llama.cpp server running Qwen3-30B-A3B-Instruct-2507 Q4_K_M with MoE expert offload (`-ngl 99 --n-cpu-moe 36`, single request). Provider is recorded as `llamacpp` (the bench ran through the OpenAI-compatible adapter).

Context for calibration: on this box `llmfit info` estimates 35.6 tok/s for this model (roofline 448 GB/s x 0.55, expert streaming bounded by the measured ~102 GB/s quad-channel DDR4). Pure generation speed measured by the server itself is 36.7 tok/s; the bench avg below (33.7) includes prompt processing in `total_ms`. Estimate landed within ~3-6% of measurement on a GPU not yet in the community table.