### PR TITLE
fix(providers): match every K-quant and I-quant GGUF variant

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -3172,10 +3172,16 @@ fn docker_mr_installed_matches(installed_name: &str, candidate: &str) -> bool {
 /// Strip quantization suffix from a GGUF file stem.
 /// "llama-3.1-8b-instruct-q4_k_m" → "llama-3.1-8b-instruct"
 pub fn strip_gguf_quant_suffix(stem: &str) -> Option<String> {
+    // Matched on the quant *family* stem rather than each published variant:
+    // K-quants as `-qN_k` and I-quants as `-iqN_`, so `_S`/`_M`/`_L`/`_XL`
+    // and `_NL`/`_XS`/`_XXS` all reduce to the same base. Enumerating the
+    // variants instead left whole publishers unmatched — bartowski `_L` files
+    // and Unsloth Dynamic `_XL`/`IQ4_NL` files never reached the catalog id,
+    // so they read as neither installed nor served.
     let quant_patterns = [
-        "-q8_0", "-q6_k", "-q6_k_l", "-q5_k_m", "-q5_k_s", "-q4_k_m", "-q4_k_s", "-q4_0",
-        "-q3_k_m", "-q3_k_s", "-q2_k", "-iq4_xs", "-iq3_m", "-iq2_m", "-iq1_m", "-f16", "-f32",
-        "-bf16", ".q8_0", ".q6_k", ".q5_k_m", ".q4_k_m", ".q4_0", ".q3_k_m", ".q2_k",
+        "-q8_0", "-q8_k", "-q6_k", "-q5_k", "-q4_k", "-q4_0", "-q3_k", "-q2_k", "-iq4_", "-iq3_",
+        "-iq2_", "-iq1_", "-f16", "-f32", "-bf16", ".q8_0", ".q6_k", ".q5_k", ".q4_k", ".q4_0",
+        ".q3_k", ".q2_k",
     ];
     for pat in &quant_patterns {
         if let Some(pos) = stem.rfind(pat) {
@@ -5034,6 +5040,53 @@ mod tests {
             strip_gguf_quant_suffix("qwen2.5-7b-instruct-q4_k_m").as_deref(),
             Some("qwen2.5-7b-instruct")
         );
+    }
+
+    #[test]
+    fn test_strip_gguf_quant_suffix_covers_every_k_and_i_variant() {
+        // Publishers ship far more variants than Q4_K_M: bartowski `_L`,
+        // Unsloth Dynamic `_XL`, and the IQ family's `_NL`/`_XS`/`_XXS`.
+        // Every one must reduce to the same base name.
+        for stem in [
+            "mymodel-q3_k_l",
+            "mymodel-q4_k_l",
+            "mymodel-q4_k_xl",
+            "mymodel-q5_k_xl",
+            "mymodel-q6_k_l",
+            "mymodel-q8_k_xl",
+            "mymodel-iq4_nl",
+            "mymodel-iq4_xs",
+            "mymodel-iq3_xxs",
+            "mymodel-iq2_m",
+            // Same set behind the Unsloth `-ud` marker.
+            "mymodel-ud-q4_k_xl",
+            "mymodel-ud-iq4_nl",
+        ] {
+            assert_eq!(
+                strip_gguf_quant_suffix(stem).as_deref(),
+                Some("mymodel"),
+                "failed to strip quant from {stem}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_tag_matches_model_unsloth_dynamic_quants() {
+        // Community submissions record the on-disk file name verbatim. These
+        // three tags from the NVIDIA GB10 set (#872) were silently dropped
+        // during lookup because their quants had no matching pattern.
+        assert!(tag_matches_model(
+            "Step-3.7-Flash-UD-IQ4_NL.gguf",
+            "stepfun-ai/Step-3.7-Flash"
+        ));
+        assert!(tag_matches_model(
+            "Qwen-AgentWorld-35B-A3B-UD-Q4_K_XL.gguf",
+            "Qwen/Qwen-AgentWorld-35B-A3B"
+        ));
+        assert!(tag_matches_model(
+            "LFM2.5-8B-A1B-UD-Q4_K_XL.gguf",
+            "LiquidAI/LFM2.5-8B-A1B"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
### Problem

`strip_gguf_quant_suffix` (`llmfit-core/src/providers.rs`) enumerated published
quant variants one at a time:

```rust
"-q8_0", "-q6_k", "-q6_k_l", "-q5_k_m", "-q5_k_s", "-q4_k_m", "-q4_k_s", ...
```

Anything not on that list never reduces to the catalog id, so
`is_model_installed_llamacpp` never reaches the repo name and the file reads as
**neither installed nor served**. The gaps were not exotic — they were whole
publishers:

- bartowski `_L` quants: `-q3_k_l`, `-q4_k_l`, `-q5_k_l` (only `-q6_k_l` was listed)
- Unsloth Dynamic `_XL` quants: `-q4_k_xl`, `-q5_k_xl`, `-q8_k_xl`
- the IQ family beyond four hand-picked entries: `-iq4_nl`, `-iq3_xxs`, …

`Q3_K_L` in particular is a stock llama.cpp quant, not a vendor variant.

### Fix

Match on the quant *family* stem — `-qN_k` for K-quants, `-iqN_` for I-quants —
so `_S`/`_M`/`_L`/`_XL` and `_NL`/`_XS`/`_XXS` all reduce identically and the
next published variant needs no code change. `-q6_k` and `-q2_k` already worked
this way; the rest now follow. The existing `-ud` marker strip is unchanged and
still runs after a quant hit.

### Why now

Found while reviewing #872. Three of its 122 GB10 entries are silently dropped
during lookup on this bug:

| Tag | tok/s |
|---|---|
| `Step-3.7-Flash-UD-IQ4_NL.gguf` | 21.41 |
| `Qwen-AgentWorld-35B-A3B-UD-Q4_K_XL.gguf` | 64.17 |
| `LFM2.5-8B-A1B-UD-Q4_K_XL.gguf` | 151.04 |

Greptile flagged the `IQ4_NL` one and the submitter renamed the tag to add a
`.gguf` extension — but `tag_matches_model` trims `.gguf` *before* stripping the
quant, so that rename is a no-op for matching. The data was never the problem;
**#872 can land its files unmodified once this merges.**

Scanning the whole `data/community` tree, one already-merged entry
(`hf.co/unsloth/Qwen3.6-27B-MTP-GGUF:UD-Q4_K_XL`) is also recovered. The
remaining unmatched tags there are MLX `-4bit` and AWQ, handled by
`strip_mlx_quant_suffix` on a separate path.

The blast radius is wider than community data: this function also backs local
install detection, so anyone with an Unsloth UD-XL or bartowski `_L` GGUF on
disk was being told the model was not installed.

### Tests

Two new cases in `providers::tests` — one over every K/I variant (with and
without the `-ud` marker), one asserting `tag_matches_model` now resolves the
three GB10 tags above. Full suite green: 549 + 6 + 1 passing, `cargo fmt
--check` clean, no new clippy warnings.

### Not in scope

`select_best_gguf`'s `quant_order` has the same enumeration shape, so a repo
publishing only `UD-Q4_K_XL` falls through to its "largest that fits" branch
rather than preferring by quality. That still yields a usable file, so I left
it for a separate change.
