### PR TITLE
fix(cli): return structured JSON errors for missing models

### DIFF
--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -512,6 +512,20 @@ pub fn display_json_fits(specs: &SystemSpecs, fits: &[ModelFit]) {
     );
 }
 
+/// Serialize a CLI error for machine consumers.
+pub fn display_json_error(kind: &str, message: &str) {
+    let output = serde_json::json!({
+        "error": {
+            "kind": kind,
+            "message": message,
+        },
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("JSON serialization failed")
+    );
+}
+
 /// Serialize system specs + model fits to JSON with llama.cpp commands and print to stdout.
 pub fn display_json_fits_with_llamacpp(specs: &SystemSpecs, fits: &[ModelFit]) {
     use llmfit_core::fit::InferenceRuntime;

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1207,6 +1207,14 @@ fn find_fit_index_by_selector(fits: &[ModelFit], selector: &str) -> Result<usize
     find_name_index_by_selector(fits, selector, |fit| fit.model.name.as_str())
 }
 
+fn selector_error_kind(message: &str) -> &'static str {
+    if message.starts_with("No model found") {
+        "model_not_found"
+    } else {
+        "invalid_selector"
+    }
+}
+
 fn run_diff(
     model_a: Option<String>,
     model_b: Option<String>,
@@ -1245,14 +1253,22 @@ fn run_diff(
             let a_idx = match find_fit_index_by_selector(&fits, a) {
                 Ok(i) => i,
                 Err(e) => {
-                    eprintln!("Error: {}", e);
+                    if json {
+                        display::display_json_error(selector_error_kind(&e), &e);
+                    } else {
+                        eprintln!("Error: {}", e);
+                    }
                     std::process::exit(1);
                 }
             };
             let b_idx = match find_fit_index_by_selector(&fits, b) {
                 Ok(i) => i,
                 Err(e) => {
-                    eprintln!("Error: {}", e);
+                    if json {
+                        display::display_json_error(selector_error_kind(&e), &e);
+                    } else {
+                        eprintln!("Error: {}", e);
+                    }
                     std::process::exit(1);
                 }
             };
@@ -2928,8 +2944,12 @@ fn main() {
                 let idx = match find_name_index_by_selector(models, &model, |m| m.name.as_str()) {
                     Ok(i) => i,
                     Err(err) => {
-                        println!("\n{}", err);
-                        return;
+                        if cli.json {
+                            display::display_json_error(selector_error_kind(&err), &err);
+                        } else {
+                            println!("\n{}", err);
+                        }
+                        std::process::exit(1);
                     }
                 };
 

--- a/llmfit-tui/tests/cli_smoke.rs
+++ b/llmfit-tui/tests/cli_smoke.rs
@@ -14,6 +14,21 @@ fn run_json_command(args: &[&str]) -> Value {
     serde_json::from_slice(&output).expect("command did not emit valid JSON")
 }
 
+fn run_json_failure(args: &[&str]) -> (i32, Value) {
+    let output = Command::cargo_bin("llmfit")
+        .expect("failed to locate llmfit test binary")
+        .args(args)
+        .output()
+        .expect("failed to run llmfit");
+
+    let code = output
+        .status
+        .code()
+        .expect("process was terminated by a signal");
+    let json = serde_json::from_slice(&output.stdout).expect("command did not emit valid JSON");
+    (code, json)
+}
+
 fn models_array(json: &Value) -> &[Value] {
     json.get("models")
         .and_then(Value::as_array)
@@ -224,4 +239,35 @@ fn cpu_cores_parser_rejects_zero() {
         .args(["--cpu-cores", "0", "--json", "system"])
         .assert()
         .failure();
+}
+
+#[test]
+fn info_json_model_not_found_is_structured_and_fails() {
+    let (code, json) =
+        run_json_failure(&["--no-dashboard", "--json", "info", "does-not-exist-xyz"]);
+
+    assert_eq!(code, 1);
+    assert_eq!(json["error"]["kind"], "model_not_found");
+    assert_eq!(
+        json["error"]["message"],
+        "No model found matching 'does-not-exist-xyz'"
+    );
+}
+
+#[test]
+fn diff_json_model_not_found_is_structured_and_fails() {
+    let (code, json) = run_json_failure(&[
+        "--no-dashboard",
+        "--json",
+        "diff",
+        "does-not-exist-xyz",
+        "also-not-real",
+    ]);
+
+    assert_eq!(code, 1);
+    assert_eq!(json["error"]["kind"], "model_not_found");
+    assert_eq!(
+        json["error"]["message"],
+        "No model found matching 'does-not-exist-xyz'"
+    );
 }


### PR DESCRIPTION
Fixes #901

## What changed

When `info` or `diff` cannot resolve a model selector, `--json` now emits a valid structured error containing a machine-readable `kind` and a human-readable `message`, and the command exits with status 1. The normal text output remains unchanged. Ambiguous selectors use `invalid_selector`, while missing models use `model_not_found`.

## Validation

- `cargo test -p llmfit`: 83 unit tests and 11 CLI integration tests passed.
- `cargo check -p llmfit --all-targets` passed.
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.
- `cargo clippy -p llmfit --all-targets` completed with pre-existing warnings; strict `-D warnings` remains blocked by unrelated existing lints in `llmfit-core`.
