### PR TITLE
bench: Qwen3.8-27B on amd-radeon-rx-7900-xt

### DIFF
--- a/llmfit-core/data/community/amd-radeon-rx-7900-xt/1786727248-720fe9e2.json
+++ b/llmfit-core/data/community/amd-radeon-rx-7900-xt/1786727248-720fe9e2.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786727248,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.9"
+  },
+  "hardware": {
+    "hwClass": "DISCRETE_GPU",
+    "hardwareName": "AMD Radeon RX 7900 XT",
+    "memTierGb": 16,
+    "vramGb": 19.98,
+    "gpuCount": 1,
+    "unifiedMemory": false,
+    "cpu": "Intel(R) Core(TM) i9-10900X CPU @ 3.70GHz",
+    "cpuCores": 20,
+    "ramGb": 62.49,
+    "os": "linux"
+  },
+  "results": [
+    {
+      "model": "Qwen3.8-27B-Q4_K_M.gguf",
+      "provider": "llamacpp",
+      "numRuns": 3,
+      "avgTps": 30.83,
+      "minTps": 30.67,
+      "maxTps": 31.06,
+      "avgTtftMs": null,
+      "avgTotalMs": 9730.93,
+      "avgOutputTokens": 300.0
+    }
+  ]
+}


### PR DESCRIPTION
One community result for Qwen3.8-27B (Q4_K_M) on a single AMD Radeon RX 7900 XT, llama.cpp Vulkan backend.

Result: Qwen3.8-27B-Q4_K_M.gguf at 30.83 tok/s (min 30.67, max 31.06, 3 runs, spread 1.27%). Each run generates 300 output tokens (`--ignore-eos`), ctx 4096, `-ngl 99`, KV f16.

Hardware: single RX 7900 XT (Navi 31, RADV/Vulkan). Full offload, confirmed by 16.29 GiB resident on the card. The hardware block matches the existing amd-radeon-rx-7900-xt slug (gpuCount 1, 19.98 GB). The host carries a second identical card; this run used one card exclusively, with no cross-GPU split.

Provenance: model unsloth/Qwen3.8-27B-GGUF, Q4_K_M, sha256 verified against the Hub. Measured with llmfit 1.1.9, `bench --provider llamacpp`, 3 runs. Same methodology as the recent Muse-Glimmer submission in this slug, which also forces 300 output tokens via `--ignore-eos`. The July batches in this slug (v1.1.3) predate that flag, so their output-token counts vary.
