### PR TITLE
bench: RTX 2080 (8GB) community benchmarks — 19 more models (batches 2 & 3)

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784627096-7bd7947b.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784627096-7bd7947b.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784627096,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.3"
+  },
+  "hardware": {
+    "hwClass": "DISCRETE_GPU",
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "memTierGb": 8,
+    "vramGb": 8.0,
+    "gpuCount": 1,
+    "unifiedMemory": false,
+    "cpu": "Intel(R) Core(TM) i9-10900X CPU @ 3.70GHz",
+    "cpuCores": 20,
+    "ramGb": 62.49,
+    "os": "linux"
+  },
+  "results": [
+    {
+      "model": "Mistral-7B-Instruct-v0.3-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 77.76,
+      "minTps": 77.39,
+      "maxTps": 78.27,
+      "avgTtftMs": null,
+      "avgTotalMs": 2798.74,
+      "avgOutputTokens": 218.0
+    },
+    {
+      "model": "Qwen2.5-7B-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 76.96,
+      "minTps": 76.37,
+      "maxTps": 77.35,
+      "avgTtftMs": null,
+      "avgTotalMs": 2716.64,
+      "avgOutputTokens": 209.67
+    },
+    {
+      "model": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 76.5,
+      "minTps": 75.42,
+      "maxTps": 77.32,
+      "avgTtftMs": null,
+      "avgTotalMs": 2179.08,
+      "avgOutputTokens": 167.67
+    },
+    {
+      "model": "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 77.18,
+      "minTps": 76.98,
+      "maxTps": 77.45,
+      "avgTtftMs": null,
+      "avgTotalMs": 3886.82,
+      "avgOutputTokens": 300.0
+    },
+    {
+      "model": "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 140.33,
+      "minTps": 138.15,
+      "maxTps": 141.42,
+      "avgTtftMs": null,
+      "avgTotalMs": 1210.64,
+      "avgOutputTokens": 170.67
+    },
+    {
+      "model": "DeepSeek-Coder-V2-Lite-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 49.57,
+      "minTps": 47.22,
+      "maxTps": 51.29,
+      "avgTtftMs": null,
+      "avgTotalMs": 4446.1,
+      "avgOutputTokens": 219.0
+    },
+    {
+      "model": "gemma-2-9b-it-Q4_K_M-fp16.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 23.69,
+      "minTps": 20.4,
+      "maxTps": 25.61,
+      "avgTtftMs": null,
+      "avgTotalMs": 7122.85,
+      "avgOutputTokens": 176.0
+    },
+    {
+      "model": "Qwen2.5-14B-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 20.77,
+      "minTps": 20.36,
+      "maxTps": 21.54,
+      "avgTtftMs": null,
+      "avgTotalMs": 8631.79,
+      "avgOutputTokens": 179.33
+    },
+    {
+      "model": "Qwen2.5-Coder-14B-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 20.7,
+      "minTps": 19.66,
+      "maxTps": 21.63,
+      "avgTtftMs": null,
+      "avgTotalMs": 7850.26,
+      "avgOutputTokens": 164.33
+    }
+  ]
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784627097-07f3856f.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1784627097-07f3856f.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784627097,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.3"
+  },
+  "hardware": {
+    "hwClass": "DISCRETE_GPU",
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "memTierGb": 8,
+    "vramGb": 8.0,
+    "gpuCount": 1,
+    "unifiedMemory": false,
+    "cpu": "Intel(R) Core(TM) i9-10900X CPU @ 3.70GHz",
+    "cpuCores": 20,
+    "ramGb": 62.49,
+    "os": "linux"
+  },
+  "results": [
+    {
+      "model": "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 304.27,
+      "minTps": 301.45,
+      "maxTps": 308.93,
+      "avgTtftMs": null,
+      "avgTotalMs": 594.16,
+      "avgOutputTokens": 181.33
+    },
+    {
+      "model": "gemma-2-2b-it-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 140.27,
+      "minTps": 136.93,
+      "maxTps": 142.58,
+      "avgTtftMs": null,
+      "avgTotalMs": 1481.44,
+      "avgOutputTokens": 209.67
+    },
+    {
+      "model": "Qwen2.5-Coder-3B-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 136.51,
+      "minTps": 131.37,
+      "maxTps": 139.23,
+      "avgTtftMs": null,
+      "avgTotalMs": 1403.91,
+      "avgOutputTokens": 194.67
+    },
+    {
+      "model": "Phi-3.5-mini-instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 121.46,
+      "minTps": 120.27,
+      "maxTps": 123.5,
+      "avgTtftMs": null,
+      "avgTotalMs": 2470.23,
+      "avgOutputTokens": 300.0
+    },
+    {
+      "model": "granite-3.1-8b-instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 65.63,
+      "minTps": 65.43,
+      "maxTps": 65.96,
+      "avgTtftMs": null,
+      "avgTotalMs": 3273.39,
+      "avgOutputTokens": 215.0
+    },
+    {
+      "model": "DeepSeek-R1-Distill-Llama-8B-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 71.74,
+      "minTps": 71.49,
+      "maxTps": 72.13,
+      "avgTtftMs": null,
+      "avgTotalMs": 4181.99,
+      "avgOutputTokens": 300.0
+    },
+    {
+      "model": "Falcon3-7B-Instruct-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 75.78,
+      "minTps": 75.01,
+      "maxTps": 76.24,
+      "avgTtftMs": null,
+      "avgTotalMs": 2393.46,
+      "avgOutputTokens": 182.0
+    },
+    {
+      "model": "DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 17.87,
+      "minTps": 16.72,
+      "maxTps": 18.97,
+      "avgTtftMs": null,
+      "avgTotalMs": 16834.32,
+      "avgOutputTokens": 300.0
+    },
+    {
+      "model": "Codestral-22B-v0.1-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 5.05,
+      "minTps": 4.35,
+      "maxTps": 5.49,
+      "avgTtftMs": null,
+      "avgTotalMs": 26714.97,
+      "avgOutputTokens": 140.33
+    },
+    {
+      "model": "gemma-2-27b-it-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 3.89,
+      "minTps": 3.87,
+      "maxTps": 3.92,
+      "avgTtftMs": null,
+      "avgTotalMs": 44158.88,
+      "avgOutputTokens": 172.0
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up to #773 / #774 / #775 (all merged) — 19 additional models measured on the same **NVIDIA GeForce RTX 2080 (8 GB)**, extending coverage from 1B up to 27B dense.

## Method
- Engine: **llama.cpp** (`llamacpp` provider), all models **Q4_K_M** GGUF, context 4096, single slot, **warmed** before timing.
- Tool: **llmfit v1.1.3**, `bench --runs 3`.
- Host: Intel i9-10900X, 62 GB RAM, Linux.
- Offload tuned per model to fit the 8 GB VRAM budget (config not part of the schema, listed below for transparency).

## Results (19 models, two submission files)

### Full-GPU (`-ngl 99`, fits in 8 GB)
| Model | tok/s |
|---|---|
| Llama-3.2-1B | 304.3 |
| gemma-2-2B | 140.3 |
| Llama-3.2-3B | 140.3 |
| Qwen2.5-Coder-3B | 136.5 |
| Phi-3.5-mini (3.8B) | 121.5 |
| Mistral-7B-Instruct-v0.3 | 77.8 |
| DeepSeek-R1-Distill-Qwen-7B | 77.2 |
| Qwen2.5-7B | 77.0 |
| Qwen2.5-Coder-7B | 76.5 |
| Falcon3-7B | 75.8 |
| DeepSeek-R1-Distill-Llama-8B | 71.7 |
| Granite-3.1-8B | 65.6 |

### MoE (expert offload)
| Model | tok/s |
|---|---|
| DeepSeek-Coder-V2-Lite (16B total / 2.4B active, `--n-cpu-moe 16`) | 49.6 |

### Dense > 8 GB (partial CPU offload)
| Model | offload | tok/s |
|---|---|---|
| gemma-2-9B | `-ngl 36` | 23.7 |
| Qwen2.5-14B | `-ngl 42` | 20.8 |
| Qwen2.5-Coder-14B | `-ngl 42` | 20.7 |
| DeepSeek-R1-Distill-Qwen-14B | `-ngl 40` | 17.9 |
| Codestral-22B | `-ngl 24` | 5.0 |
| gemma-2-27B | `-ngl 14` | 3.9 |

## Takeaway
Everything up to ~8B runs fully on the card (66–304 tok/s). A lightweight MoE stays fast (50 tok/s at 16B total, thanks to only 2.4B active params). Dense models past the 8 GB line fall off a cliff as weights spill to system RAM — a 27B lands around 4 tok/s.