### PR TITLE
fix: use trendingScore when searching the HF Hub for GGUF repos

### DIFF
--- a/llmfit-core/src/providers.rs
+++ b/llmfit-core/src/providers.rs
@@ -900,6 +900,20 @@ impl Default for LlamaCppProvider {
     }
 }
 
+/// Build the HuggingFace Hub query used to search GGUF repositories.
+///
+/// The `sort` key must be a field name the Hub actually exposes:
+/// `sort=trending` is rejected with HTTP 400 (`Invalid sort parameter:
+/// trending`), which `search_hf_gguf` would silently turn into "no results".
+/// The trending rank lives in `trendingScore`, which is what
+/// `update::hf_get_list_for_pipeline` already sorts on.
+fn hf_gguf_search_url(query: &str) -> String {
+    format!(
+        "https://huggingface.co/api/models?library=gguf&search={}&sort=trendingScore&limit=20",
+        urlencoding::encode(query)
+    )
+}
+
 impl LlamaCppProvider {
     pub fn new() -> Self {
         Self::default()
@@ -995,10 +1009,7 @@ impl LlamaCppProvider {
     /// Search HuggingFace for GGUF repositories matching a query.
     /// Returns a list of (repo_id, description) tuples.
     pub fn search_hf_gguf(query: &str) -> Vec<(String, String)> {
-        let url = format!(
-            "https://huggingface.co/api/models?library=gguf&search={}&sort=trending&limit=20",
-            urlencoding::encode(query)
-        );
+        let url = hf_gguf_search_url(query);
         let Ok(resp) = ureq::get(&url)
             .config()
             .timeout_global(Some(std::time::Duration::from_secs(15)))
@@ -4393,6 +4404,25 @@ mod tests {
                     && !tag.ends_with(".gguf")
             );
         }
+    }
+
+    #[test]
+    fn test_hf_gguf_search_url_sorts_on_a_valid_hub_field() {
+        let url = hf_gguf_search_url("qwen3");
+        // `sort=trending` is not a Hub field: it answers HTTP 400 and
+        // search_hf_gguf then reports "no GGUF models found" for every query.
+        assert!(
+            url.contains("sort=trendingScore"),
+            "unexpected sort parameter in {url}"
+        );
+        assert!(!url.contains("sort=trending&"));
+        assert!(url.contains("library=gguf"));
+        assert!(url.contains("search=qwen3"));
+    }
+
+    #[test]
+    fn test_hf_gguf_search_url_encodes_the_query() {
+        assert!(hf_gguf_search_url("qwen 3/coder").contains("search=qwen%203%2Fcoder"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`hf-search` returns nothing for every query on v1.1.10:

```
$ llmfit hf-search qwen3
Searching HuggingFace for GGUF models matching 'qwen3'...

No GGUF models found. Try a different search term.
```

`LlamaCppProvider::search_hf_gguf` builds its query with `sort=trending`, which the Hub rejects:

```
$ curl -s "https://huggingface.co/api/models?library=gguf&search=qwen3&sort=trending&limit=3"
{"error":"✖ Invalid sort parameter: trending"}     # HTTP 400
```

The `let Ok(resp) = ureq::get(&url)...else { return Vec::new() }` swallows the 400 and the caller reports "no models found", so the failure looks like an empty catalog rather than a bad request.

## Fix

The trending rank is exposed as `trendingScore` — which `update::hf_get_list_for_pipeline` already sorts on, which is why `llmfit update` kept working while search did not. This switches `search_hf_gguf` to the same field and extracts the URL into `hf_gguf_search_url` so the query can be asserted without a network round-trip.

## Impact

All four `search_hf_gguf` callers were affected:

- `llmfit hf-search` (`llmfit-tui/src/main.rs:1888`)
- the TUI download flow (`llmfit-tui/src/main.rs:1581`, `:2904`)
- the llama.cpp provider's GGUF resolution fallback (`llmfit-core/src/providers.rs`)

## Verification

Built from source on Linux (Rust 1.97.1, `cargo build --release`), same binary before and after:

```
$ ./target/release/llmfit hf-search qwen3
Repository                                         Type
-----------------------------------------------------------------
Qwen/Qwen3.8-27B                                   image-text-to-text
unsloth/Qwen3.8-27B-GGUF                           model
orcarouter/Qwen3.8-27B-Uncensored-MLX              image-text-to-text
...
```

`cargo fmt --check` clean, `cargo test --workspace` green (666 passed, 0 failed) including the two new unit tests. `cargo clippy --all-targets` reports no new findings for the touched file.