### PR TITLE
bench: community results for amd-radeon-rx-6800

### DIFF
--- a/llmfit-core/data/community/amd-radeon-rx-6800/1787148179-236ae802.json
+++ b/llmfit-core/data/community/amd-radeon-rx-6800/1787148179-236ae802.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 5800X 8-Core Processor",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "AMD Radeon RX 6800",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "windows",
+    "ramGb": 31.93,
+    "unifiedMemory": false,
+    "vramGb": 16.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 245.33,
+      "avgTotalMs": 3320.1,
+      "avgTps": 80.44,
+      "avgTtftMs": 82.9,
+      "maxTps": 81.17,
+      "minTps": 79.95,
+      "model": "deepseek-r1:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787148179,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/amd-radeon-rx-6800/1787228004-51452456.json
+++ b/llmfit-core/data/community/amd-radeon-rx-6800/1787228004-51452456.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 5800X 8-Core Processor",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "AMD Radeon RX 6800",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "windows",
+    "ramGb": 31.93,
+    "unifiedMemory": false,
+    "vramGb": 16.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 6389.27,
+      "avgTps": 49.47,
+      "avgTtftMs": 145.03,
+      "maxTps": 49.64,
+      "minTps": 49.37,
+      "model": "deepseek-r1:14B",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787228004,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| deepseek-r1:latest | ollama | 80.4 | 82.9 |

_Submitted without the `gh` CLI via the GitHub device flow._
