### PR TITLE
fix(fit): stop flagging pre-quantized models that fit as insufficient

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -924,10 +924,16 @@ fn best_quant_for_runtime_budget(
     runtime: InferenceRuntime,
     budget: f64,
     estimation_ctx: u32,
-) -> Option<(&'static str, f64)> {
-    // Pre-quantized models (vLLM) don't support dynamic re-quantization
+) -> Option<(String, f64)> {
+    // Pre-quantized models (vLLM) can't be re-quantized, so there is no
+    // hierarchy to search — but they still have one fixed footprint. Report
+    // that footprint when it fits the budget: returning `None` here would tell
+    // callers the model does not fit at all, which is how a 9 GB AWQ model on a
+    // 24 GB card ended up labelled "Perfect" alongside an "Insufficient VRAM
+    // and system RAM" note.
     if runtime == InferenceRuntime::Vllm {
-        return None;
+        let required = model.estimate_memory_gb(model.quantization.as_str(), estimation_ctx);
+        return (required <= budget).then(|| (model.quantization.clone(), required));
     }
     let hierarchy: &[&str] = if model.format == models::ModelFormat::Onnx {
         models::ONNX_QUANT_HIERARCHY
@@ -945,6 +951,7 @@ fn best_quant_for_runtime_budget(
                 None
             }
         })
