### PR TITLE
fix(tui): force a full clear after entering the alternate screen

### DIFF
--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1279,6 +1279,12 @@ fn run_tui_inner(
 
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
     let mut terminal = ratatui::Terminal::new(backend)?;
+    // Force a full clear before the first frame: ratatui only paints the cells
+    // a frame renders and trusts EnterAlternateScreen to start from a blank
+    // screen, but some terminals (notably Windows Terminal, #732) switch to the
+    // alternate screen without clearing it, leaving the previous shell content
+    // visible underneath sparse frames.
+    terminal.clear()?;
     draw_boot_screen(&mut terminal, "Detecting system hardware...")?;
 
     // Create app state (provider detection runs in background threads)


### PR DESCRIPTION
Closes #732

## What

One-line behavioral fix (plus comment): call `terminal.clear()` on the freshly created ratatui terminal immediately after `EnterAlternateScreen`, before the boot screen draws.

## Why

@benbaker76's `llmfit doctor` output and Windows Terminal confirmation pinned the mechanism (see the diagnosis in #732): ratatui only paints the cells a frame actually renders and trusts the alternate screen to start blank — but Windows Terminal switches to the alternate screen **without reliably clearing it**. The result is the reported corruption: previous shell content showing through underneath the TUI's sparse first frames.

`Terminal::clear()` forces every cell to be written on the next draw, so the TUI owns the whole viewport from frame one. On terminals that already clear the alt screen (macOS/Linux/most emulators) this is a no-op visually — one extra full-screen write at startup only.

## Verification

- The change is confined to TUI startup in `run_tui_inner`; no logic paths change.
- CI on this PR runs the full suite on all three platforms; there is no automated way to assert what a real Windows Terminal leaves on the alt screen, so the definitive confirmation is @benbaker76 running a build of this branch — asked in #732.

🤝 _Handled by Alex's [Repo Steward](https://github.com/AlexsJones/repo-steward) — replies reviewed by [@AlexsJones](https://github.com/AlexsJones)._

Learn more or run your own: https://github.com/AlexsJones/repo-steward
