### PR TITLE
bench: community results for apple-m3-max

### DIFF
--- a/llmfit-core/data/community/apple-m3-max/1787699128-65d3f56f.json
+++ b/llmfit-core/data/community/apple-m3-max/1787699128-65d3f56f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Max",
+    "cpuCores": 14,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Max",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "macos",
+    "ramGb": 36.0,
+    "unifiedMemory": true,
+    "vramGb": 36.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 76.0,
+      "avgTotalMs": 33879.91,
+      "avgTps": 34.25,
+      "avgTtftMs": 133.18,
+      "maxTps": 34.25,
+      "minTps": 34.25,
+      "model": "qwen3-coder:30b-32k",
+      "numRuns": 1,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787700406,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-max/1787700406-52d79e39.json
+++ b/llmfit-core/data/community/apple-m3-max/1787700406-52d79e39.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Max",
+    "cpuCores": 14,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Max",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "macos",
+    "ramGb": 36.0,
+    "unifiedMemory": true,
+    "vramGb": 36.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 185.0,
+      "avgTotalMs": 3167.18,
+      "avgTps": 66.07,
+      "avgTtftMs": 140.68,
+      "maxTps": 72.46,
+      "minTps": 61.98,
+      "model": "qwen3-coder:30b-32k",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787700406,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-max/1787738897-8370bd0e.json
+++ b/llmfit-core/data/community/apple-m3-max/1787738897-8370bd0e.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Max",
+    "cpuCores": 14,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Max",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "macos",
+    "ramGb": 36.0,
+    "unifiedMemory": true,
+    "vramGb": 36.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 270.0,
+      "avgTotalMs": 9254.06,
+      "avgTps": 29.11,
+      "avgTtftMs": null,
+      "maxTps": 29.96,
+      "minTps": 28.42,
+      "model": "lmstudio-community/DeepSeek-R1-0528-Qwen3-8B-MLX-8bit",
+      "numRuns": 3,
+      "provider": "mlx"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787738897,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.10"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen3-coder:30b-32k | ollama | 34.2 | 133.2 |
| qwen3-coder:30b-32k | ollama | 66.1 | 140.7 |

_Submitted without the `gh` CLI via the GitHub device flow._
