### PR TITLE
feat(tui): mark list rows matched through a GGUF source

### DIFF
--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -856,7 +856,7 @@ fn provider_selected(name: &str, providers: &[String], selected: &[bool]) -> boo
 /// by a GGUF publisher surfaces rows whose own provider was never selected.
 /// Returns `None` when the primary provider is selected (nothing to attribute)
 /// or when nothing matched at all.
-pub fn matched_gguf_provider<'a>(
+pub(crate) fn matched_gguf_provider<'a>(
     model: &'a LlmModel,
     providers: &[String],
     selected: &[bool],

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -5306,6 +5306,15 @@ mod tests {
     }
 
     #[test]
+    fn matched_gguf_provider_is_none_without_a_provider_filter() {
+        // No filter is `vec![true; n]` (see `App::new`), so every row is there
+        // on its own merit and the list marker must stay off.
+        let model = model_with_gguf_sources();
+        let selected = vec![true, true, true];
+        assert_eq!(matched_gguf_provider(&model, &providers(), &selected), None);
+    }
+
+    #[test]
     fn matched_gguf_provider_returns_first_selected_source_in_catalog_order() {
         let model = model_with_gguf_sources();
         let selected = vec![false, true, true];

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1,6 +1,6 @@
 use llmfit_core::fit::{CalcConfig, FitLevel, ModelFit, SortColumn, backend_compatible};
 use llmfit_core::hardware::SystemSpecs;
-use llmfit_core::models::{Capability, ModelDatabase, UseCase};
+use llmfit_core::models::{Capability, LlmModel, ModelDatabase, UseCase};
 use llmfit_core::plan::{PlanEstimate, PlanRequest, estimate_model_plan};
 use llmfit_core::providers::{
     self, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
@@ -837,6 +837,38 @@ fn fuzzy_match(query: &str, candidate: &str) -> bool {
         }
     }
     q.peek().is_none()
+}
+
+/// Whether `name` is one of the currently selected entries of the provider filter.
+fn provider_selected(name: &str, providers: &[String], selected: &[bool]) -> bool {
+    providers
+        .iter()
+        .position(|p| p == name)
+        .and_then(|idx| selected.get(idx).copied())
+        .unwrap_or(false)
+}
+
+/// The GGUF-source provider that got this model through the provider filter,
+/// when the model's own provider is not selected.
+///
+/// The catalog lists base models (e.g. `Qwen/Qwen3-4B` from Alibaba) while the
+/// GGUF quants are published by others (unsloth, bartowski, ...), so filtering
+/// by a GGUF publisher surfaces rows whose own provider was never selected.
+/// Returns `None` when the primary provider is selected (nothing to attribute)
+/// or when nothing matched at all.
+pub fn matched_gguf_provider<'a>(
+    model: &'a LlmModel,
+    providers: &[String],
+    selected: &[bool],
+) -> Option<&'a str> {
+    if provider_selected(&model.provider, providers, selected) {
+        return None;
+    }
+    model
+        .gguf_sources
+        .iter()
+        .find(|gs| provider_selected(&gs.provider, providers, selected))
+        .map(|gs| gs.provider.as_str())
 }
 
 pub struct App {
@@ -1760,22 +1792,16 @@ impl App {
                 };
 
                 // Provider filter (check primary provider and GGUF source providers)
-                let matches_provider = {
-                    let primary_match = self
-                        .providers
-                        .iter()
-                        .position(|p| p == &fit.model.provider)
-                        .map(|idx| self.selected_providers[idx])
-                        .unwrap_or(false);
-                    let gguf_match = fit.model.gguf_sources.iter().any(|gs| {
-                        self.providers
-                            .iter()
-                            .position(|p| p == &gs.provider)
-                            .map(|idx| self.selected_providers[idx])
-                            .unwrap_or(false)
-                    });
-                    primary_match || gguf_match
-                };
+                let matches_provider = provider_selected(
+                    &fit.model.provider,
+                    &self.providers,
+                    &self.selected_providers,
+                ) || matched_gguf_provider(
+                    &fit.model,
+                    &self.providers,
+                    &self.selected_providers,
+                )
+                .is_some();
                 let use_case_idx = self.use_cases.iter().position(|uc| *uc == fit.use_case);
                 let matches_use_case = use_case_idx
                     .map(|idx| self.selected_use_cases[idx])
@@ -5136,7 +5162,7 @@ mod tests {
     use super::*;
     use llmfit_core::fit::{InferenceRuntime, RunMode, ScoreComponents};
     use llmfit_core::hardware::GpuBackend;
-    use llmfit_core::models::{LlmModel, ModelFormat, UseCase};
+    use llmfit_core::models::{GgufSource, LlmModel, ModelFormat, UseCase};
 
     fn test_app() -> App {
         App::with_specs_and_context(
@@ -5224,6 +5250,84 @@ mod tests {
             estimate_basis: Default::default(),
             measured_tps: None,
         }
+    }
+
+    // ── matched GGUF source attribution (issue #569) ─────────────────
+
+    /// `Qwen/Qwen3-4B`-shaped entry: base model from one provider, GGUF quants
+    /// published by others.
+    fn model_with_gguf_sources() -> LlmModel {
+        let mut model = test_model("Qwen/Qwen3-4B");
+        model.provider = "Alibaba".to_string();
+        model.gguf_sources = vec![
+            GgufSource {
+                repo: "unsloth/Qwen3-4B-GGUF".to_string(),
+                provider: "unsloth".to_string(),
+            },
+            GgufSource {
+                repo: "bartowski/Qwen3-4B-GGUF".to_string(),
+                provider: "bartowski".to_string(),
+            },
+        ];
+        model
+    }
+
+    fn providers() -> Vec<String> {
+        ["Alibaba", "unsloth", "bartowski"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn matched_gguf_provider_reports_the_selected_source() {
+        let model = model_with_gguf_sources();
+        let selected = vec![false, true, false];
+        assert_eq!(
+            matched_gguf_provider(&model, &providers(), &selected),
+            Some("unsloth")
+        );
+    }
+
+    #[test]
+    fn matched_gguf_provider_is_none_when_primary_provider_selected() {
+        let model = model_with_gguf_sources();
+        // Both the base provider and a GGUF source are on: the row is there on
+        // its own merit, so there is nothing to attribute.
+        let selected = vec![true, true, false];
+        assert_eq!(matched_gguf_provider(&model, &providers(), &selected), None);
+    }
+
+    #[test]
+    fn matched_gguf_provider_is_none_when_nothing_selected() {
+        let model = model_with_gguf_sources();
+        let selected = vec![false, false, false];
+        assert_eq!(matched_gguf_provider(&model, &providers(), &selected), None);
+    }
+
+    #[test]
+    fn matched_gguf_provider_returns_first_selected_source_in_catalog_order() {
+        let model = model_with_gguf_sources();
+        let selected = vec![false, true, true];
+        assert_eq!(
+            matched_gguf_provider(&model, &providers(), &selected),
+            Some("unsloth")
+        );
+    }
+
+    #[test]
+    fn matched_gguf_provider_is_none_without_gguf_sources() {
+        let mut model = test_model("some/model");
+        model.provider = "Alibaba".to_string();
+        let selected = vec![false, true, true];
+        assert_eq!(matched_gguf_provider(&model, &providers(), &selected), None);
+    }
+
+    #[test]
+    fn provider_selected_tolerates_a_short_selection_slice() {
+        // The names and selection vectors are built in parallel, but never
+        // index out of bounds if they ever drift.
+        assert!(!provider_selected("bartowski", &providers(), &[false]));
     }
 
     // ── available_download_providers MLX gating (issue #294) ─────────

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -840,7 +840,7 @@ fn fuzzy_match(query: &str, candidate: &str) -> bool {
 }
 
 /// Whether `name` is one of the currently selected entries of the provider filter.
-fn provider_selected(name: &str, providers: &[String], selected: &[bool]) -> bool {
+pub(crate) fn provider_selected(name: &str, providers: &[String], selected: &[bool]) -> bool {
     providers
         .iter()
         .position(|p| p == name)

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -15,6 +15,7 @@ use crate::tui_app::{
     AdvConfigField, App, AvailabilityFilter, BenchOfferState, BenchViewMode, DL_DOCKER,
     DL_LLAMACPP, DL_LMSTUDIO, DL_OLLAMA, DL_VLLM, DownloadCapability, DownloadManagerFocus,
     DownloadProvider, FitFilter, InputMode, PlanField, SimulationField, matched_gguf_provider,
+    provider_selected,
 };
 use llmfit_core::fit::{FitLevel, ModelFit, SortColumn};
 use llmfit_core::hardware::is_running_in_wsl;
@@ -744,6 +745,20 @@ fn truncate_with_ellipsis(text: &str, max_chars: usize) -> String {
 
 /// Display width of the Provider column in the model table.
 const PROVIDER_COL_WIDTH: usize = 12;
+
+/// Whether this GGUF source is one of the reasons the row is in the list: the
+/// row came in through a publisher rather than its own provider, and this
+/// source's publisher is selected. Several sources qualify at once when several
+/// publishers are selected, so this asks per source instead of comparing
+/// against the single first match.
+fn gguf_source_attributed(
+    matched_gguf: Option<&str>,
+    src_provider: &str,
+    providers: &[String],
+    selected: &[bool],
+) -> bool {
+    matched_gguf.is_some() && provider_selected(src_provider, providers, selected)
+}
 
 /// The Provider cell: the model's own provider, plus a `*` when the row is only
 /// in the list because one of its GGUF publishers is selected (issue #569).
@@ -2204,11 +2219,16 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             Style::default().fg(tc.accent),
         )));
         right_lines.push(Line::from(""));
-        // When the row is only in the list because one of these publishers is
-        // selected in the provider filter, point at that one (issue #569).
+        // When the row is only in the list because these publishers are
+        // selected in the provider filter, point at them (issue #569).
         let matched = matched_gguf_provider(&fit.model, &app.providers, &app.selected_providers);
         for src in &fit.model.gguf_sources {
-            let is_match = matched == Some(src.provider.as_str());
+            let is_match = gguf_source_attributed(
+                matched,
+                &src.provider,
+                &app.providers,
+                &app.selected_providers,
+            );
             // "▸" replaces a leading space, so the column stays aligned.
             let provider_str = if is_match {
                 format!("▸ 📦 {:<12}", src.provider)
@@ -5702,6 +5722,42 @@ mod tests {
         assert_eq!(truncate_str("🚀 hello", 4), "🚀 h~");
         // Exact max length — no truncation
         assert_eq!(truncate_str("abc", 3), "abc");
+    }
+
+    #[test]
+    fn gguf_source_attributed_marks_every_selected_publisher() {
+        let providers = ["Alibaba", "unsloth", "bartowski"]
+            .map(String::from)
+            .to_vec();
+        // unsloth + bartowski selected, the model's own provider is not: both
+        // publishers are why the row is in the list, so both get marked.
+        let selected = vec![false, true, true];
+        assert!(gguf_source_attributed(
+            Some("unsloth"),
+            "unsloth",
+            &providers,
+            &selected
+        ));
+        assert!(gguf_source_attributed(
+            Some("unsloth"),
+            "bartowski",
+            &providers,
+            &selected
+        ));
+        // A source nobody selected stays unmarked.
+        assert!(!gguf_source_attributed(
+            Some("unsloth"),
+            "mradermacher",
+            &providers,
+            &selected
+        ));
+        // Own provider selected: the row is there on its own merit, mark nothing.
+        assert!(!gguf_source_attributed(
+            None,
+            "unsloth",
+            &providers,
+            &vec![true, true, true]
+        ));
     }
 
     #[test]

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -2221,7 +2221,7 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
                 Style::default().fg(tc.info)
             };
             let url_str = format!("hf.co/{}", src.repo);
-            // Visual width: "  📦 " = 5 display cols (📦 is 2-wide), plus padded provider
+            // Visual width: "  📦 " / "▸ 📦 " = 5 display cols (📦 is 2-wide), plus padded provider
             let provider_visual_width = 5 + src.provider.len().max(12);
             if provider_visual_width + url_str.len() <= right_inner_width {
                 // Fits on one line

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -14,7 +14,7 @@ use crate::theme::ThemeColors;
 use crate::tui_app::{
     AdvConfigField, App, AvailabilityFilter, BenchOfferState, BenchViewMode, DL_DOCKER,
     DL_LLAMACPP, DL_LMSTUDIO, DL_OLLAMA, DL_VLLM, DownloadCapability, DownloadManagerFocus,
-    DownloadProvider, FitFilter, InputMode, PlanField, SimulationField,
+    DownloadProvider, FitFilter, InputMode, PlanField, SimulationField, matched_gguf_provider,
 };
 use llmfit_core::fit::{FitLevel, ModelFit, SortColumn};
 use llmfit_core::hardware::is_running_in_wsl;
@@ -2174,23 +2174,34 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
             Style::default().fg(tc.accent),
         )));
         right_lines.push(Line::from(""));
+        // When the row is only in the list because one of these publishers is
+        // selected in the provider filter, point at that one (issue #569).
+        let matched = matched_gguf_provider(&fit.model, &app.providers, &app.selected_providers);
         for src in &fit.model.gguf_sources {
-            let provider_str = format!("  📦 {:<12}", src.provider);
+            let is_match = matched == Some(src.provider.as_str());
+            // "▸" replaces a leading space, so the column stays aligned.
+            let provider_str = if is_match {
+                format!("▸ 📦 {:<12}", src.provider)
+            } else {
+                format!("  📦 {:<12}", src.provider)
+            };
+            let provider_style = if is_match {
+                Style::default().fg(tc.accent).bold()
+            } else {
+                Style::default().fg(tc.info)
+            };
             let url_str = format!("hf.co/{}", src.repo);
             // Visual width: "  📦 " = 5 display cols (📦 is 2-wide), plus padded provider
             let provider_visual_width = 5 + src.provider.len().max(12);
             if provider_visual_width + url_str.len() <= right_inner_width {
                 // Fits on one line
                 right_lines.push(Line::from(vec![
-                    Span::styled(provider_str, Style::default().fg(tc.info)),
+                    Span::styled(provider_str, provider_style),
                     Span::styled(url_str, Style::default().fg(tc.fg)),
                 ]));
             } else {
                 // Too wide: put URL on its own indented line
-                right_lines.push(Line::from(Span::styled(
-                    provider_str,
-                    Style::default().fg(tc.info),
-                )));
+                right_lines.push(Line::from(Span::styled(provider_str, provider_style)));
                 right_lines.push(Line::from(Span::styled(
                     format!("       {}", url_str),
                     Style::default().fg(tc.fg),

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -742,6 +742,26 @@ fn truncate_with_ellipsis(text: &str, max_chars: usize) -> String {
     format!("{}…", head)
 }
 
+/// Display width of the Provider column in the model table.
+const PROVIDER_COL_WIDTH: usize = 12;
+
+/// The Provider cell: the model's own provider, plus a `*` when the row is only
+/// in the list because one of its GGUF publishers is selected (issue #569).
+///
+/// Catalog provider names run up to 30 chars while the column is 12, so a
+/// marked name is truncated to leave the marker its own column. Appending to
+/// the raw name would let the terminal clip the `*` away on the very rows it
+/// explains. Unmarked cells are returned untouched.
+fn provider_cell(provider: &str, matched_gguf: Option<&str>, width: usize) -> String {
+    match matched_gguf {
+        None => provider.to_string(),
+        Some(_) => format!(
+            "{}*",
+            truncate_with_ellipsis(provider, width.saturating_sub(1))
+        ),
+    }
+}
+
 fn marquee_text(text: &str, window_chars: usize, tick: u64) -> String {
     if window_chars == 0 {
         return String::new();
@@ -949,11 +969,21 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
                 truncate_with_ellipsis(&fit.model.name, model_col_chars)
             };
 
+            // The row may be here because one of its GGUF publishers is
+            // selected rather than its own provider — say so (issue #569).
+            let matched_gguf =
+                matched_gguf_provider(&fit.model, &app.providers, &app.selected_providers);
+
             Row::new(vec![
                 Cell::from(marker).style(Style::default().fg(color)),
                 Cell::from(installed_icon).style(Style::default().fg(installed_color)),
                 Cell::from(model_text).style(Style::default().fg(tc.fg)),
-                Cell::from(fit.model.provider.clone()).style(Style::default().fg(tc.muted)),
+                Cell::from(provider_cell(
+                    &fit.model.provider,
+                    matched_gguf,
+                    PROVIDER_COL_WIDTH,
+                ))
+                .style(Style::default().fg(tc.muted)),
                 Cell::from(fit.model.parameter_count.clone()).style(Style::default().fg(tc.fg)),
                 Cell::from(format!("{:.0}", fit.score)).style(Style::default().fg(score_color)),
                 Cell::from(tps_text).style(Style::default().fg(tc.fg)),
@@ -990,21 +1020,21 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
         .collect();
 
     let widths = [
-        Constraint::Length(2),  // indicator
-        Constraint::Length(5),  // installed / pull %
-        Constraint::Min(20),    // model name
-        Constraint::Length(12), // provider
-        Constraint::Length(8),  // params
-        Constraint::Length(8),  // score
-        Constraint::Length(8),  // tok/s
-        Constraint::Length(10), // quant (AWQ-4bit, GPTQ-Int4, GPTQ-Int8)
-        Constraint::Length(6),  // disk
-        Constraint::Length(7),  // mode
-        Constraint::Length(7),  // mem %
-        Constraint::Length(10), // ctx ("262k→14k" when memory-constrained)
-        Constraint::Length(8),  // date (YYYY-MM)
-        Constraint::Length(10), // fit
-        Constraint::Min(10),    // use case
+        Constraint::Length(2),                         // indicator
+        Constraint::Length(5),                         // installed / pull %
+        Constraint::Min(20),                           // model name
+        Constraint::Length(PROVIDER_COL_WIDTH as u16), // provider
+        Constraint::Length(8),                         // params
+        Constraint::Length(8),                         // score
+        Constraint::Length(8),                         // tok/s
+        Constraint::Length(10),                        // quant (AWQ-4bit, GPTQ-Int4, GPTQ-Int8)
+        Constraint::Length(6),                         // disk
+        Constraint::Length(7),                         // mode
+        Constraint::Length(7),                         // mem %
+        Constraint::Length(10),                        // ctx ("262k→14k" when memory-constrained)
+        Constraint::Length(8),                         // date (YYYY-MM)
+        Constraint::Length(10),                        // fit
+        Constraint::Min(10),                           // use case
     ];
 
     let count_text = format!(
@@ -5672,6 +5702,43 @@ mod tests {
         assert_eq!(truncate_str("🚀 hello", 4), "🚀 h~");
         // Exact max length — no truncation
         assert_eq!(truncate_str("abc", 3), "abc");
+    }
+
+    #[test]
+    fn provider_cell_leaves_unmatched_rows_untouched() {
+        assert_eq!(
+            provider_cell("Alibaba", None, PROVIDER_COL_WIDTH),
+            "Alibaba"
+        );
+        // Long names keep rendering exactly as they did before the marker
+        // existed — the terminal clips them at the column edge.
+        assert_eq!(
+            provider_cell("optimum-intel-internal-testing", None, PROVIDER_COL_WIDTH),
+            "optimum-intel-internal-testing"
+        );
+    }
+
+    #[test]
+    fn provider_cell_marks_a_gguf_match() {
+        assert_eq!(
+            provider_cell("Alibaba", Some("unsloth"), PROVIDER_COL_WIDTH),
+            "Alibaba*"
+        );
+    }
+
+    #[test]
+    fn provider_cell_keeps_the_marker_inside_the_column() {
+        // `NousResearch` is exactly the column width, so appending the marker
+        // to the raw name would push it past the edge and lose it.
+        for name in [
+            "NousResearch",
+            "mlx-community",
+            "optimum-intel-internal-testing",
+        ] {
+            let cell = provider_cell(name, Some("unsloth"), PROVIDER_COL_WIDTH);
+            assert_eq!(cell.chars().count(), PROVIDER_COL_WIDTH, "{}", name);
+            assert!(cell.ends_with('*'), "{}", cell);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #569.

Your ruling from the issue: the Provider column keeps the canonical name and takes a `*` when the row is only in the list because one of its GGUF publishers is selected. The detail pane names the actual repo.

### The three commits

1. **`refactor(tui)`** — the filter's `gguf_sources` half was inlined in the filter closure, so nothing downstream could tell which of the two names got a row through. Pulled out as `provider_selected` and `matched_gguf_provider`, both pure over the name/selection slices. No behaviour change: `matched_gguf_provider` returns `None` when the primary provider is selected, so `primary || matched.is_some()` is the same predicate as before — verified with the provider filter set to `unsloth` only, 366/4476 rows before and after.
2. **`feat(tui)`** — detail pane: the matched publisher in the GGUF Downloads list gets `▸` and the accent style. The marker replaces a leading space, so the column stays aligned.
3. **`feat(tui)`** — the list column, below.

### The marker gets its own column rather than the raw name

Appending to the provider string would have dropped the marker on exactly the rows it explains. 1382 catalog rows carry `gguf_sources`, spread over 495 distinct provider names, and around 150 of those are 12 chars or longer — `NousResearch` (12), `mlx-community` (13), `openai-community` (16), up to `optimum-intel-internal-testing` (30). Against `Constraint::Length(12)`, `NousResearch*` is clipped straight back to `NousResearch`.

The width is now a named constant so the cell formatter and the constraint can't drift apart. It replaces only the `Length(12)` that the table actually renders with: the other copy of the widths array, the one `model_col_text_width` is fed at `tui_ui.rs` L822, has drifted independently (14 constraints against the table's 15, no `disk`, three lengths disagreeing) and I would rather report that separately than hide it behind a rename here.

So a marked name is truncated to 11 chars and the marker owns column 12. Unmarked cells are returned untouched, so rows that matched on their own provider render exactly as they do today. `provider_cell` is pure and width-parameterised; four tests cover unmarked passthrough, `Alibaba*`, the 12-char-and-longer cases staying inside the column, and no marker at all when no provider filter is active (`vec![true; n]`).

### Before / after

Provider filter = `unsloth` only, 150x40 pty, debug build. `upstream/main` at afbaae1:

```
┌ Models (366/4476) ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────↑
│     Inst  Model                Provider     Params   Score ▼  tok/s*   Quant      Disk   Mode    Mem %   Ctx        Date     Fit        Use Case   █
│▶ ●   —    th/Qwen3-4B-Instruct unsloth      3.1B     88       45.0     Q8_0       3.3G   GPU     71%     4k         —        Perfect    Chat       █
│  ●   —    unsloth/Llama-3.2-3B unsloth      3.3B     87       42.7     Q8_0       3.5G   GPU     74%     4k         —        Perfect    Chat       ║
│  ●   —    unsloth/Llama-3.2-3B unsloth      3.3B     87       42.7     Q8_0       3.5G   GPU     74%     4k         —        Perfect    Chat       ║
│  ●   —    Qwen/Qwen2.5-Coder-3 Alibaba      3.1B     86       45.6     Q8_0       3.2G   GPU     73%     32k        —        Perfect    Coding     ║
│  ●   —    unsloth/Qwen2.5-Code unsloth      3.2B     86       44.4     Q8_0       3.3G   GPU     75%     32k        —        Perfect    Coding     ║
```

Same filter, this branch:

```
┌ Models (366/4476) ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────↑
│     Inst  Model                Provider     Params   Score ▼  tok/s*   Quant      Disk   Mode    Mem %   Ctx        Date     Fit        Use Case   █
│▶ ●   —    07-unsloth-bnb-4bit  unsloth      3.1B     88       45.0     Q8_0       3.3G   GPU     71%     4k         —        Perfect    Chat       █
│  ●   —    unsloth/Llama-3.2-3B unsloth      3.3B     87       42.7     Q8_0       3.5G   GPU     74%     4k         —        Perfect    Chat       ║
│  ●   —    unsloth/Llama-3.2-3B unsloth      3.3B     87       42.7     Q8_0       3.5G   GPU     74%     4k         —        Perfect    Chat       ║
│  ●   —    Qwen/Qwen2.5-Coder-3 Alibaba*     3.1B     86       45.6     Q8_0       3.2G   GPU     73%     32k        —        Perfect    Coding     ║
│  ●   —    unsloth/Qwen2.5-Code unsloth      3.2B     86       44.4     Q8_0       3.3G   GPU     75%     32k        —        Perfect    Coding     ║
```

366/4476 in both — display only. The `DeepSeek`, `Meta`, `Microsoft` and `TII` rows further down the same list are marked the same way. (The Model cell of the selected row marquees, so the two captures caught it at different scroll phases; same model.)

Truncation case, filter = `mradermacher`, search `Zion` — own provider `sicariussicariistuff`, 20 chars. Before:

```
┌ Models (3/4476) ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│     Inst  Model                Provider     Params   Score ▼  tok/s*   Quant      Disk   Mode    Mem %   Ctx        Date     Fit        Use Case   │
│▶ ●   —    riiStuff/Zion_Alpha_ sicariussica 7.2B     72       27.9     Q4_K_M     4.2G   GPU     90%     4k         —        Marginal   Chat       │
```

After:

```
┌ Models (3/4476) ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│     Inst  Model                Provider     Params   Score ▼  tok/s*   Quant      Disk   Mode    Mem %   Ctx        Date     Fit        Use Case   │
│▶ ●   —    riiStuff/Zion_Alpha_ sicariussi…* 7.2B     72       27.9     Q4_K_M     4.2G   GPU     90%     4k         —        Marginal   Chat       │
```

Local: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` (no new warnings), `cargo test` — 577 pass.

### One thing I left to you

`*` is not spelled out anywhere in the UI. Since #783 replaced the cryptic `R`/`M` markers with the range spelled out in the Fit/Filter box, you may want the same treatment here. I kept it out to hold the PR to the issue: happy to add a line naming the provider marker in that box, or leave the detail pane as the only explanation.
