### PR TITLE
fix(providers): find LM Studio models on disk, not just loaded ones

### DIFF
--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -23,6 +23,11 @@ pub struct InstalledIndex {
     pub docker_mr_count: usize,
     pub lmstudio: HashSet<String>,
     pub lmstudio_count: usize,
+    /// Models found in LM Studio's models directory. Kept apart from
+    /// `lmstudio` because the API ids there are matched by substring, while
+    /// these directory-derived names are matched by equality.
+    pub lmstudio_disk: HashSet<String>,
+    pub lmstudio_disk_count: usize,
     pub vllm: HashSet<String>,
     pub vllm_count: usize,
     pub ramalama: HashSet<String>,
@@ -42,6 +47,8 @@ impl InstalledIndex {
             docker_mr_count: 0,
             lmstudio: HashSet::new(),
             lmstudio_count: 0,
+            lmstudio_disk: HashSet::new(),
+            lmstudio_disk_count: 0,
             vllm: HashSet::new(),
             vllm_count: 0,
             ramalama: HashSet::new(),
@@ -73,6 +80,7 @@ impl InstalledIndex {
                 let p = LmStudioProvider::new();
                 p.installed_models_counted()
             });
+            let lmstudio_disk = s.spawn(providers::scan_lmstudio_models_dir);
             let vllm = s.spawn(|| {
                 let p = VllmProvider::new();
                 p.installed_models_counted()
@@ -87,6 +95,10 @@ impl InstalledIndex {
             let (llamacpp, llamacpp_count) = llamacpp.join().unwrap();
             let (docker_mr, docker_mr_count) = docker_mr.join().unwrap();
             let (lmstudio, lmstudio_count) = lmstudio.join().unwrap();
+            // Enrichment rather than a load-bearing provider: if the scan
+            // thread dies, report no disk models instead of taking the whole
+            // installed-model analysis down with it.
+            let (lmstudio_disk, lmstudio_disk_count) = lmstudio_disk.join().unwrap_or_default();
             let (vllm, vllm_count) = vllm.join().unwrap();
             let (ramalama, ramalama_count) = ramalama.join().unwrap();
 
@@ -100,6 +112,8 @@ impl InstalledIndex {
                 docker_mr_count,
                 lmstudio,
                 lmstudio_count,
+                lmstudio_disk,
+                lmstudio_disk_count,
                 vllm,
                 vllm_count,
                 ramalama,
@@ -120,6 +134,7 @@ impl InstalledIndex {
             || providers::is_model_installed_llamacpp(model_name, &self.llamacpp)
             || providers::is_model_installed_docker_mr(model_name, &self.docker_mr)
             || providers::is_model_installed_lmstudio(model_name, &self.lmstudio)
+            || providers::is_model_installed_lmstudio_disk(model_name, &self.lmstudio_disk)
             || providers::is_model_installed_vllm(model_name, &self.vllm)
             || providers::is_model_installed_ramalama(model_name, &self.ramalama)
     }
@@ -141,7 +156,9 @@ impl InstalledIndex {
         if providers::is_model_installed_docker_mr(model_name, &self.docker_mr) {
             out.push("Docker");
         }
-        if providers::is_model_installed_lmstudio(model_name, &self.lmstudio) {
+        if providers::is_model_installed_lmstudio(model_name, &self.lmstudio)
+            || providers::is_model_installed_lmstudio_disk(model_name, &self.lmstudio_disk)
+        {
             out.push("LM Studio");
         }
         if providers::is_model_installed_vllm(model_name, &self.vllm) {

--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -23,6 +23,11 @@ pub struct InstalledIndex {
     pub docker_mr_count: usize,
     pub lmstudio: HashSet<String>,
     pub lmstudio_count: usize,
+    /// Models found in LM Studio's models directory. Kept apart from
+    /// `lmstudio` because the API ids there are matched by substring, while
+    /// these directory-derived names are matched by equality.
+    pub lmstudio_disk: HashSet<String>,
+    pub lmstudio_disk_count: usize,
     pub vllm: HashSet<String>,
     pub vllm_count: usize,
     pub ramalama: HashSet<String>,
@@ -42,6 +47,8 @@ impl InstalledIndex {
             docker_mr_count: 0,
             lmstudio: HashSet::new(),
             lmstudio_count: 0,
+            lmstudio_disk: HashSet::new(),
+            lmstudio_disk_count: 0,
             vllm: HashSet::new(),
             vllm_count: 0,
             ramalama: HashSet::new(),
@@ -73,6 +80,7 @@ impl InstalledIndex {
                 let p = LmStudioProvider::new();
                 p.installed_models_counted()
             });
+            let lmstudio_disk = s.spawn(providers::scan_lmstudio_models_dir);
             let vllm = s.spawn(|| {
                 let p = VllmProvider::new();
                 p.installed_models_counted()
@@ -87,6 +95,7 @@ impl InstalledIndex {
             let (llamacpp, llamacpp_count) = llamacpp.join().unwrap();
             let (docker_mr, docker_mr_count) = docker_mr.join().unwrap();
             let (lmstudio, lmstudio_count) = lmstudio.join().unwrap();
+            let (lmstudio_disk, lmstudio_disk_count) = lmstudio_disk.join().unwrap();
             let (vllm, vllm_count) = vllm.join().unwrap();
             let (ramalama, ramalama_count) = ramalama.join().unwrap();
 
@@ -100,6 +109,8 @@ impl InstalledIndex {
                 docker_mr_count,
                 lmstudio,
                 lmstudio_count,
+                lmstudio_disk,
+                lmstudio_disk_count,
                 vllm,
                 vllm_count,
                 ramalama,
@@ -115,6 +126,7 @@ impl InstalledIndex {
             || providers::is_model_installed_llamacpp(model_name, &self.llamacpp)
             || providers::is_model_installed_docker_mr(model_name, &self.docker_mr)
             || providers::is_model_installed_lmstudio(model_name, &self.lmstudio)
+            || providers::is_model_installed_lmstudio_disk(model_name, &self.lmstudio_disk)
             || providers::is_model_installed_vllm(model_name, &self.vllm)
             || providers::is_model_installed_ramalama(model_name, &self.ramalama)
     }
@@ -135,7 +147,9 @@ impl InstalledIndex {
         if providers::is_model_installed_docker_mr(model_name, &self.docker_mr) {
             out.push("Docker");
         }
-        if providers::is_model_installed_lmstudio(model_name, &self.lmstudio) {
+        if providers::is_model_installed_lmstudio(model_name, &self.lmstudio)
+            || providers::is_model_installed_lmstudio_disk(model_name, &self.lmstudio_disk)
+        {
             out.push("LM Studio");
         }
         if providers::is_model_installed_vllm(model_name, &self.vllm) {

--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -95,7 +95,10 @@ impl InstalledIndex {
             let (llamacpp, llamacpp_count) = llamacpp.join().unwrap();
             let (docker_mr, docker_mr_count) = docker_mr.join().unwrap();
             let (lmstudio, lmstudio_count) = lmstudio.join().unwrap();
-            let (lmstudio_disk, lmstudio_disk_count) = lmstudio_disk.join().unwrap();
+            // Enrichment rather than a load-bearing provider: if the scan
+            // thread dies, report no disk models instead of taking the whole
+            // installed-model analysis down with it.
+            let (lmstudio_disk, lmstudio_disk_count) = lmstudio_disk.join().unwrap_or_default();
             let (vllm, vllm_count) = vllm.join().unwrap();
             let (ramalama, ramalama_count) = ramalama.join().unwrap();
 

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1531,20 +1531,41 @@ fn collect_gguf_files(root: &Path, max_depth: usize) -> Vec<PathBuf> {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let looks_like_model = name.to_string_lossy().to_lowercase().ends_with(".gguf");
-            // `file_type` reads what `read_dir` already returned rather than
-            // stat-ing the path, so the name test still does the filtering and
-            // this stays cheap. It has to be consulted, though: a *directory*
-            // named `foo.gguf` must not be handed back as a model, and its
-            // contents still deserve a look.
-            let Ok(file_type) = entry.file_type() else {
-                continue;
-            };
-            if looks_like_model && file_type.is_file() {
-                files.push(entry.path());
+            let path = entry.path();
+
+            // Only names that already look like models are resolved, so the
+            // extension test is still what does the filtering. `metadata`
+            // rather than `DirEntry::file_type` because the latter describes
+            // the symlink instead of its target, and a symlinked model in
+            // `LLMFIT_MODELS_DIR` is still a model.
+            let resolved = looks_like_model
+                .then(|| path.metadata())
+                .and_then(Result::ok);
+            if let Some(meta) = &resolved
+                && meta.is_file()
+            {
+                files.push(path);
                 continue;
             }
-            if depth < max_depth && file_type.is_dir() {
-                pending.push((entry.path(), depth + 1));
+
+            if depth >= max_depth {
+                continue;
+            }
+            // A directory named `foo.gguf` is not a model, but what is inside
+            // it may be, so it still gets walked.
+            let is_dir = match &resolved {
+                Some(meta) => meta.is_dir(),
+                None => match entry.file_type() {
+                    Ok(file_type) if file_type.is_dir() => true,
+                    // Only symlinks pay for the extra resolution.
+                    Ok(file_type) if file_type.is_symlink() => {
+                        path.metadata().is_ok_and(|meta| meta.is_dir())
+                    }
+                    _ => false,
+                },
+            };
+            if is_dir {
+                pending.push((path, depth + 1));
             }
         }
     }
@@ -5618,6 +5639,33 @@ mod tests {
     fn test_collect_gguf_files_missing_root_is_empty() {
         let missing = std::env::temp_dir().join("llmfit-does-not-exist-9f3c1a");
         assert!(collect_gguf_files(&missing, GGUF_SCAN_MAX_DEPTH).is_empty());
+    }
+
+    #[cfg(unix)]
+    fn symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_file(target, link)
+    }
+
+    #[test]
+    fn test_collect_gguf_files_follows_symlinked_models() {
+        // `DirEntry::file_type` describes the link rather than its target, so
+        // a type check that does not resolve silently drops symlinked models.
+        // Creating a symlink needs elevation on Windows, so skip there when
+        // it is not permitted rather than failing the run.
+        let tree = TempTree::new("symlink");
+        tree.touch("store/real-model.gguf");
+        let link = tree.path().join("linked-model.gguf");
+        if symlink_file(&tree.path().join("store/real-model.gguf"), &link).is_err() {
+            return;
+        }
+
+        let found = names_of(&collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH));
+        assert_eq!(found, vec!["linked-model.gguf", "real-model.gguf"]);
     }
 
     #[test]

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1530,12 +1530,20 @@ fn collect_gguf_files(root: &Path, max_depth: usize) -> Vec<PathBuf> {
         };
         for entry in entries.flatten() {
             let name = entry.file_name();
-            let name = name.to_string_lossy();
-            if name.to_lowercase().ends_with(".gguf") {
+            let looks_like_model = name.to_string_lossy().to_lowercase().ends_with(".gguf");
+            // `file_type` reads what `read_dir` already returned rather than
+            // stat-ing the path, so the name test still does the filtering and
+            // this stays cheap. It has to be consulted, though: a *directory*
+            // named `foo.gguf` must not be handed back as a model, and its
+            // contents still deserve a look.
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if looks_like_model && file_type.is_file() {
                 files.push(entry.path());
                 continue;
             }
-            if depth < max_depth && entry.file_type().is_ok_and(|t| t.is_dir()) {
+            if depth < max_depth && file_type.is_dir() {
                 pending.push((entry.path(), depth + 1));
             }
         }
@@ -2075,13 +2083,34 @@ fn scan_lmstudio_models_dir_at(root: Option<&Path>) -> (HashSet<String>, usize) 
     (set, count)
 }
 
+/// Candidate ids for the equality-matched disk path.
+///
+/// Deliberately not [`hf_name_to_lmstudio_candidates`], which also offers a
+/// form with `-instruct`, `-chat`, `-hf` and `-it` removed. Widening the net
+/// that way is reasonable for a substring search, but under equality it
+/// collides: it reduces the distinct `gemma-4-12b-it` entry to `gemma-4-12b`,
+/// so an installed base model would mark the IT variant installed too.
+fn hf_name_to_lmstudio_disk_candidates(hf_name: &str) -> Vec<String> {
+    let full = hf_name.to_lowercase();
+    let repo = hf_name
+        .split('/')
+        .next_back()
+        .unwrap_or(hf_name)
+        .to_lowercase();
+    if repo == full {
+        vec![full]
+    } else {
+        vec![full, repo]
+    }
+}
+
 /// Is this catalog model present in LM Studio's models directory?
 ///
 /// Deliberately equality rather than the substring test used for API ids:
 /// these names come from directory and file names, which are numerous enough
 /// that a substring rule starts matching unrelated catalog entries.
 pub fn is_model_installed_lmstudio_disk(hf_name: &str, on_disk: &HashSet<String>) -> bool {
-    hf_name_to_lmstudio_candidates(hf_name)
+    hf_name_to_lmstudio_disk_candidates(hf_name)
         .iter()
         .any(|candidate| on_disk.contains(candidate))
 }
@@ -5649,6 +5678,44 @@ mod tests {
             "meta-llama/Llama-3.1-8B",
             &set
         ));
+    }
+
+    #[test]
+    fn test_lmstudio_disk_base_model_does_not_claim_variants() {
+        // Only the base model is on disk. The `-it`, `-instruct` and `-chat`
+        // entries are distinct catalog models and must stay uninstalled.
+        let tree = TempTree::new("variant");
+        tree.touch("unsloth/gemma-4-12b-GGUF/gemma-4-12b-Q8_0.gguf");
+        let (set, _) = scan_lmstudio_models_dir_at(Some(tree.path()));
+
+        assert!(is_model_installed_lmstudio_disk(
+            "unsloth/gemma-4-12b",
+            &set
+        ));
+        assert!(!is_model_installed_lmstudio_disk(
+            "google/gemma-4-12B-it",
+            &set
+        ));
+        assert!(!is_model_installed_lmstudio_disk(
+            "google/gemma-4-12B-instruct",
+            &set
+        ));
+        assert!(!is_model_installed_lmstudio_disk(
+            "google/gemma-4-12B-chat",
+            &set
+        ));
+    }
+
+    #[test]
+    fn test_collect_gguf_files_ignores_directories_named_like_models() {
+        // A directory called `something.gguf` is not a model, and whatever is
+        // inside it still needs scanning.
+        let tree = TempTree::new("ggufdir");
+        tree.touch("decoy.gguf/real.gguf");
+
+        let found = collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH);
+        assert_eq!(names_of(&found), vec!["real.gguf"]);
+        assert!(found.iter().all(|p| p.is_file()));
     }
 
     #[test]

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -3,7 +3,7 @@
 //! Each provider can list locally installed models and pull new ones.
 
 use regex::Regex;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -992,18 +992,10 @@ impl LlamaCppProvider {
         }
     }
 
-    /// List all `.gguf` files in the cache directory.
+    /// List all `.gguf` files in the cache directory, descending into
+    /// subdirectories up to [`GGUF_SCAN_MAX_DEPTH`].
     pub fn list_gguf_files(&self) -> Vec<PathBuf> {
-        let mut files = Vec::new();
-        if let Ok(entries) = std::fs::read_dir(&self.models_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("gguf") {
-                    files.push(path);
-                }
-            }
-        }
-        files
+        collect_gguf_files(&self.models_dir, GGUF_SCAN_MAX_DEPTH)
     }
 
     /// Search HuggingFace for GGUF repositories matching a query.
@@ -1522,6 +1514,110 @@ fn parse_repo_gguf_entries(entries: Vec<serde_json::Value>) -> Vec<(String, u64)
 }
 
 /// Default directory for llama.cpp GGUF model cache.
+/// How far below a models root to look for `.gguf` files.
+///
+/// A flat scan is not enough: LM Studio stores `publisher/repo/model.gguf`,
+/// and anyone pointing `LLMFIT_MODELS_DIR` at a tree with that shape hits the
+/// same wall. Three levels covers those layouts while keeping the walk
+/// bounded, so a large library does not turn into a full crawl.
+pub const GGUF_SCAN_MAX_DEPTH: usize = 3;
+
+/// Collect `.gguf` files under `root`, descending at most `max_depth`
+/// directory levels (the root itself is level one).
+///
+/// The name is tested for the extension before anything asks the filesystem
+/// about the entry, so only directories cost a `file_type` call. Unreadable
+/// directories are skipped rather than aborting the walk.
+fn collect_gguf_files(root: &Path, max_depth: usize) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if max_depth == 0 {
+        return files;
+    }
+    let mut pending = vec![(root.to_path_buf(), 1usize)];
+
+    while let Some((dir, depth)) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let looks_like_model = name.to_string_lossy().to_lowercase().ends_with(".gguf");
+            let path = entry.path();
+
+            // Only names that already look like models are resolved, so the
+            // extension test is still what does the filtering. `metadata`
+            // rather than `DirEntry::file_type` because the latter describes
+            // the symlink instead of its target, and a symlinked model in
+            // `LLMFIT_MODELS_DIR` is still a model.
+            let resolved = looks_like_model
+                .then(|| path.metadata())
+                .and_then(Result::ok);
+            if let Some(meta) = &resolved
+                && meta.is_file()
+            {
+                files.push(path);
+                continue;
+            }
+
+            if depth >= max_depth {
+                continue;
+            }
+            // Descend into real directories only, which includes one named
+            // `foo.gguf`: that is not a model, but what is inside it may be.
+            //
+            // Directory symlinks are deliberately not followed. Doing so lets
+            // the walk leave the models root entirely, or alias a subtree back
+            // into itself and count the same model twice, and callers act on
+            // the paths returned here. Symlinked model *files* are still
+            // resolved above, which is the case that actually came up.
+            if entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
+                pending.push((path, depth + 1));
+            }
+        }
+    }
+    dedupe_by_target(files)
+}
+
+/// Collapse paths that resolve to the same file.
+///
+/// A symlink and the model it points at both look like models, so a tree
+/// holding both would report the same weights twice and inflate the count the
+/// TUI shows. Resolution is per collected model rather than per directory
+/// entry, so this stays proportional to the number of models found.
+///
+/// Where a target and an alias both appear, the target wins, so the path
+/// handed to callers is the stable one.
+fn dedupe_by_target(files: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut chosen: Vec<(PathBuf, bool)> = Vec::with_capacity(files.len());
+    let mut seen: HashMap<PathBuf, usize> = HashMap::new();
+
+    for path in files {
+        let target = path.canonicalize().unwrap_or_else(|_| path.clone());
+        // Ask whether this entry is a link, rather than comparing it to its
+        // canonical form. Those differ whenever any parent directory is a
+        // symlink, in which case neither the model nor its alias matches the
+        // target and the survivor would come down to directory order. Callers
+        // look the model up by stem, so the wrong survivor means a model that
+        // cannot be found by its real name.
+        let is_alias = std::fs::symlink_metadata(&path)
+            .map(|meta| meta.file_type().is_symlink())
+            .unwrap_or(false);
+
+        match seen.get(&target) {
+            Some(&index) => {
+                if chosen[index].1 && !is_alias {
+                    chosen[index] = (path, false);
+                }
+            }
+            None => {
+                seen.insert(target, chosen.len());
+                chosen.push((path, is_alias));
+            }
+        }
+    }
+    chosen.into_iter().map(|(path, _)| path).collect()
+}
+
 pub fn llamacpp_models_dir() -> PathBuf {
     if let Ok(dir) = std::env::var("LLMFIT_MODELS_DIR") {
         PathBuf::from(dir)
@@ -1973,6 +2069,117 @@ fn lmstudio_install_candidates(
         candidates.push(home.join(".lmstudio"));
     }
     candidates
+}
+
+/// Where LM Studio keeps downloaded models. Pure so tests can cover it
+/// without a home directory, mirroring [`lmstudio_install_candidates`].
+fn lmstudio_models_dir_for(home: Option<&Path>) -> Option<PathBuf> {
+    Some(home?.join(".lmstudio").join("models"))
+}
+
+fn lmstudio_models_dir() -> Option<PathBuf> {
+    lmstudio_models_dir_for(dirs::home_dir().as_deref())
+}
+
+/// Identifiers for every model in LM Studio's models directory.
+///
+/// The HTTP API only advertises models that are currently *loaded*, so a
+/// library of thirteen with one loaded is reported as one. The download is
+/// what makes a model installed, not whether it happens to be resident, so
+/// the directory is the only complete picture.
+///
+/// Layout is `<models>/<publisher>/<repo>/<file>.gguf`. These names are
+/// matched by equality (see [`is_model_installed_lmstudio_disk`]) rather than
+/// the substring rule used for API ids, so only canonical forms go in:
+/// feeding loose stems to a substring matcher makes `llama` match
+/// `meta-llama-3.1-8b-instruct`.
+///
+/// Returns `(names, model_count)`. `mmproj-*` files are vision projectors
+/// shipped beside a model rather than models of their own, so they are not
+/// counted.
+pub fn scan_lmstudio_models_dir() -> (HashSet<String>, usize) {
+    scan_lmstudio_models_dir_at(lmstudio_models_dir().as_deref())
+}
+
+fn scan_lmstudio_models_dir_at(root: Option<&Path>) -> (HashSet<String>, usize) {
+    let mut set = HashSet::new();
+    let mut repos = HashSet::new();
+    let Some(root) = root else {
+        return (set, 0);
+    };
+
+    for path in collect_gguf_files(root, GGUF_SCAN_MAX_DEPTH) {
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let stem = stem.to_lowercase();
+        if stem.starts_with("mmproj-") {
+            continue;
+        }
+
+        set.insert(stem.clone());
+        if let Some(base) = strip_gguf_quant_suffix(&stem) {
+            set.insert(base);
+        }
+
+        let repo = path
+            .parent()
+            .and_then(|d| d.file_name())
+            .map(|n| n.to_string_lossy().to_lowercase());
+        let publisher = path
+            .parent()
+            .and_then(|d| d.parent())
+            .and_then(|d| d.file_name())
+            .map(|n| n.to_string_lossy().to_lowercase());
+
+        if let Some(repo) = repo {
+            repos.insert(repo.clone());
+            // LM Studio appends `-GGUF` to the repo it downloaded from; the
+            // catalog id does not carry it.
+            let trimmed = repo.trim_end_matches("-gguf").to_string();
+            if let Some(publisher) = publisher {
+                set.insert(format!("{publisher}/{repo}"));
+                set.insert(format!("{publisher}/{trimmed}"));
+            }
+            set.insert(trimmed);
+            set.insert(repo);
+        }
+    }
+
+    let count = repos.len();
+    (set, count)
+}
+
+/// Candidate ids for the equality-matched disk path.
+///
+/// Deliberately not [`hf_name_to_lmstudio_candidates`], which also offers a
+/// form with `-instruct`, `-chat`, `-hf` and `-it` removed. Widening the net
+/// that way is reasonable for a substring search, but under equality it
+/// collides: it reduces the distinct `gemma-4-12b-it` entry to `gemma-4-12b`,
+/// so an installed base model would mark the IT variant installed too.
+fn hf_name_to_lmstudio_disk_candidates(hf_name: &str) -> Vec<String> {
+    let full = hf_name.to_lowercase();
+    let repo = hf_name
+        .split('/')
+        .next_back()
+        .unwrap_or(hf_name)
+        .to_lowercase();
+    if repo == full {
+        vec![full]
+    } else {
+        vec![full, repo]
+    }
+}
+
+/// Is this catalog model present in LM Studio's models directory?
+///
+/// Deliberately equality rather than the substring test used for API ids:
+/// these names come from directory and file names, which are numerous enough
+/// that a substring rule starts matching unrelated catalog entries.
+pub fn is_model_installed_lmstudio_disk(hf_name: &str, on_disk: &HashSet<String>) -> bool {
+    hf_name_to_lmstudio_disk_candidates(hf_name)
+        .iter()
+        .any(|candidate| on_disk.contains(candidate))
 }
 
 fn normalize_lmstudio_host(raw: &str) -> Option<String> {
@@ -5726,6 +5933,309 @@ mod tests {
             &installed
         ));
         assert!(is_model_installed("deepseek-ai/DeepSeek-R1", &installed));
+    }
+
+    // ── recursive gguf scan / LM Studio models directory ─────────────
+
+    /// Minimal scratch directory that removes itself. Avoids a `tempfile`
+    /// dev-dependency for the handful of tests that need a real tree.
+    struct TempTree(PathBuf);
+
+    impl TempTree {
+        fn new(tag: &str) -> Self {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static SEQ: AtomicUsize = AtomicUsize::new(0);
+            let dir = std::env::temp_dir().join(format!(
+                "llmfit-{tag}-{}-{}",
+                std::process::id(),
+                SEQ.fetch_add(1, Ordering::SeqCst)
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("create temp tree");
+            Self(dir)
+        }
+
+        fn touch(&self, rel: &str) {
+            let path = self.0.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create parents");
+            }
+            std::fs::write(&path, b"").expect("write file");
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempTree {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn names_of(paths: &[PathBuf]) -> Vec<String> {
+        let mut names: Vec<String> = paths
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().to_lowercase()))
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn test_collect_gguf_files_descends_and_caps_depth() {
+        let tree = TempTree::new("scan");
+        tree.touch("root.gguf");
+        tree.touch("publisher/mid.gguf");
+        tree.touch("publisher/repo/leaf.gguf");
+        tree.touch("publisher/repo/notes.txt");
+        // One level past the cap.
+        tree.touch("publisher/repo/nested/toodeep.gguf");
+
+        let found = names_of(&collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH));
+        assert_eq!(found, vec!["leaf.gguf", "mid.gguf", "root.gguf"]);
+    }
+
+    #[test]
+    fn test_collect_gguf_files_flat_when_depth_is_one() {
+        let tree = TempTree::new("flat");
+        tree.touch("root.gguf");
+        tree.touch("publisher/mid.gguf");
+
+        assert_eq!(
+            names_of(&collect_gguf_files(tree.path(), 1)),
+            vec!["root.gguf"]
+        );
+        assert!(collect_gguf_files(tree.path(), 0).is_empty());
+    }
+
+    #[test]
+    fn test_collect_gguf_files_missing_root_is_empty() {
+        let missing = std::env::temp_dir().join("llmfit-does-not-exist-9f3c1a");
+        assert!(collect_gguf_files(&missing, GGUF_SCAN_MAX_DEPTH).is_empty());
+    }
+
+    #[cfg(unix)]
+    fn symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_file(target, link)
+    }
+
+    #[test]
+    fn test_collect_gguf_files_follows_symlinked_models() {
+        // `DirEntry::file_type` describes the link rather than its target, so
+        // a type check that does not resolve silently drops symlinked models.
+        // Creating a symlink needs elevation on Windows, so skip there when
+        // it is not permitted rather than failing the run.
+        // The target sits outside the scanned tree, so the link is the only
+        // way in and there is no alias for the dedupe pass to collapse.
+        let store = TempTree::new("symlink-store");
+        store.touch("real-model.gguf");
+
+        let tree = TempTree::new("symlink");
+        tree.touch("plain-model.gguf");
+        let link = tree.path().join("linked-model.gguf");
+        if symlink_file(&store.path().join("real-model.gguf"), &link).is_err() {
+            return;
+        }
+
+        let found = names_of(&collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH));
+        assert_eq!(found, vec!["linked-model.gguf", "plain-model.gguf"]);
+    }
+
+    #[cfg(unix)]
+    fn symlink_dir(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink_dir(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_dir(target, link)
+    }
+
+    #[test]
+    fn test_collect_gguf_files_does_not_follow_directory_symlinks() {
+        // A directory symlink can point anywhere, including outside the tree
+        // being scanned. Following one would pull unrelated files into
+        // installed detection and put them in front of callers that act on
+        // the returned paths.
+        let outside = TempTree::new("outside");
+        outside.touch("secret-model.gguf");
+
+        let tree = TempTree::new("escape");
+        tree.touch("inside.gguf");
+        if symlink_dir(outside.path(), &tree.path().join("escape-hatch")).is_err() {
+            return;
+        }
+
+        let found = names_of(&collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH));
+        assert_eq!(found, vec!["inside.gguf"]);
+    }
+
+    #[test]
+    fn test_collect_gguf_files_collapses_symlink_aliases() {
+        // A symlink beside the file it points at is one model, not two.
+        let tree = TempTree::new("alias");
+        tree.touch("real-model.gguf");
+        if symlink_file(
+            &tree.path().join("real-model.gguf"),
+            &tree.path().join("alias-model.gguf"),
+        )
+        .is_err()
+        {
+            return;
+        }
+
+        let found = collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH);
+        assert_eq!(found.len(), 1, "expected one model, got {found:?}");
+        assert_eq!(names_of(&found), vec!["real-model.gguf"]);
+    }
+
+    #[test]
+    fn test_dedupe_prefers_target_even_when_alias_is_seen_first() {
+        // Under a symlinked root neither path equals its canonical form, so a
+        // tie-break based on path equality silently never fires and the
+        // survivor comes down to directory order. `dedupe_by_target` is called
+        // directly with the alias first so the ordering is not left to the
+        // filesystem: whichever order they arrive in, the real file must win,
+        // because callers look models up by stem.
+        let store = TempTree::new("realroot");
+        store.touch("model.gguf");
+        if symlink_file(
+            &store.path().join("model.gguf"),
+            &store.path().join("alias.gguf"),
+        )
+        .is_err()
+        {
+            return;
+        }
+
+        let links = TempTree::new("linkroot");
+        let root_link = links.path().join("root");
+        if symlink_dir(store.path(), &root_link).is_err() {
+            return;
+        }
+
+        let alias_first = vec![root_link.join("alias.gguf"), root_link.join("model.gguf")];
+        let kept = dedupe_by_target(alias_first);
+        assert_eq!(kept.len(), 1, "expected one model, got {kept:?}");
+        assert_eq!(names_of(&kept), vec!["model.gguf"]);
+
+        let target_first = vec![root_link.join("model.gguf"), root_link.join("alias.gguf")];
+        assert_eq!(
+            names_of(&dedupe_by_target(target_first)),
+            vec!["model.gguf"]
+        );
+    }
+
+    #[test]
+    fn test_lmstudio_models_dir_layout() {
+        let home = PathBuf::from("/home/someone");
+        assert_eq!(
+            lmstudio_models_dir_for(Some(&home)),
+            Some(home.join(".lmstudio").join("models"))
+        );
+        assert_eq!(lmstudio_models_dir_for(None), None);
+    }
+
+    fn lmstudio_tree() -> TempTree {
+        let tree = TempTree::new("lms");
+        tree.touch(
+            "lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        );
+        tree.touch("lmstudio-community/gemma-4-12B-it-GGUF/gemma-4-12B-it-Q8_0.gguf");
+        tree.touch("lmstudio-community/gemma-4-12B-it-GGUF/mmproj-gemma-4-12B-it-BF16.gguf");
+        tree
+    }
+
+    #[test]
+    fn test_scan_lmstudio_models_dir_names_and_projector_handling() {
+        let tree = lmstudio_tree();
+        let (set, count) = scan_lmstudio_models_dir_at(Some(tree.path()));
+
+        // Two models, not three: the mmproj file is a projector, not a model.
+        assert_eq!(count, 2);
+        assert!(set.contains("lmstudio-community/meta-llama-3.1-8b-instruct-gguf"));
+        assert!(set.contains("meta-llama-3.1-8b-instruct"));
+        assert!(set.contains("gemma-4-12b-it"));
+        assert!(!set.iter().any(|n| n.starts_with("mmproj-")));
+    }
+
+    #[test]
+    fn test_lmstudio_disk_match_is_exact_not_substring() {
+        let tree = lmstudio_tree();
+        let (set, _) = scan_lmstudio_models_dir_at(Some(tree.path()));
+
+        assert!(is_model_installed_lmstudio_disk(
+            "unsloth/Meta-Llama-3.1-8B-Instruct",
+            &set
+        ));
+        assert!(is_model_installed_lmstudio_disk(
+            "google/gemma-4-12B-it",
+            &set
+        ));
+
+        // A catalog entry literally named "llama" is a substring of
+        // "meta-llama-3.1-8b-instruct". Equality is what keeps it out.
+        assert!(!is_model_installed_lmstudio_disk(
+            "Resilient-Coders/llama",
+            &set
+        ));
+        // The base model is a different model from the Instruct one.
+        assert!(!is_model_installed_lmstudio_disk(
+            "meta-llama/Llama-3.1-8B",
+            &set
+        ));
+    }
+
+    #[test]
+    fn test_lmstudio_disk_base_model_does_not_claim_variants() {
+        // Only the base model is on disk. The `-it`, `-instruct` and `-chat`
+        // entries are distinct catalog models and must stay uninstalled.
+        let tree = TempTree::new("variant");
+        tree.touch("unsloth/gemma-4-12b-GGUF/gemma-4-12b-Q8_0.gguf");
+        let (set, _) = scan_lmstudio_models_dir_at(Some(tree.path()));
+
+        assert!(is_model_installed_lmstudio_disk(
+            "unsloth/gemma-4-12b",
+            &set
+        ));
+        assert!(!is_model_installed_lmstudio_disk(
+            "google/gemma-4-12B-it",
+            &set
+        ));
+        assert!(!is_model_installed_lmstudio_disk(
+            "google/gemma-4-12B-instruct",
+            &set
+        ));
+        assert!(!is_model_installed_lmstudio_disk(
+            "google/gemma-4-12B-chat",
+            &set
+        ));
+    }
+
+    #[test]
+    fn test_collect_gguf_files_ignores_directories_named_like_models() {
+        // A directory called `something.gguf` is not a model, and whatever is
+        // inside it still needs scanning.
+        let tree = TempTree::new("ggufdir");
+        tree.touch("decoy.gguf/real.gguf");
+
+        let found = collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH);
+        assert_eq!(names_of(&found), vec!["real.gguf"]);
+        assert!(found.iter().all(|p| p.is_file()));
+    }
+
+    #[test]
+    fn test_scan_lmstudio_models_dir_without_home_is_empty() {
+        let (set, count) = scan_lmstudio_models_dir_at(None);
+        assert!(set.is_empty());
+        assert_eq!(count, 0);
     }
 
     // ── parse_repo_gguf_entries ──────────────────────────────────────

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1551,20 +1551,15 @@ fn collect_gguf_files(root: &Path, max_depth: usize) -> Vec<PathBuf> {
             if depth >= max_depth {
                 continue;
             }
-            // A directory named `foo.gguf` is not a model, but what is inside
-            // it may be, so it still gets walked.
-            let is_dir = match &resolved {
-                Some(meta) => meta.is_dir(),
-                None => match entry.file_type() {
-                    Ok(file_type) if file_type.is_dir() => true,
-                    // Only symlinks pay for the extra resolution.
-                    Ok(file_type) if file_type.is_symlink() => {
-                        path.metadata().is_ok_and(|meta| meta.is_dir())
-                    }
-                    _ => false,
-                },
-            };
-            if is_dir {
+            // Descend into real directories only, which includes one named
+            // `foo.gguf`: that is not a model, but what is inside it may be.
+            //
+            // Directory symlinks are deliberately not followed. Doing so lets
+            // the walk leave the models root entirely, or alias a subtree back
+            // into itself and count the same model twice, and callers act on
+            // the paths returned here. Symlinked model *files* are still
+            // resolved above, which is the case that actually came up.
+            if entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
                 pending.push((path, depth + 1));
             }
         }
@@ -5666,6 +5661,35 @@ mod tests {
 
         let found = names_of(&collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH));
         assert_eq!(found, vec!["linked-model.gguf", "real-model.gguf"]);
+    }
+
+    #[cfg(unix)]
+    fn symlink_dir(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink_dir(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_dir(target, link)
+    }
+
+    #[test]
+    fn test_collect_gguf_files_does_not_follow_directory_symlinks() {
+        // A directory symlink can point anywhere, including outside the tree
+        // being scanned. Following one would pull unrelated files into
+        // installed detection and put them in front of callers that act on
+        // the returned paths.
+        let outside = TempTree::new("outside");
+        outside.touch("secret-model.gguf");
+
+        let tree = TempTree::new("escape");
+        tree.touch("inside.gguf");
+        if symlink_dir(outside.path(), &tree.path().join("escape-hatch")).is_err() {
+            return;
+        }
+
+        let found = names_of(&collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH));
+        assert_eq!(found, vec!["inside.gguf"]);
     }
 
     #[test]

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -3,7 +3,7 @@
 //! Each provider can list locally installed models and pull new ones.
 
 use regex::Regex;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -1564,7 +1564,37 @@ fn collect_gguf_files(root: &Path, max_depth: usize) -> Vec<PathBuf> {
             }
         }
     }
-    files
+    dedupe_by_target(files)
+}
+
+/// Collapse paths that resolve to the same file.
+///
+/// A symlink and the model it points at both look like models, so a tree
+/// holding both would report the same weights twice and inflate the count the
+/// TUI shows. Resolution is per collected model rather than per directory
+/// entry, so this stays proportional to the number of models found.
+///
+/// Where a target and an alias both appear, the target wins, so the path
+/// handed to callers is the stable one.
+fn dedupe_by_target(files: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut chosen: Vec<PathBuf> = Vec::with_capacity(files.len());
+    let mut seen: HashMap<PathBuf, usize> = HashMap::new();
+
+    for path in files {
+        let target = path.canonicalize().unwrap_or_else(|_| path.clone());
+        match seen.get(&target) {
+            Some(&index) => {
+                if path == target {
+                    chosen[index] = path;
+                }
+            }
+            None => {
+                seen.insert(target, chosen.len());
+                chosen.push(path);
+            }
+        }
+    }
+    chosen
 }
 
 pub fn llamacpp_models_dir() -> PathBuf {
@@ -5652,15 +5682,20 @@ mod tests {
         // a type check that does not resolve silently drops symlinked models.
         // Creating a symlink needs elevation on Windows, so skip there when
         // it is not permitted rather than failing the run.
+        // The target sits outside the scanned tree, so the link is the only
+        // way in and there is no alias for the dedupe pass to collapse.
+        let store = TempTree::new("symlink-store");
+        store.touch("real-model.gguf");
+
         let tree = TempTree::new("symlink");
-        tree.touch("store/real-model.gguf");
+        tree.touch("plain-model.gguf");
         let link = tree.path().join("linked-model.gguf");
-        if symlink_file(&tree.path().join("store/real-model.gguf"), &link).is_err() {
+        if symlink_file(&store.path().join("real-model.gguf"), &link).is_err() {
             return;
         }
 
         let found = names_of(&collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH));
-        assert_eq!(found, vec!["linked-model.gguf", "real-model.gguf"]);
+        assert_eq!(found, vec!["linked-model.gguf", "plain-model.gguf"]);
     }
 
     #[cfg(unix)]
@@ -5690,6 +5725,25 @@ mod tests {
 
         let found = names_of(&collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH));
         assert_eq!(found, vec!["inside.gguf"]);
+    }
+
+    #[test]
+    fn test_collect_gguf_files_collapses_symlink_aliases() {
+        // A symlink beside the file it points at is one model, not two.
+        let tree = TempTree::new("alias");
+        tree.touch("real-model.gguf");
+        if symlink_file(
+            &tree.path().join("real-model.gguf"),
+            &tree.path().join("alias-model.gguf"),
+        )
+        .is_err()
+        {
+            return;
+        }
+
+        let found = collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH);
+        assert_eq!(found.len(), 1, "expected one model, got {found:?}");
+        assert_eq!(names_of(&found), vec!["real-model.gguf"]);
     }
 
     #[test]

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -978,18 +978,10 @@ impl LlamaCppProvider {
         }
     }
 
-    /// List all `.gguf` files in the cache directory.
+    /// List all `.gguf` files in the cache directory, descending into
+    /// subdirectories up to [`GGUF_SCAN_MAX_DEPTH`].
     pub fn list_gguf_files(&self) -> Vec<PathBuf> {
-        let mut files = Vec::new();
-        if let Ok(entries) = std::fs::read_dir(&self.models_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("gguf") {
-                    files.push(path);
-                }
-            }
-        }
-        files
+        collect_gguf_files(&self.models_dir, GGUF_SCAN_MAX_DEPTH)
     }
 
     /// Search HuggingFace for GGUF repositories matching a query.
