### PR TITLE
feat(cli): add provider filter to fit

### DIFF
--- a/llmfit-core/src/models.rs
+++ b/llmfit-core/src/models.rs
@@ -686,6 +686,18 @@ pub struct GgufSource {
     pub provider: String,
 }
 
+/// Returns whether a model's canonical provider or any GGUF publisher matches.
+///
+/// The caller supplies the matching rule so interactive filters can retain
+/// exact selection semantics while CLI filters can be case-insensitive.
+pub fn matches_provider_filter(model: &LlmModel, mut matches: impl FnMut(&str) -> bool) -> bool {
+    matches(&model.provider)
+        || model
+            .gguf_sources
+            .iter()
+            .any(|source| matches(&source.provider))
+}
+
 impl LlmModel {
     /// MLX models are Apple-only — they won't run on NVIDIA/AMD/Intel hardware.
     /// We detect them by the `-MLX-` suffix that's standard on HuggingFace
@@ -2968,6 +2980,20 @@ mod tests {
             architecture: None,
             license: None,
         }
+    }
+
+    #[test]
+    fn provider_filter_matches_canonical_and_gguf_providers() {
+        let mut model = tp_test_model("Test-8B", 8.0, Some(32), Some(8));
+        model.provider = "Alibaba".to_string();
+        model.gguf_sources = vec![GgufSource {
+            repo: "bartowski/Test-8B-GGUF".to_string(),
+            provider: "bartowski".to_string(),
+        }];
+
+        assert!(matches_provider_filter(&model, |name| name.eq_ignore_ascii_case("ALIBABA")));
+        assert!(matches_provider_filter(&model, |name| name.eq_ignore_ascii_case("BARTOWSKI")));
+        assert!(!matches_provider_filter(&model, |name| name.eq_ignore_ascii_case("unsloth")));
     }
 
     #[test]

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use llmfit_core::bench;
 use llmfit_core::fit::{ModelFit, SortColumn, backend_compatible};
 use llmfit_core::hardware::SystemSpecs;
-use llmfit_core::models::ModelDatabase;
+use llmfit_core::models::{ModelDatabase, matches_provider_filter};
 use llmfit_core::plan::{PlanRequest, estimate_model_plan, resolve_model_selector};
 use llmfit_core::quality;
 use llmfit_core::share;
@@ -330,6 +330,7 @@ EXIT CODES:
 AGENT USAGE:
   llmfit fit --json
   llmfit fit --json --perfect -n 5
