### PR TITLE
bench: community results for amd-ati

### DIFF
--- a/llmfit-core/data/community/amd-ati/1787414658-e8b526e8.json
+++ b/llmfit-core/data/community/amd-ati/1787414658-e8b526e8.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 7730U with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "AMD/ATI",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 2,
+    "os": "linux",
+    "ramGb": 30.74,
+    "unifiedMemory": false,
+    "vramGb": 0.5
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 39906.31,
+      "avgTps": 7.86,
+      "avgTtftMs": 1064.92,
+      "maxTps": 7.87,
+      "minTps": 7.83,
+      "model": "qwen3.5:9b-q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787414658,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/amd-ati/1787414905-8f06b380.json
+++ b/llmfit-core/data/community/amd-ati/1787414905-8f06b380.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 7730U with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "AMD/ATI",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 2,
+    "os": "linux",
+    "ramGb": 30.74,
+    "unifiedMemory": false,
+    "vramGb": 0.5
+  },
+  "results": [
+    {
+      "avgOutputTokens": 292.33,
+      "avgTotalMs": 35579.51,
+      "avgTps": 8.41,
+      "avgTtftMs": 616.5,
+      "maxTps": 8.41,
+      "minTps": 8.41,
+      "model": "qwen3:8b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787414905,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/amd-ati/1787415809-b0c428aa.json
+++ b/llmfit-core/data/community/amd-ati/1787415809-b0c428aa.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 7730U with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "AMD/ATI",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 2,
+    "os": "linux",
+    "ramGb": 30.74,
+    "unifiedMemory": false,
+    "vramGb": 0.5
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 40066.22,
+      "avgTps": 7.83,
+      "avgTtftMs": 1071.95,
+      "maxTps": 7.83,
+      "minTps": 7.82,
+      "model": "qwen3.5:9b-q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787415809,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen3.5:9b-q4_K_M | ollama | 7.9 | 1064.9 |

_Submitted without the `gh` CLI via the GitHub device flow._
