### PR TITLE
bench: community results for intel-alder-lake-p-gt2-iris-xe-graphics-integrated

### DIFF
--- a/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786014822-8408f994.json
+++ b/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786014822-8408f994.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "12th Gen Intel(R) Core(TM) i7-1270P",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "Intel Alder Lake-P GT2 [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.05,
+    "unifiedMemory": true,
+    "vramGb": 31.05
+  },
+  "results": [
+    {
+      "avgOutputTokens": 163.0,
+      "avgTotalMs": 22084.0,
+      "avgTps": 8.21,
+      "avgTtftMs": 1441.5,
+      "maxTps": 8.58,
+      "minTps": 7.81,
+      "model": "gemma3:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786015128,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| gemma3:4b | ollama | 8.2 | 1441.5 |

_Submitted without the `gh` CLI via the GitHub device flow._
