### PR TITLE
fix: don't offer MLX downloads for AWQ/GPTQ repos; verify the mlx-community fallback exists before pulling

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -595,6 +595,18 @@ fn is_likely_gguf_repo(repo_lower: &str) -> bool {
     repo_lower.contains("-gguf") || repo_lower.ends_with("gguf")
 }
 
+/// Detect repos whose name marks a pre-quantized non-MLX format (AWQ, GPTQ,
+/// AutoRound). These are vLLM/CUDA formats: guessing an `mlx-community`
+/// equivalent for them almost always fabricates a repo that does not exist
+/// (issue #294). A name that also carries an MLX marker (e.g. an
+/// mlx-community conversion that keeps "AWQ" in its name) is not excluded —
+/// callers check MLX markers first.
+pub fn is_likely_prequantized_repo(repo_lower: &str) -> bool {
+    ["awq", "gptq", "autoround", "auto-round"]
+        .iter()
+        .any(|marker| repo_lower.contains(marker))
+}
+
 /// Scan HuggingFace cache directories for MLX model directories.
 fn scan_hf_cache_for_mlx() -> HashSet<String> {
     let mut set = HashSet::new();
@@ -737,11 +749,7 @@ impl ModelProvider for MlxProvider {
     }
 
     fn start_pull(&self, model_tag: &str) -> Result<PullHandle, String> {
-        let repo_id = if model_tag.contains('/') {
-            model_tag.to_string()
-        } else {
-            format!("mlx-community/{}", model_tag)
-        };
+        let repo_id = resolve_mlx_fallback_repo(model_tag, &hf_repo_exists)?;
         let repo_for_thread = repo_id.clone();
         let (tx, rx) = std::sync::mpsc::channel();
 
@@ -3369,6 +3377,47 @@ pub fn mlx_pull_tag(hf_name: &str) -> String {
         })
 }
 
+/// Resolve the repo id an MLX pull should download, guarding the
+/// `mlx-community/{tag}` fallback (issue #294).
+///
+/// An explicit `owner/name` tag is trusted as typed. A bare tag is a guess:
+/// llmfit assumes an `mlx-community` equivalent exists. Before that guess is
+/// handed to `hf download` we (a) refuse names that mark a pre-quantized
+/// non-MLX format (AWQ/GPTQ/AutoRound have no fabricated MLX twin), and
+/// (b) verify the guessed repo actually exists, so the user gets a clear
+/// error instead of a "Model not found" pull failure against a repo llmfit
+/// invented.
+///
+/// `repo_exists` is injected so tests don't hit the network.
+fn resolve_mlx_fallback_repo(
+    model_tag: &str,
+    repo_exists: &dyn Fn(&str) -> bool,
+) -> Result<String, String> {
+    if model_tag.contains('/') {
+        return Ok(model_tag.to_string());
+    }
+
+    let tag_lower = model_tag.to_lowercase();
+    let has_mlx_marker = tag_lower.contains("mlx");
+    if !has_mlx_marker && is_likely_prequantized_repo(&tag_lower) {
+        return Err(format!(
+            "{model_tag} looks like a pre-quantized AWQ/GPTQ repo — that's a vLLM/CUDA \
+             format, not MLX, and there is no mlx-community equivalent to guess. If an \
+             MLX build of this model exists, pass its full repo id (owner/name)."
+        ));
+    }
+
+    let candidate = format!("mlx-community/{model_tag}");
+    if !repo_exists(&candidate) {
+        return Err(format!(
+            "No MLX build found: {candidate} does not exist on Hugging Face (or could not \
+             be reached). If an MLX build exists under a different name, pass its full \
+             repo id (owner/name)."
+        ));
+    }
+    Ok(candidate)
+}
+
 // ---------------------------------------------------------------------------
 // Ollama name-matching helpers
 // ---------------------------------------------------------------------------
