### PR TITLE
bench: community results for nvidia-rtx-5880-ada-generation

### DIFF
--- a/llmfit-core/data/community/nvidia-rtx-5880-ada-generation/1784978714-a021e906.json
+++ b/llmfit-core/data/community/nvidia-rtx-5880-ada-generation/1784978714-a021e906.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD EPYC 9654 96-Core Processor",
+    "cpuCores": 384,
+    "gpuCount": 8,
+    "hardwareName": "NVIDIA RTX 5880 Ada Generation",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 256,
+    "os": "linux",
+    "ramGb": 377.4,
+    "unifiedMemory": false,
+    "vramGb": 383.11
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 1495.58,
+      "avgTps": 200.82,
+      "avgTtftMs": null,
+      "maxTps": 206.18,
+      "minTps": 191.31,
+      "model": "Qwen3.6-35B-A3B-NVFP4-Fast",
+      "numRuns": 3,
+      "provider": "vllm"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784978714,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/nvidia-rtx-5880-ada-generation/1784978871-54ae51d4.json
+++ b/llmfit-core/data/community/nvidia-rtx-5880-ada-generation/1784978871-54ae51d4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD EPYC 9654 96-Core Processor",
+    "cpuCores": 384,
+    "gpuCount": 8,
+    "hardwareName": "NVIDIA RTX 5880 Ada Generation",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 256,
+    "os": "linux",
+    "ramGb": 377.4,
+    "unifiedMemory": false,
+    "vramGb": 383.11
+  },
+  "results": [
+    {
+      "avgOutputTokens": 245.33,
+      "avgTotalMs": 1706.48,
+      "avgTps": 143.98,
+      "avgTtftMs": null,
+      "maxTps": 144.92,
+      "minTps": 143.07,
+      "model": "Qwen3-VL-30B-A3B-Thinking-AWQ",
+      "numRuns": 3,
+      "provider": "vllm"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784978871,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/nvidia-rtx-5880-ada-generation/1784982934-d81f1c0c.json
+++ b/llmfit-core/data/community/nvidia-rtx-5880-ada-generation/1784982934-d81f1c0c.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD EPYC 9654 96-Core Processor",
+    "cpuCores": 384,
+    "gpuCount": 8,
+    "hardwareName": "NVIDIA RTX 5880 Ada Generation",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 256,
+    "os": "linux",
+    "ramGb": 377.4,
+    "unifiedMemory": false,
+    "vramGb": 383.11
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 1559.71,
+      "avgTps": 192.9,
+      "avgTtftMs": null,
+      "maxTps": 201.99,
+      "minTps": 178.7,
+      "model": "Qwen3.6-35B-A3B-NVFP4-Fast",
+      "numRuns": 3,
+      "provider": "vllm"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784982934,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/nvidia-rtx-5880-ada-generation/1784990632-60d664dc.json
+++ b/llmfit-core/data/community/nvidia-rtx-5880-ada-generation/1784990632-60d664dc.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD EPYC 9654 96-Core Processor",
+    "cpuCores": 384,
+    "gpuCount": 8,
+    "hardwareName": "NVIDIA RTX 5880 Ada Generation",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 256,
+    "os": "linux",
+    "ramGb": 377.4,
+    "unifiedMemory": false,
+    "vramGb": 383.11
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 1549.35,
+      "avgTps": 193.99,
+      "avgTtftMs": null,
+      "maxTps": 202.61,
+      "minTps": 182.76,
+      "model": "Qwen3.6-35B-A3B-NVFP4-Fast",
+      "numRuns": 3,
+      "provider": "vllm"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1784990632,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| Qwen3.6-35B-A3B-NVFP4-Fast | vllm | 200.8 | — |

_Submitted without the `gh` CLI via the GitHub device flow._
