### PR TITLE
bench: community results for apple-m1-max

### DIFF
--- a/llmfit-core/data/community/apple-m1-max/1786995154-7cbcebe0.json
+++ b/llmfit-core/data/community/apple-m1-max/1786995154-7cbcebe0.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "submittedAtUnix": 1786995154,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  },
+  "hardware": {
+    "hwClass": "UNIFIED",
+    "hardwareName": "Apple M1 Max",
+    "memTierGb": 32,
+    "vramGb": 32.0,
+    "gpuCount": 1,
+    "unifiedMemory": true,
+    "cpu": "Apple M1 Max",
+    "cpuCores": 10,
+    "ramGb": 32.0,
+    "os": "macos"
+  },
+  "results": [
+    {
+      "model": "qwen3.6:27b",
+      "provider": "ollama",
+      "numRuns": 3,
+      "avgTps": 9.74,
+      "minTps": 9.71,
+      "maxTps": 9.77,
+      "avgTtftMs": 489.02,
+      "avgTotalMs": 142129.96,
+      "avgOutputTokens": 300.0
+    }
+  ]
+}


### PR DESCRIPTION
Community benchmark from llmfit 1.1.10.

Hardware: **Apple M1 Max** (32 GB unified memory, 10 cores, macOS).

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen3.6:27b | ollama | 9.7 | 489.0 |