### PR TITLE
feat(mcp): add RamaLama runtime discovery

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -2939,16 +2939,22 @@ impl RamaLamaProvider {
             .stderr(std::process::Stdio::null())
             .spawn()
             .ok()?;
+        let mut stdout = child.stdout.take()?;
+        let reader = std::thread::spawn(move || {
+            let mut output = Vec::new();
+            std::io::Read::read_to_end(&mut stdout, &mut output).map(|_| output)
+        });
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
             match child.try_wait() {
                 Ok(Some(status)) => {
                     if !status.success() {
+                        let _ = reader.join();
                         return None;
                     }
-                    let output = child.wait_with_output().ok()?;
-                    return parse_ramalama_store(&output.stdout);
+                    let output = reader.join().ok()?.ok()?;
+                    return parse_ramalama_store(&output);
                 }
                 Ok(None) if std::time::Instant::now() < deadline => {
                     std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2956,9 +2962,15 @@ impl RamaLamaProvider {
                 Ok(None) => {
                     let _ = child.kill();
                     let _ = child.wait();
+                    let _ = reader.join();
                     return None;
                 }
-                Err(_) => return None,
+                Err(_) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = reader.join();
+                    return None;
+                }
             }
         }
     }

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -3019,6 +3019,19 @@ fn parse_ramalama_store(json: &[u8]) -> Option<(HashSet<String>, usize)> {
     Some((set, count))
 }
 
+fn resolve_ramalama_detection(
+    server_models: Option<(HashSet<String>, usize)>,
+    store_models: Option<(HashSet<String>, usize)>,
+) -> (bool, HashSet<String>, usize) {
+    if let Some((set, count)) = server_models {
+        return (true, set, count);
+    }
+    match store_models {
+        Some((set, count)) => (true, set, count),
+        None => (false, HashSet::new(), 0),
+    }
+}
+
 impl ModelProvider for RamaLamaProvider {
     fn name(&self) -> &str {
         "RamaLama"
@@ -3042,6 +3055,37 @@ impl ModelProvider for RamaLamaProvider {
         Err("RamaLama does not support downloading models at runtime. \
              Serve the desired model with `ramalama serve <model>`."
             .to_string())
+    }
+}
+
+#[cfg(test)]
+mod ramalama_detection_tests {
+    use super::{insert_ramalama_name, parse_ramalama_store, resolve_ramalama_detection};
+    use std::collections::HashSet;
+
+    #[test]
+    fn unavailable_server_uses_local_store_model() {
+        let json = br#"[{"name":"huggingface://org/model-x","shortname":""}]"#;
+        let store_models = parse_ramalama_store(json).expect("store data should parse");
+        let (available, installed, count) = resolve_ramalama_detection(None, Some(store_models));
+
+        assert!(available);
+        assert_eq!(count, 1);
+        assert!(installed.contains("model-x"));
+    }
+
+    #[test]
+    fn server_models_take_precedence_over_local_store() {
+        let mut server = HashSet::new();
+        insert_ramalama_name(&mut server, "org/server-model");
+        let mut store = HashSet::new();
+        insert_ramalama_name(&mut store, "org/local-model");
+
+        let (_, installed, count) = resolve_ramalama_detection(Some((server, 1)), Some((store, 1)));
+
+        assert_eq!(count, 1);
+        assert!(installed.contains("server-model"));
+        assert!(!installed.contains("local-model"));
     }
 }
 

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -2933,14 +2933,34 @@ impl RamaLamaProvider {
     /// so detection works without a running server. Returns `None` when the
     /// `ramalama` binary is absent or the command fails.
     fn installed_from_store() -> Option<(HashSet<String>, usize)> {
-        let output = std::process::Command::new("ramalama")
+        let mut child = std::process::Command::new("ramalama")
             .args(["ls", "--json"])
-            .output()
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
             .ok()?;
-        if !output.status.success() {
-            return None;
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if !status.success() {
+                        return None;
+                    }
+                    let output = child.wait_with_output().ok()?;
+                    return parse_ramalama_store(&output.stdout);
+                }
+                Ok(None) if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                }
+                Ok(None) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                Err(_) => return None,
+            }
         }
-        parse_ramalama_store(&output.stdout)
     }
 
     pub fn installed_models_counted(&self) -> (HashSet<String>, usize) {

--- a/llmfit-tui/src/mcp_server.rs
+++ b/llmfit-tui/src/mcp_server.rs
@@ -260,7 +260,7 @@ impl LlmfitMcpServer {
         });
         set.spawn_blocking(|| RuntimeInfo {
             name: "ramalama",
-            installed: RamaLamaProvider::new().is_available(),
+            installed: RamaLamaProvider::new().detect_with_installed().0,
         });
 
         let mut runtimes = Vec::new();
@@ -311,7 +311,8 @@ impl LlmfitMcpServer {
         });
         set.spawn_blocking(|| {
             let p = RamaLamaProvider::new();
-            ("ramalama", p.is_available(), p.installed_models())
+            let (available, installed, _) = p.detect_with_installed();
+            ("ramalama", available, installed)
         });
 
         let mut models = Vec::new();

