### PR TITLE
bench: community results for apple-m3-pro

### DIFF
--- a/llmfit-core/data/community/apple-m3-pro/1787061718-5023ef6b.json
+++ b/llmfit-core/data/community/apple-m3-pro/1787061718-5023ef6b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "macos",
+    "ramGb": 36.0,
+    "unifiedMemory": true,
+    "vramGb": 36.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 291.67,
+      "avgTotalMs": 12153.46,
+      "avgTps": 24.56,
+      "avgTtftMs": 119.92,
+      "maxTps": 25.27,
+      "minTps": 24.18,
+      "model": "qwen3:8b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787072925,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-pro/1787061784-485c5458.json
+++ b/llmfit-core/data/community/apple-m3-pro/1787061784-485c5458.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "macos",
+    "ramGb": 36.0,
+    "unifiedMemory": true,
+    "vramGb": 36.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 14159.46,
+      "avgTps": 21.93,
+      "avgTtftMs": 225.39,
+      "maxTps": 22.24,
+      "minTps": 21.74,
+      "model": "qwen3.5:9b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787072925,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-pro/1787070836-6865b9c3.json
+++ b/llmfit-core/data/community/apple-m3-pro/1787070836-6865b9c3.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "macos",
+    "ramGb": 36.0,
+    "unifiedMemory": true,
+    "vramGb": 36.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 216.33,
+      "avgTotalMs": 37896.61,
+      "avgTps": 0.12,
+      "avgTtftMs": 1006.22,
+      "maxTps": 0.16,
+      "minTps": 0.05,
+      "model": "qwen2.5-coder:14b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787072925,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-pro/1787071607-5ccea88a.json
+++ b/llmfit-core/data/community/apple-m3-pro/1787071607-5ccea88a.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "macos",
+    "ramGb": 36.0,
+    "unifiedMemory": true,
+    "vramGb": 36.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 167.0,
+      "avgTotalMs": 17292.97,
+      "avgTps": 5.09,
+      "avgTtftMs": 217.56,
+      "maxTps": 13.3,
+      "minTps": 0.27,
+      "model": "qwen2.5-coder:14b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787072925,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-pro/1787071869-3826a7a0.json
+++ b/llmfit-core/data/community/apple-m3-pro/1787071869-3826a7a0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "macos",
+    "ramGb": 36.0,
+    "unifiedMemory": true,
+    "vramGb": 36.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 182.0,
+      "avgTotalMs": 12457.15,
+      "avgTps": 15.05,
+      "avgTtftMs": 216.8,
+      "maxTps": 15.15,
+      "minTps": 14.98,
+      "model": "qwen2.5-coder:14b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787072925,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen3:8b | ollama | 24.6 | 119.9 |
| qwen3.5:9b | ollama | 21.9 | 225.4 |
| qwen2.5-coder:14b | ollama | 0.1 | 1006.2 |
| qwen2.5-coder:14b | ollama | 5.1 | 217.6 |
| qwen2.5-coder:14b | ollama | 15.1 | 216.8 |

_Submitted without the `gh` CLI via the GitHub device flow._
