### PR TITLE
bench: community results for radeon-rx-9060-xt

### DIFF
--- a/llmfit-core/data/community/amd-radeon-rx-9060-xt/1787953827-a95905cc.json
+++ b/llmfit-core/data/community/amd-radeon-rx-9060-xt/1787953827-a95905cc.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 5500GT with Radeon Graphics",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "AMD Radeon RX 9060 XT",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 74.5,
+    "unifiedMemory": false,
+    "vramGb": 15.92
+  },
+  "results": [
+    {
+      "avgOutputTokens": 195.33,
+      "avgTotalMs": 3780.73,
+      "avgTps": 49.38,
+      "avgTtftMs": null,
+      "maxTps": 52.28,
+      "minTps": 43.78,
+      "model": "Qwen2.5-Coder-3B-Instruct-Q8_0",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787953827,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/amd-radeon-rx-9060-xt/1787954130-762d9978.json
+++ b/llmfit-core/data/community/amd-radeon-rx-9060-xt/1787954130-762d9978.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 5500GT with Radeon Graphics",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "AMD Radeon RX 9060 XT",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 74.5,
+    "unifiedMemory": false,
+    "vramGb": 15.92
+  },
+  "results": [
+    {
+      "avgOutputTokens": 231.33,
+      "avgTotalMs": 2711.03,
+      "avgTps": 83.14,
+      "avgTtftMs": null,
+      "maxTps": 87.35,
+      "minTps": 74.97,
+      "model": "DeepSeek-Coder-V2-Lite-Instruct-Q4_K_M",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787954130,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/amd-radeon-rx-9060-xt/1787954274-9d8b0472.json
+++ b/llmfit-core/data/community/amd-radeon-rx-9060-xt/1787954274-9d8b0472.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 5500GT with Radeon Graphics",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "AMD Radeon RX 9060 XT",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 74.5,
+    "unifiedMemory": false,
+    "vramGb": 15.92
+  },
+  "results": [
+    {
+      "avgOutputTokens": 191.0,
+      "avgTotalMs": 4292.99,
+      "avgTps": 43.35,
+      "avgTtftMs": null,
+      "maxTps": 45.16,
+      "minTps": 40.17,
+      "model": "Qwen2.5-Coder-7B-Instruct-Q6_K",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787954274,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/radeon-rx-9060-xt/1787688387-2650432a.json
+++ b/llmfit-core/data/community/radeon-rx-9060-xt/1787688387-2650432a.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 5500GT with Radeon Graphics",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Radeon RX 9060 XT",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 74.5,
+    "unifiedMemory": false,
+    "vramGb": 15.92
+  },
+  "results": [
+    {
+      "avgOutputTokens": 204.0,
+      "avgTotalMs": 2982.18,
+      "avgTps": 66.1,
+      "avgTtftMs": null,
+      "maxTps": 69.56,
+      "minTps": 59.57,
+      "model": "Qwen2.5-Coder-3B-Instruct-Q8_0",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787953827,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.11"
+  }
+}

--- a/llmfit-core/data/community/radeon-rx-9060-xt/1787688457-624b1d89.json
+++ b/llmfit-core/data/community/radeon-rx-9060-xt/1787688457-624b1d89.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 5500GT with Radeon Graphics",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Radeon RX 9060 XT",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 74.5,
+    "unifiedMemory": false,
+    "vramGb": 15.92
+  },
+  "results": [
+    {
+      "avgOutputTokens": 205.67,
+      "avgTotalMs": 4547.58,
+      "avgTps": 43.9,
+      "avgTtftMs": null,
+      "maxTps": 45.8,
+      "minTps": 40.21,
+      "model": "Qwen2.5-Coder-7B-Instruct-Q6_K",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787953827,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.11"
+  }
+}

--- a/llmfit-core/data/community/radeon-rx-9060-xt/1787688507-be1c9a39.json
+++ b/llmfit-core/data/community/radeon-rx-9060-xt/1787688507-be1c9a39.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 5500GT with Radeon Graphics",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Radeon RX 9060 XT",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 74.5,
+    "unifiedMemory": false,
+    "vramGb": 15.92
+  },
+  "results": [
+    {
+      "avgOutputTokens": 172.33,
+      "avgTotalMs": 1606.5,
+      "avgTps": 101.16,
+      "avgTtftMs": null,
+      "maxTps": 111.53,
+      "minTps": 80.43,
+      "model": "GigaChat3.1-10B-A1.8B-Q4_K_M",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787953827,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.11"
+  }
+}

--- a/llmfit-core/data/community/radeon-rx-9060-xt/1787688549-bf4cf917.json
+++ b/llmfit-core/data/community/radeon-rx-9060-xt/1787688549-bf4cf917.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 5500GT with Radeon Graphics",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Radeon RX 9060 XT",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 74.5,
+    "unifiedMemory": false,
+    "vramGb": 15.92
+  },
+  "results": [
+    {
+      "avgOutputTokens": 230.0,
+      "avgTotalMs": 2798.76,
+      "avgTps": 80.11,
+      "avgTtftMs": null,
+      "maxTps": 84.0,
+      "minTps": 72.68,
+      "model": "DeepSeek-Coder-V2-Lite-Instruct-Q4_K_M",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1787953827,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.11"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| Qwen2.5-Coder-3B-Instruct-Q8_0 | llamacpp | 66.1 | — |
| Qwen2.5-Coder-7B-Instruct-Q6_K | llamacpp | 43.9 | — |
| GigaChat3.1-10B-A1.8B-Q4_K_M | llamacpp | 101.2 | — |
| DeepSeek-Coder-V2-Lite-Instruct-Q4_K_M | llamacpp | 80.1 | — |
| Qwen2.5-Coder-3B-Instruct-Q8_0 | llamacpp | 49.4 | — |

_Submitted without the `gh` CLI via the GitHub device flow._
