### PR TITLE
fix(cli): don't auto-spawn a detached dashboard server for read-only subcommands

### DIFF
--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -938,6 +938,24 @@ impl Drop for DashboardGuard {
     }
 }
 
+fn is_readonly_subcommand(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::System
+            | Commands::Doctor
+            | Commands::Info { .. }
+            | Commands::Diff { .. }
+            | Commands::Plan { .. }
+            | Commands::Recommend { .. }
+            | Commands::Fit { .. }
+            | Commands::Search { .. }
+            | Commands::HfSearch { .. }
+            | Commands::List { .. }
+            | Commands::Claim { .. }
+            | Commands::Bench { .. }
+    )
+}
+
 fn dashboard_target_from_env() -> (String, u16) {
     let host = std::env::var("LLMFIT_DASHBOARD_HOST")
         .ok()
@@ -2760,7 +2778,9 @@ fn main() {
     };
     let auto_dashboard = !cli.no_dashboard
         && (cli.tui
-            || (!cli.json && !matches!(cli.command.as_ref(), Some(Commands::Serve { .. }))));
+            || (!cli.json
+                && !matches!(cli.command.as_ref(), Some(Commands::Serve { .. }))
+                && !cli.command.as_ref().is_some_and(is_readonly_subcommand)));
 
     let _dashboard_guard = if auto_dashboard {
         ensure_dashboard_available(&overrides, context_limit)
@@ -3335,5 +3355,46 @@ mod tests {
         assert_eq!(truncate_str("🚀 hello", 4), "🚀 h…");
         // Exact max length — no truncation
         assert_eq!(truncate_str("abc", 3), "abc");
+    }
+
+    #[test]
+    fn readonly_subcommands_never_autostart_dashboard() {
+        // Read-only informational commands must not spawn the background
+        // dashboard server, so a failing run cannot orphan a `serve` child
+        // (regression for #837).
+        assert!(is_readonly_subcommand(&Commands::Plan {
+            model: "qwen".into(),
+            context: 32768,
+            quant: None,
+            kv_quant: None,
+            target_tps: None,
+        }));
+        assert!(is_readonly_subcommand(&Commands::System));
+        assert!(is_readonly_subcommand(&Commands::Info {
+            model: "qwen".into()
+        }));
+        // Commands that may meaningfully want a dashboard or mutate state.
+        assert!(!is_readonly_subcommand(&Commands::Serve {
+            host: "127.0.0.1".into(),
+            port: 8787,
+            unix_socket: None,
+            mcp: false,
+            send_events: false,
+            nats_url: "nats://localhost:4222".into(),
+        }));
+        assert!(!is_readonly_subcommand(&Commands::Download {
+            model: "qwen".into(),
+            quant: None,
+            budget: None,
+            list: false,
+            output_dir: None,
+        }));
+        assert!(!is_readonly_subcommand(&Commands::Run {
+            model: "qwen".into(),
+            server: false,
+            port: 8080,
+            ngl: -1,
+            ctx_size: 4096,
+        }));
     }
 }


### PR DESCRIPTION
Fixes #837.

## Problem

`llmfit plan` (and the other read-only informational subcommands) auto-start a **detached background `serve` process** because `auto_dashboard` in `main()` treats *any* non-`serve` subcommand as interactive:

```rust
let auto_dashboard = !cli.no_dashboard
    && (cli.tui
        || (!cli.json && !matches!(cli.command.as_ref(), Some(Commands::Serve { .. }))));
```

On `plan`'s selector-error path, `main()` calls `std::process::exit(1)`, which **skips the `DashboardGuard` destructor**, so the orphaned server survives, gets reparented to PID 1, keeps listening on `127.0.0.1:8787`, and even survives `brew uninstall`. This openly contradicts the documented `SIDE EFFECTS: None — read-only` contract on `plan --help`.

## Fix

Exclude read-only, side-effect-free subcommands from `auto_dashboard` so no background server is ever spawned for them in the first place (nothing to leak). The interactive TUI and `serve`/mutating commands are unchanged.

Adds an `is_readonly_subcommand` helper covering `System, Doctor, Info, Diff, Plan, Recommend, Fit, Search, HfSearch, List, Claim, Bench`, plus a unit test asserting the read-only commands are excluded and `serve`/mutating commands are not.

## Test

`cargo test -p llmfit` — 89 pass (incl. the new `readonly_subcommands_never_autostart_dashboard`). Repo's own suite green locally.