### PR TITLE
bench: community results for apple-m5-pro

### DIFF
--- a/llmfit-core/data/community/apple-m5-pro/1785311808-421556ef.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785311808-421556ef.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 2232.63,
+      "avgTps": 139.11,
+      "avgTtftMs": 26.98,
+      "maxTps": 143.53,
+      "minTps": 131.21,
+      "model": "gemma4:e4b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785334082,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785328035-90122fc9.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785328035-90122fc9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 3854.34,
+      "avgTps": 80.2,
+      "avgTtftMs": 74.15,
+      "maxTps": 81.07,
+      "minTps": 79.27,
+      "model": "qwen3.6:35b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785334082,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785328170-3ce8ff2d.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785328170-3ce8ff2d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 18849.6,
+      "avgTps": 16.18,
+      "avgTtftMs": 223.36,
+      "maxTps": 16.19,
+      "minTps": 16.16,
+      "model": "qwen3.6:27b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785334082,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785333484-6240bf1e.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785333484-6240bf1e.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 180.33,
+      "avgTotalMs": 3223.24,
+      "avgTps": 61.42,
+      "avgTtftMs": 146.37,
+      "maxTps": 61.9,
+      "minTps": 61.05,
+      "model": "qwen3-coder-next:Q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785334082,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785333581-cfdcaaba.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785333581-cfdcaaba.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 219.67,
+      "avgTotalMs": 1702.92,
+      "avgTps": 130.15,
+      "avgTtftMs": 26.18,
+      "maxTps": 150.96,
+      "minTps": 113.86,
+      "model": "gemma4:e4b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785334082,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785333632-5353aabf.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785333632-5353aabf.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 4639.45,
+      "avgTps": 66.45,
+      "avgTtftMs": 101.04,
+      "maxTps": 67.07,
+      "minTps": 65.91,
+      "model": "gemma4:12b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785334082,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785333729-0fa72ca1.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785333729-0fa72ca1.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 294.0,
+      "avgTotalMs": 3601.38,
+      "avgTps": 84.75,
+      "avgTtftMs": 102.33,
+      "maxTps": 86.32,
+      "minTps": 83.62,
+      "model": "gemma4:26b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785334082,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785333821-f40df0fd.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785333821-f40df0fd.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 268.67,
+      "avgTotalMs": 8457.25,
+      "avgTps": 33.24,
+      "avgTtftMs": 262.03,
+      "maxTps": 34.99,
+      "minTps": 31.97,
+      "model": "gemma4:31b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785334082,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785333935-a57e9421.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785333935-a57e9421.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 204.0,
+      "avgTotalMs": 10708.53,
+      "avgTps": 19.76,
+      "avgTtftMs": 222.04,
+      "maxTps": 20.0,
+      "minTps": 19.62,
+      "model": "hf.co/unsloth/Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785334082,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785334817-e7a18256.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785334817-e7a18256.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 3704.8,
+      "avgTps": 83.85,
+      "avgTtftMs": 96.7,
+      "maxTps": 86.32,
+      "minTps": 80.74,
+      "model": "gemma4:26b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785444024,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785334917-44100718.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785334917-44100718.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 18976.17,
+      "avgTps": 16.07,
+      "avgTtftMs": 222.42,
+      "maxTps": 16.1,
+      "minTps": 16.05,
+      "model": "qwen3.6:27b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785444024,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785335093-27fd237b.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785335093-27fd237b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 3818.44,
+      "avgTps": 80.89,
+      "avgTtftMs": 71.28,
+      "maxTps": 80.91,
+      "minTps": 80.88,
+      "model": "qwen3.6:35b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785444024,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785335296-8d908ba6.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785335296-8d908ba6.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 19239.12,
+      "avgTps": 15.85,
+      "avgTtftMs": 223.23,
+      "maxTps": 16.05,
+      "minTps": 15.58,
+      "model": "qwen3.6:27b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785444024,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785355831-e157b91d.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785355831-e157b91d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 15963.96,
+      "avgTps": 19.65,
+      "avgTtftMs": 457.99,
+      "maxTps": 21.09,
+      "minTps": 18.44,
+      "model": "qwen3.6:27b-mtp-q8_0",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785444024,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785356568-6461f05d.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785356568-6461f05d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 21231.88,
+      "avgTps": 14.52,
+      "avgTtftMs": 389.23,
+      "maxTps": 14.55,
+      "minTps": 14.5,
+      "model": "hf.co/unsloth/Qwen3.6-27B-MTP-GGUF:UD-Q4_K_XL",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785444024,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785357082-4617dedb.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785357082-4617dedb.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 14124.81,
+      "avgTps": 22.26,
+      "avgTtftMs": 404.63,
+      "maxTps": 23.99,
+      "minTps": 20.62,
+      "model": "qwen3.6:27b-mtp-q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785444024,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785395838-6f46e3bb.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785395838-6f46e3bb.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 13212.89,
+      "avgTps": 24.16,
+      "avgTtftMs": 405.9,
+      "maxTps": 28.36,
+      "minTps": 20.82,
+      "model": "qwen3.6:27b-mtp-q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785444024,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/apple-m5-pro/1785439736-dcd891fe.json
+++ b/llmfit-core/data/community/apple-m5-pro/1785439736-dcd891fe.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M5 Pro",
+    "cpuCores": 18,
+    "gpuCount": 1,
+    "hardwareName": "Apple M5 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 64,
+    "os": "macos",
+    "ramGb": 64.0,
+    "unifiedMemory": true,
+    "vramGb": 64.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 6002.01,
+      "avgTps": 52.85,
+      "avgTtftMs": 175.63,
+      "maxTps": 52.86,
+      "minTps": 52.82,
+      "model": "glm-4.7-flash:q8_0",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1785444024,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| gemma4:e4b-mlx | ollama | 139.1 | 27.0 |
| qwen3.6:35b-mlx | ollama | 80.2 | 74.2 |
| qwen3.6:27b-mlx | ollama | 16.2 | 223.4 |
| qwen3-coder-next:Q4_K_M | ollama | 61.4 | 146.4 |
| gemma4:e4b-mlx | ollama | 130.2 | 26.2 |
| gemma4:12b-mlx | ollama | 66.5 | 101.0 |
| gemma4:26b-mlx | ollama | 84.8 | 102.3 |
| gemma4:31b-mlx | ollama | 33.2 | 262.0 |
| hf.co/unsloth/Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q4_K_M | ollama | 19.8 | 222.0 |

_Submitted without the `gh` CLI via the GitHub device flow._
