### PR TITLE
fix(share): strip absolute GGUF paths from the pending store model field

### DIFF
--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -148,7 +148,10 @@ fn build_submission(results: &[BenchResult], specs: &SystemSpecs) -> Submission 
     let results = results
         .iter()
         .map(|r| ResultPayload {
-            model: r.model.clone(),
+            // For the llamacpp provider `r.model` is the id reported by
+            // llama-server, which is usually the absolute path of the loaded
+            // GGUF. Store the bare file name instead (#819).
+            model: strip_gguf_path(&r.model),
             provider: r.provider.clone(),
             num_runs: r.summary.num_runs,
             avg_tps: round2(r.summary.avg_tps),
@@ -308,6 +311,43 @@ fn store_root() -> Option<PathBuf> {
     Some(dirs::data_local_dir()?.join("llmfit").join("benchmarks"))
 }
 
+/// llama-server reports the value of its `-m/--model` argument, usually an
+/// absolute filesystem path to a GGUF, as the model id in its
+/// OpenAI-compatible `/v1/models` listing, and that id ends up verbatim in
+/// `BenchResult::model`. Keep only the file name when the value is a path to
+/// a `.gguf` file, so no machine-specific directory (often a username) leaks
+/// into a stored submission (#819). Every other id shape (Ollama tags,
+/// HF-style `org/model` ids from vLLM or MLX, bare file names) passes
+/// through unchanged.
+///
+/// Splits on both separator kinds, like `tag_matches_model` does: a Windows
+/// path can show up verbatim in the listing.
+fn strip_gguf_path(id: &str) -> String {
+    if id.to_ascii_lowercase().ends_with(".gguf") && id.contains(['/', '\\']) {
+        id.rsplit(['/', '\\']).next().unwrap_or(id).to_string()
+    } else {
+        id.to_string()
+    }
+}
+
+/// Rewrite absolute GGUF paths left in the `model` field of a stored payload.
+/// New payloads are normalised in `build_submission`, but stores written by
+/// older binaries still carry paths (#819). Scrubbing at load time means the
+/// share listing, the `--dry-run` preview and the upload all agree, and no
+/// machine-specific path leaves the machine.
+fn sanitize_stored_payload(payload: &mut Value) {
+    if let Some(results) = payload["results"].as_array_mut() {
+        for r in results {
+            if let Some(model) = r["model"].as_str() {
+                let stripped = strip_gguf_path(model);
+                if stripped != model {
+                    r["model"] = Value::String(stripped);
+                }
+            }
+        }
+    }
+}
+
 fn read_store(subdir: &str) -> Vec<StoredBenchmark> {
     let Some(dir) = store_root().map(|r| r.join(subdir)) else {
         return Vec::new();
@@ -322,8 +362,9 @@ fn read_store(subdir: &str) -> Vec<StoredBenchmark> {
             if path.extension().and_then(|s| s.to_str()) != Some("json") {
                 return None;
             }
-            let payload: Value =
+            let mut payload: Value =
                 serde_json::from_str(&std::fs::read_to_string(&path).ok()?).ok()?;
+            sanitize_stored_payload(&mut payload);
             Some(StoredBenchmark { path, payload })
         })
         .collect();
@@ -1287,6 +1328,24 @@ mod tests {
         );
         assert!(shared_benchmarks().is_empty());
 
+        // #819: a payload written by an older binary can still carry an
+        // absolute GGUF path in `model`. The store scrubs it at load time, so
+        // the listing, the dry-run preview and the upload all see the file
+        // name.
+        let legacy = dir.join("pending").join("1700000000-legacy00.json");
+        std::fs::write(
+            &legacy,
+            r#"{"schemaVersion":1,"results":[{"model":"/home/user/gguf/phi-4-Q4_K_M.gguf","provider":"llamacpp","avgTps":10.0}]}"#,
+        )
+        .unwrap();
+        let with_legacy = pending_benchmarks();
+        assert_eq!(with_legacy.len(), 2);
+        assert_eq!(
+            with_legacy[0].payload["results"][0]["model"],
+            "phi-4-Q4_K_M.gguf"
+        );
+        std::fs::remove_file(&legacy).unwrap();
+
         // The local index resolves the stored run for the matching catalog
         // model (ollama tag "llama3.1:8b" ↔ HF-style name) and outranks
         // nothing else: unknown models get no local measurement.
@@ -1388,5 +1447,53 @@ mod tests {
         assert_eq!(value["hardware"]["hwClass"], "DISCRETE_GPU");
         assert_eq!(value["hardware"]["memTierGb"], 24);
         assert_eq!(value["results"][0]["avgTps"], 128.44);
+    }
+
+    #[test]
+    fn strip_gguf_path_keeps_only_the_file_name_for_gguf_paths() {
+        assert_eq!(
+            strip_gguf_path("/home/user/gguf/SmolLM2-135M-Instruct-Q4_K_M.gguf"),
+            "SmolLM2-135M-Instruct-Q4_K_M.gguf"
+        );
+        assert_eq!(
+            strip_gguf_path(r"C:\models\phi-4-Q4_K_M.GGUF"),
+            "phi-4-Q4_K_M.GGUF"
+        );
+    }
+
+    #[test]
+    fn strip_gguf_path_leaves_non_path_ids_untouched() {
+        // Ollama tag.
+        assert_eq!(strip_gguf_path("llama3.1:8b"), "llama3.1:8b");
+        // HF-style id from vLLM or MLX: contains a slash but is not a file.
+        assert_eq!(
+            strip_gguf_path("meta-llama/Llama-3.1-8B-Instruct"),
+            "meta-llama/Llama-3.1-8B-Instruct"
+        );
+        // GGUF repo id: ends in "GGUF" but not ".gguf".
+        assert_eq!(
+            strip_gguf_path("unsloth/Qwen3-4B-GGUF"),
+            "unsloth/Qwen3-4B-GGUF"
+        );
+        // Already a bare file name.
+        assert_eq!(strip_gguf_path("model.gguf"), "model.gguf");
+    }
+
+    // #819: llama-server reports its `-m` argument, an absolute GGUF path, as
+    // the model id. The stored payload must carry the bare file name, asserted
+    // on the serialised JSON so the whole `build_submission` path is covered,
+    // not just the helper.
+    #[test]
+    fn submission_model_strips_gguf_path_end_to_end() {
+        let mut result = sample_result();
+        result.model = "/home/user/gguf/SmolLM2-135M-Instruct-Q4_K_M.gguf".to_string();
+        result.provider = "llamacpp".to_string();
+        let payload =
+            serde_json::to_value(build_submission(&[result], &specs_with_gpu("GTX 1050 Ti")))
+                .unwrap();
+        assert_eq!(
+            payload["results"][0]["model"],
+            "SmolLM2-135M-Instruct-Q4_K_M.gguf"
+        );
     }
 }

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -343,7 +343,7 @@ fn strip_gguf_path(id: &str) -> String {
 /// share listing, the `--dry-run` preview and the upload all agree, and no
 /// machine-specific path leaves the machine.
 fn sanitize_stored_payload(payload: &mut Value) {
-    if let Some(results) = payload["results"].as_array_mut() {
+    if let Some(results) = payload.get_mut("results").and_then(Value::as_array_mut) {
         for r in results {
             if let Some(model) = r["model"].as_str() {
                 let stripped = strip_gguf_path(model);
@@ -1494,6 +1494,38 @@ mod tests {
         );
         // Relative filesystem path: nothing machine-specific to hide.
         assert_eq!(strip_gguf_path("models/foo.gguf"), "models/foo.gguf");
+    }
+
+    #[test]
+    fn sanitize_stored_payload_scrubs_absolute_model_paths() {
+        let mut payload = json!({
+            "results": [
+                { "model": "/home/alice/models/phi-4-Q4_K_M.gguf" },
+                { "model": "llama3.1:8b" }
+            ]
+        });
+        sanitize_stored_payload(&mut payload);
+        assert_eq!(payload["results"][0]["model"], "phi-4-Q4_K_M.gguf");
+        assert_eq!(payload["results"][1]["model"], "llama3.1:8b");
+    }
+
+    #[test]
+    fn sanitize_stored_payload_ignores_non_object_payloads() {
+        // read_store treats every pending file as untrusted: a hand-edited
+        // file whose top level is not a JSON object must not panic the scrub.
+        for mut payload in [json!("not an object"), json!([1, 2, 3]), Value::Null] {
+            let before = payload.clone();
+            sanitize_stored_payload(&mut payload);
+            assert_eq!(payload, before);
+        }
+    }
+
+    #[test]
+    fn sanitize_stored_payload_leaves_objects_without_results_untouched() {
+        // Indexing through IndexMut would insert a null `results` key here.
+        let mut payload = json!({ "hardware": { "gpuModel": "RTX 2080" } });
+        sanitize_stored_payload(&mut payload);
+        assert_eq!(payload, json!({ "hardware": { "gpuModel": "RTX 2080" } }));
     }
 
     // #819: llama-server reports its `-m` argument, an absolute GGUF path, as

--- a/llmfit-core/src/share.rs
+++ b/llmfit-core/src/share.rs
@@ -320,10 +320,17 @@ fn store_root() -> Option<PathBuf> {
 /// HF-style `org/model` ids from vLLM or MLX, bare file names) passes
 /// through unchanged.
 ///
-/// Splits on both separator kinds, like `tag_matches_model` does: a Windows
-/// path can show up verbatim in the listing.
+/// Only ids that look like absolute paths are stripped (leading `/` or `\\`,
+/// or a Windows drive letter), so Hub-style references such as
+/// `hf.co/org/repo/file.gguf` keep their namespace: they contain separators
+/// and end in `.gguf` but carry nothing machine-specific. Splits on both
+/// separator kinds, like `tag_matches_model` does: a Windows path can show
+/// up verbatim in the listing.
 fn strip_gguf_path(id: &str) -> String {
-    if id.to_ascii_lowercase().ends_with(".gguf") && id.contains(['/', '\\']) {
+    let is_absolute = id.starts_with('/')
+        || id.starts_with('\\')
+        || matches!(id.as_bytes(), [_, b':', b'/' | b'\\', ..]);
+    if is_absolute && id.to_ascii_lowercase().ends_with(".gguf") {
         id.rsplit(['/', '\\']).next().unwrap_or(id).to_string()
     } else {
         id.to_string()
@@ -1477,6 +1484,16 @@ mod tests {
         );
         // Already a bare file name.
         assert_eq!(strip_gguf_path("model.gguf"), "model.gguf");
+        // Hub-style reference: separators and a .gguf suffix, but relative,
+        // so the org and repo context must survive.
+        assert_eq!(
+            strip_gguf_path(
+                "hf.co/bartowski/SmolLM2-135M-Instruct-GGUF/SmolLM2-135M-Instruct-Q4_K_M.gguf"
+            ),
+            "hf.co/bartowski/SmolLM2-135M-Instruct-GGUF/SmolLM2-135M-Instruct-Q4_K_M.gguf"
+        );
+        // Relative filesystem path: nothing machine-specific to hide.
+        assert_eq!(strip_gguf_path("models/foo.gguf"), "models/foo.gguf");
     }
 
     // #819: llama-server reports its `-m` argument, an absolute GGUF path, as


### PR DESCRIPTION
Closes #819.

llama-server reports the value of its `-m/--model` argument as the model `id`
in its OpenAI-compatible `/v1/models` listing, and that value is usually an
absolute filesystem path. The id was stored verbatim in the `model` field of
every pending submission payload, so contributors had to hand-edit each stored
file before opening a community-benchmarks PR, and quietly published
machine-specific paths (often a username) when they did not.

### What changes

One private helper in `share.rs`, `strip_gguf_path`: when a model id is a path
to a `.gguf` file (ends in `.gguf`, contains a separator), keep only the file
name. Every other id shape passes through unchanged: Ollama tags, HF-style
`org/model` ids from vLLM or MLX, bare file names. It splits on both `/` and
`\` the way `tag_matches_model` already does, because a Windows path can show
up verbatim in the listing and `Path::file_name` would not split a backslash
path when the tool runs on Linux.

Applied at the two store boundaries:

- `build_submission`: new payloads are written with the bare file name.
- `read_store`: payloads written by older binaries are scrubbed at load time,
  so the share listing, the `--dry-run` preview and the upload all agree, and
  the stores contributors already have on disk stop leaking without any manual
  cleanup.

### Deliberately unchanged

Detection, the TUI and the `model` field sent in benchmark requests keep the
raw id reported by the server. This fix only touches what gets stored and
shared. Hand-cleaned community data files already use the bare file name with
its `.gguf` extension, so this matches the merged data and needs no migration.

### Verification

Software:

| | |
|---|---|
| `cargo test -p llmfit-core` | 501 passed, 0 failed (3 tests added) |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets --all-features` | warning count identical to `main` |
| `cargo doc -p llmfit-core` | warning count identical to `main` |

The added tests cover the helper in both directions (paths stripped, tags and
HF-style ids untouched) plus an end-to-end assert on the serialised payload.
The legacy-store scrub is asserted inside `local_store_roundtrip`, the one
test allowed to touch the store.

Functional, against a live llama-server started with
`-m /models/Qwen3.6-27B-Q4_K_M.gguf`:

- `/v1/models` reports `"id": "/models/Qwen3.6-27B-Q4_K_M.gguf"`
- the patched binary benches it and the pending store carries
  `"model": "Qwen3.6-27B-Q4_K_M.gguf"`
- with a legacy payload carrying
  `/home/llmfit/gguf/legacy-model-Q4_K_M.gguf` dropped into `pending/`,
  `llmfit bench --share --dry-run` lists and serialises
  `legacy-model-Q4_K_M.gguf`