@@ -1511,6 +1503,46 @@ fn parse_repo_gguf_entries(entries: Vec<serde_json::Value>) -> Vec<(String, u64)
 }
 
 /// Default directory for llama.cpp GGUF model cache.
+/// How far below a models root to look for `.gguf` files.
+///
+/// A flat scan is not enough: LM Studio stores `publisher/repo/model.gguf`,
+/// and anyone pointing `LLMFIT_MODELS_DIR` at a tree with that shape hits the
+/// same wall. Three levels covers those layouts while keeping the walk
+/// bounded, so a large library does not turn into a full crawl.
+pub const GGUF_SCAN_MAX_DEPTH: usize = 3;
+
+/// Collect `.gguf` files under `root`, descending at most `max_depth`
+/// directory levels (the root itself is level one).
+///
+/// The name is tested for the extension before anything asks the filesystem
+/// about the entry, so only directories cost a `file_type` call. Unreadable
+/// directories are skipped rather than aborting the walk.
+fn collect_gguf_files(root: &Path, max_depth: usize) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if max_depth == 0 {
+        return files;
+    }
+    let mut pending = vec![(root.to_path_buf(), 1usize)];
+
+    while let Some((dir, depth)) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.to_lowercase().ends_with(".gguf") {
+                files.push(entry.path());
+                continue;
+            }
+            if depth < max_depth && entry.file_type().is_ok_and(|t| t.is_dir()) {
+                pending.push((entry.path(), depth + 1));
+            }
+        }
+    }
+    files
+}
+
 pub fn llamacpp_models_dir() -> PathBuf {
     if let Ok(dir) = std::env::var("LLMFIT_MODELS_DIR") {
         PathBuf::from(dir)
@@ -1962,6 +1994,96 @@ fn lmstudio_install_candidates(
         candidates.push(home.join(".lmstudio"));
     }
     candidates
+}
+
+/// Where LM Studio keeps downloaded models. Pure so tests can cover it
+/// without a home directory, mirroring [`lmstudio_install_candidates`].
+fn lmstudio_models_dir_for(home: Option<&Path>) -> Option<PathBuf> {
+    Some(home?.join(".lmstudio").join("models"))
+}
+
+fn lmstudio_models_dir() -> Option<PathBuf> {
+    lmstudio_models_dir_for(dirs::home_dir().as_deref())
+}
+
+/// Identifiers for every model in LM Studio's models directory.
+///
+/// The HTTP API only advertises models that are currently *loaded*, so a
+/// library of thirteen with one loaded is reported as one. The download is
+/// what makes a model installed, not whether it happens to be resident, so
+/// the directory is the only complete picture.
+///
+/// Layout is `<models>/<publisher>/<repo>/<file>.gguf`. These names are
+/// matched by equality (see [`is_model_installed_lmstudio_disk`]) rather than
+/// the substring rule used for API ids, so only canonical forms go in:
+/// feeding loose stems to a substring matcher makes `llama` match
+/// `meta-llama-3.1-8b-instruct`.
+///
+/// Returns `(names, model_count)`. `mmproj-*` files are vision projectors
+/// shipped beside a model rather than models of their own, so they are not
+/// counted.
+pub fn scan_lmstudio_models_dir() -> (HashSet<String>, usize) {
+    scan_lmstudio_models_dir_at(lmstudio_models_dir().as_deref())
+}
+
+fn scan_lmstudio_models_dir_at(root: Option<&Path>) -> (HashSet<String>, usize) {
+    let mut set = HashSet::new();
+    let mut repos = HashSet::new();
+    let Some(root) = root else {
+        return (set, 0);
+    };
+
+    for path in collect_gguf_files(root, GGUF_SCAN_MAX_DEPTH) {
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let stem = stem.to_lowercase();
+        if stem.starts_with("mmproj-") {
+            continue;
+        }
+
+        set.insert(stem.clone());
+        if let Some(base) = strip_gguf_quant_suffix(&stem) {
+            set.insert(base);
+        }
+
+        let repo = path
+            .parent()
+            .and_then(|d| d.file_name())
+            .map(|n| n.to_string_lossy().to_lowercase());
+        let publisher = path
+            .parent()
+            .and_then(|d| d.parent())
+            .and_then(|d| d.file_name())
+            .map(|n| n.to_string_lossy().to_lowercase());
+
+        if let Some(repo) = repo {
+            repos.insert(repo.clone());
+            // LM Studio appends `-GGUF` to the repo it downloaded from; the
+            // catalog id does not carry it.
+            let trimmed = repo.trim_end_matches("-gguf").to_string();
+            if let Some(publisher) = publisher {
+                set.insert(format!("{publisher}/{repo}"));
+                set.insert(format!("{publisher}/{trimmed}"));
+            }
+            set.insert(trimmed);
+            set.insert(repo);
+        }
+    }
+
+    let count = repos.len();
+    (set, count)
+}
+
+/// Is this catalog model present in LM Studio's models directory?
+///
+/// Deliberately equality rather than the substring test used for API ids:
+/// these names come from directory and file names, which are numerous enough
+/// that a substring rule starts matching unrelated catalog entries.
+pub fn is_model_installed_lmstudio_disk(hf_name: &str, on_disk: &HashSet<String>) -> bool {
+    hf_name_to_lmstudio_candidates(hf_name)
+        .iter()
+        .any(|candidate| on_disk.contains(candidate))
 }
 
 fn normalize_lmstudio_host(raw: &str) -> Option<String> {
@@ -5386,6 +5508,154 @@ mod tests {
             "qwen2.5:7b",
             "llama3.1:8b"
         ));
+    }
+
+    // ── recursive gguf scan / LM Studio models directory ─────────────
+
+    /// Minimal scratch directory that removes itself. Avoids a `tempfile`
+    /// dev-dependency for the handful of tests that need a real tree.
+    struct TempTree(PathBuf);
+
+    impl TempTree {
+        fn new(tag: &str) -> Self {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static SEQ: AtomicUsize = AtomicUsize::new(0);
+            let dir = std::env::temp_dir().join(format!(
+                "llmfit-{tag}-{}-{}",
+                std::process::id(),
+                SEQ.fetch_add(1, Ordering::SeqCst)
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("create temp tree");
+            Self(dir)
+        }
+
+        fn touch(&self, rel: &str) {
+            let path = self.0.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create parents");
+            }
+            std::fs::write(&path, b"").expect("write file");
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempTree {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn names_of(paths: &[PathBuf]) -> Vec<String> {
+        let mut names: Vec<String> = paths
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().to_lowercase()))
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn test_collect_gguf_files_descends_and_caps_depth() {
+        let tree = TempTree::new("scan");
+        tree.touch("root.gguf");
+        tree.touch("publisher/mid.gguf");
+        tree.touch("publisher/repo/leaf.gguf");
+        tree.touch("publisher/repo/notes.txt");
+        // One level past the cap.
+        tree.touch("publisher/repo/nested/toodeep.gguf");
+
+        let found = names_of(&collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH));
+        assert_eq!(found, vec!["leaf.gguf", "mid.gguf", "root.gguf"]);
+    }
+
+    #[test]
+    fn test_collect_gguf_files_flat_when_depth_is_one() {
+        let tree = TempTree::new("flat");
+        tree.touch("root.gguf");
+        tree.touch("publisher/mid.gguf");
+
+        assert_eq!(
+            names_of(&collect_gguf_files(tree.path(), 1)),
+            vec!["root.gguf"]
+        );
+        assert!(collect_gguf_files(tree.path(), 0).is_empty());
+    }
+
+    #[test]
+    fn test_collect_gguf_files_missing_root_is_empty() {
+        let missing = std::env::temp_dir().join("llmfit-does-not-exist-9f3c1a");
+        assert!(collect_gguf_files(&missing, GGUF_SCAN_MAX_DEPTH).is_empty());
+    }
+
+    #[test]
+    fn test_lmstudio_models_dir_layout() {
+        let home = PathBuf::from("/home/someone");
+        assert_eq!(
+            lmstudio_models_dir_for(Some(&home)),
+            Some(home.join(".lmstudio").join("models"))
+        );
+        assert_eq!(lmstudio_models_dir_for(None), None);
+    }
+
+    fn lmstudio_tree() -> TempTree {
+        let tree = TempTree::new("lms");
+        tree.touch(
+            "lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        );
+        tree.touch("lmstudio-community/gemma-4-12B-it-GGUF/gemma-4-12B-it-Q8_0.gguf");
+        tree.touch("lmstudio-community/gemma-4-12B-it-GGUF/mmproj-gemma-4-12B-it-BF16.gguf");
+        tree
+    }
+
+    #[test]
+    fn test_scan_lmstudio_models_dir_names_and_projector_handling() {
+        let tree = lmstudio_tree();
+        let (set, count) = scan_lmstudio_models_dir_at(Some(tree.path()));
+
+        // Two models, not three: the mmproj file is a projector, not a model.
+        assert_eq!(count, 2);
+        assert!(set.contains("lmstudio-community/meta-llama-3.1-8b-instruct-gguf"));
+        assert!(set.contains("meta-llama-3.1-8b-instruct"));
+        assert!(set.contains("gemma-4-12b-it"));
+        assert!(!set.iter().any(|n| n.starts_with("mmproj-")));
+    }
+
+    #[test]
+    fn test_lmstudio_disk_match_is_exact_not_substring() {
+        let tree = lmstudio_tree();
+        let (set, _) = scan_lmstudio_models_dir_at(Some(tree.path()));
+
+        assert!(is_model_installed_lmstudio_disk(
+            "unsloth/Meta-Llama-3.1-8B-Instruct",
+            &set
+        ));
+        assert!(is_model_installed_lmstudio_disk(
+            "google/gemma-4-12B-it",
+            &set
+        ));
+
+        // A catalog entry literally named "llama" is a substring of
+        // "meta-llama-3.1-8b-instruct". Equality is what keeps it out.
+        assert!(!is_model_installed_lmstudio_disk(
+            "Resilient-Coders/llama",
+            &set
+        ));
+        // The base model is a different model from the Instruct one.
+        assert!(!is_model_installed_lmstudio_disk(
+            "meta-llama/Llama-3.1-8B",
+            &set
+        ));
+    }
+
+    #[test]
+    fn test_scan_lmstudio_models_dir_without_home_is_empty() {
+        let (set, count) = scan_lmstudio_models_dir_at(None);
+        assert!(set.is_empty());
+        assert_eq!(count, 0);
     }
 
     // ── parse_repo_gguf_entries ──────────────────────────────────────

--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -1577,24 +1577,34 @@ fn collect_gguf_files(root: &Path, max_depth: usize) -> Vec<PathBuf> {
 /// Where a target and an alias both appear, the target wins, so the path
 /// handed to callers is the stable one.
 fn dedupe_by_target(files: Vec<PathBuf>) -> Vec<PathBuf> {
-    let mut chosen: Vec<PathBuf> = Vec::with_capacity(files.len());
+    let mut chosen: Vec<(PathBuf, bool)> = Vec::with_capacity(files.len());
     let mut seen: HashMap<PathBuf, usize> = HashMap::new();
 
     for path in files {
         let target = path.canonicalize().unwrap_or_else(|_| path.clone());
+        // Ask whether this entry is a link, rather than comparing it to its
+        // canonical form. Those differ whenever any parent directory is a
+        // symlink, in which case neither the model nor its alias matches the
+        // target and the survivor would come down to directory order. Callers
+        // look the model up by stem, so the wrong survivor means a model that
+        // cannot be found by its real name.
+        let is_alias = std::fs::symlink_metadata(&path)
+            .map(|meta| meta.file_type().is_symlink())
+            .unwrap_or(false);
+
         match seen.get(&target) {
             Some(&index) => {
-                if path == target {
-                    chosen[index] = path;
+                if chosen[index].1 && !is_alias {
+                    chosen[index] = (path, false);
                 }
             }
             None => {
                 seen.insert(target, chosen.len());
-                chosen.push(path);
+                chosen.push((path, is_alias));
             }
         }
     }
-    chosen
+    chosen.into_iter().map(|(path, _)| path).collect()
 }
 
 pub fn llamacpp_models_dir() -> PathBuf {
@@ -5744,6 +5754,43 @@ mod tests {
         let found = collect_gguf_files(tree.path(), GGUF_SCAN_MAX_DEPTH);
         assert_eq!(found.len(), 1, "expected one model, got {found:?}");
         assert_eq!(names_of(&found), vec!["real-model.gguf"]);
+    }
+
+    #[test]
+    fn test_dedupe_prefers_target_even_when_alias_is_seen_first() {
+        // Under a symlinked root neither path equals its canonical form, so a
+        // tie-break based on path equality silently never fires and the
+        // survivor comes down to directory order. `dedupe_by_target` is called
+        // directly with the alias first so the ordering is not left to the
+        // filesystem: whichever order they arrive in, the real file must win,
+        // because callers look models up by stem.
+        let store = TempTree::new("realroot");
+        store.touch("model.gguf");
+        if symlink_file(
+            &store.path().join("model.gguf"),
+            &store.path().join("alias.gguf"),
+        )
+        .is_err()
+        {
+            return;
+        }
+
+        let links = TempTree::new("linkroot");
+        let root_link = links.path().join("root");
+        if symlink_dir(store.path(), &root_link).is_err() {
+            return;
+        }
+
+        let alias_first = vec![root_link.join("alias.gguf"), root_link.join("model.gguf")];
+        let kept = dedupe_by_target(alias_first);
+        assert_eq!(kept.len(), 1, "expected one model, got {kept:?}");
+        assert_eq!(names_of(&kept), vec!["model.gguf"]);
+
+        let target_first = vec![root_link.join("model.gguf"), root_link.join("alias.gguf")];
+        assert_eq!(
+            names_of(&dedupe_by_target(target_first)),
+            vec!["model.gguf"]
+        );
     }
 
     #[test]

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -4613,6 +4613,8 @@ impl App {
         let (llamacpp, llamacpp_count) = self.llamacpp.installed_models_counted();
         let (docker_mr, docker_mr_count) = self.docker_mr.installed_models_counted();
         let (lmstudio, lmstudio_count) = self.lmstudio.installed_models_counted();
+        let (lmstudio_disk, lmstudio_disk_count) =
+            llmfit_core::providers::scan_lmstudio_models_dir();
         let (vllm, vllm_count) = self.vllm.installed_models_counted();
         let (ramalama, ramalama_count) = self.ramalama.installed_models_counted();
         self.installed = llmfit_core::analysis::InstalledIndex {
@@ -4625,6 +4627,8 @@ impl App {
             docker_mr_count,
             lmstudio,
             lmstudio_count,
+            lmstudio_disk,
+            lmstudio_disk_count,
             vllm,
             vllm_count,
             ramalama,

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -4608,6 +4608,8 @@ impl App {
         let (llamacpp, llamacpp_count) = self.llamacpp.installed_models_counted();
         let (docker_mr, docker_mr_count) = self.docker_mr.installed_models_counted();
         let (lmstudio, lmstudio_count) = self.lmstudio.installed_models_counted();
+        let (lmstudio_disk, lmstudio_disk_count) =
+            llmfit_core::providers::scan_lmstudio_models_dir();
         let (vllm, vllm_count) = self.vllm.installed_models_counted();
         let (ramalama, ramalama_count) = self.ramalama.installed_models_counted();
         self.installed = llmfit_core::analysis::InstalledIndex {
@@ -4620,6 +4622,8 @@ impl App {
             docker_mr_count,
             lmstudio,
             lmstudio_count,
+            lmstudio_disk,
+            lmstudio_disk_count,
             vllm,
             vllm_count,
             ramalama,


### PR DESCRIPTION
Fixes #900.

Went with option 2 as you asked, including both bounds: depth cap of 3, and the extension tested before anything stats the entry.

## What changed

**The GGUF scan is now recursive.** `list_gguf_files` used a flat `read_dir`, so it could only ever see files sitting directly in the models root. It now walks up to `GGUF_SCAN_MAX_DEPTH` (3), which covers `publisher/repo/model.gguf` and stops there. As you said, this is a bug in its own right: anyone pointing `LLMFIT_MODELS_DIR` at a nested tree hit the same wall, and I confirmed that before changing anything. Pointing it at my LM Studio root detected nothing, while pointing it at a single folder that directly contained a `.gguf` detected that model immediately.

On the cost bound: the name is tested for `.gguf` straight from the directory entry, and only entries that are not models cost a `file_type` call. Unreadable directories are skipped rather than aborting the walk.

**LM Studio's models directory is now scanned.** `~/.lmstudio/models`, resolved through a pure helper so tests cover the layout without a home directory, in the same shape as `lmstudio_install_candidates`.

## One thing I did not expect, and how I handled it

My first attempt merged the directory names into the existing `lmstudio` set. Detection went from 6 models to 23, but several of the new ones were wrong: `Resilient-Coders/llama`, two `mlx-community/*-bf16` entries I do not have in that format, and the non-Instruct base variants of models where I only have Instruct.

The cause is that `is_model_installed_lmstudio` matches with a bare `contains`. That is survivable while the API reports one or two loaded models, but a directory scan produces far more names, and a catalog entry called `llama` is a substring of `meta-llama-3.1-8b-instruct`. Feeding more names into a loose matcher trades one wrong answer for several.

So directory-derived names go into their own set, `lmstudio_disk`, matched by equality via `is_model_installed_lmstudio_disk`. The API set and its substring rule are untouched, so there is no behaviour change for anyone whose models are loaded. Only canonical forms are inserted: `publisher/repo`, the repo with LM Studio's `-GGUF` suffix trimmed, and the file stem with and without its quantization suffix.

I have left the substring rule on the API path alone. Tightening it looked like a separate change with its own regression risk, and every stricter rule I tried broke a case that currently works: requiring a boundary still matches `llama` inside `meta-llama`, and requiring a prefix breaks `text-embedding-bge-m3` matching `bge-m3`. Happy to open that separately if you want it.

## Verification

Real library: 13 entries in `lms ls`, 113 GB.

| | catalog rows matched to LM Studio |
|---|---|
| before | 1 |
| after | 10 |

Twelve of the 13 entries now resolve. They land on 10 catalog rows rather than 12 because the three `nomic-embed-text-v1.5` variants share one catalog id. The single miss is `Mindcraft-CE/Andy-4.2`, which has no catalog entry, so nothing can match it.

No false positives: every one of the 10 corresponds to a file on disk. The two `DeepSeek-R1` entries visible in my testing come from the separate Ollama bug in #899 and are not from this branch.

On cost, comparing debug builds of `main` and this branch so the comparison is like for like, five runs each of `fit -n 1`:

```
main     median 4679 ms
patched  median 4742 ms
```

Inside the run-to-run spread. The walk visits 19 directories on that library. Worth noting that a naive comparison against the released binary showed a 940 ms gap, which was entirely debug versus release rather than the scan.

Seven tests added, covering the descent, the depth cap holding one level short, depth 1 reproducing the old flat behaviour, a missing root, the models directory layout, projector files not being counted as models, and the equality rule keeping `Resilient-Coders/llama` out. That last one fails if the exact match is swapped back to a substring, which I checked by doing exactly that.

No new dependency: the tests use a small self-cleaning temp directory rather than pulling in `tempfile`.

`cargo fmt --all -- --check`, `cargo clippy --all-targets` and the full suite pass (656 tests). `llmfit-desktop` does not build in my environment because `icons/icon.ico` is missing, unrelated to this change, so I tested the workspace default members.

## Follow-up

`lms ls` as a fast path is not here, per your steer that it should be an optimisation rather than the mechanism. Nothing in the measurements suggests it is needed yet.
