### PR TITLE
bench: community results for intel-alder-lake-p-gt2-iris-xe-graphics-integrated

### DIFF
--- a/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786104208-61a3a3c2.json
+++ b/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786104208-61a3a3c2.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "12th Gen Intel(R) Core(TM) i7-1270P",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "Intel Alder Lake-P GT2 [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.05,
+    "unifiedMemory": true,
+    "vramGb": 31.05
+  },
+  "results": [
+    {
+      "avgOutputTokens": 220.33,
+      "avgTotalMs": 30125.17,
+      "avgTps": 7.88,
+      "avgTtftMs": 1698.99,
+      "maxTps": 9.32,
+      "minTps": 6.74,
+      "model": "gemma3:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786505673,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786109911-27ac5d2b.json
+++ b/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786109911-27ac5d2b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "12th Gen Intel(R) Core(TM) i7-1270P",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "Intel Alder Lake-P GT2 [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.05,
+    "unifiedMemory": true,
+    "vramGb": 31.05
+  },
+  "results": [
+    {
+      "avgOutputTokens": 217.67,
+      "avgTotalMs": 25526.29,
+      "avgTps": 8.93,
+      "avgTtftMs": 1045.07,
+      "maxTps": 9.65,
+      "minTps": 8.33,
+      "model": "gemma3:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786505673,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786111568-c5238f97.json
+++ b/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786111568-c5238f97.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "12th Gen Intel(R) Core(TM) i7-1270P",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "Intel Alder Lake-P GT2 [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.05,
+    "unifiedMemory": true,
+    "vramGb": 31.05
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 211871.53,
+      "avgTps": 1.42,
+      "avgTtftMs": null,
+      "maxTps": 1.45,
+      "minTps": 1.35,
+      "model": "qwen3.5",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786505673,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}

--- a/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786423670-43ac2482.json
+++ b/llmfit-core/data/community/intel-alder-lake-p-gt2-iris-xe-graphics-integrated/1786423670-43ac2482.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "12th Gen Intel(R) Core(TM) i7-1270P",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "Intel Alder Lake-P GT2 [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.05,
+    "unifiedMemory": true,
+    "vramGb": 31.05
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 217539.36,
+      "avgTps": 1.38,
+      "avgTtftMs": null,
+      "maxTps": 1.46,
+      "minTps": 1.31,
+      "model": "muse-glimmer",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786505673,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.6"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| gemma3:4b | ollama | 7.9 | 1699.0 |
| gemma3:4b | ollama | 8.9 | 1045.1 |
| qwen3.5 | llamacpp | 1.4 | — |
| muse-glimmer | llamacpp | 1.4 | — |

_Submitted without the `gh` CLI via the GitHub device flow._
