### PR TITLE
bench: community results for radeon-840m-860m-graphics

### DIFF
--- a/llmfit-core/data/community/radeon-840m-860m-graphics/1786355096-7527bd61.json
+++ b/llmfit-core/data/community/radeon-840m-860m-graphics/1786355096-7527bd61.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen AI 7 350 w/ Radeon 860M",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "Radeon 840M / 860M Graphics",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 2,
+    "os": "linux",
+    "ramGb": 30.63,
+    "unifiedMemory": false,
+    "vramGb": 0.5
+  },
+  "results": [
+    {
+      "avgOutputTokens": 272.67,
+      "avgTotalMs": 4629.33,
+      "avgTps": 61.36,
+      "avgTtftMs": 27.02,
+      "maxTps": 65.48,
+      "minTps": 53.73,
+      "model": "qwen3:0.6b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786355096,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.9"
+  }
+}

--- a/llmfit-core/data/community/radeon-840m-860m-graphics/1786356571-753cf899.json
+++ b/llmfit-core/data/community/radeon-840m-860m-graphics/1786356571-753cf899.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen AI 7 350 w/ Radeon 860M",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "Radeon 840M / 860M Graphics",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 2,
+    "os": "linux",
+    "ramGb": 30.63,
+    "unifiedMemory": false,
+    "vramGb": 0.5
+  },
+  "results": [
+    {
+      "avgOutputTokens": 258.67,
+      "avgTotalMs": 31069.16,
+      "avgTps": 8.73,
+      "avgTtftMs": 1147.82,
+      "maxTps": 8.8,
+      "minTps": 8.69,
+      "model": "gpt-oss:20b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786356571,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.9"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen3:0.6b | ollama | 61.4 | 27.0 |

_Submitted without the `gh` CLI via the GitHub device flow._
