### PR TITLE
feat(tui): spell out active advanced range filters instead of cryptic R/M markers

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -2078,6 +2078,38 @@ impl App {
             || has_runtime_filter
     }
 
+    /// Human-readable labels for the active advanced range filters from the
+    /// `F` popup, e.g. `["≤2B", "mem≥50%"]`. Empty when no range is set.
+    /// These constrain every fit category, so the UI shows them explicitly
+    /// rather than as a cryptic marker.
+    pub fn advanced_range_labels(&self) -> Vec<String> {
+        fn range(min: &str, max: &str, prefix: &str, unit: &str) -> Option<String> {
+            match (min.is_empty(), max.is_empty()) {
+                (false, false) => Some(format!("{prefix}{min}–{max}{unit}")),
+                (false, true) => Some(format!("{prefix}≥{min}{unit}")),
+                (true, false) => Some(format!("{prefix}≤{max}{unit}")),
+                (true, true) => None,
+            }
+        }
+        [
+            range(
+                &self.filter_params_min_input,
+                &self.filter_params_max_input,
+                "",
+                "B",
+            ),
+            range(
+                &self.filter_mem_pct_min_input,
+                &self.filter_mem_pct_max_input,
+                "mem",
+                "%",
+            ),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    }
+
     pub fn cycle_sort_column(&mut self) {
         self.sort_column = self.sort_column.next();
         self.sort_ascending = false;
@@ -5639,6 +5671,20 @@ mod tests {
 
         app.bench_search_query = "nomatch".to_string();
         assert!(app.bench_visible_indices().is_empty());
+    }
+
+    #[test]
+    fn advanced_range_labels_spell_out_active_ranges() {
+        let mut app = test_app();
+        assert!(app.advanced_range_labels().is_empty());
+
+        app.filter_params_max_input = "2".to_string();
+        assert_eq!(app.advanced_range_labels(), vec!["≤2B"]);
+
+        app.filter_params_min_input = "7".to_string();
+        app.filter_params_max_input = "30".to_string();
+        app.filter_mem_pct_min_input = "50".to_string();
+        assert_eq!(app.advanced_range_labels(), vec!["7–30B", "mem≥50%"]);
     }
 
     #[test]

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -600,10 +600,8 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
     frame.render_widget(sort_text, chunks[4]);
 
     // Fit + Filter indicator [f/F]
-    let has_range_filters = !app.filter_params_min_input.is_empty()
-        || !app.filter_params_max_input.is_empty()
-        || !app.filter_mem_pct_min_input.is_empty()
-        || !app.filter_mem_pct_max_input.is_empty();
+    let range_labels = app.advanced_range_labels();
+    let has_range_filters = !range_labels.is_empty();
 
     let fit_color = if has_range_filters || app.fit_filter != FitFilter::All {
         match app.fit_filter {
@@ -623,18 +621,20 @@ fn draw_search_and_filters(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeC
         .title(" Fit [f] Filter [F] ")
         .title_style(Style::default().fg(tc.muted));
 
-    let mut parts: Vec<&str> = vec![app.fit_filter.label()];
-    if !app.filter_params_min_input.is_empty() || !app.filter_params_max_input.is_empty() {
-        parts.push("R");
-    }
-    if !app.filter_mem_pct_min_input.is_empty() || !app.filter_mem_pct_max_input.is_empty() {
-        parts.push("M");
-    }
-    let fit_text = Paragraph::new(Line::from(Span::styled(
-        parts.join(" "),
+    // Fit level label, then any active range filters spelled out (e.g.
+    // "≤2B") — a range from the F popup silently constrains every fit
+    // category, so it must be readable at a glance.
+    let mut fit_spans = vec![Span::styled(
+        app.fit_filter.label(),
         Style::default().fg(fit_color),
-    )))
-    .block(fit_block);
+    )];
+    for label in &range_labels {
+        fit_spans.push(Span::styled(
+            format!(" {}", label),
+            Style::default().fg(tc.warning).bold(),
+        ));
+    }
+    let fit_text = Paragraph::new(Line::from(fit_spans)).block(fit_block);
     frame.render_widget(fit_text, chunks[5]);
 
     // Availability filter
@@ -1039,10 +1039,17 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
 
     // Empty-state hint when filters hide all models
     if app.filtered_fits.is_empty() && !app.all_fits.is_empty() {
-        let hint = if app.has_advanced_filters_active() {
+        let ranges = app.advanced_range_labels();
+        let hint = if !ranges.is_empty() {
+            format!(
+                "No models match current filters — active range filter: {}. Press F to adjust, / to check search.",
+                ranges.join(", ")
+            )
+        } else if app.has_advanced_filters_active() {
             "No models match current filters. Press F to check advanced filters, / to check search."
+                .to_string()
         } else {
-            "No models match the selected fit level."
+            "No models match the selected fit level.".to_string()
         };
         let hint_paragraph = Paragraph::new(Line::from(Span::styled(
             hint,


### PR DESCRIPTION
Re-delivers a commit that was pushed to the #779 branch shortly after the PR was merged, so it never landed on main.

A params/mem range set in the `F` popup persists across sessions and silently constrains every fit category — the only evidence was a single-letter `R`/`M` marker in the Fit box. In practice a stale `≤2B` cap made every fit category appear empty with no visible reason.

**Change:** the Fit box now shows the actual active range (e.g. `Too Tight ≤2B`, `mem≥50%`) in warning color, and the empty-results hint names it explicitly: "No models match current filters — active range filter: ≤2B. Press F to adjust, / to check search."

**Testing:** unit test for the range-label builder (`≤2B`, `7–30B`, `mem≥50%`), full suite passes (64 unit + 8 smoke), verified rendering live in the TUI with an isolated config.