### PR TITLE
chore: replace deprecated serde_yml dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,6 +2579,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,10 +2650,10 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_yml",
  "sysinfo",
  "ureq",
  "which",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -2870,19 +2876,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "noyalib"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e493c05128df7a83b9676b709d590e0ebc285c7ed3152bc679668e8c1e506af5"
-dependencies = [
- "indexmap 2.14.0",
- "memchr",
- "rustc-hash",
- "serde",
- "smallvec",
 ]
 
 [[package]]
@@ -4539,16 +4532,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909764a65f86829ccdb5eea9ab355843aa02c019a7bfd47465092953565caa05"
-dependencies = [
- "noyalib",
- "serde",
 ]
 
 [[package]]
@@ -7012,6 +6995,19 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "yoke"

--- a/llmfit-core/Cargo.toml
+++ b/llmfit-core/Cargo.toml
@@ -18,7 +18,7 @@ http = "1"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yml = "0.0"
+yaml_serde = "0.10.4"
 sysinfo = "0.39"
 ureq = { version = "3.2", features = ["json"] }
 which = "8.0.2"

--- a/llmfit-core/src/quality.rs
+++ b/llmfit-core/src/quality.rs
@@ -539,7 +539,7 @@ pub fn compute_runner_ups(results: &[ModelQualityResult]) -> Vec<RoutingRecommen
 
 /// Parse a YAML string into a `QualityConfig`.
 pub fn load_quality_config(yaml: &str) -> Result<QualityConfig, String> {
-    serde_yml::from_str(yaml).map_err(|e| format!("Failed to parse quality config: {}", e))
+    yaml_serde::from_str(yaml).map_err(|e| format!("Failed to parse quality config: {}", e))
 }
 
 /// Return the built-in default quality config (embedded from `data/benchmarks.yaml`).
@@ -817,6 +817,12 @@ roles:
             config.roles.contains_key("general"),
             "default config should have 'general' role"
         );
+    }
+
+    #[test]
+    fn test_load_quality_config_rejects_invalid_yaml() {
+        let error = load_quality_config("roles: [").expect_err("invalid YAML must fail");
+        assert!(error.starts_with("Failed to parse quality config:"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace deprecated `serde_yml` with YAML Organization maintained `yaml_serde`
- keep the existing quality configuration parsing contract
- add a regression test for invalid YAML input

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy -p llmfit-core --lib`
- `cargo tree -p llmfit-core -i yaml_serde`

`cargo test --workspace` reports 633 passed and 1 ignored. Clippy reports no errors and retains existing warnings.

Closes #858