### PR TITLE
fix(ollama): stop a size-less family tag claiming a much larger model

### DIFF
--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -1,6 +1,6 @@
 use crate::fit::{InferenceRuntime, ModelFit};
 use crate::hardware::SystemSpecs;
-use crate::models::ModelDatabase;
+use crate::models::{LlmModel, ModelDatabase};
 use crate::providers::{
     self, DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider,
     ModelProvider, OllamaProvider, RamaLamaProvider, VllmProvider,
@@ -109,8 +109,13 @@ impl InstalledIndex {
     }
 
     /// Returns `true` when the model is installed in **any** provider.
-    pub fn is_installed(&self, model_name: &str) -> bool {
-        providers::is_model_installed(model_name, &self.ollama)
+    ///
+    /// Takes the whole model rather than its name so the Ollama matcher can
+    /// use the catalog's parameter count to reject a family-level tag whose
+    /// size disagrees (`deepseek-r1:14b` is not the 684B `DeepSeek-R1`).
+    pub fn is_installed(&self, model: &LlmModel) -> bool {
+        let model_name = model.name.as_str();
+        providers::is_model_installed_sized(model_name, model.known_params_b(), &self.ollama)
             || providers::is_model_installed_mlx(model_name, &self.mlx)
             || providers::is_model_installed_llamacpp(model_name, &self.llamacpp)
             || providers::is_model_installed_docker_mr(model_name, &self.docker_mr)
@@ -121,9 +126,10 @@ impl InstalledIndex {
 
     /// Returns the display names of all providers that have this model
     /// installed. Used by the detail panel in the TUI.
-    pub fn installed_providers(&self, model_name: &str) -> Vec<&'static str> {
+    pub fn installed_providers(&self, model: &LlmModel) -> Vec<&'static str> {
+        let model_name = model.name.as_str();
         let mut out = Vec::new();
-        if providers::is_model_installed(model_name, &self.ollama) {
+        if providers::is_model_installed_sized(model_name, model.known_params_b(), &self.ollama) {
             out.push("Ollama");
         }
         if providers::is_model_installed_mlx(model_name, &self.mlx) {
@@ -176,7 +182,7 @@ pub fn build_model_fits(
         .map(|m| {
             let mut fit =
                 ModelFit::analyze_with_forced_runtime(m, specs, context_limit, forced_runtime);
-            fit.installed = installed.is_installed(&m.name);
+            fit.installed = installed.is_installed(m);
             fit.measured_tps = local_index
                 .as_ref()
                 .and_then(|idx| idx.lookup(&m.name))

--- a/llmfit-core/src/models.rs
+++ b/llmfit-core/src/models.rs
@@ -772,6 +772,24 @@ impl LlmModel {
     }
 
     /// Parameter count in billions, extracted from parameters_raw or parameter_count.
+    /// Parameter count in billions, or `None` when the catalog does not
+    /// record it. Unlike [`params_b`], this never guesses: callers that use
+    /// the size to *reject* a match need to tell "unknown" apart from a
+    /// default, or an unsized entry gets discarded on a made-up number.
+    pub fn known_params_b(&self) -> Option<f64> {
+        if let Some(raw) = self.parameters_raw {
+            return Some(raw as f64 / 1_000_000_000.0);
+        }
+        let s = self.parameter_count.trim().to_uppercase();
+        if let Some(num) = s.strip_suffix('B') {
+            num.parse::<f64>().ok()
+        } else if let Some(num) = s.strip_suffix('M') {
+            num.parse::<f64>().ok().map(|v| v / 1000.0)
+        } else {
+            None
+        }
+    }
+
     pub fn params_b(&self) -> f64 {
         if let Some(raw) = self.parameters_raw {
             raw as f64 / 1_000_000_000.0

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -4067,7 +4067,45 @@ pub fn has_ollama_mapping(hf_name: &str) -> bool {
     lookup_ollama_tag(hf_name).is_some()
 }
 
-fn ollama_installed_matches_candidate(installed_name: &str, candidate: &str) -> bool {
+/// Largest ratio between a catalog entry's parameter count and an installed
+/// tag's size before the two are treated as different models. Deliberately
+/// loose: Ollama tags round (`phi4:14b` for a 14.7B model), so the check is
+/// only meant to catch mismatches of a different order, like a 14B tag
+/// standing in for a 684B model.
+const OLLAMA_SIZE_MISMATCH_RATIO: f64 = 2.0;
+
+/// Parse the size out of an Ollama tag: `deepseek-r1:14b` -> `14.0`,
+/// `qwen2.5-coder:7b-instruct-q4_K_M` -> `7.0`. Returns `None` for tags with
+/// no parseable size, including `8x7b`-style MoE tags and bare family stems.
+fn ollama_tag_size_b(installed_name: &str) -> Option<f64> {
+    let size = installed_name.split(':').nth(1)?;
+    let head = size.split('-').next()?;
+    head.strip_suffix('b')?.parse::<f64>().ok()
+}
+
+/// Does an installed tag's size agree with the catalog entry's parameter
+/// count? Unknown on either side means "no opinion", which keeps the previous
+/// permissive behaviour rather than dropping a real install.
+fn ollama_size_is_compatible(installed_name: &str, catalog_params_b: Option<f64>) -> bool {
+    let (Some(catalog), Some(tag)) = (catalog_params_b, ollama_tag_size_b(installed_name)) else {
+        return true;
+    };
+    if catalog <= 0.0 || tag <= 0.0 {
+        return true;
+    }
+    let ratio = if catalog > tag {
+        catalog / tag
+    } else {
+        tag / catalog
+    };
+    ratio <= OLLAMA_SIZE_MISMATCH_RATIO
+}
+
+fn ollama_installed_matches_candidate(
+    installed_name: &str,
+    candidate: &str,
+    catalog_params_b: Option<f64>,
+) -> bool {
     if installed_name == candidate {
         return true;
     }
@@ -4082,16 +4120,31 @@ fn ollama_installed_matches_candidate(installed_name: &str, candidate: &str) -> 
     // A size-less candidate is family-level by construction — either an
     // `OLLAMA_MAPPINGS` entry whose tag carries no size (`phi-4` → `phi4`,
     // `qwq-32b` → `qwq`) or an HF name with no size to parse. Any tag of that
-    // family is then the model in question, so match `phi4:14b` too. Candidates
-    // derived from a *sized* HF name never reach here (see
-    // `hf_name_to_ollama_candidates`), which is what keeps this from matching
-    // a whole family again.
+    // family is *usually* the model in question, so match `phi4:14b` too.
+    //
+    // "Usually" is why the size check is here. Some families publish one bare
+    // tag for wildly different models: `deepseek-r1` covers both the 684B
+    // original and the 14B Qwen distill, so `deepseek-r1:14b` would otherwise
+    // mark the 397 GB entry installed. Candidates derived from a *sized* HF
+    // name never reach here (see `hf_name_to_ollama_candidates`).
     installed_name.starts_with(&format!("{candidate}:"))
+        && ollama_size_is_compatible(installed_name, catalog_params_b)
 }
 
 /// Check if any of the Ollama candidates for an HF model appear in the
 /// installed set.
 pub fn is_model_installed(hf_name: &str, installed: &HashSet<String>) -> bool {
+    is_model_installed_sized(hf_name, None, installed)
+}
+
+/// Like [`is_model_installed`], but takes the catalog entry's parameter count
+/// so a family-level tag match can be rejected when the sizes disagree. Pass
+/// `None` when the size is unknown; the match is then as permissive as before.
+pub fn is_model_installed_sized(
+    hf_name: &str,
+    catalog_params_b: Option<f64>,
+    installed: &HashSet<String>,
+) -> bool {
     // Quick check: the installed set may contain the full HF name (lowercased)
     // from providers that report it verbatim (e.g. MLX server, /api/v1/installed).
     if installed.contains(&hf_name.to_lowercase()) {
@@ -4100,9 +4153,9 @@ pub fn is_model_installed(hf_name: &str, installed: &HashSet<String>) -> bool {
 
     let candidates = hf_name_to_ollama_candidates(hf_name);
     candidates.iter().any(|candidate| {
-        installed
-            .iter()
-            .any(|installed_name| ollama_installed_matches_candidate(installed_name, candidate))
+        installed.iter().any(|installed_name| {
+            ollama_installed_matches_candidate(installed_name, candidate, catalog_params_b)
+        })
     })
 }
 
@@ -5368,7 +5421,8 @@ mod tests {
     fn test_ollama_installed_matches_exact() {
         assert!(ollama_installed_matches_candidate(
             "llama3.1:8b",
-            "llama3.1:8b"
+            "llama3.1:8b",
+            None
         ));
     }
 
@@ -5376,7 +5430,8 @@ mod tests {
     fn test_ollama_installed_matches_variant_suffix() {
         assert!(ollama_installed_matches_candidate(
             "llama3.1:8b-instruct-q4_K_M",
-            "llama3.1:8b"
+            "llama3.1:8b",
+            None
         ));
     }
 
@@ -5384,8 +5439,99 @@ mod tests {
     fn test_ollama_installed_no_match() {
         assert!(!ollama_installed_matches_candidate(
             "qwen2.5:7b",
-            "llama3.1:8b"
+            "llama3.1:8b",
+            None
         ));
+    }
+
+    // ── size-aware family matching ───────────────────────────────────
+
+    fn deepseek_14b_installed() -> HashSet<String> {
+        let mut installed = HashSet::new();
+        installed.insert("deepseek-r1:14b".to_string());
+        installed
+    }
+
+    #[test]
+    fn test_ollama_tag_size_parsing() {
+        assert_eq!(ollama_tag_size_b("deepseek-r1:14b"), Some(14.0));
+        assert_eq!(ollama_tag_size_b("deepseek-r1:1.5b"), Some(1.5));
+        assert_eq!(
+            ollama_tag_size_b("qwen2.5-coder:7b-instruct-q4_K_M"),
+            Some(7.0)
+        );
+        // No size to read: bare family stem, MoE-style tag, or a plain name.
+        assert_eq!(ollama_tag_size_b("glm-4.7-flash"), None);
+        assert_eq!(ollama_tag_size_b("mixtral:8x7b"), None);
+        assert_eq!(ollama_tag_size_b("deepseek-r1:latest"), None);
+    }
+
+    #[test]
+    fn test_sized_family_tag_does_not_mark_much_larger_model_installed() {
+        // `deepseek-r1` is the mapped tag for the 684B original *and* the
+        // family prefix of the 14B distill. Having the distill must not claim
+        // the 397 GB model is on disk.
+        let installed = deepseek_14b_installed();
+        assert!(!is_model_installed_sized(
+            "deepseek-ai/DeepSeek-R1",
+            Some(684.5),
+            &installed
+        ));
+        assert!(!is_model_installed_sized(
+            "deepseek-ai/DeepSeek-R1-0528",
+            Some(684.5),
+            &installed
+        ));
+    }
+
+    #[test]
+    fn test_sized_family_tag_still_matches_the_model_it_belongs_to() {
+        let installed = deepseek_14b_installed();
+        // The distill maps to `deepseek-r1:14b` outright.
+        assert!(is_model_installed_sized(
+            "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+            Some(14.8),
+            &installed
+        ));
+        // And the real 684B model is matched by a tag of its own size.
+        let mut big = HashSet::new();
+        big.insert("deepseek-r1:671b".to_string());
+        assert!(is_model_installed_sized(
+            "deepseek-ai/DeepSeek-R1",
+            Some(684.5),
+            &big
+        ));
+    }
+
+    #[test]
+    fn test_size_rounding_in_tags_still_matches() {
+        // Ollama tags round: phi4:14b is a 14.7B model, qwq:32b is 32.8B.
+        let mut installed = HashSet::new();
+        installed.insert("phi4:14b".to_string());
+        installed.insert("qwq:32b".to_string());
+        assert!(is_model_installed_sized(
+            "microsoft/phi-4",
+            Some(14.7),
+            &installed
+        ));
+        assert!(is_model_installed_sized(
+            "Qwen/QwQ-32B",
+            Some(32.8),
+            &installed
+        ));
+    }
+
+    #[test]
+    fn test_unknown_catalog_size_stays_permissive() {
+        // With no parameter count recorded there is nothing to compare, so
+        // behaviour must be exactly what it was before the size check.
+        let installed = deepseek_14b_installed();
+        assert!(is_model_installed_sized(
+            "deepseek-ai/DeepSeek-R1",
+            None,
+            &installed
+        ));
+        assert!(is_model_installed("deepseek-ai/DeepSeek-R1", &installed));
     }
 
     // ── parse_repo_gguf_entries ──────────────────────────────────────

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1262,7 +1262,7 @@ impl App {
             .filter(|m| backend_compatible(m, &specs))
             .map(|m| {
                 let mut fit = ModelFit::analyze_with_context_limit(m, &specs, context_limit);
-                fit.installed = installed.is_installed(&m.name);
+                fit.installed = installed.is_installed(m);
                 fit.measured_tps = local_index
                     .as_ref()
                     .and_then(|idx| idx.lookup(&m.name))
@@ -2475,7 +2475,7 @@ impl App {
             && fit.installed
         {
             let name = fit.model.name.clone();
-            let providers = self.installed.installed_providers(&name);
+            let providers = self.installed.installed_providers(&fit.model);
             if !providers.is_empty() {
                 self.bench_offer_state = BenchOfferState::Offer;
                 self.bench_offer_model = name;
@@ -3728,7 +3728,7 @@ impl App {
             .map(|m| {
                 let mut fit =
                     ModelFit::analyze_with_context_limit(m, &self.specs, self.context_limit);
-                fit.installed = self.installed.is_installed(&m.name);
+                fit.installed = self.installed.is_installed(m);
                 fit.measured_tps = measured_index
                     .as_ref()
                     .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
@@ -4178,7 +4178,7 @@ impl App {
             .map(|m| {
                 let mut fit =
                     ModelFit::analyze_with_config(m, &self.specs, self.calc_config.clone());
-                fit.installed = self.installed.is_installed(&m.name);
+                fit.installed = self.installed.is_installed(m);
                 fit.measured_tps = measured_index
                     .as_ref()
                     .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
@@ -4626,7 +4626,7 @@ impl App {
             ramalama_count,
         };
         for fit in &mut self.all_fits {
-            fit.installed = self.installed.is_installed(&fit.model.name);
+            fit.installed = self.installed.is_installed(&fit.model);
         }
         self.re_sort();
         self.enqueue_capability_probes_for_visible(24);
@@ -4794,7 +4794,7 @@ impl App {
         if got_any {
             // Re-mark installed status for all models
             for fit in &mut self.all_fits {
-                fit.installed = self.installed.is_installed(&fit.model.name);
+                fit.installed = self.installed.is_installed(&fit.model);
             }
             self.re_sort();
         }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -1894,7 +1894,7 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
         Line::from(vec![
             Span::styled("  Installed:   ", Style::default().fg(tc.muted)),
             {
-                let installed_providers = app.installed.installed_providers(&fit.model.name);
+                let installed_providers = app.installed.installed_providers(&fit.model);
                 let any_available = app.ollama_available
                     || app.mlx_available
                     || app.llamacpp_available


### PR DESCRIPTION
Follow-up to #863, which closed one half of this. Related to #866, which tracks the false-negative half.

## What happens now

`deepseek-ai/DeepSeek-R1` is a 684.5B model, 397 GB on disk. On a 24 GB card with only `deepseek-r1:14b` pulled, llmfit marks it installed. Same for `DeepSeek-R1-0528`.

On my machine (RTX 3090, seven Ollama models, one loaded in LM Studio) the installed set came back as six entries, two of them models I have never downloaded:

```
deepseek-ai/DeepSeek-R1-Distill-Qwen-14B      14.8B
Qwen/Qwen3-Coder-30B-A3B-Instruct             30.5B
zai-org/GLM-4.7-Flash                         31.2B
Xenova/bge-m3                                 558M
deepseek-ai/DeepSeek-R1                       684.5B   <- not installed
deepseek-ai/DeepSeek-R1-0528                  684.5B   <- not installed
```

Since `installed` gates the download action, this fails the same way #863 described: it silently puts a model out of reach.

## Why

#863 made size the discriminator when the installed tag carries one. This is the mirror case, where the catalog name carries none.

`OLLAMA_MAPPINGS` maps both R1 entries to the bare tag `deepseek-r1`:

```rust
("deepseek-r1", "deepseek-r1"),
("deepseek-r1-0528", "deepseek-r1"),
```

A size-less candidate is treated as family-level in `ollama_installed_matches_candidate`, matching any tag in the family:

```rust
installed_name.starts_with(&format!("{candidate}:"))
```

That assumption holds for `phi-4` to `phi4:14b`, where the family has one member. It breaks for `deepseek-r1`, where the same bare tag covers the 684B original and the 1.5B to 70B distills. The distills are mapped explicitly and resolve on their own, so the only entry that needs the family fallback is the one it gets wrong.

## The change

Family matching stays, because removing it would break `phi-4` and the rest of the single-member families. It now also has to agree on size: a match is rejected when the catalog parameter count and the tag size differ by more than 2x.

The threshold is loose on purpose. Ollama tags round, so `phi4:14b` is a 14.7B model and `qwq:32b` is 32.8B, and I would rather let a near-miss through than reintroduce the false negatives #866 is about. It only catches mismatches of a different order, which is what 14B standing in for 684B is.

Unknown size on either side means no opinion, and the match stays exactly as permissive as before. That matters more than it sounds, so the size accessor is new rather than reused: `params_b()` falls back to 7.0 when nothing is recorded, and rejecting a real install on a defaulted number would be worse than the bug. `known_params_b()` returns `None` instead.

`is_model_installed` keeps its signature and delegates with `None`, so existing callers and tests are untouched. `InstalledIndex::is_installed` and `installed_providers` now take the model rather than its name, which is what supplies the parameter count.

## Verification

Same machine, before and after, with the two phantoms gone and every real detection kept:

```
before: 6 installed  (4 real, 2 phantom)
after:  4 installed  (4 real, 0 phantom)
```

Five tests added, covering the tag size parser, the rejection, the distill and the 671B tag still matching, rounded tags like `phi4:14b` and `qwq:32b`, and the unknown-size path staying permissive. The rejection test fails without the size check, which I confirmed by stubbing it out and re-running.

`cargo fmt --all -- --check`, `cargo clippy --all-targets` and the full suite pass (654 tests). `llmfit-desktop` does not build in my environment because `icons/icon.ico` is missing, unrelated to this change, so I tested the workspace default members.

## Not in scope

The false-negative half from #866 is untouched here. This only stops a match that should not happen; it does not add any that are missing.
