### PR TITLE
fix(share): give the declared memory tier a floor below 8 GB

### DIFF
--- a/llmfit-core/src/benchmarks.rs
+++ b/llmfit-core/src/benchmarks.rs
@@ -277,12 +277,12 @@ pub fn hw_leaderboard_params(specs: &SystemSpecs) -> Vec<(&'static str, String)>
 
     // VRAM tier
     if let Some(vram) = specs.total_gpu_vram_gb {
-        let tier = nearest_mem_tier(vram);
+        let tier = lookup_mem_tier(vram);
         if tier > 0 {
             params.push(("memTier", tier.to_string()));
         }
     } else if specs.unified_memory {
-        let tier = nearest_mem_tier(specs.total_ram_gb);
+        let tier = lookup_mem_tier(specs.total_ram_gb);
         if tier > 0 {
             params.push(("memTier", tier.to_string()));
         }
@@ -301,7 +301,18 @@ pub fn hw_leaderboard_params(specs: &SystemSpecs) -> Vec<(&'static str, String)>
     params
 }
 
-fn nearest_mem_tier(gb: f64) -> u32 {
+/// Bucket a memory size into the tier used as a *lookup key* against the
+/// cached community results.
+///
+/// Nearest-match is the right rule here and the wrong one in `share.rs`: a
+/// lookup wants the closest bucket that has data even when the fit is not
+/// exact, because returning nothing is worse than returning an approximation.
+/// A declared capacity wants the opposite.
+///
+/// That is why this is not the same function as `declared_mem_tier` in
+/// `share.rs` despite looking almost identical, and why the two ladders are
+/// allowed to differ. Please do not unify them.
+fn lookup_mem_tier(gb: f64) -> u32 {
     const TIERS: [u32; 9] = [8, 12, 16, 24, 32, 48, 80, 96, 128];
     let mut best = 0u32;
     let mut best_dist = f64::MAX;

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -110,10 +110,22 @@ fn os_name() -> &'static str {
     }
 }
 
-/// Round a memory size to the nearest common tier (matches the leaderboard's
-/// coarse buckets so submissions group cleanly).
-fn nearest_mem_tier(gb: f64) -> u32 {
-    const TIERS: [u32; 12] = [8, 12, 16, 24, 32, 48, 64, 80, 96, 128, 192, 256];
+/// Round a memory size to the nearest common tier, for the capacity a
+/// submission *declares* about the machine it ran on.
+///
+/// The ladder is deliberately coarse so submissions group cleanly, but it has
+/// a floor: capacities that shipped below 8 GB get their own rungs, otherwise
+/// a 4 GB card is published as an 8 GB part and compared against hardware it
+/// has nothing in common with.
+///
+/// Exact ties resolve downward, which understates rather than overstates. That
+/// is the safe direction here, because this value is a claim about what a
+/// machine actually has.
+///
+/// Not to be merged with `lookup_mem_tier` in `benchmarks.rs`, which looks
+/// almost identical and means something else. See the note there.
+fn declared_mem_tier(gb: f64) -> u32 {
+    const TIERS: [u32; 16] = [2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 80, 96, 128, 192, 256];
     let mut best = 0u32;
     let mut best_d = f64::MAX;
     for &t in &TIERS {
@@ -136,10 +148,10 @@ fn build_submission(results: &[BenchResult], specs: &SystemSpecs) -> Submission 
     };
 
     let mem_tier_gb = if let Some(vram) = specs.total_gpu_vram_gb {
-        let t = nearest_mem_tier(vram);
+        let t = declared_mem_tier(vram);
         (t > 0).then_some(t)
     } else if specs.unified_memory {
-        let t = nearest_mem_tier(specs.total_ram_gb);
+        let t = declared_mem_tier(specs.total_ram_gb);
         (t > 0).then_some(t)
     } else {
         None
@@ -1126,10 +1138,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn mem_tier_rounds_to_nearest() {
-        assert_eq!(nearest_mem_tier(23.9), 24);
-        assert_eq!(nearest_mem_tier(31.0), 32);
-        assert_eq!(nearest_mem_tier(7.5), 8);
+    fn submission_declares_a_4gb_card_as_4gb() {
+        // End-to-end on the payload, not just the helper: a 4 GB card used to
+        // be published as an 8 GB part. Guards the whole build_submission path.
+        let submission = build_submission(
+            &[sample_result()],
+            &specs_with_vram("NVIDIA GeForce GTX 1050 Ti", 4.0),
+        );
+        let value = serde_json::to_value(&submission).unwrap();
+        assert_eq!(value["hardware"]["vramGb"], 4.0);
+        assert_eq!(value["hardware"]["memTierGb"], 4);
+    }
+
+    #[test]
+    fn declared_mem_tier_has_a_floor() {
+        // The ladder used to start at 8, so anything smaller was published as
+        // an 8 GB part. These are the capacities that actually shipped below
+        // it: GT 710 and GTX 1050 at 2, GTX 1060 3 GB, GTX 1050 Ti at 4,
+        // GTX 1060 6 GB and RTX 2060 at 6.
+        assert_eq!(declared_mem_tier(2.0), 2);
+        assert_eq!(declared_mem_tier(3.0), 3);
+        assert_eq!(declared_mem_tier(4.0), 4);
+        assert_eq!(declared_mem_tier(6.0), 6);
+    }
+
+    #[test]
+    fn declared_mem_tier_ties_resolve_downward() {
+        // 7 GB is equidistant from 6 and 8; understating is the safe
+        // direction for a declared capacity.
+        assert_eq!(declared_mem_tier(7.0), 6);
+    }
+
+    #[test]
+    fn declared_mem_tier_rounds_to_nearest() {
+        assert_eq!(declared_mem_tier(23.9), 24);
+        assert_eq!(declared_mem_tier(31.0), 32);
+        assert_eq!(declared_mem_tier(7.5), 8);
     }
 
     #[test]
@@ -1175,6 +1219,14 @@ mod tests {
             gpus: vec![],
             cluster_mode: false,
             cluster_node_count: 0,
+        }
+    }
+
+    fn specs_with_vram(name: &str, vram_gb: f64) -> SystemSpecs {
+        SystemSpecs {
+            gpu_vram_gb: Some(vram_gb),
+            total_gpu_vram_gb: Some(vram_gb),
+            ..specs_with_gpu(name)
         }
     }
 


### PR DESCRIPTION
Closes #816.

`nearest_mem_tier` had no rung below 8, so any GPU with less than 8 GB of VRAM was
published as an 8 GB part. A 4 GB card was declared at twice its capacity, a 2 GB one
at four times. For a coarse grouping key that is not imprecision, it is a missing
floor: small cards get bucketed upward into hardware they should not be compared
against.

### What changes

```diff
- const TIERS: [u32; 12] = [8, 12, 16, 24, 32, 48, 64, 80, 96, 128, 192, 256];
+ const TIERS: [u32; 16] = [2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 80, 96, 128, 192, 256];
```

The four added rungs are the capacities that actually shipped below 8 GB: GT 710 and
GTX 1050 at 2, GTX 1060 3 GB, GTX 1050 Ti and RX 570 at 4, GTX 1060 6 GB and RTX 2060
at 6.

Deliberate properties:

- **No tier at or above 8 moves**, so no previously submitted value changes.
- Only inputs below roughly 7 GB are affected, and no shipping card sits in the
  6.5 to 7.0 band that shifts.
- Exact ties still resolve downward, understating rather than overstating. That is
  the safe direction for a value claiming what a machine has.
- The existing rounding test still passes untouched (7.5 gives 8). It is renamed to
  `declared_mem_tier_rounds_to_nearest` to match the function.

### Your two asks

**Floor the submission ladder, leave 8 and above alone, ties keep resolving down.**
Done, as above.

**Fix the 1050 Ti entry from #815.** Already in `main`. It was corrected to
`memTierGb: 4` during the Greptile review on that PR, before it merged, so there is
nothing to do here and I have left the data file untouched to keep this a
one-concern change. Worth a quick check on your side in case we are looking at
different states.

**Make the split legible.** The two copies are renamed to carry their intent:

| file | name | role |
|---|---|---|
| `share.rs` | `declared_mem_tier` | the capacity a submission *declares* |
| `benchmarks.rs` | `lookup_mem_tier` | the bucket used as a *lookup key* |

Each carries a doc comment explaining why nearest-match is correct for one and wrong
for the other. A lookup wants the closest bucket that has data, because returning an
approximation beats returning nothing; a declared capacity wants the opposite. Each
points at the other by name, and the one in `benchmarks.rs` ends with "Please do not
unify them."

### Deliberately unchanged

`benchmarks.rs` keeps its own ladder and its exact current behaviour. This PR changes
what a submission *declares*, never which cached results a machine is matched
against. 10 GB and 11 GB are left alone as agreed.

### Verification

Software, using the commands from `CONTRIBUTING.md`:

| | |
|---|---|
| `make test` | 498 passed, 0 failed |
| `make fmt` | clean |
| `make clippy` | clean, no new warnings |
| `cargo doc` | same warning count as `main`, none introduced |

Three tests added, including an end-to-end one that runs `build_submission` with a
4 GB spec and asserts `memTierGb == 4` on the serialised payload rather than on the
helper's return value.

Hardware, on the card that surfaced this. GTX 1050 Ti back in the machine, driver
550.163.01, llama.cpp `da5b448` with `GGML_VULKAN=ON`, three models benchmarked with
the patched binary after a GPU preheat. `llmfit bench --share --dry-run` emits:

```json
"hardwareName": "NVIDIA GeForce GTX 1050 Ti",
"memTierGb": 4,
"vramGb": 4.0
```

All three entries in the local store agree. Before the patch the same payload
declared 8.

### Unrelated, spotted while validating

The `model` field written into the pending store carries the **absolute path** of the
GGUF (`/home/.../gguf/SmolLM2-135M-Instruct-Q4_K_M.gguf`) for the `llamacpp` provider,
so every submitter has to strip it by hand before opening a PR. Out of scope here.
Happy to file it separately if it is not already known.

---

@AlexsJones thanks again for this project.