### PR TITLE
fix(plan): route speed estimates through fit.rs so MoE models aren't 4x underestimated

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -1165,7 +1165,13 @@ fn ddr_bandwidth_gbps(config: &CalcConfig) -> f64 {
     crate::hardware::measured_ram_bandwidth_gbps().unwrap_or(50.0)
 }
 
-fn estimate_tps(
+/// Estimate decode throughput in tok/s.
+///
+/// This is the single source of truth for speed estimation. `plan.rs` delegates
+/// to it on the bandwidth path rather than reimplementing the model — an earlier
+/// duplicate there silently missed every MoE fix (#133, #464, #475) and
+/// underestimated sparse MoE throughput by ~4x.
+pub(crate) fn estimate_tps(
     model: &LlmModel,
     quant: &str,
     system: &SystemSpecs,

--- a/llmfit-core/src/plan.rs
+++ b/llmfit-core/src/plan.rs
@@ -182,40 +182,62 @@ fn estimate_tps(
     estimate_tps_with_gpu(model, quant, backend, path, cpu_cores, None)
 }
 
-/// Bandwidth-aware tok/s estimation (mirrors fit.rs logic).
-/// When `gpu_name` is provided and recognized, uses memory-bandwidth-based
-/// estimation instead of fixed constants.
+/// Run mode to estimate speed under.
+///
+/// A MoE model on the CPU-offload path keeps its inactive experts in system RAM,
+/// so per-token cost is bounded by DDR bandwidth. That is [`RunMode::MoeOffload`],
+/// which `fit.rs` already calibrates — not the dense `CpuOffload` factor, which
+/// would otherwise rank CPU offload *above* full-GPU execution.
+fn speed_run_mode(path: PlanRunPath, model: &LlmModel) -> RunMode {
+    match path {
+        PlanRunPath::CpuOffload if model.is_moe => RunMode::MoeOffload,
+        other => other.run_mode(),
+    }
+}
+
+/// Bandwidth-aware tok/s estimation.
+///
+/// When `system` describes a GPU whose memory bandwidth we know, this delegates
+/// to [`crate::fit::estimate_tps`] so `plan` and `fit` cannot report different
+/// speeds for the same model. Otherwise it falls back to fixed per-backend
+/// constants, which is all we can do for an unrecognized GPU.
 fn estimate_tps_with_gpu(
     model: &LlmModel,
     quant: &str,
     backend: GpuBackend,
     path: PlanRunPath,
     cpu_cores: usize,
-    gpu_name: Option<&str>,
+    system: Option<&SystemSpecs>,
 ) -> f64 {
+    use crate::fit::{CalcConfig, InferenceRuntime};
     use crate::hardware::gpu_memory_bandwidth_gbps;
-    use crate::models::quant_bytes_per_param;
 
     let params = model.params_b().max(0.1);
 
-    // Bandwidth-based estimation when GPU is recognized
+    // Delegate to the shared estimator when we can resolve real GPU bandwidth.
+    //
+    // This module used to reimplement the bandwidth formula as
+    // `(bw / total_params_gb) * 0.55`, which ignored MoE sparsity entirely: only
+    // the active experts are read per token, so a 30B-A3B model was estimated at
+    // ~34 tok/s against fit.rs's ~160. Delegating keeps the MoE decomposition,
+    // the VRAM cache-pressure penalty, and the run-mode factors in one place.
+    //
+    // `runtime` only selects fixed-constant K values inside `estimate_tps`; on
+    // the bandwidth path it is unused, so LlamaCpp is a safe stand-in for a
+    // subcommand that has no runtime concept of its own.
     if path != PlanRunPath::CpuOnly
-        && let Some(name) = gpu_name
-        && let Some(bw) = gpu_memory_bandwidth_gbps(name)
+        && let Some(specs) = system
+        && let Some(name) = specs.gpu_name.as_deref()
+        && gpu_memory_bandwidth_gbps(name).is_some()
     {
-        let model_gb = params * quant_bytes_per_param(quant);
-        let efficiency = 0.55;
-        let raw_tps = (bw / model_gb) * efficiency;
-
-        // CpuOnly is unreachable here (guarded above). The default fallback handles
-        // any future PlanRunPath variants gracefully.
-        let mode_factor = match path {
-            PlanRunPath::Gpu => 1.0,
-            PlanRunPath::CpuOffload => 0.5,
-            _ => 1.0,
-        };
-
-        return (raw_tps * mode_factor).max(0.1);
+        return crate::fit::estimate_tps(
+            model,
+            quant,
+            specs,
+            speed_run_mode(path, model),
+            InferenceRuntime::LlamaCpp,
+            &CalcConfig::default(),
+        );
     }
 
     // Fallback: fixed-constant approach
@@ -338,14 +360,13 @@ fn evaluate_current(
             gpu_vram,
             model.recommended_ram_gb,
         );
-        let gpu_name = system.gpu_name.as_deref();
         let gpu_tps = estimate_tps_with_gpu(
             model,
             quant,
             system.backend,
             PlanRunPath::Gpu,
             system.total_cpu_cores,
-            gpu_name,
+            Some(system),
         );
         if target_tps.is_none_or(|t| gpu_tps >= t) {
             candidates.push((gpu_fit, PlanRunPath::Gpu, gpu_tps));
@@ -364,7 +385,7 @@ fn evaluate_current(
                 system.backend,
                 PlanRunPath::CpuOffload,
                 system.total_cpu_cores,
-                gpu_name,
+                Some(system),
             );
             if target_tps.is_none_or(|t| offload_tps >= t) {
                 candidates.push((offload_fit, PlanRunPath::CpuOffload, offload_tps));
@@ -453,15 +474,13 @@ fn build_path_estimate(
 
     let recommended_cores = min_cores.max(8);
 
-    let gpu_name = system.gpu_name.as_deref();
-
     match path {
         PlanRunPath::Gpu => {
             let min_vram = model_mem;
             let rec_vram = model.recommended_ram_gb.max(model_mem * 1.2);
             let min_ram = (model_mem * 0.2).max(8.0);
             let rec_ram = (min_ram * 1.25).max(12.0);
-            let tps = estimate_tps_with_gpu(model, quant, backend, path, min_cores, gpu_name);
+            let tps = estimate_tps_with_gpu(model, quant, backend, path, min_cores, Some(system));
 
             let fit = fit_level_for(path, min_vram, min_vram, model.recommended_ram_gb);
             notes.push(
@@ -504,7 +523,7 @@ fn build_path_estimate(
             let min_ram = model_mem;
             let rec_ram = model_mem * 1.2;
             let fit = fit_level_for(path, min_ram, min_ram, model.recommended_ram_gb);
-            let tps = estimate_tps_with_gpu(model, quant, backend, path, min_cores, gpu_name);
+            let tps = estimate_tps_with_gpu(model, quant, backend, path, min_cores, Some(system));
             notes.push("RAM is the primary memory pool for CPU offload".to_string());
 
             PathEstimate {
@@ -1123,16 +1142,42 @@ mod tests {
         assert!(tps_16 >= tps_4);
     }
 
+    /// Specs whose GPU name resolves to a known memory bandwidth, so the
+    /// bandwidth path (not the fixed-constant fallback) is exercised.
+    fn test_specs_known_gpu() -> SystemSpecs {
+        SystemSpecs {
+            gpu_name: Some("NVIDIA GeForce RTX 4090".to_string()),
+            gpu_vram_gb: Some(24.0),
+            total_gpu_vram_gb: Some(24.0),
+            ..test_specs()
+        }
+    }
+
+    /// A sparse MoE model in the shape of Qwen3-30B-A3B: 30B total, 3.3B active.
+    fn test_moe_model() -> LlmModel {
+        LlmModel {
+            name: "Qwen-Test-30B-A3B".to_string(),
+            parameter_count: "30B".to_string(),
+            parameters_raw: Some(30_000_000_000),
+            is_moe: true,
+            num_experts: Some(128),
+            active_experts: Some(8),
+            active_parameters: Some(3_300_000_000),
+            ..test_model()
+        }
+    }
+
     #[test]
     fn test_estimate_tps_with_known_gpu_uses_bandwidth() {
         let model = test_model();
+        let specs = test_specs_known_gpu();
         let bw_tps = estimate_tps_with_gpu(
             &model,
             "Q4_K_M",
             GpuBackend::Cuda,
             PlanRunPath::Gpu,
             8,
-            Some("NVIDIA RTX 4090"),
+            Some(&specs),
         );
         let fallback_tps = estimate_tps_with_gpu(
             &model,
@@ -1144,6 +1189,112 @@ mod tests {
         );
         // Known GPU should give a different (bandwidth-based) estimate
         assert!((bw_tps - fallback_tps).abs() > 0.01);
+    }
+
+    /// Regression test for the duplicate estimator: `plan` must not report a
+    /// different speed than `fit` for the same model on the same hardware.
+    /// A local reimplementation here previously diverged by ~4x on MoE models
+    /// because it divided bandwidth by *total* rather than *active* params.
+    #[test]
+    fn test_plan_speed_matches_fit_speed() {
+        let specs = test_specs_known_gpu();
+        let config = crate::fit::CalcConfig::default();
+
+        for model in [test_model(), test_moe_model()] {
+            let plan_tps = estimate_tps_with_gpu(
+                &model,
+                "Q4_K_M",
+                GpuBackend::Cuda,
+                PlanRunPath::Gpu,
+                8,
+                Some(&specs),
+            );
+            let fit_tps = crate::fit::estimate_tps(
+                &model,
+                "Q4_K_M",
+                &specs,
+                RunMode::Gpu,
+                crate::fit::InferenceRuntime::LlamaCpp,
+                &config,
+            );
+            assert!(
+                (plan_tps - fit_tps).abs() < 1e-9,
+                "{} : plan={plan_tps} fit={fit_tps}",
+                model.name
+            );
+        }
+    }
+
+    /// Offloading inactive experts to system RAM can never be faster than keeping
+    /// the whole model in VRAM. Estimating the offload path with the dense
+    /// `CpuOffload` factor instead of `MoeOffload` used to invert this.
+    #[test]
+    fn test_moe_offload_is_not_faster_than_gpu() {
+        let model = test_moe_model();
+        let specs = test_specs_known_gpu();
+        let gpu = estimate_tps_with_gpu(
+            &model,
+            "Q4_K_M",
+            GpuBackend::Cuda,
+            PlanRunPath::Gpu,
+            8,
+            Some(&specs),
+        );
+        let offload = estimate_tps_with_gpu(
+            &model,
+            "Q4_K_M",
+            GpuBackend::Cuda,
+            PlanRunPath::CpuOffload,
+            8,
+            Some(&specs),
+        );
+        assert!(
+            offload < gpu,
+            "MoE offload {offload} should be slower than full GPU {gpu}"
+        );
+    }
+
+    #[test]
+    fn test_speed_run_mode_maps_moe_offload() {
+        assert_eq!(
+            speed_run_mode(PlanRunPath::CpuOffload, &test_moe_model()),
+            RunMode::MoeOffload
+        );
+        assert_eq!(
+            speed_run_mode(PlanRunPath::CpuOffload, &test_model()),
+            RunMode::CpuOffload
+        );
+        assert_eq!(
+            speed_run_mode(PlanRunPath::Gpu, &test_moe_model()),
+            RunMode::Gpu
+        );
+    }
+
+    /// A sparse MoE model reads only its active experts per token, so it must be
+    /// estimated well above the dense-equivalent figure that total-param
+    /// accounting would produce.
+    #[test]
+    fn test_moe_gpu_speed_uses_active_params() {
+        let specs = test_specs_known_gpu();
+        let moe_tps = estimate_tps_with_gpu(
+            &test_moe_model(),
+            "Q4_K_M",
+            GpuBackend::Cuda,
+            PlanRunPath::Gpu,
+            8,
+            Some(&specs),
+        );
+
+        // What the old total-params formula produced: (bw / 30B*bpp) * 0.55.
+        let bw = crate::hardware::gpu_memory_bandwidth_gbps("NVIDIA GeForce RTX 4090")
+            .expect("RTX 4090 bandwidth is known");
+        let dense_equivalent =
+            (bw / (30.0 * crate::models::quant_bytes_per_param("Q4_K_M"))) * 0.55;
+
+        assert!(
+            moe_tps > dense_equivalent * 2.0,
+            "MoE estimate {moe_tps} should far exceed dense-equivalent {dense_equivalent}"
+        );
     }
 
     // ── minimum_cores_for_target ─────────────────────────────────────


### PR DESCRIPTION
Fixes #805.

## Summary

`plan.rs` carried its own copy of the tok/s estimator, separate from `fit.rs::estimate_tps`. Its doc comment claimed to *"mirror fit.rs logic"*, but the body reduced every model to its total parameter count:

```rust
let model_gb = params * quant_bytes_per_param(quant);   // params = TOTAL
let efficiency = 0.55;
let raw_tps = (bw / model_gb) * efficiency;
```

There was no `is_moe` branch anywhere in the file. Since only the active experts are read per token, the divisor was wrong by the sparsity ratio — and because the estimator was duplicated, every MoE fix (#133, #464, #475, and the current Tier 1 decomposition) landed in `fit.rs` only and silently missed `plan`. On an RTX 3090, `llmfit plan Qwen3-30B-A3B-Instruct-2507 --quant Q4_K_M --context 32768` reported **33.7 tok/s** where `fit` reported **~160** for the same model on the same hardware.

## Changes

**Delegate instead of duplicate.** `plan::estimate_tps_with_gpu` now calls `fit::estimate_tps` whenever the GPU's memory bandwidth is resolvable, so the two commands cannot drift again. The fixed-constant fallback is kept for unrecognized GPUs, which is all that's possible there. `fit::estimate_tps` becomes `pub(crate)`.

Two details worth flagging for review:

- The delegation is gated on `gpu_memory_bandwidth_gbps(name).is_some()`. `runtime` only selects fixed-constant K values inside `estimate_tps` and is unused on the bandwidth path, so passing `InferenceRuntime::LlamaCpp` is inert for a subcommand that has no runtime concept of its own.
- `RunModeFactors::default().gpu` is `1.0` and `cpu_offload` is `0.5` — identical to the mode factors `plan` applied locally, so dense behaviour is unchanged by construction.

**Map CPU offload to `MoeOffload` for MoE models.** `fit.rs`'s MoE branch matches only `MoeOffload | Gpu`, so a MoE model on `PlanRunPath::CpuOffload` fell through to the dense formula — active params, no MoE overhead, only a 0.5 factor. Once the GPU figure was corrected this ranked CPU offload *above* full-GPU execution (154 vs 136 tok/s), which can't be right when offloading experts to system RAM. A new `speed_run_mode` helper handles the mapping; `PlanRunPath::run_mode()` is untouched, so its existing test still holds.

Happy to split this second change into its own PR if you'd prefer one fix per PR — the helper and its two tests separate cleanly. I kept them together because landing the first without the second ships a visibly contradictory ordering.

## Measured

RTX 3090 24 GB, Q4_K_M, 32k context, `gpu / cpu_offload` tok/s:

| model | before | after |
|---|---|---|
| Qwen3-30B-A3B-Instruct-2507 | 33.7 / 16.9 | **136.3 / 12.9** |
| Qwen3.6-35B-A3B | 28.6 / 14.3 | **102.9 / 14.3** |
| Qwen3-32B (dense) | 31.4 / 15.7 | 31.4 / 15.7 |
| gemma-3-27b-it (dense) | 37.5 / 18.8 | 37.5 / 18.8 |

Both dense models are byte-identical, confirming the delegation is exact parity and the only behaviour change is MoE-specific.

The 4x figure is hardware- and quant-specific — it tracks model sparsity and the VRAM cache-pressure penalty, so the magnitude will differ on other cards.

## Tests

Four new tests in `plan.rs`:

- `test_plan_speed_matches_fit_speed` — plan and fit agree exactly, for both a dense and a MoE fixture. This is the regression guard for the duplication itself.
- `test_moe_gpu_speed_uses_active_params` — MoE estimate must far exceed the dense-equivalent figure the old formula produced.
- `test_moe_offload_is_not_faster_than_gpu` — the ordering invariant.
- `test_speed_run_mode_maps_moe_offload` — the run-mode mapping.

## Verification

- `cargo test -p llmfit-core` — **490 passed, 0 failed, 1 ignored** (486 before this PR)
- `cargo fmt --check` — clean
- `cargo clippy -p llmfit-core --all-targets -- -D warnings` — **23 errors before and after, none in the touched files.** They're pre-existing under clippy 1.97, which is newer than CI's pinned version.
- Verified end-to-end against a locally built binary, not just the test suite.

Tested on Ubuntu 22.04.5, RTX 3090 24 GB (driver 580.173.02), Ryzen 9 3900X, 32 GB RAM.
