### PR TITLE
feat(mcp): report catalog provenance to external model consumers

### DIFF
--- a/API.md
+++ b/API.md
@@ -337,6 +337,54 @@ Add to your MCP client config (e.g. `claude_desktop_config.json`):
 | `get_runtimes` | Installed inference runtimes | None |
 | `get_installed_models` | Models in local runtimes | None |
 
+`recommend_models` and `search_models` return a `catalog` block alongside their
+results (see [Catalog provenance](#catalog-provenance)). Their descriptions ask
+the calling agent to recommend only models present in the response and to keep
+`measured_tps` and `estimated_tps` distinct — llmfit cannot enforce this the way
+an in-process check could, but it can state the contract where the model reads
+it.
+
+---
+
+## Catalog provenance
+
+Every response that returns a model list — CLI `--json`, the HTTP API, and the
+MCP model tools — carries a `catalog` block describing the list it was computed
+from:
+
+```json
+{
+  "catalog": {
+    "catalog_models": 1247,
+    "llmfit_version": "1.1.10",
+    "embedded_catalog_pinned_to_build": true,
+    "update_cache_present": true,
+    "update_cache_models": 63,
+    "update_cache_updated_unix_s": 1755950000,
+    "update_cache_age_days": 3,
+    "is_live_registry_view": false,
+    "note": "Snapshot, not a live registry view. ..."
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `catalog_models` | Size of the catalog the response was computed from. Named apart from the surrounding `total_models`, which counts models matching the query |
+| `llmfit_version` | Build the embedded catalog is pinned to |
+| `embedded_catalog_pinned_to_build` | Always `true`; the embedded list is fixed at compile time |
+| `update_cache_present` | Whether `llmfit update` has written a readable cache |
+| `update_cache_models` | Models held in that cache. `0` for a corrupt or schema-stale file that is nonetheless present |
+| `update_cache_updated_unix_s` | Last successful `llmfit update`, or `null` |
+| `update_cache_age_days` | Whole days since that update, or `null` when unknown. A cache dated in the future reports `null` rather than `0`, so clock skew cannot make a stale catalog look fresh |
+| `is_live_registry_view` | Always `false` |
+
+llmfit answers from a snapshot: the compile-time embedded list, overlaid with
+user custom models, plus models appended by `llmfit update`. The update cache
+only adds models llmfit did not already know — it never refreshes metadata for
+an embedded entry. A consumer that wants to describe the catalog honestly needs
+both facts, which is why they are reported rather than implied.
+
 ---
 
 ## NATS Event Publishing

--- a/llmfit-core/src/update.rs
+++ b/llmfit-core/src/update.rs
@@ -90,6 +90,73 @@ pub fn save_cache(models: &[LlmModel]) -> Result<(), String> {
     Ok(())
 }
 
+/// Provenance of the update cache that `ModelDatabase::new()` merges in.
+///
+/// The runtime catalog is always a snapshot: the compile-time embedded list,
+/// overlaid with user custom models, plus any models `llmfit update` has
+/// appended. It is never a live view of an external registry, and the update
+/// cache only *adds* models it does not already know — it never refreshes the
+/// metadata of an embedded entry. Consumers that present the catalog to a user
+/// need both facts to describe it honestly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CacheStatus {
+    /// Whether a cache file written by `llmfit update` is present and readable.
+    pub present: bool,
+    /// Models held in the cache. Zero when absent, corrupt, or schema-stale.
+    pub model_count: usize,
+    /// Unix seconds of the last successful `llmfit update`, when known.
+    ///
+    /// `None` if no cache exists, or if the platform did not report a
+    /// modification time.
+    pub updated_unix_s: Option<u64>,
+}
+
+impl CacheStatus {
+    /// Whole days since the last successful `llmfit update`.
+    ///
+    /// `None` when the timestamp is unknown or lies in the future (clock skew
+    /// or a restored file); a negative age is not reported as zero, because
+    /// "unknown" is the honest answer.
+    pub fn age_days(&self, now_unix_s: u64) -> Option<u64> {
+        let updated = self.updated_unix_s?;
+        now_unix_s
+            .checked_sub(updated)
+            .map(|elapsed| elapsed / 86_400)
+    }
+}
+
+/// Inspect the update cache without loading the models into memory.
+pub fn cache_status() -> CacheStatus {
+    let Some(path) = cache_file() else {
+        return CacheStatus {
+            present: false,
+            model_count: 0,
+            updated_unix_s: None,
+        };
+    };
+    let Ok(metadata) = std::fs::metadata(&path) else {
+        return CacheStatus {
+            present: false,
+            model_count: 0,
+            updated_unix_s: None,
+        };
+    };
+    let updated_unix_s = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|elapsed| elapsed.as_secs());
+
+    // load_cache() returns an empty vec for a corrupt or schema-stale file, so
+    // a present-but-unusable cache is reported as present with zero models
+    // rather than being hidden.
+    CacheStatus {
+        present: true,
+        model_count: load_cache().len(),
+        updated_unix_s,
+    }
+}
+
 /// Delete the cache file.  Returns the number of models that were removed.
 pub fn clear_cache() -> Result<usize, String> {
     let path = match cache_file() {
@@ -831,6 +898,42 @@ pub fn update_model_cache(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_age_is_whole_days_since_the_last_update() {
+        let status = CacheStatus {
+            present: true,
+            model_count: 12,
+            updated_unix_s: Some(1_000_000),
+        };
+        // Just under two days later still reads as one full day elapsed.
+        assert_eq!(status.age_days(1_000_000 + 86_400 * 2 - 1), Some(1));
+        assert_eq!(status.age_days(1_000_000 + 86_400 * 2), Some(2));
+        assert_eq!(status.age_days(1_000_000), Some(0));
+    }
+
+    #[test]
+    fn cache_age_is_unknown_rather_than_zero_when_the_clock_disagrees() {
+        // A cache file dated in the future (clock skew, restored backup) must
+        // not be reported as freshly updated — callers would present a stale
+        // catalog as current.
+        let status = CacheStatus {
+            present: true,
+            model_count: 12,
+            updated_unix_s: Some(2_000_000),
+        };
+        assert_eq!(status.age_days(1_000_000), None);
+    }
+
+    #[test]
+    fn cache_age_is_unknown_without_a_timestamp() {
+        let status = CacheStatus {
+            present: false,
+            model_count: 0,
+            updated_unix_s: None,
+        };
+        assert_eq!(status.age_days(1_000_000), None);
+    }
 
     #[test]
     fn test_parse_param_str_billions() {

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -500,11 +500,15 @@ pub fn display_json_system(specs: &SystemSpecs) {
 }
 
 /// Serialize system specs + model fits to JSON and print to stdout.
-pub fn display_json_fits(specs: &SystemSpecs, fits: &[ModelFit]) {
+///
+/// `catalog_models` is the number of models llmfit knows about, so consumers of
+/// `--json` can tell how old and how complete the list behind these fits is.
+pub fn display_json_fits(specs: &SystemSpecs, fits: &[ModelFit], catalog_models: usize) {
     let models: Vec<serde_json::Value> = fits.iter().map(fit_to_json).collect();
     let output = serde_json::json!({
         "system": system_json(specs),
         "models": models,
+        "catalog": crate::serve_shared::catalog_json(catalog_models),
     });
     println!(
         "{}",
@@ -513,7 +517,11 @@ pub fn display_json_fits(specs: &SystemSpecs, fits: &[ModelFit]) {
 }
 
 /// Serialize system specs + model fits to JSON with llama.cpp commands and print to stdout.
-pub fn display_json_fits_with_llamacpp(specs: &SystemSpecs, fits: &[ModelFit]) {
+pub fn display_json_fits_with_llamacpp(
+    specs: &SystemSpecs,
+    fits: &[ModelFit],
+    catalog_models: usize,
+) {
     use llmfit_core::fit::InferenceRuntime;
 
     let models: Vec<serde_json::Value> = fits
@@ -538,6 +546,7 @@ pub fn display_json_fits_with_llamacpp(specs: &SystemSpecs, fits: &[ModelFit]) {
     let output = serde_json::json!({
         "system": system_json(specs),
         "models": models,
+        "catalog": crate::serve_shared::catalog_json(catalog_models),
     });
     println!(
         "{}",

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1130,7 +1130,7 @@ fn run_fit(
     if csv {
         display::display_csv_fits(&fits);
     } else if json {
-        display::display_json_fits(&specs, &fits);
+        display::display_json_fits(&specs, &fits, db.get_all_models().len());
     } else {
         if hidden > 0 {
             eprintln!(
@@ -1526,9 +1526,9 @@ fn run_recommend(
         display::display_csv_fits(&fits);
     } else if json {
         if output_llamacpp {
-            display::display_json_fits_with_llamacpp(&specs, &fits);
+            display::display_json_fits_with_llamacpp(&specs, &fits, db.get_all_models().len());
         } else {
-            display::display_json_fits(&specs, &fits);
+            display::display_json_fits(&specs, &fits, db.get_all_models().len());
         }
     } else {
         if !fits.is_empty() {
@@ -2941,7 +2941,7 @@ fn main() {
                     &fit.best_quant,
                 );
                 if cli.json {
-                    display::display_json_fits(&specs, &[fit]);
+                    display::display_json_fits(&specs, &[fit], models.len());
                 } else {
                     display::display_model_detail(&fit);
                 }

--- a/llmfit-tui/src/mcp_server.rs
+++ b/llmfit-tui/src/mcp_server.rs
@@ -115,7 +115,14 @@ impl LlmfitMcpServer {
     /// Recommend LLM models that fit this system's hardware
     #[tool(
         name = "recommend_models",
-        description = "Recommend LLM models that fit this system's hardware, with optional filtering by use case, fit level, runtime, and license"
+        description = "Recommend LLM models that fit this system's hardware, with \
+optional filtering by use case, fit level, runtime, and license. The returned \
+`models` array is the complete set of valid recommendations for this call: name \
+only models that appear in it, and do not substitute a model, quantization, or \
+runtime that is absent from the response. `measured_tps` is observed evidence; \
+`estimated_tps` is a single-request generation estimate, not a benchmark result \
+— keep the two distinct when reporting speed. The `catalog` block states how old \
+this model list is; do not describe it as a live or globally current registry."
     )]
     async fn recommend_models(&self, params: Parameters<RecommendModelsParams>) -> String {
         let params = params.0;
@@ -153,6 +160,7 @@ impl LlmfitMcpServer {
             "total_models": total,
             "returned_models": ranked.len(),
             "models": ranked.iter().map(serve_shared::fit_to_json).collect::<Vec<_>>(),
+            "catalog": serve_shared::catalog_json(self.models.len()),
         });
         serde_json::to_string_pretty(&result).unwrap_or_default()
     }
@@ -160,7 +168,11 @@ impl LlmfitMcpServer {
     /// Search for models by name, provider, or use case
     #[tool(
         name = "search_models",
-        description = "Search for LLM models by name, provider, or use case"
+        description = "Search for LLM models by name, provider, or use case. \
+Matches are limited to models llmfit knows about and that fit this hardware; an \
+empty result means llmfit has no such model, not that one does not exist. Name \
+only models present in the returned `models` array, and read `catalog` before \
+describing how current the list is."
     )]
     async fn search_models(&self, params: Parameters<SearchModelsParams>) -> String {
         let params = params.0;
@@ -189,6 +201,7 @@ impl LlmfitMcpServer {
             "total_matches": total,
             "returned_models": ranked.len(),
             "models": ranked.iter().map(serve_shared::fit_to_json).collect::<Vec<_>>(),
+            "catalog": serve_shared::catalog_json(self.models.len()),
         });
         serde_json::to_string_pretty(&result).unwrap_or_default()
     }
@@ -465,6 +478,51 @@ mod tests {
             None,
             "test-node".to_string(),
         )
+    }
+
+    /// Every model list an agent receives must carry its own provenance, or the
+    /// agent has no way to tell a catalog refreshed today from one frozen at
+    /// build time — and will present either as current.
+    #[test]
+    fn model_listing_tools_carry_catalog_provenance() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should build");
+
+        let recommended = runtime.block_on(test_server().recommend_models(Parameters(
+            RecommendModelsParams {
+                limit: Some(3),
+                use_case: None,
+                min_fit: None,
+                runtime: None,
+                license: None,
+                sort: None,
+            },
+        )));
+        let value: Value =
+            serde_json::from_str(&recommended).expect("recommend output should be JSON");
+        let catalog = value
+            .get("catalog")
+            .expect("recommend_models should report catalog provenance");
+        assert_eq!(catalog["is_live_registry_view"], false);
+        assert!(
+            catalog["catalog_models"].as_u64().unwrap_or(0) > 0,
+            "catalog size should be reported"
+        );
+
+        let searched =
+            runtime.block_on(test_server().search_models(Parameters(SearchModelsParams {
+                query: "llama".to_string(),
+                limit: Some(3),
+            })));
+        let value: Value = serde_json::from_str(&searched).expect("search output should be JSON");
+        assert_eq!(
+            value
+                .get("catalog")
+                .expect("search_models should report catalog provenance")["is_live_registry_view"],
+            false
+        );
     }
 
     #[test]

--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -99,6 +99,8 @@ struct ApiEnvelope {
     returned_models: usize,
     filters: serde_json::Value,
     models: Vec<serde_json::Value>,
+    /// Age and origin of the model list these results were computed from.
+    catalog: serde_json::Value,
 }
 
 #[derive(Debug)]
@@ -351,6 +353,7 @@ async fn models(
         returned_models: fits.len(),
         filters: active_filters_json(&query, false),
         models: fits.iter().map(fit_to_json).collect(),
+        catalog: serve_shared::catalog_json(state.models.len()),
     };
 
     Ok(Json(envelope))
@@ -379,6 +382,7 @@ async fn top_models(
         returned_models: fits.len(),
         filters: active_filters_json(&query, true),
         models: fits.iter().map(fit_to_json).collect(),
+        catalog: serve_shared::catalog_json(state.models.len()),
     };
 
     Ok(Json(envelope))
@@ -411,6 +415,7 @@ async fn model_by_name(
         returned_models: fits.len(),
         filters: active_filters_json(&scoped, false),
         models: fits.iter().map(fit_to_json).collect(),
+        catalog: serve_shared::catalog_json(state.models.len()),
     };
 
     Ok(Json(envelope))

--- a/llmfit-tui/src/serve_shared.rs
+++ b/llmfit-tui/src/serve_shared.rs
@@ -1,5 +1,51 @@
 use llmfit_core::fit::{FitLevel, InferenceRuntime, ModelFit, RunMode};
 use llmfit_core::hardware::SystemSpecs;
+use llmfit_core::update::{CacheStatus, cache_status};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Describes where the model list a response was computed from came from, and
+/// how old it is.
+///
+/// Every llmfit surface answers from a snapshot, never from a live registry.
+/// Without this block a consumer — a dashboard, an agent reading the MCP tools,
+/// a script — cannot tell a catalog refreshed an hour ago from one frozen at
+/// build time, and will tend to present either as current.
+///
+/// `catalog_models` is the size of the catalog the response was computed from,
+/// so it reflects custom models and cache merging as the caller saw them. It is
+/// deliberately named apart from the `total_models` that surfaces already use
+/// for "models matching this query".
+pub fn catalog_json(catalog_models: usize) -> serde_json::Value {
+    catalog_json_at(catalog_models, cache_status(), unix_now_s())
+}
+
+fn unix_now_s() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0)
+}
+
+fn catalog_json_at(
+    catalog_models: usize,
+    status: CacheStatus,
+    now_unix_s: u64,
+) -> serde_json::Value {
+    serde_json::json!({
+        "catalog_models": catalog_models,
+        "llmfit_version": env!("CARGO_PKG_VERSION"),
+        "embedded_catalog_pinned_to_build": true,
+        "update_cache_present": status.present,
+        "update_cache_models": status.model_count,
+        "update_cache_updated_unix_s": status.updated_unix_s,
+        "update_cache_age_days": status.age_days(now_unix_s),
+        "is_live_registry_view": false,
+        "note": "Snapshot, not a live registry view. The catalog is the \
+    build-time embedded list plus user custom models plus models appended by \
+    `llmfit update`; the update cache never refreshes metadata for models that \
+    are already embedded. Run `llmfit update` to append newly released models.",
+    })
+}
 
 pub fn system_json(specs: &SystemSpecs) -> serde_json::Value {
     let gpus_json: Vec<serde_json::Value> = specs
@@ -144,6 +190,58 @@ pub fn round2(v: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn catalog_block_reports_a_fresh_update_cache() {
+        let status = CacheStatus {
+            present: true,
+            model_count: 40,
+            updated_unix_s: Some(1_000_000),
+        };
+        let json = catalog_json_at(1200, status, 1_000_000 + 86_400 * 3);
+
+        assert_eq!(json["catalog_models"], 1200);
+        assert_eq!(json["update_cache_present"], true);
+        assert_eq!(json["update_cache_models"], 40);
+        assert_eq!(json["update_cache_updated_unix_s"], 1_000_000);
+        assert_eq!(json["update_cache_age_days"], 3);
+        assert_eq!(json["is_live_registry_view"], false);
+    }
+
+    #[test]
+    fn catalog_block_reports_a_build_time_only_catalog() {
+        let status = CacheStatus {
+            present: false,
+            model_count: 0,
+            updated_unix_s: None,
+        };
+        let json = catalog_json_at(1200, status, 1_000_000);
+
+        assert_eq!(json["update_cache_present"], false);
+        assert_eq!(json["update_cache_models"], 0);
+        // Absent rather than a misleading 0 — `llmfit update` has never run.
+        assert!(json["update_cache_updated_unix_s"].is_null());
+        assert!(json["update_cache_age_days"].is_null());
+        assert_eq!(json["embedded_catalog_pinned_to_build"], true);
+    }
+
+    #[test]
+    fn catalog_block_never_claims_to_be_a_live_registry() {
+        let json = catalog_json(0);
+        assert_eq!(json["is_live_registry_view"], false);
+        let note = json["note"].as_str().expect("note is a string");
+        assert!(note.contains("Snapshot"), "note should name it a snapshot");
+        assert!(
+            note.contains("llmfit update"),
+            "note should say how to refresh"
+        );
+    }
+
+    #[test]
+    fn catalog_block_carries_the_llmfit_version() {
+        let json = catalog_json(0);
+        assert_eq!(json["llmfit_version"], env!("CARGO_PKG_VERSION"));
+    }
     use llmfit_core::hardware::{GpuBackend, GpuInfo};
 
     fn specs_with_gpu(name: &str) -> SystemSpecs {

--- a/skills/llmfit-advisor/SKILL.md
+++ b/skills/llmfit-advisor/SKILL.md
@@ -132,6 +132,65 @@ Each model in the `models` array includes:
 | `utilization_pct` | How much of available memory the model uses |
 | `use_case` | What the model is designed for |
 | `context_length` | Maximum context window |
+| `measured_tps` | Observed throughput, when a benchmark exists for this machine or an equivalent one. Absent when nothing has been measured |
+| `estimate_basis` | How `estimated_tps` was derived, including the method used |
+| `installed` | Whether the model is already present in a local runtime |
+
+`estimated_tps` and `measured_tps` are not interchangeable. `estimated_tps` is a
+single-request generation estimate derived from memory bandwidth and model
+shape; `measured_tps` is a number someone actually observed. Report an estimate
+as an estimate, and prefer the measured value when both are present.
+
+### Catalog freshness
+
+Every response carries a `catalog` block describing the model list the answer was
+computed from:
+
+```json
+{
+  "catalog": {
+    "catalog_models": 1247,
+    "llmfit_version": "1.1.10",
+    "embedded_catalog_pinned_to_build": true,
+    "update_cache_present": true,
+    "update_cache_models": 63,
+    "update_cache_updated_unix_s": 1755950000,
+    "update_cache_age_days": 3,
+    "is_live_registry_view": false
+  }
+}
+```
+
+llmfit never answers from a live registry. The catalog is the list embedded when
+the binary was built, plus user custom models, plus models appended by
+`llmfit update`. Two consequences worth stating to the user rather than
+discovering later:
+
+- A model released after this llmfit build simply is not there. Absence from the
+  results is not evidence that a model does not exist. If the user asks about
+  something recent and it is missing, say so and suggest `llmfit update`.
+- The update cache only *appends* models llmfit did not already know. It never
+  refreshes metadata for an embedded entry, so a large `update_cache_age_days`
+  does not mean the embedded figures are correspondingly old — and a small one
+  does not mean they were rechecked.
+
+When `update_cache_present` is `false`, the catalog is exactly as old as the
+installed llmfit build. Mention that before framing a recommendation as current.
+
+### Rules for recommending
+
+These keep the recommendation traceable to what llmfit actually reported:
+
+1. **Recommend only from the returned results.** Do not name a model,
+   quantization, or runtime that is absent from the `models` array. If nothing
+   suitable came back, say that instead of substituting a model you know of.
+2. **Never present a `TooTight` model as workable.** It does not fit.
+3. **Keep measured and estimated throughput distinct**, as above.
+4. **Do not describe the catalog as current** without reading the `catalog`
+   block first.
+5. **Re-run llmfit when the question changes.** Do not carry an earlier result
+   into a new set of constraints — filters, use case, and context limit all
+   change which models qualify.
 
 ### Fit levels explained
 


### PR DESCRIPTION
## What

Adds catalog provenance to llmfit's machine-readable output: a `catalog` block that states what the model list actually is, how old it is, and — explicitly — that it is not a live registry view.

```json
"catalog": {
  "catalog_models": 11271,
  "llmfit_version": "1.1.10",
  "embedded_catalog_pinned_to_build": true,
  "update_cache_present": false,
  "update_cache_models": 0,
  "update_cache_updated_unix_s": null,
  "update_cache_age_days": null,
  "is_live_registry_view": false,
  "note": "Snapshot, not a live registry view. The catalog is the build-time embedded list plus user custom models plus models appended by `llmfit update`; the update cache never refreshes metadata for models that are already embedded. Run `llmfit update` to append newly released models."
}
```

It is emitted once per response envelope, not per model, because freshness is a property of the catalog rather than of any single entry. All three surfaces get it from one place (`serve_shared::catalog_json`): CLI `--json`, the HTTP API, and the MCP tools.

The MCP tool descriptions are also rewritten to carry a grounding contract — name only models present in the response, keep `measured_tps` and `estimated_tps` distinct, read `catalog` before calling the list current, and treat an empty search result as "llmfit has no such model" rather than "no such model exists".

## Why

llmfit already ships `skills/llmfit-advisor/SKILL.md`, so "an external LLM reads llmfit's JSON and advises the user" is an established pattern in this repo. The problem is that the JSON never says how old the catalog is, and a model asked "is this list current?" will not answer "unknown" — it will fill the gap.

That is not a hypothetical. I built upstream `6a2e660` in a throwaway worktree and ran the same prompts through the same local model at the same temperature against both builds. The upstream build produced:

> "The catalog is served by the backend that powers these tools, and it is refreshed periodically (not in real time)."

There is no backend, and nothing refreshes — the update cache is append-only and never revises metadata for models that are already embedded. Every clause is invented. The patched build reported the actual state instead: build-time embedded catalog, no update cache present, age unknown because `llmfit update` had never run.

The fix is not a better prompt. It is that the payload contained no ground truth for the question, so the only difference between a grounded answer and a fabricated one was luck.

## Relationship to #935

This is deliberately the opposite design. #935 put an inference client inside llmfit; the objection there was the trust boundary, and it was a fair one. Here llmfit stays what it is — a local measurement and catalog tool — and does nothing but describe its own evidence more honestly. No outbound network, no new runtime dependencies, no inference in-process. Whatever model consumes this runs entirely on the user's side of the boundary, via MCP or via the existing skill.

## Implementation notes

- `update::cache_status()` reports presence, model count and mtime of the update cache; `CacheStatus::age_days()` derives the age.
- Age uses `checked_sub`, so a future-dated cache file yields `None` rather than `0`. Clock skew must not be able to make a stale catalog look fresh.
- A catalog with no update cache reports `null` for age and timestamp, not `0` — "unknown" and "zero days old" are different claims and a consumer must be able to tell them apart.
- `total_models` (models matching this query) and `catalog_models` (models llmfit knows about) are kept as separate names; they genuinely differ — 8970 vs 11271 in a live run here.
- `API.md` documents the block field by field; `skills/llmfit-advisor/SKILL.md` gains a catalog-freshness section so the existing skill path benefits too.

## Tests

8 new tests: cache age in whole days, age unknown on clock skew, age unknown without a timestamp, fresh-cache reporting, build-time-only catalog reporting nulls rather than zeros, never claiming a live view, version passthrough, and MCP tools carrying the catalog block.

One pre-existing failure is unrelated to this change: `tui_app::tests::changing_search_query_resets_selection_to_top` fails on my machine on clean `6a2e660` as well (verified by stashing). It appears hardware-dependent. I have deliberately not touched it.