@@ -4693,6 +4742,65 @@ mod tests {
     fn test_mlx_pull_tag_fallback() {
         let tag = mlx_pull_tag("SomeUnknown/Model-7B");
         assert!(!tag.is_empty());
+    }
+
+    // ── resolve_mlx_fallback_repo (issue #294) ───────────────────────
+
+    #[test]
+    fn test_resolve_mlx_explicit_repo_passes_through_unverified() {
+        // An explicit owner/name is trusted as typed — no existence probe.
+        let repo = resolve_mlx_fallback_repo("mlx-community/Qwen3-8B-4bit", &|_: &str| {
+            panic!("explicit repo ids must not be probed")
+        });
+        assert_eq!(repo.unwrap(), "mlx-community/Qwen3-8B-4bit");
+    }
+
+    #[test]
+    fn test_resolve_mlx_fallback_verified_when_repo_exists() {
+        let repo = resolve_mlx_fallback_repo("qwen3-8b-4bit", &|r: &str| {
+            r == "mlx-community/qwen3-8b-4bit"
+        });
+        assert_eq!(repo.unwrap(), "mlx-community/qwen3-8b-4bit");
+    }
+
+    #[test]
+    fn test_resolve_mlx_fallback_errors_when_repo_missing() {
+        let err = resolve_mlx_fallback_repo("qwen3-30b-a3b-instruct-2507-4bit", &|_: &str| false)
+            .unwrap_err();
+        assert!(
+            err.contains("mlx-community/qwen3-30b-a3b-instruct-2507-4bit"),
+            "error should name the guessed repo, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_mlx_fallback_refuses_awq_tag() {
+        // The #294 shape: an AWQ repo name with no MLX marker must be
+        // refused before any network probe or download starts.
+        let err = resolve_mlx_fallback_repo("qwen3-30b-a3b-instruct-2507-awq-4bit", &|_: &str| {
+            panic!("prequantized tags must be refused before probing")
+        })
+        .unwrap_err();
+        assert!(err.contains("AWQ/GPTQ"), "got: {err}");
+    }
+
+    #[test]
+    fn test_resolve_mlx_fallback_allows_awq_named_mlx_conversion() {
+        // mlx-community conversions sometimes keep "AWQ" in the name; an MLX
+        // marker wins over the prequantized marker (existence still checked).
+        let repo = resolve_mlx_fallback_repo("qwen3-8b-awq-mlx-4bit", &|_: &str| true);
+        assert_eq!(repo.unwrap(), "mlx-community/qwen3-8b-awq-mlx-4bit");
+    }
+
+    #[test]
+    fn test_is_likely_prequantized_repo() {
+        assert!(is_likely_prequantized_repo(
+            "qwen3-30b-a3b-instruct-2507-awq-4bit"
+        ));
+        assert!(is_likely_prequantized_repo("model-gptq-int4"));
+        assert!(is_likely_prequantized_repo("model-autoround-4bit"));
+        assert!(!is_likely_prequantized_repo("qwen3-8b-4bit"));
+        assert!(!is_likely_prequantized_repo("llama-3.1-8b-instruct"));
     }
 
     // ── ollama_installed_matches_candidate ────────────────────────────

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -4085,7 +4085,12 @@ impl App {
         let is_mlx_model = fit.model.is_mlx_model();
         let has_catalog_gguf = !fit.model.gguf_sources.is_empty();
 
-        let download_options = self.available_download_providers(&model_name, has_catalog_gguf);
+        let download_options = self.available_download_providers(
+            &model_name,
+            model_format,
+            is_mlx_model,
+            has_catalog_gguf,
+        );
         if !download_options.is_empty() {
             self.open_download_provider_popup(model_name, download_options);
         } else {
@@ -4350,6 +4355,8 @@ impl App {
     fn available_download_providers(
         &self,
         model_name: &str,
+        model_format: llmfit_core::models::ModelFormat,
+        is_mlx_model: bool,
         has_catalog_gguf: bool,
     ) -> Vec<DownloadProvider> {
         let mut providers_for_model = Vec::new();
@@ -4358,7 +4365,13 @@ impl App {
         {
             providers_for_model.push(DownloadProvider::Ollama);
         }
-        if self.mlx_available {
+        // AWQ/GPTQ/AutoRound are vLLM/CUDA formats with no MLX equivalent to
+        // guess — offering MLX for them fabricates a nonexistent
+        // mlx-community repo (issue #294). Scanned HF models default to
+        // ModelFormat::Gguf, so the name is checked as well as the format.
+        let prequantized = model_format.is_prequantized()
+            || providers::is_likely_prequantized_repo(&model_name.to_lowercase());
+        if self.mlx_available && (is_mlx_model || !prequantized) {
             providers_for_model.push(DownloadProvider::Mlx);
         }
         // Check catalog gguf_sources first (no HTTP probe needed), then
@@ -5102,6 +5115,68 @@ mod tests {
             estimate_basis: Default::default(),
             measured_tps: None,
         }
+    }
+
+    // ── available_download_providers MLX gating (issue #294) ─────────
+
+    fn mlx_only_app() -> App {
+        let mut app = test_app();
+        app.mlx_available = true;
+        // Keep every other provider off so no network probe runs and the
+        // returned options are exactly the MLX decision.
+        app.ollama_available = false;
+        app.ollama_binary_available = false;
+        app.llamacpp_available = false;
+        app.docker_mr_available = false;
+        app.lmstudio_available = false;
+        app.vllm_available = false;
+        app
+    }
+
+    #[test]
+    fn awq_named_model_is_not_offered_mlx_download() {
+        let app = mlx_only_app();
+        // The #294 model: format comes back as the Gguf default for scanned
+        // HF models, so the name heuristic must catch it.
+        let options = app.available_download_providers(
+            "cyankiwi/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit",
+            ModelFormat::Gguf,
+            false,
+            true,
+        );
+        assert!(options.is_empty(), "got: {options:?}");
+    }
+
+    #[test]
+    fn awq_format_model_is_not_offered_mlx_download() {
+        let app = mlx_only_app();
+        let options =
+            app.available_download_providers("some/quantized-model", ModelFormat::Awq, false, true);
+        assert!(options.is_empty(), "got: {options:?}");
+    }
+
+    #[test]
+    fn plain_model_is_offered_mlx_download() {
+        let app = mlx_only_app();
+        let options = app.available_download_providers(
+            "meta-llama/Llama-3.1-8B-Instruct",
+            ModelFormat::Gguf,
+            false,
+            true,
+        );
+        assert_eq!(options, vec![DownloadProvider::Mlx]);
+    }
+
+    #[test]
+    fn mlx_conversion_keeping_awq_in_name_is_still_offered() {
+        let app = mlx_only_app();
+        let options = app.available_download_providers(
+            "mlx-community/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit-MLX",
+            ModelFormat::Gguf,
+            true,
+            true,
+        );
+        assert_eq!(options, vec![DownloadProvider::Mlx]);
     }
 
     #[test]


### PR DESCRIPTION
Implements both fixes named in @AlexsJones's diagnosis on #294: AWQ repos were being offered for MLX download, and the `mlx-community/{tag}` fallback pulled a guessed repo without checking it exists.

## What was happening

`cyankiwi/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit` is an AWQ quant (vLLM/CUDA format). The TUI offered MLX as a download option for it purely because the MLX runtime was available, then `mlx_pull_tag` fell back to a bare lowercased tag, and `start_pull` prefixed `mlx-community/` and ran `hf download` against `mlx-community/qwen3-30b-a3b-instruct-2507-awq-4bit` — a repo that doesn't exist. Result: an opaque "Model not found" mid-pull, which looked like an auth problem to the reporter.

## Fix 1 — don't offer MLX for pre-quantized repos (mirrors the GGUF exclusion)

`available_download_providers` now excludes the MLX option when the model is AWQ/GPTQ/AutoRound — checked via `ModelFormat::is_prequantized()` **and** a new `is_likely_prequantized_repo` name heuristic, because HF-scanned models currently default to `ModelFormat::Gguf` (see note below). Genuine MLX conversions that keep "AWQ" in the name (`…-AWQ-4bit-MLX`) are still offered — the MLX marker wins.

With no other provider available, the existing `format_no_download_message` AWQ/GPTQ explanation ("requires vLLM or a CUDA/ROCm GPU") now surfaces instead of a doomed pull.

## Fix 2 — verify the mlx-community fallback before pulling

`MlxProvider::start_pull`'s bare-tag branch now goes through `resolve_mlx_fallback_repo`, which (a) refuses prequantized-named tags outright with a format explanation, and (b) probes the guessed `mlx-community/{tag}` with the existing `hf_repo_exists` helper before spawning `hf download`, returning an actionable error naming the repo it guessed. Explicit `owner/name` tags are trusted as typed and not probed — the resolver is injected as a closure so tests run without network.

## Tests

- 6 new core tests on `resolve_mlx_fallback_repo` / `is_likely_prequantized_repo` (including the exact #294 tag shape, and the AWQ-named-MLX-conversion counter-case).
- 4 new TUI tests on the MLX offer gate (AWQ by name, AWQ by format, plain model still offered, MLX conversion still offered).
- Full suite: 487 core + 68 TUI pass; clippy warning count unchanged vs main; fmt clean.

## Out of scope, observed while fixing

- HF-scanned models get `ModelFormat::default()` (= `Gguf`) in `update.rs` regardless of actual weights — inferring AWQ/GPTQ/MLX/Safetensors from the repo name/files there would let the format check carry more weight than the name heuristic. Happy to follow up.
- The `serve` API's `"mlx"` download branch passes the raw model name to `start_pull` without `mlx_pull_tag` resolution, so web downloads of a full `owner/name` AWQ repo would fetch the AWQ weights under the MLX runtime label. The existence guard here doesn't change that path's behaviour for explicit ids.

Closes #294

🤝 _Handled by Alex's [Repo Steward](https://github.com/AlexsJones/repo-steward) — replies reviewed by [@AlexsJones](https://github.com/AlexsJones)._

Learn more or run your own: https://github.com/AlexsJones/repo-steward
