### PR TITLE
feat(tui): [SIMULATED] GPU indicator and / search in the community leaderboard

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1035,6 +1035,10 @@ pub struct App {
     /// Index into HardwarePreset::all() when the picker is open.
     pub bench_hw_picker_cursor: usize,
     pub bench_hw_picker_open: bool,
+    /// `/` filter over the leaderboard rows (model, engine, quant, user).
+    pub bench_search_query: String,
+    /// True while the `/` search box is capturing keystrokes.
+    pub bench_search_active: bool,
 
     // Live inference-bench view (llmfit bench — distinct from community benchmarks above)
     pub show_bench: bool,
@@ -1543,6 +1547,8 @@ impl App {
             bench_hw_label: None,
             bench_hw_picker_cursor: 0,
             bench_hw_picker_open: false,
+            bench_search_query: String::new(),
+            bench_search_active: false,
             // Live inference-bench view
             show_bench: false,
             bench_model_status: Vec::new(),
@@ -2403,6 +2409,8 @@ impl App {
         self.input_mode = InputMode::Benchmarks;
         self.bench_cursor = 0;
         self.bench_scroll = 0;
+        self.bench_search_query.clear();
+        self.bench_search_active = false;
 
         // If the selected model is installed and a provider has it, offer to
         // benchmark it (with optional share-as-PR) before showing the board.
@@ -2453,6 +2461,16 @@ impl App {
     pub fn close_benchmarks(&mut self) {
         self.show_benchmarks = false;
         self.input_mode = InputMode::Normal;
+        // Leaving the leaderboard drops any simulated card: the top bar goes
+        // back to the detected GPU, and the cached preset rows are discarded
+        // so the next open refetches for the real hardware.
+        if self.bench_hw_label.take().is_some() {
+            self.bench_entries.clear();
+            self.bench_total = 0;
+            self.bench_cursor = 0;
+            self.bench_scroll = 0;
+            self.bench_error = None;
+        }
     }
 
     /// Toggle the "share with llmfit" checkbox in the bench-offer modal.
@@ -2668,8 +2686,9 @@ impl App {
         }
         local.append(&mut self.bench_entries);
         self.bench_entries = local;
-        if self.bench_cursor >= self.bench_entries.len() {
-            self.bench_cursor = self.bench_entries.len().saturating_sub(1);
+        let visible = self.bench_visible_indices().len();
+        if self.bench_cursor >= visible {
+            self.bench_cursor = visible.saturating_sub(1);
         }
     }
 
@@ -2708,9 +2727,67 @@ impl App {
     }
 
     pub fn bench_move_down(&mut self) {
-        if !self.bench_entries.is_empty() && self.bench_cursor < self.bench_entries.len() - 1 {
+        let visible = self.bench_visible_indices().len();
+        if visible > 0 && self.bench_cursor < visible - 1 {
             self.bench_cursor += 1;
         }
+    }
+
+    /// Indices into `bench_entries` that match the `/` search. Same semantics
+    /// as the main table search: space-separated terms, all must appear
+    /// (case-insensitive) somewhere in the row's searchable text.
+    pub fn bench_visible_indices(&self) -> Vec<usize> {
+        let query = self.bench_search_query.to_lowercase();
+        let terms: Vec<&str> = query.split_whitespace().collect();
+        self.bench_entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| {
+                if terms.is_empty() {
+                    return true;
+                }
+                let haystack = format!(
+                    "{} {} {} {}",
+                    e.hf_id().to_lowercase(),
+                    e.engine_name().to_lowercase(),
+                    e.quantization().to_lowercase(),
+                    e.username().to_lowercase(),
+                );
+                terms.iter().all(|t| haystack.contains(t))
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    pub fn bench_search_start(&mut self) {
+        self.bench_search_active = true;
+    }
+
+    /// Accept the current query and return to list navigation; the filter
+    /// stays applied until cleared with Esc or the view is reopened.
+    pub fn bench_search_accept(&mut self) {
+        self.bench_search_active = false;
+    }
+
+    pub fn bench_search_clear(&mut self) {
+        self.bench_search_active = false;
+        self.bench_search_query.clear();
+        self.bench_cursor = 0;
+        self.bench_scroll = 0;
+    }
+
+    pub fn bench_search_input(&mut self, c: char) {
+        if c.is_ascii_graphic() || c == ' ' {
+            self.bench_search_query.push(c);
+            self.bench_cursor = 0;
+            self.bench_scroll = 0;
+        }
+    }
+
+    pub fn bench_search_backspace(&mut self) {
+        self.bench_search_query.pop();
+        self.bench_cursor = 0;
+        self.bench_scroll = 0;
     }
 
     pub fn bench_refresh(&mut self) {
@@ -5494,5 +5571,122 @@ mod tests {
             "/home/user/.cache/llmfit/models/gemma-3.Q8_0.gguf",
             "google/gemma-3-27b-it"
         ));
+    }
+
+    fn bench_entry(
+        id: &str,
+        model: &str,
+        engine: &str,
+        user: &str,
+    ) -> llmfit_core::benchmarks::LeaderboardEntry {
+        use llmfit_core::benchmarks::{
+            LeaderboardEngine, LeaderboardEntry, LeaderboardModel, LeaderboardUser,
+        };
+        LeaderboardEntry {
+            id: id.to_string(),
+            tok_s_out: Some(10.0),
+            tok_s_total: None,
+            ttft_ms: None,
+            context_length: None,
+            batch_size: None,
+            peak_vram_gb: None,
+            notes: None,
+            model: Some(LeaderboardModel {
+                hf_id: model.to_string(),
+                display_name: None,
+                family: None,
+                params: None,
+                is_mo_e: None,
+            }),
+            hardware: None,
+            engine: Some(LeaderboardEngine {
+                engine_name: engine.to_string(),
+                engine_version: None,
+                quantization: "Q4_K_M".to_string(),
+                backend: None,
+            }),
+            engine_flags: None,
+            user: Some(LeaderboardUser {
+                username: Some(user.to_string()),
+                verified: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn bench_search_filters_by_model_engine_and_user() {
+        let mut app = test_app();
+        app.bench_entries = vec![
+            bench_entry("1", "meta-llama/Llama-3.1-8B", "ollama", "alice"),
+            bench_entry("2", "Qwen/Qwen2.5-7B", "llama.cpp", "bob"),
+            bench_entry("3", "meta-llama/Llama-3.1-70B", "vllm", "carol"),
+        ];
+
+        // Empty query shows everything
+        assert_eq!(app.bench_visible_indices(), vec![0, 1, 2]);
+
+        // Case-insensitive substring on the model id
+        app.bench_search_query = "LLAMA-3.1".to_string();
+        assert_eq!(app.bench_visible_indices(), vec![0, 2]);
+
+        // AND across space-separated terms (model + engine)
+        app.bench_search_query = "llama-3.1 vllm".to_string();
+        assert_eq!(app.bench_visible_indices(), vec![2]);
+
+        // Username matches too
+        app.bench_search_query = "bob".to_string();
+        assert_eq!(app.bench_visible_indices(), vec![1]);
+
+        app.bench_search_query = "nomatch".to_string();
+        assert!(app.bench_visible_indices().is_empty());
+    }
+
+    #[test]
+    fn closing_benchmarks_resets_simulated_card_and_cached_rows() {
+        let mut app = test_app();
+        app.bench_hw_label = Some("RTX 5080 (16 GB)".to_string());
+        app.bench_entries = vec![bench_entry("1", "Qwen/Qwen3.6-35B-A3B", "llama.cpp", "bob")];
+        app.bench_total = 12;
+        app.bench_cursor = 1;
+
+        app.close_benchmarks();
+        assert!(app.bench_hw_label.is_none());
+        assert!(app.bench_entries.is_empty());
+        assert_eq!(app.bench_total, 0);
+        assert_eq!(app.bench_cursor, 0);
+
+        // Without a simulated card the cached board is kept.
+        app.bench_entries = vec![bench_entry("1", "Qwen/Qwen3.6-35B-A3B", "llama.cpp", "bob")];
+        app.close_benchmarks();
+        assert_eq!(app.bench_entries.len(), 1);
+    }
+
+    #[test]
+    fn bench_search_edits_reset_cursor_and_clear_restores() {
+        let mut app = test_app();
+        app.bench_entries = vec![
+            bench_entry("1", "meta-llama/Llama-3.1-8B", "ollama", "alice"),
+            bench_entry("2", "Qwen/Qwen2.5-7B", "llama.cpp", "bob"),
+        ];
+        app.bench_cursor = 1;
+        app.bench_search_start();
+        assert!(app.bench_search_active);
+
+        app.bench_search_input('q');
+        app.bench_search_input('w');
+        assert_eq!(app.bench_cursor, 0);
+        assert_eq!(app.bench_visible_indices(), vec![1]);
+
+        // Cursor moves are bounded by the filtered list, not all entries
+        app.bench_move_down();
+        assert_eq!(app.bench_cursor, 0);
+
+        app.bench_search_accept();
+        assert!(!app.bench_search_active);
+        assert_eq!(app.bench_search_query, "qw");
+
+        app.bench_search_clear();
+        assert!(app.bench_search_query.is_empty());
+        assert_eq!(app.bench_visible_indices(), vec![0, 1]);
     }
 }

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -752,8 +752,27 @@ fn handle_benchmarks_mode(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // `/` search box captures keystrokes while active
+    if app.bench_search_active {
+        match key.code {
+            KeyCode::Esc => app.bench_search_clear(),
+            KeyCode::Enter => app.bench_search_accept(),
+            KeyCode::Backspace => app.bench_search_backspace(),
+            KeyCode::Up => app.bench_move_up(),
+            KeyCode::Down => app.bench_move_down(),
+            KeyCode::Char(c) if allows_search_text_input(key.modifiers) => {
+                app.bench_search_input(c)
+            }
+            _ => {}
+        }
+        return;
+    }
+
     match key.code {
+        // With a filter applied, Esc clears it first; q/b still close directly.
+        KeyCode::Esc if !app.bench_search_query.is_empty() => app.bench_search_clear(),
         KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('b') => app.close_benchmarks(),
+        KeyCode::Char('/') => app.bench_search_start(),
         KeyCode::Up | KeyCode::Char('k') => app.bench_move_up(),
         KeyCode::Down | KeyCode::Char('j') => app.bench_move_down(),
         KeyCode::Char('r') => app.bench_refresh(),

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -439,27 +439,27 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         Style::default().fg(tc.accent_secondary)
     } else {
         match app.input_mode {
-        InputMode::Search => Style::default().fg(tc.accent_secondary),
-        InputMode::Normal
-        | InputMode::Plan
-        | InputMode::ProviderPopup
-        | InputMode::UseCasePopup
-        | InputMode::CapabilityPopup
-        | InputMode::DownloadProviderPopup
-        | InputMode::Visual
-        | InputMode::Select
-        | InputMode::QuantPopup
-        | InputMode::RunModePopup
-        | InputMode::ParamsBucketPopup
-        | InputMode::LicensePopup
-        | InputMode::RuntimePopup
-        | InputMode::HelpPopup
-        | InputMode::Simulation
-        | InputMode::AdvancedConfig
-        | InputMode::DownloadManager
-        | InputMode::FilterPopup
-        | InputMode::Benchmarks
-        | InputMode::BenchOffer => Style::default().fg(tc.muted),
+            InputMode::Search => Style::default().fg(tc.accent_secondary),
+            InputMode::Normal
+            | InputMode::Plan
+            | InputMode::ProviderPopup
+            | InputMode::UseCasePopup
+            | InputMode::CapabilityPopup
+            | InputMode::DownloadProviderPopup
+            | InputMode::Visual
+            | InputMode::Select
+            | InputMode::QuantPopup
+            | InputMode::RunModePopup
+            | InputMode::ParamsBucketPopup
+            | InputMode::LicensePopup
+            | InputMode::RuntimePopup
+            | InputMode::HelpPopup
+            | InputMode::Simulation
+            | InputMode::AdvancedConfig
+            | InputMode::DownloadManager
+            | InputMode::FilterPopup
+            | InputMode::Benchmarks
+            | InputMode::BenchOffer => Style::default().fg(tc.muted),
         }
     };
 

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -98,7 +98,12 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 }
 
 fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
-    let gpu_info = if app.specs.gpus.is_empty() {
+    // Browsing another card's leaderboard: temporarily stand in for the real
+    // GPU string so the bar can't be mistaken for the board being shown.
+    // Session-only state — never persisted, so it always resets on restart.
+    let gpu_info = if let Some(ref label) = app.bench_hw_label {
+        format!("GPU: [SIMULATED] {}", label)
+    } else if app.specs.gpus.is_empty() {
         format!("GPU: none ({})", app.specs.backend.label())
     } else {
         let primary = &app.specs.gpus[0];
@@ -266,7 +271,14 @@ fn draw_system_bar(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             Style::default().fg(tc.accent),
         ),
         Span::styled("  │  ", Style::default().fg(tc.muted)),
-        Span::styled(gpu_info, Style::default().fg(tc.accent_secondary)),
+        Span::styled(
+            gpu_info,
+            if app.bench_hw_label.is_some() {
+                Style::default().fg(tc.warning).bold()
+            } else {
+                Style::default().fg(tc.accent_secondary)
+            },
+        ),
     ]);
     let hardware_line = Line::from(hw_spans);
 
@@ -420,8 +432,13 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         ])
         .split(area);
 
-    // Search box
-    let search_style = match app.input_mode {
+    // Search box — in the leaderboard view it shows the `/` benchmark search
+    let bench_search = app.input_mode == InputMode::Benchmarks
+        && (app.bench_search_active || !app.bench_search_query.is_empty());
+    let search_style = if bench_search && app.bench_search_active {
+        Style::default().fg(tc.accent_secondary)
+    } else {
+        match app.input_mode {
         InputMode::Search => Style::default().fg(tc.accent_secondary),
         InputMode::Normal
         | InputMode::Plan
@@ -443,11 +460,17 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         | InputMode::FilterPopup
         | InputMode::Benchmarks
         | InputMode::BenchOffer => Style::default().fg(tc.muted),
+        }
     };
 
+    let (query, query_cursor) = if bench_search {
+        (&app.bench_search_query, app.bench_search_query.len())
+    } else {
+        (&app.search_query, app.cursor_position)
+    };
     let search_inner_width = chunks[0].width.saturating_sub(2) as usize;
     let (visible_query, cursor_offset) =
-        visible_search_query(&app.search_query, app.cursor_position, search_inner_width);
+        visible_search_query(query, query_cursor, search_inner_width);
 
     let search_text = if app.search_query.is_empty() && app.input_mode == InputMode::Normal {
         Line::from(Span::styled(
@@ -467,7 +490,7 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
     let search = Paragraph::new(search_text).block(search_block);
     frame.render_widget(search, chunks[0]);
 
-    if app.input_mode == InputMode::Search {
+    if app.input_mode == InputMode::Search || (bench_search && app.bench_search_active) {
         frame.set_cursor_position((chunks[0].x + cursor_offset + 1, chunks[0].y + 1));
     }
 
@@ -3075,7 +3098,14 @@ fn status_keys_and_mode(app: &App) -> (String, String) {
             "FILTER".to_string(),
         ),
         InputMode::Benchmarks => (
-            " ↑/k:up  ↓/j:down  H:change GPU  r:refresh  b/q/Esc:close".to_string(),
+            if app.bench_search_active {
+                " type:filter  ↑↓:move  Enter:apply  Esc:clear".to_string()
+            } else if !app.bench_search_query.is_empty() {
+                " ↑/k:up  ↓/j:down  /:edit search  Esc:clear search  H:change GPU  r:refresh  b/q:close"
+                    .to_string()
+            } else {
+                " ↑/k:up  ↓/j:down  /:search  H:change GPU  r:refresh  b/q/Esc:close".to_string()
+            },
             "COMMUNITY LEADERBOARD".to_string(),
         ),
         InputMode::BenchOffer => (
@@ -3615,6 +3645,7 @@ fn draw_help_popup(frame: &mut Frame, app: &App, tc: &ThemeColors) {
             "Inference Bench (local quality scoring against your models)",
         ),
         ("  H", "Change GPU (in community leaderboard view)"),
+        ("  /", "Search results (in community leaderboard view)"),
         ("  y", "Copy model name"),
         ("", ""),
         ("Comparison", ""),
@@ -4448,9 +4479,28 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
     let mut summary_spans = vec![
         Span::styled("  Hardware: ", Style::default().fg(tc.muted)),
         Span::styled(&hw_desc, Style::default().fg(tc.fg).bold()),
-        Span::styled(counts, Style::default().fg(tc.muted)),
-        Span::styled("  H:change GPU", Style::default().fg(tc.accent)),
     ];
+    if app.bench_hw_label.is_some() {
+        summary_spans.push(Span::styled(
+            " [SIMULATED]",
+            Style::default().fg(tc.warning).bold(),
+        ));
+    }
+    summary_spans.push(Span::styled(counts, Style::default().fg(tc.muted)));
+    summary_spans.push(Span::styled(
+        "  H:change GPU",
+        Style::default().fg(tc.accent),
+    ));
+
+    // The query itself is typed into the Search box up top; here just the
+    // match count.
+    let visible = app.bench_visible_indices();
+    if app.bench_search_active || !app.bench_search_query.is_empty() {
+        summary_spans.push(Span::styled(
+            format!("  {}/{} match", visible.len(), app.bench_entries.len()),
+            Style::default().fg(tc.accent).bold(),
+        ));
+    }
     if let Some(ref err) = app.bench_error {
         summary_spans.push(Span::styled(
             format!("  ⚠ {}", err),
@@ -4481,21 +4531,24 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
     .height(1);
 
     let visible_height = inner.height.saturating_sub(3) as usize; // 1 summary + 1 header + 1 spacing
-    // Adjust scroll to keep cursor visible
+    // The cursor indexes into the filtered list; keep it valid and visible.
+    if !visible.is_empty() && app.bench_cursor >= visible.len() {
+        app.bench_cursor = visible.len() - 1;
+    }
     if app.bench_cursor < app.bench_scroll {
         app.bench_scroll = app.bench_cursor;
     } else if app.bench_cursor >= app.bench_scroll + visible_height {
         app.bench_scroll = app.bench_cursor.saturating_sub(visible_height - 1);
     }
 
-    let rows: Vec<Row> = app
-        .bench_entries
+    let rows: Vec<Row> = visible
         .iter()
         .enumerate()
         .skip(app.bench_scroll)
         .take(visible_height)
-        .map(|(i, entry)| {
-            let is_selected = i == app.bench_cursor;
+        .map(|(vi, &i)| {
+            let entry = &app.bench_entries[i];
+            let is_selected = vi == app.bench_cursor;
             let style = if is_selected {
                 Style::default().bg(tc.highlight_bg).fg(tc.fg)
             } else {
@@ -4582,7 +4635,22 @@ fn draw_benchmarks(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColor
         .split(inner);
 
     frame.render_widget(Paragraph::new(summary), chunks[0]);
-    frame.render_widget(table, chunks[1]);
+    if visible.is_empty() && !app.bench_search_query.is_empty() {
+        let no_match = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("  No results match /{}", app.bench_search_query),
+                Style::default().fg(tc.muted),
+            )),
+            Line::from(Span::styled(
+                "  Esc to clear the search",
+                Style::default().fg(tc.muted),
+            )),
+        ]);
+        frame.render_widget(no_match, chunks[1]);
+    } else {
+        frame.render_widget(table, chunks[1]);
+    }
 
     // Draw hardware picker popup overlay if open
     if app.bench_hw_picker_open {


### PR DESCRIPTION
## What

Two UX improvements to the community leaderboard (benchmark) view:

**`[SIMULATED]` indicator when browsing another card's board.** Selecting a hardware preset via `H` now temporarily replaces the GPU string in the top system bar with a warning-colored bold `GPU: [SIMULATED] RTX 5080 (16 GB)`, and tags the leaderboard summary line with `[SIMULATED]`. The simulation resets when:
- the card is deselected via "My Hardware (auto-detect)",
- the leaderboard view is closed back to the main TUI (also drops the cached preset rows so the next open refetches for the detected hardware), or
- the app restarts (the selection was already session-only).

**`/` search over leaderboard rows.** Pressing `/` in the leaderboard types into the top Search box (same widget and semantics as the main table search: case-insensitive, space-separated AND terms) and filters rows live across model, engine, quant, and submitting user, with an `N/M match` count in the summary line. Enter applies the filter, Esc clears it; includes a no-match state and updated status-bar/help hints.

## Testing

- `cargo test -p llmfit`: 63 unit + 8 smoke tests pass (3 new tests: search filtering/AND terms, cursor bounds + clear behavior, close-resets-simulation)
- clippy clean for the touched files
- Verified live in a tmux-driven TUI session: badge on select/replace, live filtering (20→4 rows), no-match state, Esc clear, badge removal on deselect and on view close, refetch for detected hardware on reopen

## Follow-up in this PR

**Active range filters spelled out.** Advanced range filters from the `F` popup (params min/max, mem% min/max) persist across sessions and silently constrain every fit category; previously the only indicator was a cryptic `R`/`M` letter in the Fit box. The Fit box now shows the actual range (e.g. `Too Tight ≤2B`, `mem≥50%`) in warning color, and the empty-results hint names the active range explicitly.