### PR TITLE
docs: place --memory before the recommend subcommand in Termux/Android examples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -898,7 +898,7 @@ llmfit のデータベースは HuggingFace のモデル名（例: `Qwen/Qwen2.5
 
 ```sh
 llmfit --memory=8G fit -n 20
-llmfit recommend --json --memory=8G --limit 10
+llmfit --memory=8G recommend --json --limit 10
 ```
 
 これは推奨/スコアリングのみのための回避策であり、真の Android GPU ランタイム検出を提供するものではありません。

--- a/README.zh.md
+++ b/README.zh.md
@@ -907,7 +907,7 @@ llmfit 的数据库使用 HuggingFace 模型名称（例如 `Qwen/Qwen2.5-Coder-
 
 ```sh
 llmfit --memory=8G fit -n 20
-llmfit recommend --json --memory=8G --limit 10
+llmfit --memory=8G recommend --json --limit 10
 ```
 
 这仅是推荐/评分的变通方案；不提供真正的 Android GPU 运行时检测。

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -31,7 +31,7 @@ If you still want GPU-style recommendations on a unified-memory phone or tablet,
 
 ```sh
 llmfit --memory=8G fit -n 20
-llmfit recommend --json --memory=8G --limit 10
+llmfit --memory=8G recommend --json --limit 10
 ```
 
 This is a workaround for recommendation/scoring only; it does not provide true Android GPU runtime detection.


### PR DESCRIPTION
## What & why

Fixes #932.

The Termux/Android "manual memory override" example places the global `--memory` flag *after* the `recommend` subcommand, so the documented command fails immediately:

```sh
llmfit recommend --json --memory=8G --limit 10
# → error: unexpected argument '--memory' found   (exit 2)
``"

`--memory` is a root-level flag and must appear *before* the subcommand — as the sibling `fit` line in the same code block already shows (`llmfit --memory=8G fit -n 20`).

## Changes

Update the identical example to the flag-first form in all three files that share the same copy:

- `docs/platform-support.md`
- `README.zh.md`
- `README.ja.md`

```diff
-llmfit recommend --json --memory=8G --limit 10
+llmfit --memory=8G recommend --json --limit 10
```

Verified the failure reproduces on `main` with the current `recommend` form and that the flag-first form succeeds. Docs-only change, no code or tests affected.