+  llmfit fit --json --providers unsloth,bartowski
   llmfit fit --json --sort tps
 
   JSON output fields: { system: {...}, models: [{ name, provider,
@@ -345,6 +346,10 @@ AGENT USAGE:
         /// Show only models with tool/function-call capability
         #[arg(long)]
         tool_use: bool,
+
+        /// Filter by canonical or GGUF providers (comma-separated, case-insensitive)
+        #[arg(long, value_delimiter = ',', value_name = "PROVIDER")]
+        providers: Vec<String>,
 
         /// Limit number of results
         #[arg(short = 'n', long)]
@@ -1050,6 +1055,7 @@ fn ensure_dashboard_available(
 fn run_fit(
     perfect: bool,
     tool_use: bool,
+    providers: &[String],
     limit: Option<usize>,
     sort: SortColumn,
     json: bool,
@@ -1084,6 +1090,16 @@ fn run_fit(
             f.model
                 .capabilities
                 .contains(&llmfit_core::models::Capability::ToolUse)
+        });
+    }
+
+    if !providers.is_empty() {
+        fits.retain(|fit| {
+            matches_provider_filter(&fit.model, |candidate| {
+                providers
+                    .iter()
+                    .any(|provider| candidate.eq_ignore_ascii_case(provider.trim()))
+            })
         });
     }
 
@@ -2838,12 +2854,14 @@ fn main() {
             Commands::Fit {
                 perfect,
                 tool_use,
+                providers,
                 limit,
                 sort,
             } => {
                 run_fit(
                     perfect,
                     tool_use,
+                    &providers,
                     limit,
                     sort.into(),
                     cli.json,
@@ -3117,6 +3135,7 @@ fn main() {
         run_fit(
             cli.perfect,
             cli.tool_use,
+            &[],
             cli.limit,
             cli.sort.into(),
             cli.json,

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1,6 +1,6 @@
 use llmfit_core::fit::{CalcConfig, FitLevel, ModelFit, SortColumn, backend_compatible};
 use llmfit_core::hardware::SystemSpecs;
-use llmfit_core::models::{Capability, LlmModel, ModelDatabase, UseCase};
+use llmfit_core::models::{Capability, LlmModel, ModelDatabase, UseCase, matches_provider_filter};
 use llmfit_core::plan::{PlanEstimate, PlanRequest, estimate_model_plan};
 use llmfit_core::providers::{
     self, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
@@ -1792,16 +1792,9 @@ impl App {
                 };
 
                 // Provider filter (check primary provider and GGUF source providers)
-                let matches_provider = provider_selected(
-                    &fit.model.provider,
-                    &self.providers,
-                    &self.selected_providers,
-                ) || matched_gguf_provider(
-                    &fit.model,
-                    &self.providers,
-                    &self.selected_providers,
-                )
-                .is_some();
+                let matches_provider = matches_provider_filter(&fit.model, |provider| {
+                    provider_selected(provider, &self.providers, &self.selected_providers)
+                });
                 let use_case_idx = self.use_cases.iter().position(|uc| *uc == fit.use_case);
                 let matches_use_case = use_case_idx
                     .map(|idx| self.selected_use_cases[idx])

--- a/llmfit-tui/tests/cli_smoke.rs
+++ b/llmfit-tui/tests/cli_smoke.rs
@@ -112,6 +112,41 @@ fn fit_json_obeys_limit_and_contains_models_field() {
 }
 
 #[test]
+fn fit_provider_filter_accepts_commas_case_insensitively_and_matches_gguf_sources() {
+    let json = run_json_command(&[
+        "--no-dashboard",
+        "--json",
+        "--memory",
+        "8G",
+        "--ram",
+        "16G",
+        "--cpu-cores",
+        "4",
+        "fit",
+        "--providers",
+        "not-a-provider,BaRtOwSkI",
+        "--limit",
+        "3",
+    ]);
+    let models = models_array(&json);
+
+    assert!(
+        !models.is_empty(),
+        "GGUF-source provider should match models"
+    );
+    assert!(
+        models.len() <= 3,
+        "provider filter should apply before the limit"
+    );
+    assert!(models.iter().all(|model| {
+        model
+            .get("provider")
+            .and_then(Value::as_str)
+            .is_some_and(|provider| !provider.eq_ignore_ascii_case("bartowski"))
+    }));
+}
+
+#[test]
 fn recommend_capability_filter_does_not_ignore_unknown_or_tts() {
     let tts_json = run_json_command(&[
         "--no-dashboard",


### PR DESCRIPTION
## Summary

Add a `--providers` option to `llmfit fit` for comma-separated, case-insensitive provider filtering.

The filter matches both a model's canonical provider and its GGUF source publishers, as requested. Matching is shared with the TUI while preserving the TUI's existing exact-selection behavior. CLI filtering runs before ranking and `--limit`, and the help text includes an agent-mode example.

Fixes #804.

## Validation

Using the stable `x86_64-pc-windows-gnu` toolchain:

- Core provider matcher regression: 1 passed
- CLI JSON integration regression: 1 passed
- Existing provider selector tests: 2 passed
- Existing GGUF attribution tests: 6 passed
- `cargo check -p llmfit`
- `cargo fmt --all -- --check`
- `llmfit fit --help` smoke test
- `git diff --check`

The CLI integration test exercises mixed-case, comma-separated input, an unknown provider, GGUF-source matching, JSON output, and filtering before `--limit`.

## Environment limitations

- `cargo check --workspace` reaches an existing `llmfit-desktop` Tauri configuration failure: the current schema rejects the untouched `downloadBootstrapper` value in `tauri.conf.json`.
- Package-scoped clippy with `-D warnings` reaches existing warnings in untouched core code (including `fit.rs`, `hardware.rs`, `quality.rs`, and `update.rs`); the new provider-filter code introduced no reported lint warning.
- The MSVC linker is not installed on this machine, so successful Rust validation used the GNU Windows target.
