### PR TITLE
fix(ci): list Cargo.lock/Cargo.toml separately in workflow path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,17 @@ on:
       - main    # Run after merging into the "main" target
     paths:      # Run only if files relevant to CI have changed (i.e. not install.sh, scripts or .github/workflows)
       - 'llmfit-*/**'
-      - 'Cargo.{lock,toml}'
+      # Listed separately: workflow path filters have no brace expansion.
+      - 'Cargo.lock'
+      - 'Cargo.toml'
   pull_request:
     branches:
       - main    # Run in PRs targeting the "main" branch
     paths:
       - 'llmfit-*/**'
-      - 'Cargo.{lock,toml}'
+      # Listed separately: workflow path filters have no brace expansion.
+      - 'Cargo.lock'
+      - 'Cargo.toml'
     types:      # Avoid low-impact events like "edited" or "labeled"
       - opened
       - synchronize


### PR DESCRIPTION
## The problem

`.github/workflows/ci.yml` gates CI on these path filters:

```yaml
on:
  push:
    paths:
      - 'llmfit-*/**'
      - 'Cargo.{lock,toml}'
  pull_request:
    paths:
      - 'llmfit-*/**'
      - 'Cargo.{lock,toml}'
```

**GitHub Actions workflow path filters do not support brace expansion.** The supported syntax is `*`, `**`, `?`, `+`, `!`, and character ranges `[]` — `{a,b}` is not in it. The pattern `Cargo.{lock,toml}` is matched literally, against a file named `Cargo.{lock,toml}`, which does not exist. It has never matched anything.

The practical result: **a PR that touches only `Cargo.lock` and/or `Cargo.toml` runs no CI at all.** Every Rust dependency bump in this repo is currently merging entirely unverified.

## Evidence

Two dependency PRs open right now, both approved and awaiting merge:

| PR | Files changed | Checks |
|---|---|---|
| #739 — bump `rmcp` 1.7.0 → 1.8.0 | `Cargo.lock` | **0** |
| #740 — bump `jsonschema` 0.46.5 → 0.46.9 | `Cargo.lock` | **0** |
| #754 (control — touches `llmfit-*/**`) | `API.md`, `Cargo.lock`, `llmfit-core/…` | 8 |

#754 proves the workflow itself is healthy and that `llmfit-*/**` matches correctly. The Cargo-only PRs get nothing, because the only filter that could have matched them never matches.

## The fix

List the two files separately in the `on.push` and `on.pull_request` filters:

```yaml
    paths:
      - 'llmfit-*/**'
      - 'Cargo.lock'
      - 'Cargo.toml'
```

## What is deliberately *not* changed

The third occurrence, inside the `dorny/paths-filter` step:

```yaml
          filters: |
            rust:
              - 'llmfit-!(python)/**'
              - 'Cargo.{lock,toml}'
```

**This one is correct and is left alone.** `dorny/paths-filter` matches with [picomatch](https://github.com/micromatch/picomatch), which *does* support brace expansion — and the neighbouring `llmfit-!(python)/**` extglob only works under picomatch too, so that block is unambiguously written against picomatch semantics rather than GitHub's. Only the two `on.*.paths` lists are affected by this bug.

That asymmetry is exactly why this survived review: the same string is correct on line 48 and inert on lines 9/15, three lines of context apart.

## Verifying it

This is a workflow-trigger change, so it cannot fully prove itself from inside its own PR — this PR touches `.github/workflows/**`, which neither filter list matches, so CI will not run here either. That is expected.

The real check is the next Cargo-only dependency PR: it should now pick up the Test Suite matrix where #739 and #740 got nothing. If you want to confirm before merging, closing and reopening #739 after this lands will re-trigger the `pull_request` event against the updated filter.

Worth considering separately: #739 and #740 are approved and mergeable today with zero CI behind them. Once this is in, a rebase would give them real signal before they land.

🤝 _Handled by Alex's [Repo Steward](https://github.com/AlexsJones/repo-steward) — replies reviewed by [@AlexsJones](https://github.com/AlexsJones)._

Learn more or run your own: https://github.com/AlexsJones/repo-steward
