### PR TITLE
chore(deps): group dependabot minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,25 @@ updates:
       default-days: 10
       semver-minor-days: 14 # wait 14 days before applying minor updates
       semver-major-days: 28
+    groups:
+      # One PR per week for all semver-compatible bumps. Majors stay
+      # ungrouped so they still get an individual PR and review.
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     cooldown:
       default-days: 10
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Groups Dependabot version updates so semver-compatible bumps arrive as a single weekly PR per ecosystem instead of one PR per dependency.

## Changes

Adds a `groups` block to each ecosystem in `.github/dependabot.yml`:

- `cargo-minor-patch` — pattern `*`, update-types `minor` + `patch`
- `github-actions-minor-patch` — pattern `*`, update-types `minor` + `patch`

## Rationale

The one-PR-per-dependency flow was generating a lot of review churn — the most recent sweep was 7 separate PRs (http, regex, tokio, serde, plus three Action SHA pins) that would have been 2 under this config.

**Major bumps are deliberately left ungrouped** so they still arrive as individual PRs and get individual review. That is not incidental: the most recent major, `actions/setup-python` v6 → v7, had a real breaking change (removal of the `pip-install` input) that warranted a dedicated check rather than being swept along with patch bumps.

Existing `cooldown` settings are untouched (cargo: 10 / 14 / 28 days for default / minor / major; github-actions: 10 days), so grouping composes with the current "let releases settle" policy rather than bypassing it.

## Validation

Hand-checked against the documented `groups` schema — no YAML parser was available locally. GitHub validates `dependabot.yml` on push and will surface any schema error in the repo Dependabot settings.