### PR TITLE
bench: RTX 2080 (8GB) community benchmarks — 20–24B, MoE vs dense

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784560684-cacae003.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784560684-cacae003.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784560684,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.3"
+  },
+  "hardware": {
+    "hwClass": "DISCRETE_GPU",
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "memTierGb": 8,
+    "vramGb": 8.0,
+    "gpuCount": 1,
+    "unifiedMemory": false,
+    "cpu": "Intel(R) Core(TM) i9-10900X CPU @ 3.70GHz",
+    "cpuCores": 20,
+    "ramGb": 62.49,
+    "os": "linux"
+  },
+  "results": [
+    {
+      "model": "gpt-oss-20b-MXFP4.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 36.35,
+      "minTps": 28.95,
+      "maxTps": 40.54,
+      "avgTtftMs": null,
+      "avgTotalMs": 7125.59,
+      "avgOutputTokens": 247.67
+    },
+    {
+      "model": "Mistral-Small-24B-Instruct-2501-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 5.22,
+      "minTps": 5.14,
+      "maxTps": 5.31,
+      "avgTtftMs": null,
+      "avgTotalMs": 41391.69,
+      "avgOutputTokens": 216.0
+    }
+  ]
+}


### PR DESCRIPTION
Community benchmarks for the **NVIDIA GeForce RTX 2080 (8 GB)** — 20–24B models on 8 GB: sparse MoE vs dense.

Measured with **llmfit v1.1.3** (`bench --provider llamacpp --runs 3`, warmed) against **llama.cpp**, all models **Q4_K_M** GGUF (gpt-oss: MXFP4), context 4096, single slot.
Host: Intel i9-10900X, 62 GB RAM, Linux.

| Model | avg tok/s | offload |
|---|---|---|
| gpt-oss-20B (MoE, 3.6B active) | 36.4 | `--n-cpu-moe 12` |
| Mistral-Small-24B (dense) | 5.2 | `-ngl 16` |

The MoE model sustains ~7× the throughput of the similarly-sized dense 24B on the same 8 GB card — expert offload is what keeps 20B+ usable here.

Offload tuned per model to fit the 8 GB VRAM budget (config not part of the schema, listed here for transparency).
