### PR TITLE
bench: community results for intel-arc-graphics-130v-140v-integrated

### DIFF
--- a/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1787215420-9250955b.json
+++ b/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1787215420-9250955b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) Ultra 7 258V",
+    "cpuCores": 8,
+    "gpuCount": 1,
+    "hardwareName": "Intel Arc Graphics 130V/140V (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 30.83,
+    "unifiedMemory": true,
+    "vramGb": 30.83
+  },
+  "results": [
+    {
+      "avgOutputTokens": 188.0,
+      "avgTotalMs": 7219.43,
+      "avgTps": 27.86,
+      "avgTtftMs": 214.24,
+      "maxTps": 28.84,
+      "minTps": 27.19,
+      "model": "llama3.2:1b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787215420,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1787303582-0e345a84.json
+++ b/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1787303582-0e345a84.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) Ultra 7 258V",
+    "cpuCores": 8,
+    "gpuCount": 1,
+    "hardwareName": "Intel Arc Graphics 130V/140V (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 30.83,
+    "unifiedMemory": true,
+    "vramGb": 30.83
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 46311.4,
+      "avgTps": 6.7,
+      "avgTtftMs": 1302.83,
+      "maxTps": 6.98,
+      "minTps": 6.49,
+      "model": "deepseek-r1:7b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787303582,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1787303941-f5edf0aa.json
+++ b/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1787303941-f5edf0aa.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) Ultra 7 258V",
+    "cpuCores": 8,
+    "gpuCount": 1,
+    "hardwareName": "Intel Arc Graphics 130V/140V (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 30.83,
+    "unifiedMemory": true,
+    "vramGb": 30.83
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 46568.96,
+      "avgTps": 6.67,
+      "avgTtftMs": 1303.03,
+      "maxTps": 7.09,
+      "minTps": 6.15,
+      "model": "deepseek-r1:7b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787303941,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1787304662-be8c30da.json
+++ b/llmfit-core/data/community/intel-arc-graphics-130v-140v-integrated/1787304662-be8c30da.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) Ultra 7 258V",
+    "cpuCores": 8,
+    "gpuCount": 1,
+    "hardwareName": "Intel Arc Graphics 130V/140V (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 30.83,
+    "unifiedMemory": true,
+    "vramGb": 30.83
+  },
+  "results": [
+    {
+      "avgOutputTokens": 275.0,
+      "avgTotalMs": 26511.3,
+      "avgTps": 10.37,
+      "avgTtftMs": null,
+      "maxTps": 10.4,
+      "minTps": 10.31,
+      "model": "Qwen3.5-9B-Claude-4.6-Opus-Reasoning-Distilled-v2.Q8_0.gguf",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787304662,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| llama3.2:1b | ollama | 27.9 | 214.2 |

_Submitted without the `gh` CLI via the GitHub device flow._