--- a/llmfit-tui/src/mcp_server.rs
+++ b/llmfit-tui/src/mcp_server.rs
@@ -7,7 +7,7 @@ use llmfit_core::models::{LlmModel, ModelDatabase, UseCase};
 use llmfit_core::plan::{PlanRequest, estimate_model_plan};
 use llmfit_core::providers::{
     DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider, ModelProvider,
-    OllamaProvider, VllmProvider,
+    OllamaProvider, RamaLamaProvider, VllmProvider,
 };
 use rmcp::handler::server::{router::tool::ToolRouter, wrapper::Parameters};
 use rmcp::{ServerHandler, ServiceExt, tool, tool_handler, tool_router};
@@ -258,6 +258,10 @@ impl LlmfitMcpServer {
             name: "vllm",
             installed: VllmProvider::new().is_available(),
         });
+        set.spawn_blocking(|| RuntimeInfo {
+            name: "ramalama",
+            installed: RamaLamaProvider::new().is_available(),
+        });
 
         let mut runtimes = Vec::new();
         while let Some(result) = set.join_next().await {
@@ -304,6 +308,10 @@ impl LlmfitMcpServer {
         set.spawn_blocking(|| {
             let p = VllmProvider::new();
             ("vllm", p.is_available(), p.installed_models())
+        });
+        set.spawn_blocking(|| {
+            let p = RamaLamaProvider::new();
+            ("ramalama", p.is_available(), p.installed_models())
         });
 
         let mut models = Vec::new();
@@ -432,4 +440,59 @@ fn fit_at_least(actual: FitLevel, minimum: FitLevel) -> bool {
         FitLevel::TooTight => 0,
     };
     rank(actual) >= rank(minimum)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn test_server() -> LlmfitMcpServer {
+        LlmfitMcpServer::new(
+            SystemSpecs::detect(),
+            ModelDatabase::new().get_all_models().clone(),
+            None,
+            "test-node".to_string(),
+        )
+    }
+
+    #[test]
+    fn runtime_discovery_includes_ramalama() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should build");
+        let output = runtime.block_on(test_server().get_runtimes());
+        let value: Value = serde_json::from_str(&output).expect("runtime output should be JSON");
+        let runtimes = value
+            .get("runtimes")
+            .and_then(Value::as_array)
+            .expect("runtime output should contain an array");
+
+        assert!(
+            runtimes
+                .iter()
+                .any(|runtime| { runtime.get("name").and_then(Value::as_str) == Some("ramalama") })
+        );
+    }
+
+    #[test]
+    fn installed_model_discovery_returns_json_when_providers_are_unavailable() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should build");
+        let output = runtime.block_on(test_server().get_installed_models());
+        let value: Value =
+            serde_json::from_str(&output).expect("installed model output should be JSON");
+        let models = value
+            .get("models")
+            .and_then(Value::as_array)
+            .expect("installed model output should contain an array");
+
+        assert!(models.iter().all(|model| {
+            model.get("name").and_then(Value::as_str).is_some()
+                && model.get("runtime").and_then(Value::as_str).is_some()
+        }));
+    }
 }

--- a/llmfit-tui/src/mcp_server.rs
+++ b/llmfit-tui/src/mcp_server.rs
@@ -315,20 +315,16 @@ impl LlmfitMcpServer {
             ("ramalama", available, installed)
         });
 
-        let mut models = Vec::new();
+        let mut detected = Vec::new();
         while let Some(result) = set.join_next().await {
             if let Ok((name, available, installed)) = result
                 && available
             {
-                for model_name in installed {
-                    models.push(InstalledModel {
-                        name: model_name,
-                        runtime: name.to_string(),
-                    });
-                }
+                detected.push((name, installed));
             }
         }
 
+        let models = installed_models_from_results(detected);
         let result = serde_json::json!({ "models": models });
         serde_json::to_string_pretty(&result).unwrap_or_default()
     }
@@ -352,6 +348,20 @@ impl LlmfitMcpServer {
 
         fits
     }
+}
+
+fn installed_models_from_results(
+    results: Vec<(&'static str, std::collections::HashSet<String>)>,
+) -> Vec<InstalledModel> {
+    results
+        .into_iter()
+        .flat_map(|(runtime, models)| {
+            models.into_iter().map(move |name| InstalledModel {
+                name,
+                runtime: runtime.to_string(),
+            })
+        })
+        .collect()
 }
 
 // --- Entry point ---
@@ -495,5 +505,17 @@ mod tests {
             model.get("name").and_then(Value::as_str).is_some()
                 && model.get("runtime").and_then(Value::as_str).is_some()
         }));
+    }
+
+    #[test]
+    fn installed_model_discovery_preserves_ramalama_model_identity() {
+        let models = installed_models_from_results(vec![(
+            "ramalama",
+            std::collections::HashSet::from(["model-x".to_string()]),
+        )]);
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].runtime, "ramalama");
+        assert_eq!(models[0].name, "model-x");
     }
 }


### PR DESCRIPTION
## Summary

Add RamaLama support to MCP runtime and installed-model discovery.

## Changes

- Add `ramalama` to `get_runtimes`.
- Add `ramalama` to `get_installed_models`.
- Add tests for runtime output and unavailable providers.

## Verification

- `cargo fmt -- --check`
- `cargo test -p llmfit`

Closes #874