### PR TITLE
feat(api): expose usable_context and effective_context_length in the models envelope

### DIFF
--- a/API.md
+++ b/API.md
@@ -130,7 +130,7 @@ Envelope shape:
       "parameter_count": "7B",
       "params_b": 7.0,
       "context_length": 32768,
-      "usable_context": 24576,
+      "usable_context": 32768,
       "effective_context_length": 8192,
       "use_case": "Coding",
       "category": "Coding",

--- a/API.md
+++ b/API.md
@@ -130,6 +130,8 @@ Envelope shape:
       "parameter_count": "7B",
       "params_b": 7.0,
       "context_length": 32768,
+      "usable_context": 24576,
+      "effective_context_length": 8192,
       "use_case": "Coding",
       "category": "Coding",
       "release_date": "2025-03-14",
@@ -158,6 +160,15 @@ Envelope shape:
   ]
 }
 ```
+
+The three context fields answer different questions:
+
+- `context_length` — the model's native window, as advertised upstream.
+- `usable_context` — how much of that window actually fits in this node's
+  available memory alongside the weights. Use this one to pick a runtime `-c`.
+- `effective_context_length` — the context the `memory_required_gb` and
+  `estimated_tps` figures on this row were computed at. Defaults to
+  `min(context_length, 8192)`; set by `max_context` when supplied.
 
 ---
 

--- a/llmfit-tui/src/serve_shared.rs
+++ b/llmfit-tui/src/serve_shared.rs
@@ -40,6 +40,8 @@ pub fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "parameter_count": fit.model.parameter_count,
         "params_b": round2(fit.model.params_b()),
         "context_length": fit.model.context_length,
+        "usable_context": fit.usable_context,
+        "effective_context_length": fit.effective_context_length,
         "use_case": fit.model.use_case,
         "category": fit.use_case.label(),
         "release_date": fit.model.release_date,
@@ -151,5 +153,25 @@ mod tests {
         let gpu = &json["gpus"][0];
         assert!(gpu.get("memory_bandwidth_gbps").is_some());
         assert!(gpu["memory_bandwidth_gbps"].is_null());
+    }
+
+    #[test]
+    fn fit_json_exposes_context_fields() {
+        let db = llmfit_core::models::ModelDatabase::new();
+        let model = db
+            .get_all_models()
+            .iter()
+            .find(|m| m.context_length > llmfit_core::fit::DEFAULT_ESTIMATION_CTX)
+            .expect("catalog has a model with a large context window");
+        let fit = ModelFit::analyze(model, &specs_with_gpu("Tesla T4"));
+
+        let json = fit_to_json(&fit);
+
+        assert_eq!(json["usable_context"], fit.usable_context);
+        assert_eq!(
+            json["effective_context_length"],
+            llmfit_core::fit::DEFAULT_ESTIMATION_CTX
+        );
+        assert!(fit.usable_context <= model.context_length);
     }
 }


### PR DESCRIPTION
## Problem

llmfit has two independent `fit_to_json` serializers. The one behind `llmfit fit --json` (`display.rs`) already emits `usable_context` and `effective_context_length`. The one behind the **REST API** (`/api/v1/models*`, via `serve_api.rs`) and the **MCP server** (`mcp_server.rs`) — `serve_shared::fit_to_json` — does not: it only exposes the model's native `context_length`.

That leaves the API/MCP consumers without the two numbers that matter most for acting on a recommendation:

- **`usable_context`** — the context that actually fits in this node's available memory alongside the weights (computed in core since #621). For an agent calling llmfit as an MCP tool, this is arguably the single most useful number in the envelope: it's the value you'd hand to `-c` / `--ctx-size`.
- **`effective_context_length`** — the context the row's `memory_required_gb` / `estimated_tps` were computed at (`DEFAULT_ESTIMATION_CTX = 8192`, or the `max_context` query param). Without it, an estimate served over the API isn't reproducible — the same gap the Estimate Basis section closed for `llmfit info` in #292.

## Change

- `serve_shared::fit_to_json`: add `usable_context` and `effective_context_length`. Purely additive — no existing key changes value or type. Both the REST endpoints and the MCP server pick it up.
- `API.md`: document the three context fields in the `/api/v1/models` envelope and what distinguishes them.
- Test: `fit_json_exposes_context_fields` analyzes a real catalog model with a >8192 window and asserts both fields serialize, that `effective_context_length` is the estimation cap, and that `usable_context <= context_length`.

## Verification

Run against the changed path (API server from this branch, macOS, 32GB, Radeon Pro 5500M):

```console
$ llmfit serve --port 8791 &
$ curl -s "localhost:8791/api/v1/models?limit=200" | jq '[.models[] | select(.usable_context < .context_length and .usable_context > .effective_context_length)][0] | {name, context_length, usable_context, effective_context_length}'
{
  "name": "second-state/DeepSeek-R1-Distill-Qwen-14B-GGUF",
  "context_length": 131072,
  "usable_context": 47768,
  "effective_context_length": 8192
}
```

All three numbers meaningfully differ on a real model: 131k advertised, ~47k actually fits, estimates computed at 8k.

Absence on `main` at the same seam:

```console
$ git show upstream/main:llmfit-tui/src/serve_shared.rs | grep -c usable_context
0
```

`make test` green (475 core + 54 tui). `make fmt` clean. `cargo clippy -- -D warnings` output is identical before and after this branch (the pre-existing errors on `main` come from rustc 1.97 being newer than CI's).

## Follow-up (separate PR, not this one)

`generate_llamacpp_command` currently emits `-c {effective_context_length}`, i.e. the 8k estimation cap rather than what fits. Driving `-c` from `usable_context` is the natural next step — happy to open that once this lands, if the direction looks right.