+        .map(|(quant, required)| (quant.to_string(), required))
 }
 
 pub fn backend_compatible(model: &LlmModel, system: &SystemSpecs) -> bool {
@@ -1966,6 +1973,68 @@ mod tests {
 
         // Model doesn't fit anywhere
         assert_eq!(fit.fit_level, FitLevel::TooTight);
+    }
+
+    #[test]
+    fn test_prequantized_gpu_fit_has_no_insufficient_note() {
+        // A 4-bit AWQ model needing ~9 GB on a 24 GB card fits comfortably.
+        // Pre-quantized models can't be re-quantized, so the quant search has
+        // nothing to return — that must not be read as "doesn't fit".
+        let mut model = test_model("14B", 8.3, Some(7.6));
+        model.format = models::ModelFormat::Awq;
+        model.quantization = "AWQ-4bit".to_string();
+        let system = test_system(32.0, true, Some(24.0));
+
+        let fit = ModelFit::analyze(&model, &system);
+
+        assert_eq!(fit.run_mode, RunMode::Gpu);
+        assert!(matches!(fit.fit_level, FitLevel::Good | FitLevel::Perfect));
+        assert!(
+            !fit.notes
+                .iter()
+                .any(|n| n.contains("Insufficient VRAM and system RAM")),
+            "model that fits must not be flagged insufficient; notes: {:?}",
+            fit.notes
+        );
+    }
+
+    #[test]
+    fn test_prequantized_too_large_still_reports_insufficient() {
+        // The counterpart: a pre-quantized model that genuinely exceeds both
+        // VRAM and RAM must keep the warning.
+        let mut model = test_model("180B", 200.0, Some(180.0));
+        model.format = models::ModelFormat::Awq;
+        model.quantization = "AWQ-4bit".to_string();
+        let system = test_system(16.0, true, Some(8.0));
+
+        let fit = ModelFit::analyze(&model, &system);
+
+        assert_eq!(fit.fit_level, FitLevel::TooTight);
+        assert!(
+            fit.notes
+                .iter()
+                .any(|n| n.contains("Insufficient VRAM and system RAM")),
+            "genuinely oversized model must keep the warning; notes: {:?}",
+            fit.notes
+        );
+    }
+
+    #[test]
+    fn test_prequantized_quant_budget_reports_own_footprint() {
+        let mut model = test_model("14B", 8.3, Some(7.6));
+        model.format = models::ModelFormat::Awq;
+        model.quantization = "AWQ-4bit".to_string();
+
+        // Fits the budget -> reports the model's own fixed quant.
+        let got = best_quant_for_runtime_budget(&model, InferenceRuntime::Vllm, 24.0, 8192);
+        assert!(
+            got.is_some(),
+            "fitting pre-quantized model must report a quant"
+        );
+        assert_eq!(got.unwrap().0, "AWQ-4bit");
+
+        // Exceeds the budget -> None, as before.
+        assert!(best_quant_for_runtime_budget(&model, InferenceRuntime::Vllm, 1.0, 8192).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What happens now

On a 24 GB card, `Qwen/Qwen2.5-Coder-14B-Instruct-AWQ` needs 9.39 GB. llmfit scores it `Perfect` and then prints this underneath:

```
Insufficient VRAM and system RAM
Need 7.6 GB VRAM or 8.3 GB system RAM
```

Both lines come from the same `ModelFit`. The verdict is right and the note is wrong, and they are printed together.

Reproduce with any pre-quantized model on a GPU that has room for it:

```sh
llmfit --json recommend --use-case coding
```

On my machine (RTX 3090, 24 GB, CUDA) three of the five recommended models came back labelled `Perfect` while carrying the insufficiency note.

## Why

`best_quant_for_runtime_budget` returns early for vLLM:

```rust
// Pre-quantized models (vLLM) don't support dynamic re-quantization
if runtime == InferenceRuntime::Vllm {
    return None;
}
```

That comment is accurate. An AWQ or GPTQ model is already quantized, so there is no hierarchy to search. The trouble is what `None` means to the caller. In the dense GPU path it means "does not fit":

```rust
} else if let Some((_, best_mem)) = choose_quant(system_vram) {
} else if let Some((_, best_mem)) = choose_quant(system.available_ram_gb) {
} else {
    notes.push("Insufficient VRAM and system RAM".to_string());
    ...
    (RunMode::Gpu, default_mem_required, system_vram)
}
```

So every pre-quantized model on a GPU lands in the failure branch no matter how much VRAM is free. The last line is why the output contradicts itself: the branch still returns correct memory figures, which then score as `Perfect`.

## The change

A pre-quantized model cannot be re-quantized, but it does have one fixed footprint. The vLLM branch now reports that footprint when it fits the budget, and keeps returning `None` when it does not:

```rust
let required = model.estimate_memory_gb(model.quantization.as_str(), estimation_ctx);
return (required <= budget).then(|| (model.quantization.clone(), required));
```

This means the return type widens from `Option<(&'static str, f64)>` to `Option<(String, f64)>`, because `quantization` is a `String`. Of the four call sites, three discard the name and the fourth passes it to `format!`, so nothing else needed changing.

I fixed it inside the function rather than at the call site because the same `None` ambiguity is reachable from the CPU path at `fit.rs:811`.

## Verification

Measured against the full catalog with hardware pinned so the runs are reproducible:

```sh
llmfit --ram 32G --memory 24G --json fit
```

| | models with the note | contradictory |
|---|---|---|
| before | 1034 | 319 |
| after | 708 | 0 |

"Contradictory" counts models that carry the note while not being labelled `Too Tight` and while reporting `memory_required_gb` below `memory_available_gb`. The 708 that remain are all `Too Tight`, where the warning is correct.

Comparing the two builds across all 9361 catalog entries, seven models change, all of them vLLM, all `Too Tight` to `Marginal`. No model's fit gets worse and no llama.cpp or MLX model is affected. With the hardware pinned the unpatched binary is deterministic run to run, so the diff is the patch and nothing else.

Three tests added. Two of them fail without the change:

- a fitting AWQ model on a 24 GB card must not carry the note
- an oversized AWQ model must still carry it, so the fix does not overshoot
- `best_quant_for_runtime_budget` reports the model's own quant within budget and `None` outside it

`cargo fmt --all -- --check`, `cargo clippy --all-targets`, and the full suite pass (652 tests). The `llmfit-desktop` crate does not build in my environment because `icons/icon.ico` is missing, which is unrelated to this change, so I tested the workspace default members.
