### PR TITLE
bench: Muse-Glimmer-30B on amd-radeon-rx-7900-xt and apple-m4-pro

### DIFF
--- a/llmfit-core/data/community/amd-radeon-rx-7900-xt/1786562074-7e61b3fb.json
+++ b/llmfit-core/data/community/amd-radeon-rx-7900-xt/1786562074-7e61b3fb.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786562074,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.9"
+  },
+  "hardware": {
+    "hwClass": "DISCRETE_GPU",
+    "hardwareName": "Radeon RX 7900 XT/7900 XTX/7900 GRE/7900M",
+    "memTierGb": 16,
+    "vramGb": 19.98,
+    "gpuCount": 1,
+    "unifiedMemory": false,
+    "cpu": "Intel(R) Core(TM) i9-10900X CPU @ 3.70GHz",
+    "cpuCores": 20,
+    "ramGb": 62.49,
+    "os": "linux"
+  },
+  "results": [
+    {
+      "model": "Muse-Glimmer-30B-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 35.17,
+      "minTps": 35.09,
+      "maxTps": 35.28,
+      "avgTtftMs": null,
+      "avgTotalMs": 8529.58,
+      "avgOutputTokens": 300.0
+    }
+  ]
+}

--- a/llmfit-core/data/community/amd-radeon-rx-7900-xt/1786562074-7e61b3fb.json
+++ b/llmfit-core/data/community/amd-radeon-rx-7900-xt/1786562074-7e61b3fb.json
@@ -7,7 +7,7 @@
   },
   "hardware": {
     "hwClass": "DISCRETE_GPU",
-    "hardwareName": "Radeon RX 7900 XT/7900 XTX/7900 GRE/7900M",
+    "hardwareName": "AMD Radeon RX 7900 XT",
     "memTierGb": 16,
     "vramGb": 19.98,
     "gpuCount": 1,

--- a/llmfit-core/data/community/apple-m4-pro/1786562271-33df4e5e.json
+++ b/llmfit-core/data/community/apple-m4-pro/1786562271-33df4e5e.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786562271,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.9"
+  },
+  "hardware": {
+    "hwClass": "UNIFIED",
+    "hardwareName": "Apple M4 Pro",
+    "memTierGb": 24,
+    "vramGb": 24.0,
+    "gpuCount": 1,
+    "unifiedMemory": true,
+    "cpu": "Apple M4 Pro",
+    "cpuCores": 14,
+    "ramGb": 24.0,
+    "os": "macos"
+  },
+  "results": [
+    {
+      "model": "Muse-Glimmer-30B-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 13.17,
+      "minTps": 12.94,
+      "maxTps": 13.36,
+      "avgTtftMs": null,
+      "avgTotalMs": 22788.39,
+      "avgOutputTokens": 300.0
+    }
+  ]
+}


### PR DESCRIPTION
Two llama.cpp results for Meta's **Muse-Glimmer-30B**, released 2026-08-10, one per existing hardware slug. Both entries come from the official Meta K-quant GGUF, measured with **llmfit v1.1.9**.

| Hardware | Backend | llama.cpp | avg tok/s | min–max |
|---|---|---|---|---|
| AMD RX 7900 XT (20 GB, Vulkan/RADV) | discrete | `84e908c` | **35.17** | 35.09–35.28 |
| Apple M4 Pro (24 GB unified, Metal) | unified | release `b10375` | **13.17** | 12.94–13.36 |

Both runs are **fully GPU-resident**, 53/53 layers offloaded, verified from the loader output rather than assumed. Context 4096, `--runs 3`, `avgTps` reported and never the max, after a 5-minute machine preheat in real generation followed by a discarded 200-token warmup and a post-warmup health re-check.

### Notes worth having in the table

- **The K-quant is unusually compact for a 30B dense model**: 15.61 GiB, leaving 4.8 GiB of headroom on a 20 GB card. At 35.17 tok/s it comes in **11.3% above Qwen3.6-27B** (31.59 in this same slug), on the same card, the same backend and the same 300-token runs, despite three billion more parameters. It is currently the fastest >24B dense entry on that slug.
- **The M4 Pro returns 0.374× the AMD card's throughput** on the identical file. Across the **41 models already published in both slugs**, the median ratio is 0.418 — and 0.374 is the lowest value in that whole sample. This is the model where Apple Silicon gives up the most ground: at 30B dense, unified memory bandwidth is the binding constraint.
- `avgOutputTokens` is **300.0 on both entries**, llmfit's generation cap reached on every run, so throughput here is not confounded by generation length.
- **No MLX entry in this PR.** The `mlx-community` 4-bit conversion weighs 18.08 GiB against 15.61 GiB for the GGUF, and on 24 GB of unified memory the run swapped (167,972 swapouts). I reject any run with swapouts rather than publish it: on unified memory that is the failure mode that silently corrupts a measurement instead of raising an error. Worth knowing for anyone sizing this model on a 24 GB Mac.
- The model is **not yet in `hf_models.json`** — expected, the weights are two days old. The results are self-describing and validate fine, they will simply not match a catalog entry until the next refresh.

### Filename convention

The published file is `Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf` (`meta-models/Muse-Glimmer-30B-GGUF`). It is recorded as `Muse-Glimmer-30B-Q4_K_M.gguf`, the same `<model>-<quant>.gguf` convention as my earlier submissions, so the stem resolves the way every other entry does.

### Worth flagging separately:

The published filename does not reduce to a catalog id through `strip_gguf_quant_suffix`, in the same way Unsloth's `-ud` marker did not. Happy to open an issue with the details if useful.

Validated locally with `python3 scripts/validate_community_benchmarks.py`: `✅ 54 community submission(s) valid`, exit 0.
