### PR TITLE
bench: RTX 2080 (8GB) community benchmarks — sub-8B, full-GPU offload

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784560682-efc5c3a6.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784560682-efc5c3a6.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784560682,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.3"
+  },
+  "hardware": {
+    "hwClass": "DISCRETE_GPU",
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "memTierGb": 8,
+    "vramGb": 8.0,
+    "gpuCount": 1,
+    "unifiedMemory": false,
+    "cpu": "Intel(R) Core(TM) i9-10900X CPU @ 3.70GHz",
+    "cpuCores": 20,
+    "ramGb": 62.49,
+    "os": "linux"
+  },
+  "results": [
+    {
+      "model": "Qwen3-4B-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 110.6,
+      "minTps": 109.93,
+      "maxTps": 111.37,
+      "avgTtftMs": null,
+      "avgTotalMs": 2712.54,
+      "avgOutputTokens": 300.0
+    },
+    {
+      "model": "Qwen3-8B-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 69.34,
+      "minTps": 68.99,
+      "maxTps": 69.76,
+      "avgTtftMs": null,
+      "avgTotalMs": 4240.85,
+      "avgOutputTokens": 294.0
+    },
+    {
+      "model": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 71.87,
+      "minTps": 71.72,
+      "maxTps": 72.02,
+      "avgTtftMs": null,
+      "avgTotalMs": 2649.48,
+      "avgOutputTokens": 190.33
+    },
+    {
+      "model": "Ministral-8B-Instruct-2410-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 70.45,
+      "minTps": 69.66,
+      "maxTps": 71.31,
+      "avgTtftMs": null,
+      "avgTotalMs": 2664.8,
+      "avgOutputTokens": 188.67
+    }
+  ]
+}


### PR DESCRIPTION
Community benchmarks for the **NVIDIA GeForce RTX 2080 (8 GB)** — sub-8B models running fully on the GPU (`-ngl 99`).

Measured with **llmfit v1.1.3** (`bench --provider llamacpp --runs 3`, warmed) against **llama.cpp**, all models **Q4_K_M** GGUF (gpt-oss: MXFP4), context 4096, single slot.
Host: Intel i9-10900X, 62 GB RAM, Linux.

| Model | avg tok/s | offload |
|---|---|---|
| Qwen3-4B | 110.6 | `-ngl 99` |
| Meta-Llama-3.1-8B-Instruct | 71.9 | `-ngl 99` |
| Ministral-8B-2410 | 70.5 | `-ngl 99` |
| Qwen3-8B | 69.3 | `-ngl 99` |

Offload tuned per model to fit the 8 GB VRAM budget (config not part of the schema, listed here for transparency).
