### PR TITLE
fix(hardware): detect Jetson/Tegra Orin iGPU as unified memory

### DIFF
--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -2858,6 +2858,15 @@ fn is_nvidia_unified_memory_gpu(name: &str) -> bool {
     if lower.contains("2e12") {
         return true;
     }
+    // Jetson / older Tegra SoCs (Orin, Xavier, Nano, ...) run the legacy
+    // nvgpu/gk20a driver stack, which reports `addressing_mode` as "N/A"
+    // rather than "ATS" (that field is only populated on newer Grace/Thor
+    // chips). nvidia-smi always suffixes these iGPUs' name with "(nvgpu)",
+    // so use that as a reliable unified-memory signal independent of
+    // addressing_mode.
+    if lower.contains("nvgpu") {
+        return true;
+    }
     false
 }
 
@@ -3235,6 +3244,31 @@ mod tests {
         assert!(gpus[0].unified_memory, "ATS should set unified_memory=true");
         // VRAM comes from /proc/meminfo; if unavailable, it's None
         // (on Linux test machines it will be Some, on macOS CI it will be None)
+    }
+
+    #[test]
+    fn test_parse_extended_jetson_orin_unified_memory() {
+        // Jetson Orin: addressing_mode is "N/A" (legacy nvgpu/gk20a stack, not
+        // ATS), and memory.total is also "N/A" since nvidia-smi can't query
+        // dedicated VRAM for the on-chip GPU.
+        let text = "N/A, [N/A], Orin (nvgpu)\n";
+        let gpus = SystemSpecs::parse_nvidia_smi_extended(text);
+
+        assert_eq!(gpus.len(), 1);
+        assert_eq!(gpus[0].name, "Orin (nvgpu)");
+        assert!(
+            super::is_nvidia_unified_memory_gpu(&gpus[0].name),
+            "\"(nvgpu)\" name should be recognized as unified memory"
+        );
+    }
+
+    #[test]
+    fn test_is_nvidia_unified_memory_gpu_jetson_names() {
+        assert!(super::is_nvidia_unified_memory_gpu("Orin (nvgpu)"));
+        assert!(super::is_nvidia_unified_memory_gpu("Xavier (nvgpu)"));
+        assert!(!super::is_nvidia_unified_memory_gpu(
+            "NVIDIA GeForce RTX 4090"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Jetson Orin's `nvidia-smi` reports `addressing_mode` as `N/A` rather than `ATS` (the legacy nvgpu/gk20a driver stack used by Orin/Xavier; `ATS` is only populated on newer Grace/Thor chips), so the existing unified-memory detection missed it and treated the on-chip GPU as a discrete CUDA device with unknown VRAM instead of unified memory shared with system RAM.
- `nvidia-smi` always suffixes Tegra/Jetson iGPU names with `(nvgpu)` (e.g. `"Orin (nvgpu)"`), so `is_nvidia_unified_memory_gpu()` now also matches on that substring, independent of `addressing_mode`.
- Added two regression tests alongside the existing GB10/ATS unified-memory tests.

Verified live on a Jetson Orin NX: before the fix, `llmfit doctor` reported `has_gpu: true, unified_memory: false, gpu_vram_gb: None` (breaking model-fit sizing); after the fix it reports `unified_memory: true, gpu_vram_gb: Some(7.1)` matching total system RAM, and `llmfit recommend` produces correctly-sized recommendations.

## Test plan
- [x] `cargo test -p llmfit-core --lib hardware::` — 85/85 pass, including new Jetson tests
- [x] `cargo test -p llmfit-core --lib` — full suite, 488/488 pass
- [x] Built release binary and ran `llmfit doctor` / `llmfit recommend` live on a Jetson Orin NX Developer Kit

🤖 Generated with [Claude Code](https://claude.com/claude-code)