### PR TITLE
bench: community results for nvidia-geforce-rtx-5070

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-rtx-5070/1784931100-99599818.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-5070/1784931100-99599818.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 7600X3D 6-Core Processor",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 5070",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 12,
+    "os": "windows",
+    "ramGb": 31.17,
+    "unifiedMemory": false,
+    "vramGb": 11.94
+  },
+  "results": [
+    {
+      "avgOutputTokens": 282.67,
+      "avgTotalMs": 4983.55,
+      "avgTps": 56.66,
+      "avgTtftMs": null,
+      "maxTps": 60.75,
+      "minTps": 51.58,
+      "model": "gemma-4-e4b-it",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784931100,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-5070/1784931282-e173655a.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-5070/1784931282-e173655a.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 7600X3D 6-Core Processor",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 5070",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 12,
+    "os": "windows",
+    "ramGb": 31.17,
+    "unifiedMemory": false,
+    "vramGb": 11.94
+  },
+  "results": [
+    {
+      "avgOutputTokens": 148.67,
+      "avgTotalMs": 18194.05,
+      "avgTps": 7.99,
+      "avgTtftMs": null,
+      "maxTps": 8.54,
+      "minTps": 7.25,
+      "model": "qwen/qwen2.5-coder-14b",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784933153,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-5070/1784931840-d429dedc.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-5070/1784931840-d429dedc.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 7600X3D 6-Core Processor",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 5070",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 12,
+    "os": "windows",
+    "ramGb": 31.17,
+    "unifiedMemory": false,
+    "vramGb": 11.94
+  },
+  "results": [
+    {
+      "avgOutputTokens": 186.0,
+      "avgTotalMs": 4809.07,
+      "avgTps": 35.17,
+      "avgTtftMs": null,
+      "maxTps": 44.37,
+      "minTps": 18.7,
+      "model": "qwen2.5-coder-7b-instruct",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784933153,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-5070/1784933153-e11ea270.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-5070/1784933153-e11ea270.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 7600X3D 6-Core Processor",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 5070",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 12,
+    "os": "windows",
+    "ramGb": 31.17,
+    "unifiedMemory": false,
+    "vramGb": 11.94
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 6228.08,
+      "avgTps": 48.25,
+      "avgTtftMs": null,
+      "maxTps": 49.72,
+      "minTps": 45.54,
+      "model": "deepseek-r1-distill-qwen-7b",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784933153,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| gemma-4-e4b-it | llamacpp | 56.7 | — |

_Submitted without the `gh` CLI via the GitHub device flow._
