### PR TITLE
bench: community results for apple-m4-pro

### DIFF
--- a/llmfit-core/data/community/apple-m4-pro/1787042206-b1a521ec.json
+++ b/llmfit-core/data/community/apple-m4-pro/1787042206-b1a521ec.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M4 Pro",
+    "cpuCores": 14,
+    "gpuCount": 1,
+    "hardwareName": "Apple M4 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 48,
+    "os": "macos",
+    "ramGb": 48.0,
+    "unifiedMemory": true,
+    "vramGb": 48.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 244.67,
+      "avgTotalMs": 8344.7,
+      "avgTps": 30.5,
+      "avgTtftMs": 299.59,
+      "maxTps": 31.83,
+      "minTps": 29.46,
+      "model": "qwen3.8:27b-mlx",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787042206,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen3.8:27b-mlx | ollama | 30.5 | 299.6 |

_Submitted without the `gh` CLI via the GitHub device flow._
