### PR TITLE
fix: resolve generic AMD/ATI Strix Halo identity

### DIFF
--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -2432,7 +2432,7 @@ fn is_generic_amd_gpu_name(name: &str) -> bool {
     let lower = name.trim().to_lowercase();
     matches!(
         lower.as_str(),
-        "amd gpu" | "radeon graphics" | "amd radeon graphics"
+        "amd gpu" | "amd/ati" | "radeon graphics" | "amd radeon graphics"
     )
 }
 
@@ -4609,6 +4609,7 @@ GPU[0]          : GFX Version:            gfx1151";
         assert!(super::is_placeholder_gpu_name("unknown"));
         assert!(!super::is_placeholder_gpu_name("Radeon 8060S"));
         assert!(super::is_generic_amd_gpu_name("AMD GPU"));
+        assert!(super::is_generic_amd_gpu_name("AMD/ATI"));
         assert!(super::is_generic_amd_gpu_name("Radeon Graphics"));
         assert!(!super::is_generic_amd_gpu_name("AMD Radeon RX 7900 XTX"));
     }


### PR DESCRIPTION
## What changed

Treat the `AMD/ATI` string returned by `lspci` as a generic AMD GPU identity.

On a Ryzen AI MAX+ 395 / Radeon 8060S system, `lspci -nnD` currently reports the display controller as:

```text
Advanced Micro Devices, Inc. [AMD/ATI] Device [1002:1586]
```

`extract_model_from_lspci_line()` therefore produces `AMD/ATI`. Because that value was not considered generic, the existing Ryzen AI MAX+ fallback never replaced it with the CPU-derived Strix Halo identity.

## User impact

Before this change, the v1.1.8 binary reported:

```text
gpu_name: AMD/ATI
memory_bandwidth_gbps: null
```

After building this branch on the same retail Beelink GTR9 Pro, `llmfit --json system` reports:

```text
gpu_name: AMD RYZEN AI MAX+ 395 w/ Radeon 8060S (integrated)
memory_bandwidth_gbps: 256.0
unified_memory: true
gpu_vram_gb: 124.94
```

This reuses llmfit's existing Strix Halo fallback and bandwidth table; it only makes the fallback reachable for this real `lspci` output. The test adds the missing `AMD/ATI` case to the generic-name regression coverage.

The reproduction machine is also the primary system used for the public [AMD Strix Halo Local LLM Guide](https://github.com/hogeheer499-commits/strix-halo-guide).

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p llmfit-core` (526 passed, 1 ignored; integration tests also passed)
- release build and live `./target/release/llmfit --json system` verification on Ryzen AI MAX+ 395 / Radeon 8060S

`make clippy` currently reaches unrelated pre-existing `-D warnings` failures on `main`; this change introduces no new clippy finding.
