### PR TITLE
feat: hardware profiles, MoE Tier-2 fixes, and estimate confidence (#969)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dist/
 .venv/
 .mypy_cache/
 .ruff_cache/
+.agents/
+.shipmates/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ Source modules in `llmfit-core/src/`:
   estimated throughput.
 - `hardware.rs`: Detects RAM, CPU, GPUs, unified memory, clusters, and memory
   bandwidth.
+- `hwprofile.rs`: Loads embedded and user hardware profiles (schema v1). Applies
+  capacity to `SystemSpecs` and bandwidth/efficiency overrides to `CalcConfig`.
 - `models.rs`: Defines model metadata. It loads embedded HF and ONNX catalogs,
   custom models, and the update cache.
 - `plan.rs`: Estimates memory, throughput, run paths, and hardware upgrade needs

--- a/API.md
+++ b/API.md
@@ -148,6 +148,10 @@ Envelope shape:
         "context": 88.0
       },
       "estimated_tps": 42.5,
+      "estimate_confidence": "estimated",
+      "estimate_confidence_label": "estimated",
+      "prefill_tps": 812.3,
+      "ttft_ms": 10.1,
       "runtime": "llamacpp",
       "runtime_label": "llama.cpp",
       "best_quant": "Q5_K_M",
@@ -199,6 +203,21 @@ The envelope also carries these fields, now at parity with `llmfit fit --json`
 - `ollama_name` — the `ollama pull` tag for this model, when derivable.
 - `estimate_basis` — how `memory_required_gb`/`estimated_tps` were derived
   (bandwidths, efficiency, assumed context), for reproducibility.
+- `estimate_confidence` / `estimate_confidence_label` — how much to trust
+  `estimated_tps`, most to least trustworthy: `measured_local` (your own
+  `llmfit bench` runs), `measured_community` (llmfit community submissions
+  or localmaxxing.com data on matching hardware), `calibrated` (a formula
+  estimate scaled by a correction factor from benchmark runs on this exact
+  hardware), `estimated` (a bare formula estimate), `unsupported` (no
+  estimate — the model needs a runtime llmfit can't model). See
+  `measured_tps`/`estimate_basis.local_calibration` for the data each level
+  is derived from.
+- `prefill_tps` / `ttft_ms` — estimated prompt-processing throughput
+  (tok/s) and time-to-first-token (ms) for a prompt of
+  `effective_context_length` tokens. Prefill is compute-bound, not
+  bandwidth-bound, so both are `null` — not `0.0` — unless the system's GPU
+  compute throughput is known. A `null` here means "not estimated", never
+  "instant" or "stalled".
 - `verify_command` — a `llama-bench` invocation measuring the same throughput
   this row estimates (llama.cpp GPU / CPU-only runs; `null` otherwise).
 - `measured_tps` — a recorded benchmark result if one exists, else `null`.
@@ -207,6 +226,28 @@ Note on vocabulary: `fit_level`, `run_mode`, and `runtime` here are stable
 machine codes (e.g. `"good"`, `"gpu"`, `"llamacpp"`), with the human string
 under the paired `*_label` key. `llmfit fit --json` emits the human string
 directly under those same keys — a CLI-only legacy overload.
+`estimate_confidence` follows the same convention (machine code, paired
+`estimate_confidence_label`) in both frontends.
+
+### A note on `best_quant`
+
+`best_quant` is normally the llama.cpp/GGUF quant llmfit picked for this
+hardware (e.g. `"Q5_K_M"`). It is `null` when the model's own repo name
+declares a native low-precision format (NVFP4/MXFP4) that a GGUF quant
+label doesn't apply to — the row's `notes` array carries the explanation
+in that case. It's never a GGUF label misattributed to a non-GGUF repo.
+
+---
+
+### Catalog sanitization
+
+`/api/v1/models` never returns speculative-decoding draft heads
+(EAGLE/DFlash/DSpark naming), entries whose name implies a wildly different
+parameter count than their declared size, or other catalog rows llmfit
+can't score honestly — they're demoted out of fit ranking, not deleted, so
+this is invisible unless you were expecting a specific draft-head repo to
+show up as a standalone model. If you maintain your own filtering on top of
+`llmfit fit --json` output today, you can likely delete that workaround.
 
 ---
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -2,6 +2,16 @@
 
 llmfit ships with a curated database of 108 LLM models from HuggingFace. All memory estimates assume Q4_K_M quantization (0.5 bytes per parameter) unless noted otherwise.
 
+The tables below are hand-curated and don't include the wider auto-scraped
+catalog (`llmfit list`/`llmfit fit`), which is much larger and noisier.
+That larger catalog sanitizes a few classes of entry out of fit ranking
+before scoring: speculative-decoding draft heads (EAGLE/DFlash/DSpark
+naming) cataloged as if they were standalone models, entries whose name
+implies a parameter count 4x+ off from their declared size, and footprints
+that are physically implausible for their declared size. Demoted entries
+stay in the catalog for lookup/search — they just don't rank as a fit. See
+`API.md` for the machine-readable shape this produces in `fit --json`.
+
 ### 01.ai
 
 | Model | Parameters | Quantization | Context | Use Case |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,6 +191,55 @@ llmfit --ram=64G recommend --json
 
 Accepted suffixes for `--memory` and `--ram`: `G`/`GB`/`GiB` (gigabytes), `M`/`MB`/`MiB` (megabytes), `T`/`TB`/`TiB` (terabytes). Case-insensitive. If no GPU was detected, `--memory` creates a synthetic GPU entry so models are scored for GPU inference. On unified-memory systems (Apple Silicon), `--ram` also updates VRAM; use `--memory` to override VRAM independently.
 
+### Hardware profiles
+
+The single-field overrides fix a bad detection, but they can't answer "what would this model do on *that* box": throughput is driven by memory bandwidth and fp16 matmul throughput, neither of which is a capacity. A **hardware profile** names a whole machine — capacity, unified-memory topology, memory bandwidth, DDR bandwidth, fp16 throughput — so the answer is reproducible instead of a pile of flags:
+
+```sh
+# What fits, and how fast, on a 256 GB/s unified APU with 128 GB
+llmfit --profile ryzen-ai-max-plus-395 fit -n 10
+
+# Profiles work with any analysis subcommand
+llmfit --profile nvidia-rtx-4090 recommend --json
+llmfit --profile apple-m3-max-128gb info "Qwen/Qwen3-4B-MLX-4bit"
+
+# Or point at a file you wrote yourself
+llmfit --profile ./my-workstation.json fit --json
+```
+
+`--profile` conflicts with `--memory`, `--ram`, and `--cpu-cores`: a profile describes the whole machine, so mixing the two would leave the result half-detected. An unresolvable profile is an error rather than a warning — a profile that quietly failed to load would score every model against the wrong machine.
+
+Manage profiles with the `hardware` subcommand:
+
+```sh
+# Every selectable profile (bundled and user), with --json for scripts
+llmfit hardware list
+llmfit hardware list --json
+
+# One profile's fields, plus what it would change on this machine
+llmfit hardware show ryzen-ai-max-plus-395
+
+# Strictly validate files you wrote (unknown keys are errors here)
+llmfit hardware validate ./my-workstation.json
+
+# Where to drop your own profiles
+llmfit hardware path
+```
+
+Profiles bundled with llmfit are embedded in the binary. Your own go in the directory printed by `llmfit hardware path` (override it with `LLMFIT_HARDWARE_PROFILES`), one `<name>.json` per profile, where `name` inside the file must match the file stem. A user profile shadows a bundled one of the same name.
+
+Loading **tolerates** unknown keys so a profile written for a newer llmfit still works, which means a misspelled key silently does nothing — `llmfit hardware validate` rejects them, so run it after hand-editing:
+
+```console
+$ llmfit hardware validate ./my-workstation.json
+FAIL  ./my-workstation.json: unknown key(s): hardware.gpu_bandwith_gbps
+```
+
+The full field list, bounds, and bundled-profile provenance live in [`llmfit-core/data/hardware/README.md`](../llmfit-core/data/hardware/README.md) with the schema next to it. Two current limitations:
+
+- `calibration[]` entries are parsed and validated but **not applied** to estimates in `schema_version` 1; they ship as reviewable data.
+- `--profile` cannot be combined with `recommend --force-runtime` yet.
+
 ### Context-length cap for estimation
 
 Use `--max-context` to cap context length used for memory estimation (without changing each model's advertised maximum context):

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -238,7 +238,8 @@ FAIL  ./my-workstation.json: unknown key(s): hardware.gpu_bandwith_gbps
 The full field list, bounds, and bundled-profile provenance live in [`llmfit-core/data/hardware/README.md`](../llmfit-core/data/hardware/README.md) with the schema next to it. Two current limitations:
 
 - `calibration[]` entries are parsed and validated but **not applied** to estimates in `schema_version` 1; they ship as reviewable data.
-- `--profile` cannot be combined with `recommend --force-runtime` yet.
+- `--profile` cannot be combined with `--force-runtime` yet, on either `recommend` or `serve`'s `/api/v1/models`.
+- `doctor` rejects `--profile`: it diagnoses the machine it runs on, so a profile could only make its report wrong. Use `llmfit hardware show <NAME>` to inspect a profile instead.
 
 ### Context-length cap for estimation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -193,53 +193,109 @@ Accepted suffixes for `--memory` and `--ram`: `G`/`GB`/`GiB` (gigabytes), `M`/`M
 
 ### Hardware profiles
 
-The single-field overrides fix a bad detection, but they can't answer "what would this model do on *that* box": throughput is driven by memory bandwidth and fp16 matmul throughput, neither of which is a capacity. A **hardware profile** names a whole machine — capacity, unified-memory topology, memory bandwidth, DDR bandwidth, fp16 throughput — so the answer is reproducible instead of a pile of flags:
+`--memory` / `--ram` / `--cpu-cores` fix capacity. They cannot answer “how fast on *that* box?” — tok/s needs memory bandwidth (and optionally fp16 TFLOPS). A **hardware profile** is a small JSON file that describes a whole machine. Pass it with `--profile` and every analysis command scores against that machine instead of the host you are sitting on.
+
+#### Try a bundled profile (30 seconds)
 
 ```sh
-# What fits, and how fast, on a 256 GB/s unified APU with 128 GB
-llmfit --profile ryzen-ai-max-plus-395 fit -n 10
-
-# Profiles work with any analysis subcommand
-llmfit --profile nvidia-rtx-4090 recommend --json
-llmfit --profile apple-m3-max-128gb info "Qwen/Qwen3-4B-MLX-4bit"
-
-# Or point at a file you wrote yourself
-llmfit --profile ./my-workstation.json fit --json
-```
-
-`--profile` conflicts with `--memory`, `--ram`, and `--cpu-cores`: a profile describes the whole machine, so mixing the two would leave the result half-detected. An unresolvable profile is an error rather than a warning — a profile that quietly failed to load would score every model against the wrong machine.
-
-Manage profiles with the `hardware` subcommand:
-
-```sh
-# Every selectable profile (bundled and user), with --json for scripts
 llmfit hardware list
-llmfit hardware list --json
-
-# One profile's fields, plus what it would change on this machine
 llmfit hardware show ryzen-ai-max-plus-395
 
-# Strictly validate files you wrote (unknown keys are errors here)
-llmfit hardware validate ./my-workstation.json
+llmfit --profile ryzen-ai-max-plus-395 fit -n 10
+llmfit --profile ryzen-ai-max-plus-395 plan openai/gpt-oss-120b
+llmfit --profile nvidia-rtx-4090 recommend --json
+llmfit --profile apple-m3-max-128gb info "Qwen/Qwen3-4B-MLX-4bit"
+```
 
-# Where to drop your own profiles
+#### Simulate unreleased (or any) hardware
+
+You do not need the machine in front of you. Write a profile, validate it, then score models against it.
+
+**1. See where user profiles live**
+
+```sh
+llmfit hardware path
+# e.g. ~/.local/share/llmfit/hardware
+# override with: LLMFIT_HARDWARE_PROFILES=/tmp/my-hw
+```
+
+**2. Write a profile** (file stem must match `"name"`)
+
+```sh
+mkdir -p "$(llmfit hardware path)"
+cat > "$(llmfit hardware path)/m5ultra512.json" <<'EOF'
+{
+  "schema_version": 1,
+  "name": "m5ultra512",
+  "match": { "gpu_name_contains": "M5 Ultra" },
+  "hardware": {
+    "total_ram_gb": 512.0,
+    "unified_memory": true,
+    "gpu_memory_bandwidth_gbps": 1200.0,
+    "ddr_bandwidth_gbps": 1200.0
+  }
+}
+EOF
+```
+
+Or keep a one-off file and pass the path — no install needed:
+
+```sh
+llmfit --profile ./m5ultra512.json fit --json
+```
+
+**3. Validate, list, inspect**
+
+```sh
+llmfit hardware validate "$(llmfit hardware path)/m5ultra512.json"
+llmfit hardware list
+llmfit hardware show m5ultra512
+```
+
+**4. Score as if you owned that box**
+
+```sh
+llmfit --profile m5ultra512 fit -n 20
+llmfit --profile m5ultra512 plan --quant Q4_K_M openai/gpt-oss-120b
+llmfit --profile m5ultra512 recommend --json
+```
+
+| Field | Effect |
+| --- | --- |
+| `total_ram_gb` | Capacity (and VRAM when `unified_memory` is true) |
+| `unified_memory` | Shared pool (Apple / APU) vs discrete GPU |
+| `gpu_memory_bandwidth_gbps` | Decode / estimated tok/s |
+| `ddr_bandwidth_gbps` | CPU / offload path |
+| `gpu_compute_tflops_fp16` | Prefill / TTFT; omit → honest `null` |
+
+#### Managing profiles
+
+```sh
+llmfit hardware list          # bundled + user
+llmfit hardware list --json
+llmfit hardware show <NAME>   # fields + what would change on this host
+llmfit hardware validate <file>
 llmfit hardware path
 ```
 
-Profiles bundled with llmfit are embedded in the binary. Your own go in the directory printed by `llmfit hardware path` (override it with `LLMFIT_HARDWARE_PROFILES`), one `<name>.json` per profile, where `name` inside the file must match the file stem. A user profile shadows a bundled one of the same name.
+Bundled profiles are embedded in the binary. Your own live under `llmfit hardware path` (or `LLMFIT_HARDWARE_PROFILES`). Same `name` → user file wins.
 
-Loading **tolerates** unknown keys so a profile written for a newer llmfit still works, which means a misspelled key silently does nothing — `llmfit hardware validate` rejects them, so run it after hand-editing:
+Loading **tolerates** unknown keys (forward-compatible). `hardware validate` **rejects** them so typos do not silently no-op:
 
 ```console
 $ llmfit hardware validate ./my-workstation.json
 FAIL  ./my-workstation.json: unknown key(s): hardware.gpu_bandwith_gbps
 ```
 
-The full field list, bounds, and bundled-profile provenance live in [`llmfit-core/data/hardware/README.md`](../llmfit-core/data/hardware/README.md) with the schema next to it. Two current limitations:
+`--profile` conflicts with `--memory` / `--ram` / `--cpu-cores` (whole machine vs one field). An unresolvable profile is a hard error.
 
-- `calibration[]` entries are parsed and validated but **not applied** to estimates in `schema_version` 1; they ship as reviewable data.
-- `--profile` cannot be combined with `--force-runtime` yet, on either `recommend` or `serve`'s `/api/v1/models`.
-- `doctor` rejects `--profile`: it diagnoses the machine it runs on, so a profile could only make its report wrong. Use `llmfit hardware show <NAME>` to inspect a profile instead.
+Full field list and bundled provenance: [`llmfit-core/data/hardware/README.md`](../llmfit-core/data/hardware/README.md).
+
+Limitations today:
+
+- `calibration[]` is stored for review but **not** applied to estimates (schema v1).
+- `--profile` cannot combine with `--force-runtime` yet.
+- `doctor` rejects `--profile` (it diagnoses *this* host). Use `hardware show` instead.
 
 ### Context-length cap for estimation
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -39,7 +39,7 @@ The scoring model, speed estimation, and the model database.
 
    The efficiency factor (0.55) and per-mode speed multipliers are tunable via the Advanced Configuration popup (`A` in the TUI). The defaults account for kernel overhead, KV-cache reads, and memory controller effects. This approach is validated against published benchmarks from llama.cpp ([Apple Silicon](https://github.com/ggml-org/llama.cpp/discussions/4167), [NVIDIA T4](https://github.com/ggml-org/llama.cpp/discussions/4225)) and real-world measurements.
 
-   The bandwidth lookup table covers ~80 GPUs across NVIDIA (consumer + datacenter), AMD (RDNA + CDNA), and Apple Silicon families.
+   The bandwidth lookup table covers ~80 GPUs across NVIDIA (consumer + datacenter), AMD (RDNA + CDNA), and Apple Silicon families. Bandwidth resolves in one place, in this order: an explicit `gpu_bandwidth_gbps_override`, then the GPU-name table, then nothing -- in which case the per-backend constant below is used. Setting the override is how you get a roofline estimate for a card the table doesn't know, or reproduce someone else's number on hardware you don't have. Whichever value was used is reported back in `estimate_basis.gpu_bandwidth_gbps`, so any estimate can be checked.
 
    For unrecognized GPUs, llmfit falls back to per-backend speed constants:
 
@@ -55,6 +55,23 @@ The scoring model, speed estimation, and the model database.
 
    Fallback formula: `K / params_b × quant_speed_multiplier`, with per-mode penalties tunable via the Advanced Configuration popup (`A` in the TUI).
 
+   **MoE decode** -- Sparse models are estimated from their *active* parameters, using the best information available:
+
+   - *Tier 1* -- with full architecture metadata (hidden size, layer count, expert intermediate size, vocab), per-token traffic is decomposed into the expert FFN weights that scale with quantization and the attention/router/embedding weights that don't.
+   - *Tier 2* -- otherwise, `active_parameters × bytes_per_param`, corrected by a per-architecture efficiency and overhead pair. Architectures without an entry fall back to picking an overhead from the model's expert count, so adding an entry only ever moves the architecture it names. That expert-count fallback fits the newest sparse designs poorly: charging 128+ experts as heavy router overhead puts gpt-oss-120b about 2.6x low, which is what the calibrated entries correct.
+
+   **Prompt processing (prefill / TTFT)** -- Unlike decode, prefill is compute-bound: it costs roughly `2 × active_parameters` FLOPs per prompt token, so memory bandwidth says nothing useful about it. llmfit reports `prefill_tps` and `ttft_ms` only when the GPU's fp16 throughput is known via `gpu_compute_tflops_fp16`; otherwise both are `null`. That is deliberately different from `0.0`, which would read as "immeasurably slow" rather than "not estimated". Quantization is ignored here because llama.cpp and vLLM both dequantize to fp16 for the matmul, leaving the FLOP count unchanged.
+
+   **Confidence** -- A measured throughput and a formula guess are both "tok/s", so every fit carries an `estimate_confidence` saying which it is. First match wins:
+
+   | Confidence           | Meaning                                                        |
+   |----------------------|----------------------------------------------------------------|
+   | `measured_local`     | Benchmarked by you on this machine (`llmfit bench`)            |
+   | `measured_community` | Benchmarked by others on hardware matching this machine        |
+   | `calibrated`         | Formula, scaled by a factor derived from runs on this hardware |
+   | `estimated`          | Formula only, with no measurement behind it                    |
+   | `unsupported`        | No estimate -- the model needs a runtime llmfit can't model    |
+
 6. **Fit analysis** -- Each model is evaluated for memory compatibility:
 
    **Run modes:**
@@ -63,11 +80,21 @@ The scoring model, speed estimation, and the model database.
    - **CPU+GPU** -- VRAM insufficient, spills to system RAM with partial GPU offload.
    - **CPU** -- No GPU. Model loaded entirely into system RAM.
 
-   **Fit levels:**
-   - **Perfect** -- Recommended memory met on GPU. Requires GPU acceleration.
-   - **Good** -- Fits with headroom. Best achievable for MoE offload or CPU+GPU.
-   - **Marginal** -- Tight fit, or CPU-only (CPU-only always caps here).
-   - **Too Tight** -- Not enough VRAM or system RAM anywhere.
+   **Fit levels:** the verdict is a pure function of one number -- how full the run mode's memory pool is (`memory_required / memory_available`) -- and is then capped by what the execution path can deliver.
+
+   | Pool utilization | Verdict      |
+   |------------------|--------------|
+   | ≤ 60%            | **Perfect**  |
+   | ≤ 85%            | **Good**     |
+   | ≤ 98%            | **Marginal** |
+   | > 98%            | **Too Tight** |
+
+   The cap: **GPU** and **TP** keep whatever the ratio says. **MoE offload**, **CPU+GPU**, and **CPU** cap at Good, because Perfect means "fits with room to spare *and* runs on the GPU". They are not pushed down to Marginal -- a model that fits comfortably in RAM is genuinely runnable.
+
+   Two details worth knowing:
+
+   - The band stops at 98% rather than 100%. A pool filled to the last percent leaves nothing for allocator slack or fragmentation, so it doesn't load in practice.
+   - `recommended_ram_gb` no longer affects the verdict. It is a catalog-wide `model_size × 2.0` heuristic, and gating Perfect on it distorted the answer in both directions. It over-promised on tight fits: a 23 GB model on a 24 GB card met its 22 GB recommendation and so scored "Perfect" at 96% pool utilization, where it will not actually load. And it under-rated roomy ones: a 9 GB model filling 56% of a 16 GB card scored only "Good", while that same model on a 24 GB card scored "Perfect" -- the verdict tracked the card's size instead of how tightly the model fits it. Utilization now answers both cases directly.
 
 ---
 

--- a/llmfit-core/build.rs
+++ b/llmfit-core/build.rs
@@ -1,7 +1,8 @@
 //! Aggregate community benchmark submissions (data/community/<slug>/*.json)
-//! into a single JSON array embedded in the binary. This is what closes the
-//! contribution loop: a submission merged into the repo ships to every user
-//! in the next release, with no CI step or network fetch involved.
+//! and hardware profiles (data/hardware/*.json) into single JSON arrays
+//! embedded in the binary. This is what closes the contribution loop: a
+//! submission merged into the repo ships to every user in the next release,
+//! with no CI step or network fetch involved.
 
 use std::env;
 use std::fs;
@@ -9,7 +10,13 @@ use std::path::{Path, PathBuf};
 
 fn main() {
     println!("cargo:rerun-if-changed=data/community");
+    println!("cargo:rerun-if-changed=data/hardware");
 
+    embed_community_benchmarks();
+    embed_hardware_profiles();
+}
+
+fn embed_community_benchmarks() {
     let community_dir = Path::new("data/community");
     let mut files: Vec<PathBuf> = Vec::new();
     if let Ok(entries) = fs::read_dir(community_dir) {
@@ -55,4 +62,51 @@ fn main() {
         .join("community_benchmarks.json");
     let json = serde_json::to_string(&payloads).expect("serialize community aggregate");
     fs::write(&out, json).expect("write community aggregate");
+}
+
+/// Aggregate `data/hardware/*.json` into one array, skipping the schema and
+/// README that live alongside the profiles.
+fn embed_hardware_profiles() {
+    let hardware_dir = Path::new("data/hardware");
+    let mut files: Vec<PathBuf> = Vec::new();
+    if let Ok(entries) = fs::read_dir(hardware_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue; // README.md
+            }
+            if path.file_stem().and_then(|s| s.to_str()) == Some("schema") {
+                continue; // schema.json is the contract, not a profile
+            }
+            files.push(path);
+        }
+    }
+    // Deterministic embed order regardless of directory iteration order.
+    files.sort();
+
+    let mut payloads: Vec<serde_json::Value> = Vec::new();
+    for f in &files {
+        let Ok(text) = fs::read_to_string(f) else {
+            println!(
+                "cargo:warning=hardware profile unreadable, skipped: {}",
+                f.display()
+            );
+            continue;
+        };
+        match serde_json::from_str::<serde_json::Value>(&text) {
+            Ok(v) => payloads.push(v),
+            // `cargo test -p llmfit-core` validates this directory against
+            // schema.json, so a bad file here should never reach a release; a
+            // warning beats breaking every build.
+            Err(e) => println!(
+                "cargo:warning=hardware profile invalid JSON, skipped: {}: {e}",
+                f.display()
+            ),
+        }
+    }
+
+    let out = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR set by cargo"))
+        .join("hardware_profiles.json");
+    let json = serde_json::to_string(&payloads).expect("serialize hardware profile aggregate");
+    fs::write(&out, json).expect("write hardware profile aggregate");
 }

--- a/llmfit-core/data/hardware/README.md
+++ b/llmfit-core/data/hardware/README.md
@@ -3,7 +3,10 @@
 A hardware profile is a named, versioned description of a machine: how much
 memory it has, whether that memory is unified, and the bandwidth/compute
 figures the throughput estimator needs. Pass one with `--profile` to score
-models against that machine instead of the detected one:
+models against that machine instead of the detected one.
+
+**User walkthrough** (bundled profiles + writing your own for unreleased
+hardware): [`docs/cli.md` → Hardware profiles](../../../docs/cli.md#hardware-profiles).
 
 ```sh
 llmfit --profile ryzen-ai-max-plus-395 fit -n 10

--- a/llmfit-core/data/hardware/README.md
+++ b/llmfit-core/data/hardware/README.md
@@ -1,0 +1,115 @@
+# Hardware profiles
+
+A hardware profile is a named, versioned description of a machine: how much
+memory it has, whether that memory is unified, and the bandwidth/compute
+figures the throughput estimator needs. Pass one with `--profile` to score
+models against that machine instead of the detected one:
+
+```sh
+llmfit --profile ryzen-ai-max-plus-395 fit -n 10
+llmfit --profile ./my-workstation.json recommend --json
+llmfit hardware list
+llmfit hardware show nvidia-rtx-4090
+```
+
+`--profile` replaces the `--memory` / `--ram` / `--cpu-cores` overrides (it
+conflicts with all three) because a profile describes a whole machine rather
+than one field.
+
+## Layout
+
+```
+hardware/
+  schema.json          JSON Schema (draft-07) every profile must satisfy
+  <name>.json          one profile; `name` must equal the file stem
+```
+
+Profiles in this directory are aggregated by `llmfit-core/build.rs` and
+**embedded into the binary**, so a merged profile ships in the next release
+and is available by name with no download. Users can add their own without
+rebuilding by dropping files into the directory printed by:
+
+```sh
+llmfit hardware path
+```
+
+A user profile whose `name` matches an embedded one takes precedence.
+`LLMFIT_HARDWARE_PROFILES` overrides that directory.
+
+## Fields
+
+| Field | Required | Applied to |
+| --- | --- | --- |
+| `schema_version` | yes | must be `1` |
+| `name` | yes | must equal the file stem; `[a-z0-9][a-z0-9._-]*` |
+| `match.gpu_name_contains` | no | provenance only — llmfit never auto-selects a profile |
+| `hardware.total_ram_gb` | yes | `SystemSpecs` capacity (and VRAM when unified) |
+| `hardware.unified_memory` | yes | `SystemSpecs::unified_memory` |
+| `hardware.gpu_memory_bandwidth_gbps` | no | `CalcConfig::gpu_bandwidth_gbps_override` |
+| `hardware.ddr_bandwidth_gbps` | no | `CalcConfig::ddr_bandwidth_gbps` |
+| `hardware.gpu_compute_tflops_fp16` | no | `CalcConfig::gpu_compute_tflops_fp16` (prefill/TTFT) |
+| `estimation.efficiency` | no | `CalcConfig::efficiency` |
+| `estimation.run_mode_factors.*` | no | `CalcConfig::run_mode_factors` (per-mode, unset keys keep defaults) |
+| `calibration[]` | no | **parsed and validated, not yet applied** in `schema_version` 1 |
+
+`calibration` records measured anchors with their provenance so they can be
+reviewed now and used by a later schema version; it changes no estimate today.
+
+A discrete-GPU profile does not carry a VRAM figure, so VRAM stays as
+detected on the host. Unified profiles are fully described: VRAM tracks
+`total_ram_gb`.
+
+## Format
+
+Each file conforms to [`schema.json`](./schema.json). Example:
+
+```json
+{
+  "schema_version": 1,
+  "name": "example-unified-256",
+  "match": { "gpu_name_contains": "Radeon 8060S" },
+  "hardware": {
+    "total_ram_gb": 128.0,
+    "unified_memory": true,
+    "gpu_memory_bandwidth_gbps": 256.0,
+    "ddr_bandwidth_gbps": 256.0,
+    "gpu_compute_tflops_fp16": 29.7
+  },
+  "estimation": {
+    "efficiency": 0.6,
+    "run_mode_factors": { "cpu_only": 0.25 }
+  },
+  "calibration": [
+    {
+      "model": "openai/gpt-oss-120b",
+      "quant": "MXFP4",
+      "run_mode": "gpu",
+      "measured_tps": 50.0,
+      "source": "https://github.com/AlexsJones/llmfit/issues/969"
+    }
+  ]
+}
+```
+
+Unknown keys are **tolerated when loading** (so a profile written for a newer
+llmfit still works) but **rejected by validation**, which is what catches a
+typo before it silently does nothing:
+
+```sh
+llmfit hardware validate ./my-workstation.json
+```
+
+## Bundled profiles
+
+| Name | Memory | Bandwidth | Notes |
+| --- | --- | --- | --- |
+| `ryzen-ai-max-plus-395` | 128 GB unified | 256 GB/s | Strix Halo APU: 256-bit LPDDR5X-8000. Radeon 8060S, 40 RDNA 3.5 CUs @ ~2.9 GHz → ~29.7 TFLOP/s packed fp16. |
+| `apple-m3-max-128gb` | 128 GB unified | 400 GB/s | 40-core-GPU M3 Max. fp16 matmul throughput is left unset, so prefill/TTFT report `null` rather than a guess. |
+| `nvidia-rtx-4090` | 64 GB system RAM | 1008 GB/s | Discrete Ada card: 165.2 TFLOP/s dense fp16 (tensor, fp32 accumulate). `ddr_bandwidth_gbps` is dual-channel DDR5-5600. |
+
+## Validation
+
+`cargo test -p llmfit-core` validates every file here against
+[`schema.json`](./schema.json) and checks that each `name` matches its file
+stem, so a malformed contribution fails CI rather than shipping as a profile
+that cannot be selected.

--- a/llmfit-core/data/hardware/apple-m3-max-128gb.json
+++ b/llmfit-core/data/hardware/apple-m3-max-128gb.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "name": "apple-m3-max-128gb",
+  "match": { "gpu_name_contains": "Apple M3 Max" },
+  "hardware": {
+    "total_ram_gb": 128.0,
+    "unified_memory": true,
+    "gpu_memory_bandwidth_gbps": 400.0,
+    "ddr_bandwidth_gbps": 400.0
+  }
+}

--- a/llmfit-core/data/hardware/nvidia-rtx-4090.json
+++ b/llmfit-core/data/hardware/nvidia-rtx-4090.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "name": "nvidia-rtx-4090",
+  "match": { "gpu_name_contains": "RTX 4090" },
+  "hardware": {
+    "total_ram_gb": 64.0,
+    "unified_memory": false,
+    "gpu_memory_bandwidth_gbps": 1008.0,
+    "ddr_bandwidth_gbps": 89.6,
+    "gpu_compute_tflops_fp16": 165.2
+  }
+}

--- a/llmfit-core/data/hardware/ryzen-ai-max-plus-395.json
+++ b/llmfit-core/data/hardware/ryzen-ai-max-plus-395.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "name": "ryzen-ai-max-plus-395",
+  "match": { "gpu_name_contains": "Radeon 8060S" },
+  "hardware": {
+    "total_ram_gb": 128.0,
+    "unified_memory": true,
+    "gpu_memory_bandwidth_gbps": 256.0,
+    "ddr_bandwidth_gbps": 256.0,
+    "gpu_compute_tflops_fp16": 29.7
+  },
+  "calibration": [
+    {
+      "model": "openai/gpt-oss-120b",
+      "quant": "MXFP4",
+      "run_mode": "gpu",
+      "measured_tps": 50.0,
+      "source": "https://github.com/AlexsJones/llmfit/issues/969"
+    }
+  ]
+}

--- a/llmfit-core/data/hardware/schema.json
+++ b/llmfit-core/data/hardware/schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://llmfit.dev/schemas/hardware-profile.json",
+  "title": "llmfit hardware profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "name", "hardware"],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9][a-z0-9._-]*$",
+      "description": "Profile id. Must equal the file name without its .json extension."
+    },
+    "match": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gpu_name_contains"],
+      "properties": {
+        "gpu_name_contains": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Case-insensitive substring of the detected GPU name this profile describes. Recorded for provenance; llmfit does not auto-select profiles."
+        }
+      }
+    },
+    "hardware": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total_ram_gb", "unified_memory"],
+      "properties": {
+        "total_ram_gb": { "type": "number", "exclusiveMinimum": 0, "maximum": 16384 },
+        "unified_memory": { "type": "boolean" },
+        "gpu_memory_bandwidth_gbps": { "type": "number", "exclusiveMinimum": 0, "maximum": 100000 },
+        "ddr_bandwidth_gbps": { "type": "number", "exclusiveMinimum": 0, "maximum": 100000 },
+        "gpu_compute_tflops_fp16": { "type": "number", "exclusiveMinimum": 0, "maximum": 100000 }
+      }
+    },
+    "estimation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "efficiency": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+        "run_mode_factors": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "gpu": { "type": "number", "exclusiveMinimum": 0, "maximum": 10 },
+            "tensor_parallel": { "type": "number", "exclusiveMinimum": 0, "maximum": 10 },
+            "moe_offload": { "type": "number", "exclusiveMinimum": 0, "maximum": 10 },
+            "cpu_offload": { "type": "number", "exclusiveMinimum": 0, "maximum": 10 },
+            "cpu_only": { "type": "number", "exclusiveMinimum": 0, "maximum": 10 }
+          }
+        }
+      }
+    },
+    "calibration": {
+      "type": "array",
+      "description": "Measured anchors for this hardware. Parsed and validated in schema_version 1, but not yet applied to estimates.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["model", "measured_tps"],
+        "properties": {
+          "model": { "type": "string", "minLength": 1 },
+          "quant": { "type": "string", "minLength": 1 },
+          "run_mode": {
+            "type": "string",
+            "enum": ["gpu", "tensor_parallel", "moe_offload", "cpu_offload", "cpu_only"]
+          },
+          "measured_tps": { "type": "number", "exclusiveMinimum": 0, "maximum": 100000 },
+          "source": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -154,6 +154,65 @@ impl InstalledIndex {
     }
 }
 
+/// The catalog entries eligible for a ranked fit sweep on this hardware.
+///
+/// Two gates, in one place so no surface can drift from another:
+///
+/// * [`backend_compatible`](crate::fit::backend_compatible) — the model can
+///   actually run on this backend.
+/// * `!`[`LlmModel::is_sanitization_demoted`] — the entry isn't a
+///   speculative-decoding draft head, a size/name divergence, or an
+///   implausible footprint (issue #969, problem 3).
+///
+/// Demoted entries stay in [`ModelDatabase`] and remain reachable through
+/// `get_all_models`/`find_model`, so `info` and `search` can still explain
+/// them; they are only kept out of anything that *ranks* models.
+///
+/// Every ranked sweep — CLI, TUI, REST, MCP — filters through here rather
+/// than repeating the predicate, so an API or MCP consumer can never be
+/// offered a draft head that the CLI hides.
+pub fn rankable_models<'a>(
+    models: &'a [LlmModel],
+    specs: &'a SystemSpecs,
+) -> impl Iterator<Item = &'a LlmModel> {
+    models
+        .iter()
+        .filter(move |m| crate::fit::backend_compatible(m, specs) && !m.is_sanitization_demoted())
+}
+
+/// How many catalog entries [`rankable_models`] drops on this hardware
+/// because the backend can't run them. Reported by UIs so a shorter list
+/// than expected is explained rather than mysterious.
+pub fn backend_hidden_count(models: &[LlmModel], specs: &SystemSpecs) -> usize {
+    models
+        .iter()
+        .filter(|m| !crate::fit::backend_compatible(m, specs))
+        .count()
+}
+
+/// Analyze one model, honouring a hardware profile's [`CalcConfig`] when the
+/// caller has one.
+///
+/// The two `ModelFit` entry points differ in more than a default —
+/// `analyze_with_config` carries the context cap *inside* the config — so
+/// surfaces that may or may not hold a profile would each have to repeat this
+/// branch, and one of them would eventually drop the config (issue #969).
+pub fn analyze_with_optional_config(
+    model: &LlmModel,
+    specs: &SystemSpecs,
+    context_limit: Option<u32>,
+    config: Option<&CalcConfig>,
+) -> ModelFit {
+    match config {
+        Some(config) => {
+            let mut config = config.clone();
+            config.context_cap = context_limit.or(config.context_cap);
+            ModelFit::analyze_with_config(model, specs, config)
+        }
+        None => ModelFit::analyze_with_context_limit(model, specs, context_limit),
+    }
+}
+
 /// How each model in the sweep is analyzed.
 enum FitMode {
     /// Automatic runtime selection, optionally forced to one runtime.
@@ -212,8 +271,6 @@ fn build_fits(
     context_limit: Option<u32>,
     mode: FitMode,
 ) -> Vec<ModelFit> {
-    use crate::fit::backend_compatible;
-
     // Measured-throughput sources, most trustworthy first: the user's own
     // runs on this machine, llmfit community submissions recorded on
     // identical hardware, then localmaxxing medians on matching presets.
@@ -221,23 +278,14 @@ fn build_fits(
     let community_index = crate::benchmarks::CommunityBenchIndex::for_specs(specs);
     let measured_index = crate::benchmarks::MeasuredTpsIndex::for_specs(specs);
 
-    let mut fits: Vec<ModelFit> = db
-        .get_all_models()
-        .iter()
-        // Demoted entries (speculative-decoding drafts, size/name
-        // divergence, implausible footprints — issue #969, problem 3) stay
-        // in the catalog but are excluded here so CLI/TUI/API fit ranking
-        // all inherit the same filter from this one call site.
-        .filter(|m| backend_compatible(m, specs) && !m.is_sanitization_demoted())
+    let mut fits: Vec<ModelFit> = rankable_models(db.get_all_models(), specs)
         .map(|m| {
             let mut fit = match &mode {
                 FitMode::Runtime(forced_runtime) => {
                     ModelFit::analyze_with_forced_runtime(m, specs, context_limit, *forced_runtime)
                 }
                 FitMode::Config(config) => {
-                    let mut config = config.as_ref().clone();
-                    config.context_cap = context_limit.or(config.context_cap);
-                    ModelFit::analyze_with_config(m, specs, config)
+                    analyze_with_optional_config(m, specs, context_limit, Some(config.as_ref()))
                 }
             };
             fit.installed = installed.is_installed(m);
@@ -360,6 +408,20 @@ mod sanitization_gate_tests {
         }
     }
 
+    fn demoted_names(db: &ModelDatabase) -> std::collections::HashSet<String> {
+        let names: std::collections::HashSet<String> = db
+            .get_all_models()
+            .iter()
+            .filter(|m| m.is_sanitization_demoted())
+            .map(|m| m.name.clone())
+            .collect();
+        assert!(
+            !names.is_empty(),
+            "expected the embedded catalog to contain at least one sanitization-demoted entry"
+        );
+        names
+    }
+
     /// `build_model_fits` must not surface a demoted catalog entry in its
     /// ranked output (issue #969, problem 3), even though the same entry
     /// stays queryable through `ModelDatabase::get_all_models`.
@@ -367,23 +429,41 @@ mod sanitization_gate_tests {
     fn build_model_fits_excludes_sanitization_demoted_entries() {
         let db = ModelDatabase::new();
         let specs = specs_with_gpu();
-
-        let demoted_names: std::collections::HashSet<String> = db
-            .get_all_models()
-            .iter()
-            .filter(|m| m.is_sanitization_demoted())
-            .map(|m| m.name.clone())
-            .collect();
-        assert!(
-            !demoted_names.is_empty(),
-            "expected the embedded catalog to contain at least one sanitization-demoted entry"
-        );
+        let demoted = demoted_names(&db);
 
         let fits = build_model_fits(&db, &specs, &InstalledIndex::empty(), None, None);
 
         assert!(
-            fits.iter().all(|f| !demoted_names.contains(&f.model.name)),
+            fits.iter().all(|f| !demoted.contains(&f.model.name)),
             "a sanitization-demoted model leaked into ranked fits"
+        );
+    }
+
+    /// The gate every ranked surface shares. `build_model_fits` is only one
+    /// caller — the TUI, REST and MCP sweeps filter through this directly, so
+    /// it needs its own coverage rather than inheriting it (issue #969).
+    #[test]
+    fn rankable_models_drops_demoted_and_backend_incompatible_entries() {
+        let db = ModelDatabase::new();
+        let specs = specs_with_gpu();
+        let demoted = demoted_names(&db);
+
+        let rankable: Vec<&LlmModel> = rankable_models(db.get_all_models(), &specs).collect();
+
+        assert!(!rankable.is_empty(), "expected some rankable models");
+        assert!(
+            rankable.iter().all(|m| !demoted.contains(&m.name)),
+            "a sanitization-demoted model survived rankable_models"
+        );
+        assert!(
+            rankable
+                .iter()
+                .all(|m| crate::fit::backend_compatible(m, &specs)),
+            "a backend-incompatible model survived rankable_models"
+        );
+        assert!(
+            rankable.len() < db.get_all_models().len(),
+            "rankable_models should be a strict subset of the catalog"
         );
     }
 }

--- a/llmfit-core/src/analysis.rs
+++ b/llmfit-core/src/analysis.rs
@@ -1,4 +1,4 @@
-use crate::fit::{InferenceRuntime, ModelFit};
+use crate::fit::{CalcConfig, InferenceRuntime, ModelFit};
 use crate::hardware::SystemSpecs;
 use crate::models::{LlmModel, ModelDatabase};
 use crate::providers::{
@@ -154,6 +154,14 @@ impl InstalledIndex {
     }
 }
 
+/// How each model in the sweep is analyzed.
+enum FitMode {
+    /// Automatic runtime selection, optionally forced to one runtime.
+    Runtime(Option<InferenceRuntime>),
+    /// Custom calculation parameters (e.g. from a hardware profile).
+    Config(Box<CalcConfig>),
+}
+
 /// Build a complete `Vec<ModelFit>` with installed markers populated.
 ///
 /// Filters models that are backend-incompatible, runs fit analysis, marks
@@ -165,6 +173,44 @@ pub fn build_model_fits(
     installed: &InstalledIndex,
     context_limit: Option<u32>,
     forced_runtime: Option<InferenceRuntime>,
+) -> Vec<ModelFit> {
+    build_fits(
+        db,
+        specs,
+        installed,
+        context_limit,
+        FitMode::Runtime(forced_runtime),
+    )
+}
+
+/// [`build_model_fits`] with custom calculation parameters, so a hardware
+/// profile's bandwidth and efficiency reach every row of the sweep.
+///
+/// Runtime selection stays automatic: `ModelFit` exposes no analysis entry
+/// point that takes both a forced runtime and a `CalcConfig`, so accepting one
+/// here could only drop it silently.
+pub fn build_model_fits_with_config(
+    db: &ModelDatabase,
+    specs: &SystemSpecs,
+    installed: &InstalledIndex,
+    context_limit: Option<u32>,
+    config: CalcConfig,
+) -> Vec<ModelFit> {
+    build_fits(
+        db,
+        specs,
+        installed,
+        context_limit,
+        FitMode::Config(Box::new(config)),
+    )
+}
+
+fn build_fits(
+    db: &ModelDatabase,
+    specs: &SystemSpecs,
+    installed: &InstalledIndex,
+    context_limit: Option<u32>,
+    mode: FitMode,
 ) -> Vec<ModelFit> {
     use crate::fit::backend_compatible;
 
@@ -178,10 +224,22 @@ pub fn build_model_fits(
     let mut fits: Vec<ModelFit> = db
         .get_all_models()
         .iter()
-        .filter(|m| backend_compatible(m, specs))
+        // Demoted entries (speculative-decoding drafts, size/name
+        // divergence, implausible footprints — issue #969, problem 3) stay
+        // in the catalog but are excluded here so CLI/TUI/API fit ranking
+        // all inherit the same filter from this one call site.
+        .filter(|m| backend_compatible(m, specs) && !m.is_sanitization_demoted())
         .map(|m| {
-            let mut fit =
-                ModelFit::analyze_with_forced_runtime(m, specs, context_limit, forced_runtime);
+            let mut fit = match &mode {
+                FitMode::Runtime(forced_runtime) => {
+                    ModelFit::analyze_with_forced_runtime(m, specs, context_limit, *forced_runtime)
+                }
+                FitMode::Config(config) => {
+                    let mut config = config.as_ref().clone();
+                    config.context_cap = context_limit.or(config.context_cap);
+                    ModelFit::analyze_with_config(m, specs, config)
+                }
+            };
             fit.installed = installed.is_installed(m);
             fit.measured_tps = local_index
                 .as_ref()
@@ -192,6 +250,7 @@ pub fn build_model_fits(
                         .as_ref()
                         .and_then(|idx| idx.lookup(&m.name, &fit.best_quant))
                 });
+            fit.refresh_estimate_confidence();
             fit
         })
         .collect();
@@ -249,6 +308,9 @@ pub fn apply_local_calibration(fits: &mut [ModelFit]) {
         }
         f.estimated_tps = uncalibrated(f) * factor;
         f.estimate_basis.local_calibration = Some(factor);
+        // A measured row keeps its measured confidence; this only promotes the
+        // formula rows that the factor was applied to.
+        f.refresh_estimate_confidence();
     }
 }
 
@@ -270,5 +332,58 @@ mod calibration_tests {
         assert_eq!(median(&[0.1]), 0.1);
         assert_eq!(median(&[0.1, 0.3]), 0.2);
         assert_eq!(median(&[0.1, 0.2, 0.9]), 0.2);
+    }
+}
+
+#[cfg(test)]
+mod sanitization_gate_tests {
+    use super::*;
+    use crate::hardware::GpuBackend;
+
+    fn specs_with_gpu() -> SystemSpecs {
+        SystemSpecs {
+            total_ram_gb: 64.0,
+            available_ram_gb: 48.0,
+            total_cpu_cores: 16,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: true,
+            gpu_vram_gb: Some(24.0),
+            total_gpu_vram_gb: Some(24.0),
+            gpu_available_gb: None,
+            gpu_name: Some("Test GPU".to_string()),
+            gpu_count: 1,
+            unified_memory: false,
+            backend: GpuBackend::Cuda,
+            gpus: vec![],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        }
+    }
+
+    /// `build_model_fits` must not surface a demoted catalog entry in its
+    /// ranked output (issue #969, problem 3), even though the same entry
+    /// stays queryable through `ModelDatabase::get_all_models`.
+    #[test]
+    fn build_model_fits_excludes_sanitization_demoted_entries() {
+        let db = ModelDatabase::new();
+        let specs = specs_with_gpu();
+
+        let demoted_names: std::collections::HashSet<String> = db
+            .get_all_models()
+            .iter()
+            .filter(|m| m.is_sanitization_demoted())
+            .map(|m| m.name.clone())
+            .collect();
+        assert!(
+            !demoted_names.is_empty(),
+            "expected the embedded catalog to contain at least one sanitization-demoted entry"
+        );
+
+        let fits = build_model_fits(&db, &specs, &InstalledIndex::empty(), None, None);
+
+        assert!(
+            fits.iter().all(|f| !demoted_names.contains(&f.model.name)),
+            "a sanitization-demoted model leaked into ranked fits"
+        );
     }
 }

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -33,6 +33,19 @@ pub struct CalcConfig {
     /// once per process, otherwise a conservative 50 GB/s.
     #[serde(default)]
     pub ddr_bandwidth_gbps: Option<f64>,
+    /// GPU memory bandwidth in GB/s, overriding the GPU-name lookup table.
+    /// Set this for a GPU the table doesn't recognize, or to reproduce an
+    /// estimate on hardware you don't have. None = use the name table.
+    /// See [`resolve_gpu_bandwidth`].
+    #[serde(default)]
+    pub gpu_bandwidth_gbps_override: Option<f64>,
+    /// GPU dense fp16 matmul throughput in TFLOP/s, used for the
+    /// prompt-processing (prefill/TTFT) estimate. None = unknown, in which
+    /// case prefill and TTFT are reported as `null` rather than guessed:
+    /// prefill is compute-bound, so there is no bandwidth roofline to fall
+    /// back on.
+    #[serde(default)]
+    pub gpu_compute_tflops_fp16: Option<f64>,
 }
 
 impl Default for CalcConfig {
@@ -43,6 +56,8 @@ impl Default for CalcConfig {
             run_mode_factors: RunModeFactors::default(),
             scoring_weights: ScoringWeights::default(),
             ddr_bandwidth_gbps: None,
+            gpu_bandwidth_gbps_override: None,
+            gpu_compute_tflops_fp16: None,
         }
     }
 }
@@ -232,6 +247,84 @@ pub struct EstimateBasis {
     pub local_calibration: Option<f64>,
 }
 
+/// How much to trust the throughput figure attached to a fit.
+///
+/// A measured number and a formula guess are both a "tok/s", and until now
+/// nothing in the payload told them apart. Ordered most to least trustworthy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EstimateConfidence {
+    /// Benchmarked by this user on this machine (`llmfit bench`).
+    MeasuredLocal,
+    /// Benchmarked by someone else on hardware matching this machine.
+    MeasuredCommunity,
+    /// Formula estimate, scaled by a correction factor derived from benchmark
+    /// runs on this hardware.
+    Calibrated,
+    /// Formula estimate with no measurement behind it.
+    #[default]
+    Estimated,
+    /// No estimate produced — the model needs a runtime llmfit can't model.
+    Unsupported,
+}
+
+impl EstimateConfidence {
+    /// Stable machine code, matching the serde representation.
+    pub fn code(&self) -> &'static str {
+        match self {
+            EstimateConfidence::MeasuredLocal => "measured_local",
+            EstimateConfidence::MeasuredCommunity => "measured_community",
+            EstimateConfidence::Calibrated => "calibrated",
+            EstimateConfidence::Estimated => "estimated",
+            EstimateConfidence::Unsupported => "unsupported",
+        }
+    }
+
+    /// Short human-readable label for UI surfaces.
+    pub fn label(&self) -> &'static str {
+        match self {
+            EstimateConfidence::MeasuredLocal => "measured (this machine)",
+            EstimateConfidence::MeasuredCommunity => "measured (community)",
+            EstimateConfidence::Calibrated => "calibrated",
+            EstimateConfidence::Estimated => "estimated",
+            EstimateConfidence::Unsupported => "unsupported — no basis",
+        }
+    }
+}
+
+/// Classify a fit's throughput figure by provenance, first match wins.
+///
+/// Measurement outranks calibration, and calibration outranks a bare formula.
+/// `Unsupported` is checked after calibration because a fit with no estimate
+/// never picks up a calibration factor in the first place
+/// (`apply_local_calibration` skips rows with `estimated_tps <= 0`), so the
+/// order only matters if that invariant is ever broken.
+pub fn derive_estimate_confidence(
+    measured: Option<&crate::benchmarks::MeasuredTps>,
+    basis: &EstimateBasis,
+) -> EstimateConfidence {
+    use crate::benchmarks::MeasuredSource;
+
+    if let Some(m) = measured {
+        return match m.source {
+            MeasuredSource::LocalBench => EstimateConfidence::MeasuredLocal,
+            MeasuredSource::Community | MeasuredSource::CommunityLlmfit => {
+                EstimateConfidence::MeasuredCommunity
+            }
+        };
+    }
+    if basis.local_calibration.is_some() {
+        return EstimateConfidence::Calibrated;
+    }
+    if basis.method == UNSUPPORTED_METHOD {
+        return EstimateConfidence::Unsupported;
+    }
+    EstimateConfidence::Estimated
+}
+
+/// `EstimateBasis::method` value marking a fit with no throughput estimate.
+pub const UNSUPPORTED_METHOD: &str = "unsupported";
+
 #[derive(Clone, serde::Serialize)]
 pub struct ModelFit {
     pub model: LlmModel,
@@ -264,6 +357,24 @@ pub struct ModelFit {
     /// with priority over `estimated_tps`. Set after analysis, like
     /// `installed`.
     pub measured_tps: Option<crate::benchmarks::MeasuredTps>,
+    /// How much to trust `estimated_tps` — measured, calibrated, or a bare
+    /// formula. Derived at construction from the estimate method, then
+    /// refreshed by [`ModelFit::refresh_estimate_confidence`] once
+    /// `measured_tps` and calibration have been filled in (both are set after
+    /// analysis, like `installed`).
+    #[serde(default)]
+    pub estimate_confidence: EstimateConfidence,
+    /// Estimated prompt-processing throughput (tok/s). Prefill is
+    /// compute-bound, not bandwidth-bound, so this is `None` unless
+    /// `CalcConfig::gpu_compute_tflops_fp16` is known — a null here means
+    /// "not estimated", which is different from a slow 0.0.
+    #[serde(default)]
+    pub prefill_tps: Option<f64>,
+    /// Estimated time to first token (ms) for a prompt of
+    /// `effective_context_length` tokens. `None` under the same conditions as
+    /// `prefill_tps`.
+    #[serde(default)]
+    pub ttft_ms: Option<f64>,
 }
 
 impl ModelFit {
@@ -369,10 +480,13 @@ impl ModelFit {
                 effective_context_length: estimation_ctx,
                 usable_context: 0,
                 estimate_basis: EstimateBasis {
-                    method: "unsupported".to_string(),
+                    method: UNSUPPORTED_METHOD.to_string(),
                     ..EstimateBasis::default()
                 },
                 measured_tps: None,
+                estimate_confidence: EstimateConfidence::Unsupported,
+                prefill_tps: None,
+                ttft_ms: None,
             };
         }
 
@@ -501,12 +615,7 @@ impl ModelFit {
         };
 
         // Score fit purely on memory headroom (Perfect requires GPU)
-        let fit_level = score_fit(
-            mem_required,
-            mem_available,
-            model.recommended_ram_gb,
-            run_mode,
-        );
+        let fit_level = score_fit(mem_required, mem_available, run_mode);
 
         let utilization_pct = if mem_available > 0.0 {
             (mem_required / mem_available) * 100.0
@@ -571,12 +680,11 @@ impl ModelFit {
 
         // Record the estimate's inputs so it can be reproduced (issue #292).
         // Mirrors the path selection in estimate_tps: bandwidth roofline when
-        // the GPU is recognized, per-backend constant otherwise.
+        // the GPU is recognized, per-backend constant otherwise. Both read the
+        // bandwidth through resolve_gpu_bandwidth so the reported basis can't
+        // drift from the number the estimate actually used.
         let estimate_basis = {
-            let gpu_bw = system
-                .gpu_name
-                .as_deref()
-                .and_then(crate::hardware::gpu_memory_bandwidth_gbps);
+            let gpu_bw = resolve_gpu_bandwidth(system, &config);
             let method = if run_mode == RunMode::CpuOnly {
                 "cpu_constant"
             } else if gpu_bw.is_some() {
@@ -666,6 +774,13 @@ impl ModelFit {
                 tq_mem <= mem_available
             };
 
+        let (prefill_tps, ttft_ms) = estimate_prefill(model, run_mode, estimation_ctx, &config);
+
+        // No measurement or calibration is available this early — both are
+        // attached after analysis, so callers must call
+        // `refresh_estimate_confidence` once they are.
+        let estimate_confidence = derive_estimate_confidence(None, &estimate_basis);
+
         ModelFit {
             model: model.clone(),
             fit_level,
@@ -687,7 +802,21 @@ impl ModelFit {
             usable_context,
             estimate_basis,
             measured_tps: None, // set later, like `installed`
+            estimate_confidence,
+            prefill_tps,
+            ttft_ms,
         }
+    }
+
+    /// Recompute [`ModelFit::estimate_confidence`] from the fit's current
+    /// `measured_tps` and `estimate_basis.local_calibration`.
+    ///
+    /// Both of those are attached after `analyze`, so the value set at
+    /// construction only reflects the formula. Call this after populating
+    /// measured throughput or applying calibration.
+    pub fn refresh_estimate_confidence(&mut self) {
+        self.estimate_confidence =
+            derive_estimate_confidence(self.measured_tps.as_ref(), &self.estimate_basis);
     }
 
     /// Context column text: `"262k→14k"` when the memory pool constrains
@@ -741,60 +870,64 @@ impl ModelFit {
     }
 }
 
-/// Pure memory headroom scoring.
-/// - GPU (including Apple Silicon unified memory): can reach Perfect.
-/// - CpuOffload: caps at Good.
-/// - CpuOnly: caps at Good -- no GPU acceleration so never Perfect, but a model
-///   that fits with comfortable headroom is genuinely runnable, not Marginal.
-fn score_fit(
-    mem_required: f64,
-    mem_available: f64,
-    recommended: f64,
-    run_mode: RunMode,
-) -> FitLevel {
-    if mem_required > mem_available {
-        return FitLevel::TooTight;
-    }
+// Memory-ratio ceilings for each verdict, as `mem_required / mem_available`.
+//
+// The verdict is a pure function of this one ratio. `recommended_ram_gb`
+// deliberately plays no part: it is a catalog-wide `model_size * 2.0` heuristic
+// (see AGENTS.md), and gating Perfect on it skewed the answer both ways. It
+// over-promised on tight fits — a 23 GB model on a 24 GB card met its 22 GB
+// recommendation and scored Perfect at 96% utilization, where it does not load
+// — and under-rated roomy ones, scoring a 9 GB model Good at 56% of a 16 GB
+// card but Perfect on a 24 GB card, so the verdict tracked the card's size
+// rather than how tightly the model fits it.
+//
+// The Marginal ceiling stops at 0.98 rather than 1.00 because a pool filled to
+// the last percent has no room for allocator slack or fragmentation, so it does
+// not load in practice.
+const FIT_PERFECT_MAX_RATIO: f64 = 0.60;
+const FIT_GOOD_MAX_RATIO: f64 = 0.85;
+const FIT_MARGINAL_MAX_RATIO: f64 = 0.98;
 
-    match run_mode {
-        RunMode::Gpu | RunMode::TensorParallel => {
-            if recommended <= mem_available {
-                FitLevel::Perfect
-            } else if mem_available >= mem_required * 1.2 {
-                FitLevel::Good
-            } else {
-                FitLevel::Marginal
-            }
-        }
-        RunMode::MoeOffload => {
-            // MoE expert offloading -- GPU handles inference, inactive experts in RAM
-            // Good performance with some latency on expert switching
-            if mem_available >= mem_required * 1.2 {
-                FitLevel::Good
-            } else {
-                FitLevel::Marginal
-            }
-        }
-        RunMode::CpuOffload => {
-            // Mixed GPU/CPU -- decent but not ideal
-            if mem_available >= mem_required * 1.2 {
-                FitLevel::Good
-            } else {
-                FitLevel::Marginal
-            }
-        }
-        RunMode::CpuOnly => {
-            // CPU-only never reaches Perfect (that requires a GPU), but a model
-            // that fits with comfortable headroom is genuinely runnable -- cap
-            // at Good rather than hiding every CPU-only model behind Marginal.
-            // (Matches the FitLevel::Good contract: "GPU tight, or CPU comfortable".)
-            if mem_available >= mem_required * 1.2 {
-                FitLevel::Good
-            } else {
-                FitLevel::Marginal
-            }
-        }
+/// The verdict from memory pressure alone, before any run-mode cap.
+///
+/// A non-finite ratio (an empty or unknown pool) is TooTight: we can't claim a
+/// model fits a pool we couldn't size.
+fn pure_ratio_verdict(memory_ratio: f64) -> FitLevel {
+    if !memory_ratio.is_finite() || memory_ratio > FIT_MARGINAL_MAX_RATIO {
+        FitLevel::TooTight
+    } else if memory_ratio <= FIT_PERFECT_MAX_RATIO {
+        FitLevel::Perfect
+    } else if memory_ratio <= FIT_GOOD_MAX_RATIO {
+        FitLevel::Good
+    } else {
+        FitLevel::Marginal
     }
+}
+
+/// Cap a verdict at what the execution path can actually deliver.
+///
+/// Perfect means "fits with room to spare *and* runs on the GPU", so only the
+/// two fully-GPU-resident paths can reach it. The offload and CPU paths cap at
+/// Good however much headroom they have — they are still genuinely runnable,
+/// which is why they are not pushed down to Marginal.
+fn cap_for_run_mode(level: FitLevel, run_mode: RunMode) -> FitLevel {
+    match run_mode {
+        RunMode::Gpu | RunMode::TensorParallel => level,
+        RunMode::MoeOffload | RunMode::CpuOffload | RunMode::CpuOnly => match level {
+            FitLevel::Perfect => FitLevel::Good,
+            other => other,
+        },
+    }
+}
+
+/// Pure memory headroom scoring: ratio verdict, capped by execution path.
+fn score_fit(mem_required: f64, mem_available: f64, run_mode: RunMode) -> FitLevel {
+    let memory_ratio = if mem_available > 0.0 {
+        mem_required / mem_available
+    } else {
+        f64::INFINITY
+    };
+    cap_for_run_mode(pure_ratio_verdict(memory_ratio), run_mode)
 }
 
 /// Determine memory pool for CPU-only inference.
@@ -1144,6 +1277,98 @@ const VRAM_PRESSURE_PENALTY_FLOOR: f64 = 0.30;
 /// Conservative 50% — assumes half the experts are inactive on average.
 const VRAM_PRESSURE_DEFAULT_EXPERT_RATIO: f64 = 0.50;
 
+/// Calibration for the Tier-2 (metadata-poor) MoE decode estimate.
+///
+/// Tier 2 approximates per-token traffic as `active_parameters * quant_bpp`,
+/// which is only a proxy: the real read set also covers attention, the router
+/// and any shared expert, at whatever precision those tensors were kept at.
+/// These two factors absorb the difference.
+///
+/// * `efficiency` — fraction of peak memory bandwidth the kernels sustain.
+/// * `overhead` — correction for per-token bytes the proxy mis-counts.
+///   Below 1.0 when more is read than `active_parameters` suggests.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct MoeTier2Params {
+    pub efficiency: f64,
+    pub overhead: f64,
+}
+
+/// Tier-2 MoE calibration for an architecture.
+///
+/// Architectures absent from the table fall back to `config_efficiency` and the
+/// original `num_experts`-tiered overhead, so adding an entry can only change
+/// the model it names.
+///
+/// The expert-count tiers are a poor proxy for the newest sparse designs:
+/// counting 128+ experts, they assume heavy router and cache overhead (0.40)
+/// and land roughly 2x low on architectures that route to very few experts
+/// through well-optimized kernels. Per-architecture entries below are fitted to
+/// published single-request decode measurements; each cites its source.
+fn moe_tier2_params(
+    architecture: Option<&str>,
+    num_experts: Option<u32>,
+    config_efficiency: f64,
+) -> MoeTier2Params {
+    // Normalize: catalog `architecture` values are HF `model_type` strings
+    // (e.g. "gpt_oss", "deepseek_v3"), but casing varies by source.
+    let arch = architecture.unwrap_or("").to_lowercase();
+
+    // gpt-oss-120b/20b: 128 experts, 4 active, MXFP4-native weights. Geometry
+    // (117B total / 5.1B active, 128 experts, 4 per token, MXFP4) from the
+    // OpenAI gpt-oss model card, `openai/gpt-oss-120b` on HuggingFace.
+    //
+    // Calibration reference: ~50 tok/s decode for the 120B on 256 GB/s-class
+    // unified memory (issue #969). The roofline for its active set is ~87
+    // tok/s, so it sustains a far higher fraction of peak than the K-quant
+    // default — MXFP4 weights are read at ~4.25 bits rather than the 4.6 that
+    // `quant_bpp("Q4_K_M")` assumes, and only 4 of 128 experts are touched.
+    if arch.starts_with("gpt_oss") || arch.starts_with("gptoss") {
+        return MoeTier2Params {
+            efficiency: 0.72,
+            overhead: 0.80,
+        };
+    }
+
+    // DeepSeek V3/V4 line: 256 routed experts + a shared expert, MLA
+    // attention. The shared expert and MLA KV projections are read on every
+    // token regardless of routing, so per-token traffic runs well above
+    // `active_parameters * bpp` — hence the lower overhead — while the large
+    // fused expert matmuls still sustain better than default efficiency.
+    // Geometry from the DeepSeek-V3 technical report (arXiv:2412.19437), which
+    // describes the 256-routed-plus-shared expert layout and MLA; DeepSeek-V2
+    // (arXiv:2405.04434) covers the per-token active-parameter accounting.
+    //
+    // Calibration reference: ~35 tok/s at 13B active on 614 GB/s-class
+    // hardware (issue #969).
+    if arch.starts_with("deepseek_v3") || arch.starts_with("deepseek_v4") {
+        return MoeTier2Params {
+            efficiency: 0.62,
+            overhead: 0.70,
+        };
+    }
+
+    MoeTier2Params {
+        efficiency: config_efficiency,
+        overhead: default_moe_overhead(num_experts),
+    }
+}
+
+/// The original `num_experts`-tiered MoE overhead, kept as the default for
+/// architectures without a calibrated entry.
+///
+/// Calibrated against llama-bench on an RX 6900 XT: 0.90 for Mixtral-class,
+/// 0.70 for the OLMoE / Qwen1.5-MoE / DeepSeek-V2-Lite 64-expert group.
+fn default_moe_overhead(num_experts: Option<u32>) -> f64 {
+    match num_experts {
+        Some(n) if n <= 8 => 0.90, // calibrated for Mixtral-class
+        Some(n) if n <= 16 => 0.85,
+        Some(n) if n <= 32 => 0.80,
+        Some(n) if n <= 64 => 0.70, // calibrated: OLMoE, Qwen1.5, DeepSeek
+        Some(_) => 0.40,            // 128+ experts
+        None => 0.60,               // unknown
+    }
+}
+
 /// Print a debug line to stderr when LLMFIT_DEBUG env var is set.
 /// Usage: `LLMFIT_DEBUG=1 llmfit fit ...` to see which estimation path is taken.
 /// Uses a macro to avoid string allocation when debug logging is disabled (hot path).
@@ -1153,6 +1378,83 @@ macro_rules! debug_log {
             eprintln!("[llmfit:debug] {}", format!($($arg)*));
         }
     };
+}
+
+/// GPU memory bandwidth (GB/s) to estimate with, or `None` when unknown.
+///
+/// Single source of truth for the bandwidth roofline, so `estimate_tps` and the
+/// `EstimateBasis` it reports can't disagree about what was assumed.
+///
+/// Resolution order:
+///  1. `CalcConfig::gpu_bandwidth_gbps_override`
+///  2. the GPU-name lookup table (`hardware::gpu_memory_bandwidth_gbps`)
+///  3. `None` — caller falls back to the per-backend constant
+///
+/// Non-positive overrides are ignored rather than trusted: a zero would make
+/// the roofline divide to nothing.
+pub fn resolve_gpu_bandwidth(system: &SystemSpecs, config: &CalcConfig) -> Option<f64> {
+    if let Some(bw) = config.gpu_bandwidth_gbps_override.filter(|b| *b > 0.0) {
+        return Some(bw);
+    }
+    system
+        .gpu_name
+        .as_deref()
+        .and_then(crate::hardware::gpu_memory_bandwidth_gbps)
+}
+
+/// Fraction of peak fp16 matmul throughput reached during prompt processing.
+///
+/// Prefill is compute-bound and runs at large batch, but still loses time to
+/// attention (quadratic, not a dense matmul), dequantization of the weights,
+/// and pipeline gaps between layers. Published model-FLOPs-utilization figures
+/// for single-request inference land around a third of peak:
+///  - Google, "Efficiently Scaling Transformer Inference" (arXiv:2211.05102)
+///  - Chowdhery et al., "PaLM" (arXiv:2204.02311), §Training efficiency
+const PREFILL_COMPUTE_UTILIZATION: f64 = 0.35;
+
+/// Estimated `(prefill_tps, ttft_ms)` for a prompt of `prompt_tokens`.
+///
+/// Returns `(None, None)` unless the GPU's fp16 throughput is configured, and
+/// on the CPU-only path: prompt processing is limited by compute, not memory
+/// bandwidth, so unlike decode there is no roofline to fall back on and a
+/// guess would be indistinguishable from a measurement. A null says
+/// "not estimated"; 0.0 would wrongly say "immeasurably slow".
+///
+/// Each parameter contributes one multiply-accumulate (2 FLOPs) per token, so
+/// `flops_per_token = 2 * params`. MoE models only route through their active
+/// experts, so active parameters drive the cost when known. Quantization is
+/// ignored deliberately: llama.cpp and vLLM both dequantize to fp16 for the
+/// matmul, so the FLOP count is the same at Q4 as at F16.
+fn estimate_prefill(
+    model: &LlmModel,
+    run_mode: RunMode,
+    prompt_tokens: u32,
+    config: &CalcConfig,
+) -> (Option<f64>, Option<f64>) {
+    let Some(tflops) = config.gpu_compute_tflops_fp16.filter(|t| *t > 0.0) else {
+        return (None, None);
+    };
+    if run_mode == RunMode::CpuOnly {
+        return (None, None);
+    }
+
+    let params = model
+        .active_parameters
+        .filter(|_| model.is_moe)
+        .map(|p| p as f64)
+        .unwrap_or_else(|| model.params_b() * 1_000_000_000.0)
+        .max(1.0);
+
+    let flops_per_token = 2.0 * params;
+    let usable_flops = tflops * 1e12 * PREFILL_COMPUTE_UTILIZATION;
+    let prefill_tps =
+        (usable_flops / flops_per_token) * config.run_mode_factors.for_run_mode(run_mode);
+    if prefill_tps <= 0.0 {
+        return (None, None);
+    }
+
+    let ttft_ms = (f64::from(prompt_tokens) / prefill_tps) * 1000.0;
+    (Some(prefill_tps), Some(ttft_ms))
 }
 
 /// System DDR bandwidth (GB/s) used for MoE-offload expert streaming.
@@ -1190,8 +1492,6 @@ pub(crate) fn estimate_tps(
     runtime: InferenceRuntime,
     config: &CalcConfig,
 ) -> f64 {
-    use crate::hardware::gpu_memory_bandwidth_gbps;
-
     // MoE models execute only active experts per token, so speed estimates should
     // use active parameters when known; fit/memory paths still use full model size.
     let params = model
@@ -1219,8 +1519,7 @@ pub(crate) fn estimate_tps(
     //  - RTX 4090 (1008 GB/s): Qwen3.5-27B Q4 → ~40 tok/s measured
     //  - T4 (320 GB/s): 7B F16 → ~16 tok/s (ggerganov benchmark)
     //  - Apple M1 Max (400 GB/s): 7B Q4_0 → ~61 tok/s (ggerganov benchmark)
-    let gpu_name = system.gpu_name.as_deref().unwrap_or("");
-    let bandwidth = gpu_memory_bandwidth_gbps(gpu_name);
+    let bandwidth = resolve_gpu_bandwidth(system, config);
 
     if run_mode != RunMode::CpuOnly
         && let Some(bw) = bandwidth
@@ -1389,22 +1688,20 @@ pub(crate) fn estimate_tps(
                 return (raw_tps * mode_factor * vram_pressure).max(0.1);
             }
 
-            // Tier 2: Fallback — active_parameters * quant_bpp with tiered moe_overhead
+            // Tier 2: Fallback — active_parameters * quant_bpp, corrected by the
+            // per-architecture calibration (default reproduces the original
+            // num_experts-tiered overhead).
             let moe_active_gb = params * models::quant_bpp(quant);
-            let moe_overhead = match model.num_experts {
-                Some(n) if n <= 8 => 0.90, // calibrated for Mixtral-class
-                Some(n) if n <= 16 => 0.85,
-                Some(n) if n <= 32 => 0.80,
-                Some(n) if n <= 64 => 0.70, // calibrated: OLMoE, Qwen1.5, DeepSeek
-                Some(_) => 0.40,            // 128+ experts
-                None => 0.60,               // unknown
-            };
-            let raw_tps = (bw / moe_active_gb) * efficiency * moe_overhead;
+            let tier2 =
+                moe_tier2_params(model.architecture.as_deref(), model.num_experts, efficiency);
+            let raw_tps = (bw / moe_active_gb) * tier2.efficiency * tier2.overhead;
             let mode_factor = config.run_mode_factors.for_run_mode(run_mode);
             debug_log!(
-                "MoE GPU Tier2 (fallback): {} moe_overhead={:.2} vram_pressure={:.2} raw_tps={:.1}",
+                "MoE GPU Tier2 (fallback): {} arch={:?} efficiency={:.2} overhead={:.2} vram_pressure={:.2} raw_tps={:.1}",
                 model.name,
-                moe_overhead,
+                model.architecture.as_deref().unwrap_or("?"),
+                tier2.efficiency,
+                tier2.overhead,
                 vram_pressure,
                 raw_tps
             );
@@ -1841,50 +2138,51 @@ mod tests {
     #[test]
     fn test_score_fit_too_tight() {
         // Model doesn't fit
-        let fit = score_fit(10.0, 8.0, 16.0, RunMode::Gpu);
+        let fit = score_fit(10.0, 8.0, RunMode::Gpu);
         assert_eq!(fit, FitLevel::TooTight);
     }
 
     #[test]
     fn test_score_fit_gpu_perfect() {
-        // GPU with recommended memory met
-        let fit = score_fit(8.0, 16.0, 12.0, RunMode::Gpu);
+        // GPU at half the pool -> comfortably inside the Perfect band
+        let fit = score_fit(8.0, 16.0, RunMode::Gpu);
         assert_eq!(fit, FitLevel::Perfect);
     }
 
     #[test]
     fn test_score_fit_gpu_good() {
-        // GPU with good headroom but not recommended
-        let fit = score_fit(8.0, 10.0, 16.0, RunMode::Gpu);
+        // GPU at 80% of the pool -> Good
+        let fit = score_fit(8.0, 10.0, RunMode::Gpu);
         assert_eq!(fit, FitLevel::Good);
     }
 
     #[test]
     fn test_score_fit_gpu_marginal() {
-        // GPU with minimal headroom
-        let fit = score_fit(8.0, 8.5, 16.0, RunMode::Gpu);
+        // GPU at 94% of the pool -> Marginal
+        let fit = score_fit(8.0, 8.5, RunMode::Gpu);
         assert_eq!(fit, FitLevel::Marginal);
     }
 
     #[test]
     fn test_score_fit_cpu_comfortable_is_good() {
         // CPU-only with comfortable headroom (4 GB of 32 GB) is runnable -> Good.
-        // It never reaches Perfect (recommended 8 GB is met, but Perfect needs a GPU).
-        let fit = score_fit(4.0, 32.0, 8.0, RunMode::CpuOnly);
+        // The ratio alone would say Perfect; the run-mode cap holds it at Good.
+        let fit = score_fit(4.0, 32.0, RunMode::CpuOnly);
         assert_eq!(fit, FitLevel::Good);
     }
 
     #[test]
     fn test_score_fit_cpu_tight_is_marginal() {
-        // CPU-only that only just fits (under the 1.2x headroom bar) stays Marginal.
-        let fit = score_fit(8.0, 8.5, 16.0, RunMode::CpuOnly);
+        // CPU-only that only just fits stays Marginal — the cap lowers Perfect
+        // to Good but never lifts a tight fit.
+        let fit = score_fit(8.0, 8.5, RunMode::CpuOnly);
         assert_eq!(fit, FitLevel::Marginal);
     }
 
     #[test]
     fn test_score_fit_cpu_never_perfect() {
         // Even with enormous headroom, CPU-only caps at Good (no GPU -> not Perfect).
-        let fit = score_fit(1.0, 64.0, 2.0, RunMode::CpuOnly);
+        let fit = score_fit(1.0, 64.0, RunMode::CpuOnly);
         assert_ne!(fit, FitLevel::Perfect);
         assert_eq!(fit, FitLevel::Good);
     }
@@ -1892,19 +2190,115 @@ mod tests {
     #[test]
     fn test_score_fit_cpu_offload_caps_at_good() {
         // CpuOffload with plenty of headroom caps at Good
-        let fit = score_fit(8.0, 16.0, 12.0, RunMode::CpuOffload);
+        let fit = score_fit(8.0, 16.0, RunMode::CpuOffload);
         assert_eq!(fit, FitLevel::Good);
     }
 
     #[test]
     fn test_score_fit_moe_offload() {
-        // MoE offload with good headroom
-        let fit = score_fit(6.0, 8.0, 12.0, RunMode::MoeOffload);
+        // MoE offload at 75% -> Good
+        let fit = score_fit(6.0, 8.0, RunMode::MoeOffload);
         assert_eq!(fit, FitLevel::Good);
 
         // MoE offload with tight fit
-        let fit_tight = score_fit(7.0, 7.5, 14.0, RunMode::MoeOffload);
+        let fit_tight = score_fit(7.0, 7.5, RunMode::MoeOffload);
         assert_eq!(fit_tight, FitLevel::Marginal);
+    }
+
+    // ── verdict = cap_for_run_mode(pure_ratio_verdict(ratio), run_mode) ──
+
+    #[test]
+    fn pure_ratio_verdict_band_boundaries_are_inclusive() {
+        // Each threshold belongs to the better verdict.
+        assert_eq!(pure_ratio_verdict(0.0), FitLevel::Perfect);
+        assert_eq!(
+            pure_ratio_verdict(FIT_PERFECT_MAX_RATIO),
+            FitLevel::Perfect,
+            "0.60 is still Perfect"
+        );
+        assert_eq!(pure_ratio_verdict(0.601), FitLevel::Good);
+        assert_eq!(
+            pure_ratio_verdict(FIT_GOOD_MAX_RATIO),
+            FitLevel::Good,
+            "0.85 is still Good"
+        );
+        assert_eq!(pure_ratio_verdict(0.851), FitLevel::Marginal);
+        assert_eq!(
+            pure_ratio_verdict(FIT_MARGINAL_MAX_RATIO),
+            FitLevel::Marginal,
+            "0.98 is still Marginal"
+        );
+    }
+
+    #[test]
+    fn pure_ratio_verdict_rejects_a_pool_filled_to_the_brim() {
+        // Above 0.98 there is no room for allocator slack, so it does not load
+        // even though required <= available.
+        assert_eq!(pure_ratio_verdict(0.99), FitLevel::TooTight);
+        assert_eq!(pure_ratio_verdict(1.0), FitLevel::TooTight);
+        assert_eq!(pure_ratio_verdict(2.5), FitLevel::TooTight);
+    }
+
+    #[test]
+    fn pure_ratio_verdict_treats_unknown_pool_as_too_tight() {
+        // An empty or unsized pool must not be reported as a fit.
+        assert_eq!(pure_ratio_verdict(f64::INFINITY), FitLevel::TooTight);
+        assert_eq!(pure_ratio_verdict(f64::NAN), FitLevel::TooTight);
+        assert_eq!(score_fit(4.0, 0.0, RunMode::Gpu), FitLevel::TooTight);
+    }
+
+    #[test]
+    fn cap_for_run_mode_only_lowers_perfect_on_non_gpu_paths() {
+        for level in [
+            FitLevel::Perfect,
+            FitLevel::Good,
+            FitLevel::Marginal,
+            FitLevel::TooTight,
+        ] {
+            // The two fully-GPU-resident paths pass every verdict through.
+            assert_eq!(cap_for_run_mode(level, RunMode::Gpu), level);
+            assert_eq!(cap_for_run_mode(level, RunMode::TensorParallel), level);
+
+            for mode in [RunMode::MoeOffload, RunMode::CpuOffload, RunMode::CpuOnly] {
+                let capped = cap_for_run_mode(level, mode);
+                assert_ne!(capped, FitLevel::Perfect, "{mode:?} must never be Perfect");
+                let expected = if level == FitLevel::Perfect {
+                    FitLevel::Good
+                } else {
+                    level
+                };
+                assert_eq!(capped, expected, "{mode:?} must not alter {level:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn verdict_ignores_recommended_ram() {
+        // recommended_ram_gb is a catalog-wide `size * 2.0` heuristic. Two
+        // models with the same footprint in the same pool must get the same
+        // verdict however far apart their recommended figures are.
+        let mut lean = test_model("7B", 4.0, Some(4.0));
+        lean.recommended_ram_gb = 4.0;
+        let mut greedy = test_model("7B", 4.0, Some(4.0));
+        greedy.recommended_ram_gb = 999.0;
+
+        let system = test_system(64.0, true, Some(24.0));
+        let lean_fit = ModelFit::analyze(&lean, &system);
+        let greedy_fit = ModelFit::analyze(&greedy, &system);
+
+        assert_eq!(lean_fit.memory_required_gb, greedy_fit.memory_required_gb);
+        assert_eq!(lean_fit.fit_level, greedy_fit.fit_level);
+        assert_eq!(greedy_fit.fit_level, FitLevel::Perfect);
+    }
+
+    #[test]
+    fn a_nearly_full_pool_is_not_perfect_however_low_recommended_is() {
+        // The old rule granted Perfect as soon as `recommended_ram_gb` was met,
+        // so a 23 GB model on a 24 GB card scored Perfect at 96% utilization —
+        // a pool that full does not actually load.
+        assert_eq!(score_fit(23.0, 24.0, RunMode::Gpu), FitLevel::Marginal);
+        // And at 83% it is Good, not Perfect.
+        assert_eq!(score_fit(20.0, 24.0, RunMode::Gpu), FitLevel::Good);
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -3974,6 +4368,594 @@ mod tests {
                 fix.measured_tps,
                 ratio,
             );
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // resolve_gpu_bandwidth
+    // ────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_gpu_bandwidth_prefers_the_config_override() {
+        // The override exists so an unrecognized GPU can still get a roofline
+        // estimate, and so a fixture can pin bandwidth without naming hardware.
+        let system = rx6900xt_system();
+        let table_value = resolve_gpu_bandwidth(&system, &CalcConfig::default());
+        assert_eq!(table_value, Some(512.0), "RX 6900 XT is in the name table");
+
+        let config = CalcConfig {
+            gpu_bandwidth_gbps_override: Some(256.0),
+            ..CalcConfig::default()
+        };
+        assert_eq!(resolve_gpu_bandwidth(&system, &config), Some(256.0));
+    }
+
+    #[test]
+    fn resolve_gpu_bandwidth_falls_back_to_the_name_table_then_none() {
+        // Unknown GPU with no override -> None, so the caller drops to the
+        // per-backend constant rather than inventing a bandwidth.
+        let unknown = test_system(16.0, true, Some(8.0));
+        assert_eq!(
+            resolve_gpu_bandwidth(&unknown, &CalcConfig::default()),
+            None
+        );
+
+        // No GPU at all -> None.
+        let headless = test_system(16.0, false, None);
+        assert_eq!(
+            resolve_gpu_bandwidth(&headless, &CalcConfig::default()),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_gpu_bandwidth_ignores_a_non_positive_override() {
+        // A zero would make the roofline divide to nothing, so it must not be
+        // trusted over the table.
+        let system = rx6900xt_system();
+        for bad in [0.0, -1.0] {
+            let config = CalcConfig {
+                gpu_bandwidth_gbps_override: Some(bad),
+                ..CalcConfig::default()
+            };
+            assert_eq!(
+                resolve_gpu_bandwidth(&system, &config),
+                Some(512.0),
+                "override of {bad} must be ignored"
+            );
+        }
+    }
+
+    #[test]
+    fn estimate_basis_reports_the_bandwidth_the_estimate_used() {
+        // The basis exists to make an estimate reproducible (issue #292), so it
+        // must record the override rather than the name-table value.
+        let model = test_model("7B", 4.0, Some(4.0));
+        let mut system = rx6900xt_system();
+        system.gpu_vram_gb = Some(24.0);
+        system.total_gpu_vram_gb = Some(24.0);
+
+        let config = CalcConfig {
+            gpu_bandwidth_gbps_override: Some(300.0),
+            ..test_config()
+        };
+        let fit = ModelFit::analyze_with_config(&model, &system, config);
+
+        assert_eq!(fit.estimate_basis.gpu_bandwidth_gbps, Some(300.0));
+        assert_eq!(fit.estimate_basis.method, "gpu_bandwidth_roofline");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // MoE Tier-2 per-architecture calibration
+    // ────────────────────────────────────────────────────────────────────
+
+    /// `bench_moe_model` plus an `architecture`, so a fixture can select a
+    /// calibrated table entry. Carries no Tier-1 metadata, so estimates run
+    /// through the Tier-2 fallback.
+    fn tier2_moe_model(
+        name: &str,
+        architecture: &str,
+        total_params_b: f64,
+        active_params_b: f64,
+        num_experts: u32,
+        active_experts: u32,
+        quant: &str,
+    ) -> LlmModel {
+        let mut model = bench_moe_model(
+            name,
+            total_params_b,
+            active_params_b,
+            num_experts,
+            active_experts,
+            quant,
+        );
+        model.architecture = Some(architecture.to_string());
+        model
+    }
+
+    /// System with a pinned bandwidth and deliberately unknown VRAM.
+    ///
+    /// `gpu_vram_gb: None` disables the VRAM cache-pressure penalty (which has
+    /// its own tests), so these fixtures measure the Tier-2 bandwidth
+    /// calibration alone instead of the product of two models.
+    fn tier2_system() -> SystemSpecs {
+        SystemSpecs {
+            gpu_vram_gb: None,
+            total_gpu_vram_gb: None,
+            ..rx6900xt_system()
+        }
+    }
+
+    fn tier2_config(bandwidth_gbps: f64) -> CalcConfig {
+        CalcConfig {
+            gpu_bandwidth_gbps_override: Some(bandwidth_gbps),
+            ..test_config()
+        }
+    }
+
+    #[test]
+    fn moe_tier2_default_reproduces_the_expert_count_tiers() {
+        // Requirement: adding architecture entries must not move any model that
+        // isn't named. For an unlisted architecture the calibration must be
+        // exactly the config efficiency and the original tiered overhead.
+        let config_efficiency = 0.55;
+        let tiers = [
+            (Some(8u32), 0.90),
+            (Some(16), 0.85),
+            (Some(32), 0.80),
+            (Some(64), 0.70),
+            (Some(128), 0.40),
+            (Some(256), 0.40),
+            (None, 0.60),
+        ];
+
+        for (num_experts, expected_overhead) in tiers {
+            for architecture in [None, Some("llama4"), Some("qwen3_moe")] {
+                let params = moe_tier2_params(architecture, num_experts, config_efficiency);
+                assert_eq!(
+                    params,
+                    MoeTier2Params {
+                        efficiency: config_efficiency,
+                        overhead: expected_overhead,
+                    },
+                    "arch={architecture:?} num_experts={num_experts:?} must use the default tier"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn moe_tier2_default_tracks_a_custom_config_efficiency() {
+        // The default path must keep honouring the user's efficiency setting
+        // (Advanced Config, issue #449) rather than hardcoding 0.55.
+        let params = moe_tier2_params(None, Some(64), 0.42);
+        assert_eq!(params.efficiency, 0.42);
+        assert_eq!(params.overhead, 0.70);
+    }
+
+    #[test]
+    fn moe_tier2_gpt_oss_120b_class_lands_near_measured() {
+        // gpt-oss-120b: 116.8B total, 5.1B active, 128 experts / 4 active,
+        // MXFP4 weights. Reference point: ~50.2 tok/s decode on 256 GB/s-class
+        // unified memory.
+        const MEASURED_TPS: f64 = 50.2;
+        let model = tier2_moe_model("gpt-oss-120b", "gpt_oss", 116.8, 5.1, 128, 4, "Q4_K_M");
+
+        let estimated = estimate_tps(
+            &model,
+            "Q4_K_M",
+            &tier2_system(),
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+            &tier2_config(256.0),
+        );
+
+        let ratio = estimated / MEASURED_TPS;
+        assert!(
+            (0.75..=1.25).contains(&ratio),
+            "gpt-oss-120b: estimate {estimated:.1} tok/s vs measured {MEASURED_TPS:.1} tok/s \
+             (ratio={ratio:.2}), expected within 25%"
+        );
+
+        // The generic 128+-expert tier is what the entry exists to correct:
+        // counting inactive experts as overhead, it lands ~2.6x low and well
+        // outside the tolerance above.
+        let mut unlisted = model.clone();
+        unlisted.architecture = Some("some_new_moe".to_string());
+        let default_tier = estimate_tps(
+            &unlisted,
+            "Q4_K_M",
+            &tier2_system(),
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+            &tier2_config(256.0),
+        );
+        assert!(
+            default_tier / MEASURED_TPS < 0.75,
+            "default tier should be the low outlier this entry fixes \
+             (got {default_tier:.1} tok/s)"
+        );
+    }
+
+    #[test]
+    fn moe_tier2_deepseek_v4_flash_class_lands_near_measured() {
+        // DeepSeek-V4-Flash class: 13B active over 256 routed experts plus a
+        // shared expert, MLA attention. Reference point: ~35 tok/s decode on
+        // 614 GB/s-class hardware.
+        const MEASURED_TPS: f64 = 35.0;
+        let model = tier2_moe_model(
+            "DeepSeek-V4-Flash",
+            "deepseek_v4",
+            235.0,
+            13.0,
+            256,
+            8,
+            "Q4_K_M",
+        );
+
+        let estimated = estimate_tps(
+            &model,
+            "Q4_K_M",
+            &tier2_system(),
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+            &tier2_config(614.0),
+        );
+
+        let ratio = estimated / MEASURED_TPS;
+        assert!(
+            (0.75..=1.25).contains(&ratio),
+            "DeepSeek-V4-Flash: estimate {estimated:.1} tok/s vs measured {MEASURED_TPS:.1} tok/s \
+             (ratio={ratio:.2}), expected within 25%"
+        );
+    }
+
+    #[test]
+    fn moe_tier2_architecture_lookup_is_case_insensitive() {
+        // Catalog `architecture` values come from several scrapers, so casing
+        // varies. "GPT_OSS" must not silently fall back to the default tier.
+        let calibrated = moe_tier2_params(Some("gpt_oss"), Some(128), 0.55);
+        for spelling in ["GPT_OSS", "Gpt_Oss", "gpt_oss_120b"] {
+            assert_eq!(
+                moe_tier2_params(Some(spelling), Some(128), 0.55),
+                calibrated,
+                "{spelling} must resolve to the gpt-oss entry"
+            );
+        }
+    }
+
+    #[test]
+    fn moe_tier2_only_applies_to_the_tier2_path() {
+        // Tier 1 (full architecture metadata) is strictly better than the
+        // calibrated fallback, so an entry in the table must not divert a model
+        // that has enough metadata for the two-component decomposition.
+        let mut model = tier2_moe_model("gpt-oss-120b", "gpt_oss", 116.8, 5.1, 128, 4, "Q4_K_M");
+        assert!(
+            model.moe_bandwidth_decomposition().is_none(),
+            "fixture must lack Tier-1 metadata"
+        );
+
+        let tier2 = estimate_tps(
+            &model,
+            "Q4_K_M",
+            &tier2_system(),
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+            &tier2_config(256.0),
+        );
+
+        // Supply the metadata Tier 1 needs; the estimate must change path.
+        model.hidden_size = Some(2880);
+        model.num_hidden_layers = Some(36);
+        model.moe_intermediate_size = Some(2880);
+        model.vocab_size = Some(201_088);
+        model.num_attention_heads = Some(64);
+        model.num_key_value_heads = Some(8);
+        model.head_dim = Some(64);
+        assert!(
+            model.moe_bandwidth_decomposition().is_some(),
+            "Tier-1 metadata must now resolve"
+        );
+
+        let tier1 = estimate_tps(
+            &model,
+            "Q4_K_M",
+            &tier2_system(),
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+            &tier2_config(256.0),
+        );
+        assert!(
+            (tier1 - tier2).abs() > 1.0,
+            "Tier 1 must take over from the Tier-2 calibration \
+             (tier1={tier1:.1}, tier2={tier2:.1})"
+        );
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // EstimateConfidence
+    // ────────────────────────────────────────────────────────────────────
+
+    fn measured(source: crate::benchmarks::MeasuredSource) -> crate::benchmarks::MeasuredTps {
+        crate::benchmarks::MeasuredTps {
+            tok_s: 42.0,
+            sample_count: 3,
+            hardware_label: "this machine".to_string(),
+            source,
+        }
+    }
+
+    #[test]
+    fn derive_estimate_confidence_ranks_measurement_above_calibration() {
+        use crate::benchmarks::MeasuredSource;
+
+        let plain = EstimateBasis {
+            method: "gpu_bandwidth_roofline".to_string(),
+            ..EstimateBasis::default()
+        };
+        let calibrated = EstimateBasis {
+            local_calibration: Some(1.4),
+            ..plain.clone()
+        };
+
+        assert_eq!(
+            derive_estimate_confidence(Some(&measured(MeasuredSource::LocalBench)), &plain),
+            EstimateConfidence::MeasuredLocal
+        );
+        assert_eq!(
+            derive_estimate_confidence(Some(&measured(MeasuredSource::Community)), &plain),
+            EstimateConfidence::MeasuredCommunity
+        );
+        assert_eq!(
+            derive_estimate_confidence(Some(&measured(MeasuredSource::CommunityLlmfit)), &plain),
+            EstimateConfidence::MeasuredCommunity
+        );
+
+        // A measured row that also carries a calibration factor stays measured:
+        // the real number outranks the corrected formula.
+        assert_eq!(
+            derive_estimate_confidence(Some(&measured(MeasuredSource::LocalBench)), &calibrated),
+            EstimateConfidence::MeasuredLocal
+        );
+
+        assert_eq!(
+            derive_estimate_confidence(None, &calibrated),
+            EstimateConfidence::Calibrated
+        );
+        assert_eq!(
+            derive_estimate_confidence(None, &plain),
+            EstimateConfidence::Estimated
+        );
+    }
+
+    #[test]
+    fn derive_estimate_confidence_marks_an_unsupported_method() {
+        let basis = EstimateBasis {
+            method: UNSUPPORTED_METHOD.to_string(),
+            ..EstimateBasis::default()
+        };
+        assert_eq!(
+            derive_estimate_confidence(None, &basis),
+            EstimateConfidence::Unsupported
+        );
+
+        // Calibration is checked first, so a calibrated row is never reported
+        // as unsupported even if the method string says so.
+        let calibrated = EstimateBasis {
+            local_calibration: Some(0.9),
+            ..basis
+        };
+        assert_eq!(
+            derive_estimate_confidence(None, &calibrated),
+            EstimateConfidence::Calibrated
+        );
+    }
+
+    #[test]
+    fn analyze_defaults_confidence_to_estimated() {
+        // Nothing is measured or calibrated at construction time.
+        let model = test_model("7B", 4.0, Some(4.0));
+        let system = test_system(32.0, true, Some(24.0));
+        let fit = ModelFit::analyze(&model, &system);
+        assert_eq!(fit.estimate_confidence, EstimateConfidence::Estimated);
+    }
+
+    #[test]
+    fn analyze_marks_a_specialized_runtime_model_unsupported() {
+        // The early-return path produces no estimate at all.
+        let mut model = test_model("1B", 2.0, Some(2.0));
+        model.capabilities = vec![models::Capability::Tts];
+        let system = test_system(32.0, true, Some(24.0));
+        let fit = ModelFit::analyze(&model, &system);
+
+        assert_eq!(fit.runtime, InferenceRuntime::Unsupported);
+        assert_eq!(fit.estimate_confidence, EstimateConfidence::Unsupported);
+        assert_eq!(fit.prefill_tps, None);
+        assert_eq!(fit.ttft_ms, None);
+    }
+
+    #[test]
+    fn refresh_estimate_confidence_picks_up_post_analysis_data() {
+        use crate::benchmarks::MeasuredSource;
+
+        let model = test_model("7B", 4.0, Some(4.0));
+        let system = test_system(32.0, true, Some(24.0));
+        let mut fit = ModelFit::analyze(&model, &system);
+        assert_eq!(fit.estimate_confidence, EstimateConfidence::Estimated);
+
+        // Calibration is attached after analysis (analysis::apply_local_calibration).
+        fit.estimate_basis.local_calibration = Some(1.1);
+        fit.refresh_estimate_confidence();
+        assert_eq!(fit.estimate_confidence, EstimateConfidence::Calibrated);
+
+        // So is measured throughput, which outranks it.
+        fit.measured_tps = Some(measured(MeasuredSource::LocalBench));
+        fit.refresh_estimate_confidence();
+        assert_eq!(fit.estimate_confidence, EstimateConfidence::MeasuredLocal);
+    }
+
+    #[test]
+    fn estimate_confidence_codes_are_stable() {
+        // These strings reach API and MCP consumers; changing one is a breaking
+        // change, so pin them.
+        for (variant, code) in [
+            (EstimateConfidence::MeasuredLocal, "measured_local"),
+            (EstimateConfidence::MeasuredCommunity, "measured_community"),
+            (EstimateConfidence::Calibrated, "calibrated"),
+            (EstimateConfidence::Estimated, "estimated"),
+            (EstimateConfidence::Unsupported, "unsupported"),
+        ] {
+            assert_eq!(variant.code(), code);
+            assert_eq!(
+                serde_json::to_value(variant).expect("confidence serializes"),
+                serde_json::json!(code),
+                "serde representation must match code()"
+            );
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Prefill / TTFT
+    // ────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn prefill_is_null_when_gpu_compute_is_unknown() {
+        // Prefill is compute-bound, so without a TFLOP/s figure there is no
+        // roofline to fall back on. A null must not be flattened to 0.0, which
+        // would read as "immeasurably slow".
+        let model = test_model("7B", 4.0, Some(4.0));
+        let system = test_system(32.0, true, Some(24.0));
+        let fit = ModelFit::analyze(&model, &system);
+
+        assert_eq!(fit.prefill_tps, None);
+        assert_eq!(fit.ttft_ms, None);
+
+        let json = serde_json::to_value(&fit).expect("fit serializes");
+        assert!(json["prefill_tps"].is_null());
+        assert!(json["ttft_ms"].is_null());
+    }
+
+    #[test]
+    fn prefill_is_estimated_when_gpu_compute_is_known() {
+        // RTX 4090: 165 TFLOP/s dense fp16. An 8B model costs 2*8e9 = 16 GFLOP
+        // per token, so prefill lands in the low thousands of tok/s — orders of
+        // magnitude above decode, which is the point of reporting it.
+        let model = test_model("8B", 4.0, Some(4.0));
+        let system = test_system(64.0, true, Some(24.0));
+        let config = CalcConfig {
+            gpu_compute_tflops_fp16: Some(165.0),
+            ..test_config()
+        };
+        let fit = ModelFit::analyze_with_config(&model, &system, config);
+
+        let prefill = fit.prefill_tps.expect("prefill estimated");
+        let ttft = fit.ttft_ms.expect("ttft estimated");
+
+        assert!(
+            (1_000.0..=20_000.0).contains(&prefill),
+            "prefill {prefill:.0} tok/s outside the plausible band for 8B on a 4090"
+        );
+        assert!(
+            prefill > fit.estimated_tps * 10.0,
+            "prefill ({prefill:.0}) must far exceed decode ({:.0})",
+            fit.estimated_tps
+        );
+
+        // TTFT is just the prompt divided by prefill throughput.
+        let expected_ttft = (f64::from(fit.effective_context_length) / prefill) * 1000.0;
+        assert!((ttft - expected_ttft).abs() < 1e-6);
+    }
+
+    #[test]
+    fn ttft_scales_with_the_assumed_prompt_length() {
+        // Halving the assumed context must halve TTFT while prefill throughput,
+        // a per-token rate, stays put.
+        let model = test_model("8B", 4.0, Some(4.0));
+        let system = test_system(64.0, true, Some(24.0));
+        let base = CalcConfig {
+            gpu_compute_tflops_fp16: Some(165.0),
+            ..test_config()
+        };
+
+        let long = ModelFit::analyze_with_config(
+            &model,
+            &system,
+            CalcConfig {
+                context_cap: Some(4096),
+                ..base.clone()
+            },
+        );
+        let short = ModelFit::analyze_with_config(
+            &model,
+            &system,
+            CalcConfig {
+                context_cap: Some(2048),
+                ..base
+            },
+        );
+
+        assert_eq!(long.prefill_tps, short.prefill_tps);
+        let ratio = long.ttft_ms.expect("long ttft") / short.ttft_ms.expect("short ttft");
+        assert!(
+            (ratio - 2.0).abs() < 1e-6,
+            "TTFT must be linear in prompt length (ratio={ratio:.3})"
+        );
+    }
+
+    #[test]
+    fn prefill_is_not_estimated_on_the_cpu_only_path() {
+        // The TFLOP/s figure describes the GPU, so it says nothing about a
+        // CPU-only run.
+        let model = test_model("8B", 4.0, Some(4.0));
+        let system = test_system(32.0, false, None);
+        let config = CalcConfig {
+            gpu_compute_tflops_fp16: Some(165.0),
+            ..test_config()
+        };
+        let fit = ModelFit::analyze_with_config(&model, &system, config);
+
+        assert_eq!(fit.run_mode, RunMode::CpuOnly);
+        assert_eq!(fit.prefill_tps, None);
+        assert_eq!(fit.ttft_ms, None);
+    }
+
+    #[test]
+    fn prefill_uses_active_parameters_for_moe() {
+        // Prefill FLOPs scale with the parameters actually routed through, so a
+        // sparse MoE must prefill far faster than its total size implies.
+        let system = test_system(64.0, true, Some(24.0));
+        let config = CalcConfig {
+            gpu_compute_tflops_fp16: Some(165.0),
+            ..test_config()
+        };
+
+        let sparse = tier2_moe_model("sparse", "qwen3_moe", 30.0, 3.0, 128, 8, "Q4_K_M");
+        let dense = test_model("30B", 16.0, Some(16.0));
+
+        let sparse_fit = ModelFit::analyze_with_config(&sparse, &system, config.clone());
+        let dense_fit = ModelFit::analyze_with_config(&dense, &system, config);
+
+        let sparse_prefill = sparse_fit.prefill_tps.expect("moe prefill");
+        let dense_prefill = dense_fit.prefill_tps.expect("dense prefill");
+        assert!(
+            sparse_prefill > dense_prefill * 5.0,
+            "3B-active MoE ({sparse_prefill:.0}) must prefill far faster than \
+             a 30B dense model ({dense_prefill:.0})"
+        );
+    }
+
+    #[test]
+    fn prefill_ignores_a_non_positive_compute_figure() {
+        let model = test_model("8B", 4.0, Some(4.0));
+        let system = test_system(64.0, true, Some(24.0));
+        for bad in [0.0, -10.0] {
+            let config = CalcConfig {
+                gpu_compute_tflops_fp16: Some(bad),
+                ..test_config()
+            };
+            let fit = ModelFit::analyze_with_config(&model, &system, config);
+            assert_eq!(fit.prefill_tps, None, "tflops={bad} must not estimate");
+            assert_eq!(fit.ttft_ms, None);
         }
     }
 }

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -815,8 +815,20 @@ impl ModelFit {
     /// construction only reflects the formula. Call this after populating
     /// measured throughput or applying calibration.
     pub fn refresh_estimate_confidence(&mut self) {
-        self.estimate_confidence =
-            derive_estimate_confidence(self.measured_tps.as_ref(), &self.estimate_basis);
+        self.estimate_confidence = self.effective_estimate_confidence();
+    }
+
+    /// The confidence implied by the fit's *current* `measured_tps` and
+    /// `estimate_basis`, ignoring the stored field.
+    ///
+    /// [`ModelFit::estimate_confidence`] is only accurate if every writer of
+    /// those two fields remembered to call
+    /// [`ModelFit::refresh_estimate_confidence`]. Display and serialization
+    /// paths ask for the label here instead, so a caller that forgot can't
+    /// make the API report "estimated" next to a measured tok/s figure
+    /// (issue #969).
+    pub fn effective_estimate_confidence(&self) -> EstimateConfidence {
+        derive_estimate_confidence(self.measured_tps.as_ref(), &self.estimate_basis)
     }
 
     /// Context column text: `"262k→14k"` when the memory pool constrains
@@ -1353,6 +1365,49 @@ fn moe_tier2_params(
     }
 }
 
+/// Bandwidth-equivalent bytes per parameter for the *fixed* component of the
+/// Tier-1 MoE decode estimate.
+///
+/// [`LlmModel::MOE_FIXED_EFFECTIVE_BPP`] is not a storage width. It converts
+/// the attention, router, shared-expert and head parameters into the bandwidth
+/// they cost per token, absorbing their compute time, and K ≈ 3.2 was fitted to
+/// OLMoE-1B-7B on an RX 6900 XT. Two properties of that fit don't carry to
+/// every sparse design, and gpt-oss breaks both:
+///
+/// * [`moe_bandwidth_decomposition`](crate::models::LlmModel::moe_bandwidth_decomposition)
+///   counts the embedding table in the fixed set, but decode reads one row of
+///   it per token, not the whole table. OLMoE's 50k-token vocabulary makes
+///   that a rounding error; gpt-oss's 201k × 2880 table is 0.58B of a 2.13B
+///   fixed set. The published active-parameter figure agrees: 5.1B is the four
+///   routed experts plus attention plus router plus a *single* vocab × hidden
+///   term, not two.
+/// * OLMoE is dense-MHA with 16 heads at 128 dim. gpt-oss is grouped-query
+///   with 8 KV heads at 64 dim on alternating sliding-window layers, so far
+///   less attention work rides on each fixed parameter.
+///
+/// Both push the same way, and no single K fits both models: re-fitting K with
+/// the embedding term removed reproduces OLMoE at 4.07 and still leaves
+/// gpt-oss-120b at ~31 tok/s against a measured ~50. So this mirrors
+/// [`moe_tier2_params`] — a per-architecture entry, fitted to a cited
+/// measurement, that can only change the models it names.
+fn moe_tier1_fixed_bpp(architecture: Option<&str>) -> f64 {
+    let arch = architecture.unwrap_or("").to_lowercase();
+
+    // Calibration reference: ~50 tok/s decode for openai/gpt-oss-120b at a
+    // Q4-class quant on 256 GB/s-class unified memory (issue #969). Applies to
+    // the 20B sibling too, which shares the vocabulary, head geometry and
+    // MXFP4-native weights.
+    //
+    // Fitted at Q4-class only. The scalable half of the Tier-1 sum still reads
+    // gpt-oss weights at `quant_bpp`, which overstates the MXFP4-native
+    // tensors these models actually ship, so a Q8_0 pick stays low.
+    if arch.starts_with("gpt_oss") || arch.starts_with("gptoss") {
+        return 1.43;
+    }
+
+    models::LlmModel::MOE_FIXED_EFFECTIVE_BPP
+}
+
 /// The original `num_experts`-tiered MoE overhead, kept as the default for
 /// architectures without a calibrated entry.
 ///
@@ -1591,7 +1646,7 @@ pub(crate) fn estimate_tps(
             // 2. FIXED: attention, router, shared experts, lm_head, embedding
             //    These are compute-bound and cost roughly constant time regardless
             //    of quantization. We represent them as bandwidth-equivalent bytes
-            //    using MOE_FIXED_EFFECTIVE_BPP (K ≈ 3.2).
+            //    using moe_tier1_fixed_bpp (K ≈ 3.2 by default).
             //
             // Formula: tps = bw / (active_ffn_bytes + fixed_equivalent_bytes)
             //
@@ -1673,7 +1728,7 @@ pub(crate) fn estimate_tps(
             if let Some((active_ffn_b, fixed_b)) = model.moe_bandwidth_decomposition() {
                 let bpp = models::quant_bpp(quant);
                 let active_ffn_bytes = active_ffn_b * bpp;
-                let fixed_bytes = fixed_b * models::LlmModel::MOE_FIXED_EFFECTIVE_BPP;
+                let fixed_bytes = fixed_b * moe_tier1_fixed_bpp(model.architecture.as_deref());
                 let per_token_bytes = active_ffn_bytes + fixed_bytes;
                 let raw_tps = bw / per_token_bytes;
                 let mode_factor = config.run_mode_factors.for_run_mode(run_mode);
@@ -4577,6 +4632,118 @@ mod tests {
         );
     }
 
+    /// The Tier-2 calibration above is fitted to the *published* 5.1B active
+    /// figure, so it is only correct if the catalog actually serves that
+    /// number. This walks the real `openai/gpt-oss-120b` entry through the
+    /// Tier-2 path and pins the ~50 tok/s reference to catalog data rather
+    /// than to a literal in the test (issue #969, problem 2).
+    ///
+    /// Tier 2 has to be forced: the catalog entry carries full MoE geometry,
+    /// so the live sweep takes the architecture-aware Tier-1 path instead.
+    /// `catalog_gpt_oss_120b_lands_near_measured_on_the_live_tier1_path`
+    /// covers that route against the same reference.
+    #[test]
+    fn catalog_gpt_oss_120b_active_params_reproduce_the_measured_tier2_estimate() {
+        const MEASURED_TPS: f64 = 50.2;
+        let db = models::ModelDatabase::embedded();
+        let catalog_entry = db
+            .get_all_models()
+            .iter()
+            .find(|m| m.name == "openai/gpt-oss-120b")
+            .expect("catalog is missing openai/gpt-oss-120b");
+        let active_params_b = catalog_entry
+            .active_parameters
+            .expect("MoE entry has active params") as f64
+            / 1e9;
+
+        let mut model = tier2_moe_model(
+            &catalog_entry.name,
+            "gpt_oss",
+            catalog_entry.params_b(),
+            active_params_b,
+            catalog_entry.num_experts.expect("MoE entry has experts"),
+            catalog_entry
+                .active_experts
+                .expect("MoE entry has active experts"),
+            "Q4_K_M",
+        );
+        model.hidden_size = None; // force the Tier-2 fallback
+
+        let estimated = estimate_tps(
+            &model,
+            "Q4_K_M",
+            &tier2_system(),
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+            &tier2_config(256.0),
+        );
+
+        let ratio = estimated / MEASURED_TPS;
+        assert!(
+            (0.75..=1.25).contains(&ratio),
+            "catalog active_parameters ({active_params_b:.2}B) put the estimate at \
+             {estimated:.1} tok/s against a measured {MEASURED_TPS:.1} tok/s (ratio={ratio:.2})"
+        );
+    }
+
+    /// The issue's own repro: the real catalog entry, on the real route it
+    /// takes (Tier 1, architecture-aware), against 256 GB/s-class unified
+    /// memory. `--profile ryzen-ai-max-plus-395 plan openai/gpt-oss-120b
+    /// --quant Q4_K_M` reads out of exactly this call (issue #969, problem 2).
+    ///
+    /// Q4-class only. `best_quant` currently picks Q8_0 for this model on a
+    /// 128 GB machine and lands near 23 tok/s, because the scalable half of
+    /// the Tier-1 sum prices gpt-oss's MXFP4-native weights at `quant_bpp`.
+    #[test]
+    fn catalog_gpt_oss_120b_lands_near_measured_on_the_live_tier1_path() {
+        const MEASURED_TPS: f64 = 50.2;
+        let db = models::ModelDatabase::embedded();
+        let model = db
+            .get_all_models()
+            .iter()
+            .find(|m| m.name == "openai/gpt-oss-120b")
+            .expect("catalog is missing openai/gpt-oss-120b")
+            .clone();
+        assert!(
+            model.moe_bandwidth_decomposition().is_some(),
+            "this test is only meaningful while the entry still routes to Tier 1"
+        );
+
+        let estimated = estimate_tps(
+            &model,
+            "Q4_K_M",
+            &tier2_system(),
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+            &tier2_config(256.0),
+        );
+
+        let ratio = estimated / MEASURED_TPS;
+        assert!(
+            (0.85..=1.15).contains(&ratio),
+            "gpt-oss-120b at Q4_K_M on 256 GB/s: estimate {estimated:.1} tok/s vs \
+             measured {MEASURED_TPS:.1} tok/s (ratio={ratio:.2})"
+        );
+
+        // Without the per-architecture entry the same geometry lands ~1.7x
+        // low, which is the reading the issue reported.
+        let mut unlisted = model.clone();
+        unlisted.architecture = Some("some_new_moe".to_string());
+        let default_bpp = estimate_tps(
+            &unlisted,
+            "Q4_K_M",
+            &tier2_system(),
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+            &tier2_config(256.0),
+        );
+        assert!(
+            default_bpp / MEASURED_TPS < 0.75,
+            "the default fixed-component constant should be the low outlier this \
+             entry fixes (got {default_bpp:.1} tok/s)"
+        );
+    }
+
     #[test]
     fn moe_tier2_deepseek_v4_flash_class_lands_near_measured() {
         // DeepSeek-V4-Flash class: 13B active over 256 routed experts plus a
@@ -4665,10 +4832,26 @@ mod tests {
             InferenceRuntime::LlamaCpp,
             &tier2_config(256.0),
         );
+
+        // Both tiers are calibrated to the same ~50 tok/s reference, so their
+        // outputs agreeing proves nothing about which one ran. Widen the
+        // expert FFN instead: Tier 1 reads `moe_intermediate_size`, Tier 2
+        // cannot see it at all.
+        let mut wider = model.clone();
+        wider.moe_intermediate_size = Some(5760);
+        let tier1_wider = estimate_tps(
+            &wider,
+            "Q4_K_M",
+            &tier2_system(),
+            RunMode::Gpu,
+            InferenceRuntime::LlamaCpp,
+            &tier2_config(256.0),
+        );
         assert!(
-            (tier1 - tier2).abs() > 1.0,
-            "Tier 1 must take over from the Tier-2 calibration \
-             (tier1={tier1:.1}, tier2={tier2:.1})"
+            tier1_wider < tier1 * 0.9,
+            "Tier 1 must take over once its metadata resolves — doubling the \
+             expert FFN should slow the estimate (tier2={tier2:.1}, \
+             tier1={tier1:.1}, tier1_wider={tier1_wider:.1})"
         );
     }
 

--- a/llmfit-core/src/hardware.rs
+++ b/llmfit-core/src/hardware.rs
@@ -2257,6 +2257,29 @@ impl SystemSpecs {
         self
     }
 
+    /// Apply a hardware profile's memory capacity (see [`crate::hwprofile`]).
+    ///
+    /// `unified_memory` is set before the RAM override so that a unified
+    /// profile makes VRAM track `total_ram_gb` — the two describe one pool, and
+    /// a profile that disagreed with itself would score models against a
+    /// machine that cannot exist.
+    ///
+    /// A unified profile applied to a host with no detected GPU synthesizes
+    /// one, exactly as `--memory` does: without it every model would fall to
+    /// the CPU-only path and the profile could never reproduce the machine it
+    /// names. Profiles carry no VRAM figure of their own, so a non-unified
+    /// profile leaves the detected VRAM alone.
+    pub fn with_profile_capacity(mut self, total_ram_gb: f64, unified_memory: bool) -> Self {
+        if unified_memory && self.gpus.is_empty() {
+            self = self.with_gpu_memory_override(total_ram_gb);
+        }
+        self.unified_memory = unified_memory;
+        for gpu in &mut self.gpus {
+            gpu.unified_memory = unified_memory;
+        }
+        self.with_ram_override(total_ram_gb)
+    }
+
     pub fn display(&self) {
         println!("\n=== System Specifications ===");
         println!("CPU: {} ({} cores)", self.cpu_name, self.total_cpu_cores);

--- a/llmfit-core/src/hwprofile.rs
+++ b/llmfit-core/src/hwprofile.rs
@@ -1,0 +1,968 @@
+//! Hardware profiles — named, versioned descriptions of a machine.
+//!
+//! `--memory` / `--ram` / `--cpu-cores` each override one detected field, which
+//! is enough to fix a bad detection but not to answer "what would this model do
+//! on *that* box": the throughput estimate is driven by memory bandwidth and
+//! fp16 matmul throughput, neither of which is a capacity. A profile names a
+//! whole machine — capacity, unified-memory topology, and the estimator inputs
+//! — so the answer is reproducible and reviewable instead of a pile of flags.
+//!
+//! Profiles under `data/hardware/` are aggregated by `build.rs` and embedded,
+//! so a merged profile ships in the next release; users can drop their own into
+//! [`user_profile_dir`] without rebuilding.
+//!
+//! Loading is **lenient** about unknown keys so a profile written for a newer
+//! llmfit still works, while [`HardwareProfile::validate_strict`] (used by
+//! `llmfit hardware validate`) rejects them — that is what turns a typo into an
+//! error instead of a field that silently does nothing.
+
+use crate::fit::CalcConfig;
+use crate::hardware::SystemSpecs;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// The only profile schema version this build understands.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Profiles from `data/hardware/*.json`, aggregated by build.rs.
+const EMBEDDED_PROFILES_JSON: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/hardware_profiles.json"));
+
+/// Run-mode keys accepted by `calibration[].run_mode`, matching
+/// [`crate::fit::RunMode`] in snake_case.
+const RUN_MODES: [&str; 5] = [
+    "gpu",
+    "tensor_parallel",
+    "moe_offload",
+    "cpu_offload",
+    "cpu_only",
+];
+
+const MAX_RAM_GB: f64 = 16_384.0;
+const MAX_BANDWIDTH_GBPS: f64 = 100_000.0;
+const MAX_TFLOPS: f64 = 100_000.0;
+const MAX_TPS: f64 = 100_000.0;
+const MAX_RUN_MODE_FACTOR: f64 = 10.0;
+
+type Unknown = BTreeMap<String, serde_json::Value>;
+
+/// A machine description. See `data/hardware/schema.json` for the contract and
+/// `data/hardware/README.md` for what each field affects.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HardwareProfile {
+    pub schema_version: u32,
+    /// Profile id, equal to the file stem.
+    pub name: String,
+    /// Which GPU this profile describes. Recorded for provenance only —
+    /// profiles are never auto-selected, so a wrong guess can't silently
+    /// replace a correct detection.
+    #[serde(rename = "match", default, skip_serializing_if = "Option::is_none")]
+    pub matcher: Option<ProfileMatch>,
+    pub hardware: ProfileHardware,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimation: Option<ProfileEstimation>,
+    /// Measured anchors with provenance. Validated but **not applied** in
+    /// schema version 1: an anchor changes every estimate on the machine, so it
+    /// ships as reviewable data first.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub calibration: Vec<CalibrationEntry>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unknown: Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProfileMatch {
+    pub gpu_name_contains: String,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unknown: Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProfileHardware {
+    pub total_ram_gb: f64,
+    pub unified_memory: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu_memory_bandwidth_gbps: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ddr_bandwidth_gbps: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu_compute_tflops_fp16: Option<f64>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unknown: Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProfileEstimation {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub efficiency: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_mode_factors: Option<ProfileRunModeFactors>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unknown: Unknown,
+}
+
+/// Per-mode speed multipliers. Every key is optional: an unset mode keeps the
+/// [`crate::fit::RunModeFactors`] default rather than being zeroed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProfileRunModeFactors {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tensor_parallel: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub moe_offload: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_offload: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_only: Option<f64>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unknown: Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CalibrationEntry {
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quant: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_mode: Option<String>,
+    pub measured_tps: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub unknown: Unknown,
+}
+
+/// Where a profile came from, so output can distinguish a bundled profile from
+/// a local file the user is iterating on.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProfileOrigin {
+    /// Embedded at build time from `data/hardware/`.
+    Embedded,
+    /// Discovered in [`user_profile_dir`].
+    User(PathBuf),
+    /// Loaded from a path the user passed explicitly.
+    File(PathBuf),
+}
+
+impl ProfileOrigin {
+    pub fn label(&self) -> String {
+        match self {
+            ProfileOrigin::Embedded => "bundled".to_string(),
+            ProfileOrigin::User(path) | ProfileOrigin::File(path) => path.display().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedProfile {
+    pub origin: ProfileOrigin,
+    pub profile: HardwareProfile,
+}
+
+/// Every selectable profile, plus the user files that could not be loaded.
+///
+/// Load failures are reported rather than skipped: a profile the user wrote and
+/// cannot select is a bug they need to see, not a file to ignore.
+#[derive(Debug, Clone, Default)]
+pub struct ProfileCatalog {
+    pub profiles: Vec<LoadedProfile>,
+    pub errors: Vec<(PathBuf, String)>,
+}
+
+impl HardwareProfile {
+    /// Parse profile JSON, tolerating unknown keys.
+    pub fn parse(text: &str) -> Result<Self, String> {
+        serde_json::from_str(text).map_err(|e| format!("invalid hardware profile JSON: {e}"))
+    }
+
+    /// Check the fields this build understands.
+    ///
+    /// Bounds are deliberately wide — the point is to reject values that would
+    /// make an estimate meaningless (zero bandwidth divides the roofline to
+    /// nothing, NaN propagates into every score) rather than to police
+    /// plausible hardware.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported schema_version {}; this build understands {}",
+                self.schema_version, SCHEMA_VERSION
+            ));
+        }
+        validate_name(&self.name)?;
+
+        if let Some(matcher) = &self.matcher
+            && matcher.gpu_name_contains.trim().is_empty()
+        {
+            return Err("match.gpu_name_contains must not be empty".to_string());
+        }
+
+        let hw = &self.hardware;
+        check_range("hardware.total_ram_gb", hw.total_ram_gb, MAX_RAM_GB)?;
+        for (label, value) in [
+            (
+                "hardware.gpu_memory_bandwidth_gbps",
+                hw.gpu_memory_bandwidth_gbps,
+            ),
+            ("hardware.ddr_bandwidth_gbps", hw.ddr_bandwidth_gbps),
+        ] {
+            if let Some(value) = value {
+                check_range(label, value, MAX_BANDWIDTH_GBPS)?;
+            }
+        }
+        if let Some(tflops) = hw.gpu_compute_tflops_fp16 {
+            check_range("hardware.gpu_compute_tflops_fp16", tflops, MAX_TFLOPS)?;
+        }
+
+        if let Some(est) = &self.estimation {
+            if let Some(eff) = est.efficiency {
+                check_range("estimation.efficiency", eff, 1.0)?;
+            }
+            if let Some(factors) = &est.run_mode_factors {
+                for (label, value) in [
+                    ("gpu", factors.gpu),
+                    ("tensor_parallel", factors.tensor_parallel),
+                    ("moe_offload", factors.moe_offload),
+                    ("cpu_offload", factors.cpu_offload),
+                    ("cpu_only", factors.cpu_only),
+                ] {
+                    if let Some(value) = value {
+                        check_range(
+                            &format!("estimation.run_mode_factors.{label}"),
+                            value,
+                            MAX_RUN_MODE_FACTOR,
+                        )?;
+                    }
+                }
+            }
+        }
+
+        for (i, entry) in self.calibration.iter().enumerate() {
+            if entry.model.trim().is_empty() {
+                return Err(format!("calibration[{i}].model must not be empty"));
+            }
+            check_range(
+                &format!("calibration[{i}].measured_tps"),
+                entry.measured_tps,
+                MAX_TPS,
+            )?;
+            if let Some(mode) = &entry.run_mode
+                && !RUN_MODES.contains(&mode.as_str())
+            {
+                return Err(format!(
+                    "calibration[{i}].run_mode '{mode}' is not one of {}",
+                    RUN_MODES.join(", ")
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// [`Self::validate`] plus a rejection of every unrecognized key.
+    pub fn validate_strict(&self) -> Result<(), String> {
+        self.validate()?;
+        let unknown = self.unknown_keys();
+        if !unknown.is_empty() {
+            return Err(format!("unknown key(s): {}", unknown.join(", ")));
+        }
+        Ok(())
+    }
+
+    /// Dotted paths of every key this build does not recognize.
+    pub fn unknown_keys(&self) -> Vec<String> {
+        fn collect(map: &Unknown, prefix: &str, out: &mut Vec<String>) {
+            for key in map.keys() {
+                if prefix.is_empty() {
+                    out.push(key.clone());
+                } else {
+                    out.push(format!("{prefix}.{key}"));
+                }
+            }
+        }
+
+        let mut out = Vec::new();
+        collect(&self.unknown, "", &mut out);
+        if let Some(matcher) = &self.matcher {
+            collect(&matcher.unknown, "match", &mut out);
+        }
+        collect(&self.hardware.unknown, "hardware", &mut out);
+        if let Some(est) = &self.estimation {
+            collect(&est.unknown, "estimation", &mut out);
+            if let Some(factors) = &est.run_mode_factors {
+                collect(&factors.unknown, "estimation.run_mode_factors", &mut out);
+            }
+        }
+        for (i, entry) in self.calibration.iter().enumerate() {
+            collect(&entry.unknown, &format!("calibration[{i}]"), &mut out);
+        }
+        out
+    }
+
+    /// Reject a profile whose `name` disagrees with its file name, which would
+    /// otherwise be selectable under a name that does not appear in listings.
+    pub fn check_name_matches_stem(&self, path: &Path) -> Result<(), String> {
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| format!("{} has no readable file name", path.display()))?;
+        if stem != self.name {
+            return Err(format!(
+                "name '{}' does not match file stem '{}'",
+                self.name, stem
+            ));
+        }
+        Ok(())
+    }
+
+    /// Apply the profile's capacity and unified-memory topology.
+    pub fn apply_to_specs(&self, specs: SystemSpecs) -> SystemSpecs {
+        specs.with_profile_capacity(self.hardware.total_ram_gb, self.hardware.unified_memory)
+    }
+
+    /// Apply the profile's estimator inputs, leaving unset fields untouched so
+    /// a partial profile keeps the calculated defaults.
+    pub fn apply_to_config(&self, config: &mut CalcConfig) {
+        let hw = &self.hardware;
+        if let Some(bandwidth) = hw.gpu_memory_bandwidth_gbps {
+            config.gpu_bandwidth_gbps_override = Some(bandwidth);
+        }
+        if let Some(bandwidth) = hw.ddr_bandwidth_gbps {
+            config.ddr_bandwidth_gbps = Some(bandwidth);
+        }
+        if let Some(tflops) = hw.gpu_compute_tflops_fp16 {
+            config.gpu_compute_tflops_fp16 = Some(tflops);
+        }
+
+        let Some(est) = &self.estimation else {
+            return;
+        };
+        if let Some(efficiency) = est.efficiency {
+            config.efficiency = efficiency;
+        }
+        if let Some(factors) = &est.run_mode_factors {
+            let target = &mut config.run_mode_factors;
+            if let Some(v) = factors.gpu {
+                target.gpu = v;
+            }
+            if let Some(v) = factors.tensor_parallel {
+                target.tensor_parallel = v;
+            }
+            if let Some(v) = factors.moe_offload {
+                target.moe_offload = v;
+            }
+            if let Some(v) = factors.cpu_offload {
+                target.cpu_offload = v;
+            }
+            if let Some(v) = factors.cpu_only {
+                target.cpu_only = v;
+            }
+        }
+    }
+
+    /// Apply both halves at once: specs describe what fits, `config` describes
+    /// how fast it runs, and a profile is only coherent if both move together.
+    pub fn apply(&self, specs: SystemSpecs, config: &mut CalcConfig) -> SystemSpecs {
+        self.apply_to_config(config);
+        self.apply_to_specs(specs)
+    }
+}
+
+fn validate_name(name: &str) -> Result<(), String> {
+    let mut chars = name.chars();
+    let ok = match chars.next() {
+        Some(first) if first.is_ascii_lowercase() || first.is_ascii_digit() => chars
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-')),
+        _ => false,
+    };
+    if ok {
+        Ok(())
+    } else {
+        Err(format!(
+            "name '{name}' must start with a lowercase letter or digit and use only [a-z0-9._-]"
+        ))
+    }
+}
+
+fn check_range(label: &str, value: f64, max: f64) -> Result<(), String> {
+    if !value.is_finite() || value <= 0.0 || value > max {
+        return Err(format!(
+            "{label} must be a finite number greater than 0 and at most {max}; got {value}"
+        ));
+    }
+    Ok(())
+}
+
+/// Profiles embedded at build time. Invalid entries are dropped — the core test
+/// suite validates `data/hardware/` against its schema, so a bad file fails CI
+/// rather than reaching a release.
+pub fn embedded() -> &'static [HardwareProfile] {
+    static CACHE: OnceLock<Vec<HardwareProfile>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let raw: Vec<serde_json::Value> =
+            serde_json::from_str(EMBEDDED_PROFILES_JSON).unwrap_or_default();
+        raw.into_iter()
+            .filter_map(|value| serde_json::from_value::<HardwareProfile>(value).ok())
+            .filter(|profile| profile.validate().is_ok())
+            .collect()
+    })
+}
+
+/// Directory scanned for user-supplied profiles, alongside the update cache
+/// (e.g. `~/.local/share/llmfit/hardware` on Linux).
+/// `LLMFIT_HARDWARE_PROFILES` overrides the location.
+pub fn user_profile_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("LLMFIT_HARDWARE_PROFILES") {
+        let trimmed = dir.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+    Some(crate::update::cache_dir()?.join("hardware"))
+}
+
+/// Read, parse, validate, and name-check one profile file.
+pub fn load_file(path: &Path) -> Result<HardwareProfile, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    let profile = HardwareProfile::parse(&text).map_err(|e| format!("{}: {e}", path.display()))?;
+    profile
+        .validate()
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    profile
+        .check_name_matches_stem(path)
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    Ok(profile)
+}
+
+/// Every selectable profile, sorted by name.
+///
+/// A user profile replaces the bundled one with the same name, so a local fix
+/// wins without editing the binary's data.
+pub fn catalog() -> ProfileCatalog {
+    catalog_in(user_profile_dir().as_deref())
+}
+
+fn catalog_in(user_dir: Option<&Path>) -> ProfileCatalog {
+    let mut catalog = ProfileCatalog::default();
+    for profile in embedded() {
+        catalog.profiles.push(LoadedProfile {
+            origin: ProfileOrigin::Embedded,
+            profile: profile.clone(),
+        });
+    }
+
+    if let Some(entries) = user_dir.and_then(|dir| std::fs::read_dir(dir).ok()) {
+        let mut paths: Vec<PathBuf> = entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("json"))
+            .collect();
+        paths.sort();
+        for path in paths {
+            match load_file(&path) {
+                Ok(profile) => {
+                    catalog
+                        .profiles
+                        .retain(|loaded| loaded.profile.name != profile.name);
+                    catalog.profiles.push(LoadedProfile {
+                        origin: ProfileOrigin::User(path),
+                        profile,
+                    });
+                }
+                Err(err) => catalog.errors.push((path, err)),
+            }
+        }
+    }
+
+    catalog
+        .profiles
+        .sort_by(|a, b| a.profile.name.cmp(&b.profile.name));
+    catalog
+}
+
+/// Look a profile up by name (user profiles shadow bundled ones).
+pub fn find(name: &str) -> Option<LoadedProfile> {
+    catalog()
+        .profiles
+        .into_iter()
+        .find(|loaded| loaded.profile.name == name)
+}
+
+/// Resolve a `--profile` selector: a path when it looks like one, otherwise a
+/// profile name.
+pub fn resolve(selector: &str) -> Result<LoadedProfile, String> {
+    let selector = selector.trim();
+    if selector.is_empty() {
+        return Err("profile selector must not be empty".to_string());
+    }
+
+    if looks_like_path(selector) {
+        let path = PathBuf::from(selector);
+        let profile = load_file(&path)?;
+        return Ok(LoadedProfile {
+            origin: ProfileOrigin::File(path),
+            profile,
+        });
+    }
+
+    find(selector).ok_or_else(|| {
+        let names: Vec<String> = catalog()
+            .profiles
+            .iter()
+            .map(|loaded| loaded.profile.name.clone())
+            .collect();
+        if names.is_empty() {
+            format!("unknown hardware profile '{selector}'; no profiles available")
+        } else {
+            format!(
+                "unknown hardware profile '{selector}'. Available: {}",
+                names.join(", ")
+            )
+        }
+    })
+}
+
+/// Whether a selector names a file rather than a profile.
+///
+/// Profile names are bare slugs, so anything with a separator, a `.json`
+/// extension, or an existing file behind it is a path.
+fn looks_like_path(selector: &str) -> bool {
+    let path = Path::new(selector);
+    selector.ends_with(".json") || path.components().count() > 1 || path.exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hardware::{GpuBackend, GpuInfo};
+
+    const MINIMAL: &str = r#"{
+        "schema_version": 1,
+        "name": "test-box",
+        "hardware": { "total_ram_gb": 64.0, "unified_memory": false }
+    }"#;
+
+    fn full_profile() -> HardwareProfile {
+        HardwareProfile::parse(
+            r#"{
+                "schema_version": 1,
+                "name": "test-box",
+                "match": { "gpu_name_contains": "Radeon 8060S" },
+                "hardware": {
+                    "total_ram_gb": 128.0,
+                    "unified_memory": true,
+                    "gpu_memory_bandwidth_gbps": 256.0,
+                    "ddr_bandwidth_gbps": 250.0,
+                    "gpu_compute_tflops_fp16": 29.7
+                },
+                "estimation": {
+                    "efficiency": 0.7,
+                    "run_mode_factors": { "cpu_only": 0.25 }
+                },
+                "calibration": [
+                    { "model": "openai/gpt-oss-120b", "quant": "MXFP4",
+                      "run_mode": "gpu", "measured_tps": 50.0, "source": "issue #969" }
+                ]
+            }"#,
+        )
+        .expect("full profile parses")
+    }
+
+    /// A per-test scratch directory: tests in one binary share a process, so a
+    /// fixed path would race between threads.
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("llmfit-hwprofile-{}-{tag}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
+    fn specs_no_gpu() -> SystemSpecs {
+        SystemSpecs {
+            total_ram_gb: 32.0,
+            available_ram_gb: 24.0,
+            total_cpu_cores: 8,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: false,
+            gpu_vram_gb: None,
+            total_gpu_vram_gb: None,
+            gpu_available_gb: None,
+            gpu_name: None,
+            gpu_count: 0,
+            unified_memory: false,
+            backend: GpuBackend::CpuX86,
+            gpus: vec![],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        }
+    }
+
+    fn specs_with_gpu() -> SystemSpecs {
+        SystemSpecs {
+            has_gpu: true,
+            gpu_vram_gb: Some(8.0),
+            total_gpu_vram_gb: Some(8.0),
+            gpu_name: Some("NVIDIA RTX 3070".to_string()),
+            gpu_count: 1,
+            backend: GpuBackend::Cuda,
+            gpus: vec![GpuInfo {
+                name: "NVIDIA RTX 3070".to_string(),
+                vram_gb: Some(8.0),
+                backend: GpuBackend::Cuda,
+                count: 1,
+                unified_memory: false,
+            }],
+            ..specs_no_gpu()
+        }
+    }
+
+    #[test]
+    fn minimal_profile_parses_with_optional_sections_absent() {
+        let profile = HardwareProfile::parse(MINIMAL).expect("minimal profile parses");
+        assert!(profile.validate_strict().is_ok());
+        assert_eq!(profile.hardware.total_ram_gb, 64.0);
+        assert!(profile.matcher.is_none());
+        assert!(profile.estimation.is_none());
+        assert!(profile.calibration.is_empty());
+        assert!(profile.hardware.gpu_memory_bandwidth_gbps.is_none());
+    }
+
+    #[test]
+    fn missing_required_field_is_a_parse_error() {
+        let err = HardwareProfile::parse(
+            r#"{ "name": "x", "hardware": { "total_ram_gb": 8.0, "unified_memory": false } }"#,
+        )
+        .expect_err("schema_version is required");
+        assert!(err.contains("schema_version"), "{err}");
+
+        let err = HardwareProfile::parse(r#"{ "schema_version": 1, "name": "x" }"#)
+            .expect_err("hardware is required");
+        assert!(err.contains("hardware"), "{err}");
+    }
+
+    #[test]
+    fn loader_tolerates_unknown_keys_but_strict_validation_rejects_them() {
+        let profile = HardwareProfile::parse(
+            r#"{
+                "schema_version": 1,
+                "name": "test-box",
+                "future_top_level": 1,
+                "hardware": { "total_ram_gb": 64.0, "unified_memory": false, "npu_tops": 50 },
+                "estimation": { "efficiency": 0.5, "future_knob": true },
+                "calibration": [{ "model": "m", "measured_tps": 10.0, "future": 1 }]
+            }"#,
+        )
+        .expect("unknown keys must not break loading");
+
+        assert!(profile.validate().is_ok(), "unknown keys are not fatal");
+        assert_eq!(
+            profile.unknown_keys(),
+            vec![
+                "future_top_level",
+                "hardware.npu_tops",
+                "estimation.future_knob",
+                "calibration[0].future",
+            ]
+        );
+        let err = profile
+            .validate_strict()
+            .expect_err("strict validation rejects unknown keys");
+        assert!(err.contains("hardware.npu_tops"), "{err}");
+    }
+
+    #[test]
+    fn wrong_schema_version_is_rejected() {
+        let profile = HardwareProfile::parse(
+            r#"{ "schema_version": 2, "name": "x",
+                 "hardware": { "total_ram_gb": 8.0, "unified_memory": false } }"#,
+        )
+        .expect("parses");
+        let err = profile.validate().expect_err("version 2 is unsupported");
+        assert!(err.contains("schema_version 2"), "{err}");
+    }
+
+    #[test]
+    fn invalid_names_are_rejected() {
+        for name in ["", "Ryzen-AI", "-leading-dash", "has space", "has/slash"] {
+            assert!(
+                validate_name(name).is_err(),
+                "'{name}' should be an invalid profile name"
+            );
+        }
+        for name in ["a", "ryzen-ai-max-plus-395", "m3.max_128"] {
+            assert!(validate_name(name).is_ok(), "'{name}' should be valid");
+        }
+    }
+
+    #[test]
+    fn non_finite_and_out_of_range_numbers_are_rejected() {
+        for ram in ["0", "-1", "1e9"] {
+            let text = format!(
+                r#"{{ "schema_version": 1, "name": "x",
+                      "hardware": {{ "total_ram_gb": {ram}, "unified_memory": false }} }}"#
+            );
+            let profile = HardwareProfile::parse(&text).expect("parses");
+            assert!(
+                profile.validate().is_err(),
+                "total_ram_gb {ram} should be rejected"
+            );
+        }
+
+        let profile = HardwareProfile::parse(
+            r#"{ "schema_version": 1, "name": "x",
+                 "hardware": { "total_ram_gb": 64.0, "unified_memory": false,
+                               "gpu_memory_bandwidth_gbps": 0 } }"#,
+        )
+        .expect("parses");
+        let err = profile.validate().expect_err("zero bandwidth is rejected");
+        assert!(err.contains("gpu_memory_bandwidth_gbps"), "{err}");
+    }
+
+    #[test]
+    fn efficiency_above_one_is_rejected() {
+        let profile = HardwareProfile::parse(
+            r#"{ "schema_version": 1, "name": "x",
+                 "hardware": { "total_ram_gb": 64.0, "unified_memory": false },
+                 "estimation": { "efficiency": 1.5 } }"#,
+        )
+        .expect("parses");
+        let err = profile.validate().expect_err("efficiency > 1 is rejected");
+        assert!(err.contains("estimation.efficiency"), "{err}");
+    }
+
+    #[test]
+    fn calibration_is_validated_even_though_it_is_not_applied() {
+        let profile = HardwareProfile::parse(
+            r#"{ "schema_version": 1, "name": "x",
+                 "hardware": { "total_ram_gb": 64.0, "unified_memory": false },
+                 "calibration": [{ "model": "m", "measured_tps": 10.0,
+                                   "run_mode": "teleport" }] }"#,
+        )
+        .expect("parses");
+        let err = profile
+            .validate()
+            .expect_err("unknown run_mode is rejected");
+        assert!(err.contains("calibration[0].run_mode"), "{err}");
+
+        let profile = HardwareProfile::parse(
+            r#"{ "schema_version": 1, "name": "x",
+                 "hardware": { "total_ram_gb": 64.0, "unified_memory": false },
+                 "calibration": [{ "model": "m", "measured_tps": 0 }] }"#,
+        )
+        .expect("parses");
+        assert!(
+            profile.validate().is_err(),
+            "zero tok/s is not a measurement"
+        );
+    }
+
+    #[test]
+    fn apply_to_config_maps_every_supported_field() {
+        let mut config = CalcConfig::default();
+        let defaults = CalcConfig::default();
+        full_profile().apply_to_config(&mut config);
+
+        assert_eq!(config.gpu_bandwidth_gbps_override, Some(256.0));
+        assert_eq!(config.ddr_bandwidth_gbps, Some(250.0));
+        assert_eq!(config.gpu_compute_tflops_fp16, Some(29.7));
+        assert_eq!(config.efficiency, 0.7);
+        assert_eq!(config.run_mode_factors.cpu_only, 0.25);
+        // Modes the profile left unset keep their defaults.
+        assert_eq!(config.run_mode_factors.gpu, defaults.run_mode_factors.gpu);
+        assert_eq!(
+            config.run_mode_factors.moe_offload,
+            defaults.run_mode_factors.moe_offload
+        );
+    }
+
+    #[test]
+    fn partial_profile_leaves_estimator_defaults_alone() {
+        let mut config = CalcConfig::default();
+        let defaults = CalcConfig::default();
+        HardwareProfile::parse(MINIMAL)
+            .expect("parses")
+            .apply_to_config(&mut config);
+
+        assert_eq!(config.efficiency, defaults.efficiency);
+        assert_eq!(config.gpu_bandwidth_gbps_override, None);
+        assert_eq!(config.ddr_bandwidth_gbps, None);
+        assert_eq!(config.gpu_compute_tflops_fp16, None);
+    }
+
+    #[test]
+    fn unified_profile_makes_vram_track_ram_and_synthesizes_a_gpu() {
+        let specs = full_profile().apply_to_specs(specs_no_gpu());
+
+        assert!(specs.unified_memory);
+        assert!(
+            specs.has_gpu,
+            "a unified profile must give the GPU path a pool"
+        );
+        assert_eq!(specs.total_ram_gb, 128.0);
+        assert_eq!(specs.gpu_vram_gb, Some(128.0));
+        assert_eq!(specs.total_gpu_vram_gb, Some(128.0));
+        assert!(specs.gpus.iter().all(|gpu| gpu.unified_memory));
+    }
+
+    #[test]
+    fn discrete_profile_sets_ram_and_leaves_detected_vram() {
+        let profile = HardwareProfile::parse(MINIMAL).expect("parses");
+        let specs = profile.apply_to_specs(specs_with_gpu());
+
+        assert!(!specs.unified_memory);
+        assert_eq!(specs.total_ram_gb, 64.0);
+        assert_eq!(
+            specs.gpu_vram_gb,
+            Some(8.0),
+            "profiles carry no VRAM figure, so detection stands"
+        );
+    }
+
+    #[test]
+    fn apply_moves_specs_and_config_together() {
+        let mut config = CalcConfig::default();
+        let specs = full_profile().apply(specs_no_gpu(), &mut config);
+
+        assert_eq!(specs.total_ram_gb, 128.0);
+        assert_eq!(config.gpu_bandwidth_gbps_override, Some(256.0));
+    }
+
+    #[test]
+    fn name_must_match_file_stem() {
+        let profile = HardwareProfile::parse(MINIMAL).expect("parses");
+        assert!(
+            profile
+                .check_name_matches_stem(Path::new("/tmp/test-box.json"))
+                .is_ok()
+        );
+        let err = profile
+            .check_name_matches_stem(Path::new("/tmp/other.json"))
+            .expect_err("stem mismatch is rejected");
+        assert!(err.contains("does not match file stem"), "{err}");
+    }
+
+    #[test]
+    fn embedded_profiles_are_present_and_valid() {
+        let profiles = embedded();
+        assert!(
+            profiles.len() >= 2,
+            "expected the bundled seed profiles, got {}",
+            profiles.len()
+        );
+        for profile in profiles {
+            profile
+                .validate_strict()
+                .unwrap_or_else(|e| panic!("bundled profile {} is invalid: {e}", profile.name));
+        }
+        assert!(
+            profiles
+                .iter()
+                .any(|p| p.name == "ryzen-ai-max-plus-395" && p.hardware.unified_memory),
+            "expected a 256 GB/s-class unified profile"
+        );
+        assert!(
+            profiles
+                .iter()
+                .any(|p| p.name == "nvidia-rtx-4090" && !p.hardware.unified_memory),
+            "expected a discrete-GPU profile"
+        );
+    }
+
+    #[test]
+    fn resolve_finds_a_bundled_profile_by_name() {
+        let loaded = resolve("ryzen-ai-max-plus-395").expect("bundled profile resolves");
+        assert_eq!(loaded.profile.name, "ryzen-ai-max-plus-395");
+        assert!(loaded.profile.hardware.unified_memory);
+    }
+
+    #[test]
+    fn user_profiles_shadow_bundled_ones_and_bad_files_are_reported() {
+        let dir = temp_dir("catalog");
+        std::fs::write(
+            dir.join("nvidia-rtx-4090.json"),
+            r#"{ "schema_version": 1, "name": "nvidia-rtx-4090",
+                 "hardware": { "total_ram_gb": 256.0, "unified_memory": false } }"#,
+        )
+        .expect("write shadow profile");
+        std::fs::write(dir.join("broken.json"), "{ not json").expect("write broken profile");
+
+        let catalog = catalog_in(Some(&dir));
+
+        let shadowed = catalog
+            .profiles
+            .iter()
+            .find(|loaded| loaded.profile.name == "nvidia-rtx-4090")
+            .expect("shadowed profile is listed once");
+        assert_eq!(shadowed.profile.hardware.total_ram_gb, 256.0);
+        assert!(matches!(shadowed.origin, ProfileOrigin::User(_)));
+        assert_eq!(
+            catalog
+                .profiles
+                .iter()
+                .filter(|loaded| loaded.profile.name == "nvidia-rtx-4090")
+                .count(),
+            1,
+            "a user profile replaces the bundled one rather than duplicating it"
+        );
+        assert!(
+            catalog
+                .profiles
+                .iter()
+                .any(|loaded| loaded.profile.name == "ryzen-ai-max-plus-395"),
+            "unshadowed bundled profiles remain"
+        );
+        assert_eq!(catalog.errors.len(), 1, "the broken file is reported");
+        assert!(catalog.errors[0].0.ends_with("broken.json"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn resolve_rejects_an_unknown_name_and_lists_alternatives() {
+        let err = resolve("no-such-box").expect_err("unknown name is an error");
+        assert!(err.contains("unknown hardware profile"), "{err}");
+        assert!(err.contains("nvidia-rtx-4090"), "{err}");
+    }
+
+    #[test]
+    fn resolve_rejects_an_empty_selector() {
+        assert!(resolve("   ").is_err());
+    }
+
+    #[test]
+    fn resolve_reads_a_path_selector() {
+        let dir = temp_dir("resolve");
+        let path = dir.join("test-box.json");
+        std::fs::write(&path, MINIMAL).expect("write profile");
+
+        let loaded = resolve(path.to_str().expect("utf-8 temp path")).expect("path resolves");
+        assert_eq!(loaded.origin, ProfileOrigin::File(path.clone()));
+        assert_eq!(loaded.profile.name, "test-box");
+
+        let renamed = dir.join("mismatch.json");
+        std::fs::write(&renamed, MINIMAL).expect("write profile");
+        let err = resolve(renamed.to_str().expect("utf-8 temp path"))
+            .expect_err("stem mismatch is rejected on load");
+        assert!(err.contains("does not match file stem"), "{err}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_path_selector_reports_the_path() {
+        let err =
+            resolve("./definitely-missing-profile.json").expect_err("missing file is an error");
+        assert!(err.contains("definitely-missing-profile.json"), "{err}");
+    }
+
+    #[test]
+    fn bare_names_are_not_treated_as_paths() {
+        assert!(!looks_like_path("ryzen-ai-max-plus-395"));
+        assert!(looks_like_path("profile.json"));
+        assert!(looks_like_path("./dir/profile"));
+    }
+}

--- a/llmfit-core/src/lib.rs
+++ b/llmfit-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod claim;
 pub mod doctor;
 pub mod fit;
 pub mod hardware;
+pub mod hwprofile;
 pub mod models;
 pub mod plan;
 pub mod providers;
@@ -14,8 +15,11 @@ pub mod task_bench;
 pub mod update;
 
 pub use analysis::{InstalledIndex, build_model_fits};
-pub use fit::{FitLevel, InferenceRuntime, ModelFit, RunMode, ScoreComponents, SortColumn};
+pub use fit::{
+    EstimateConfidence, FitLevel, InferenceRuntime, ModelFit, RunMode, ScoreComponents, SortColumn,
+};
 pub use hardware::{GpuBackend, SystemSpecs};
+pub use hwprofile::HardwareProfile;
 pub use models::{Capability, LlmModel, ModelDatabase, ModelFormat, UseCase};
 pub use plan::{
     HardwareEstimate, PathEstimate, PlanCurrentStatus, PlanEstimate, PlanRequest, PlanRunPath,

--- a/llmfit-core/src/models.rs
+++ b/llmfit-core/src/models.rs
@@ -1,4 +1,6 @@
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
 
 /// Quantization levels ordered from best quality to most compressed.
 /// Used for dynamic quantization selection: try the best that fits.
@@ -35,6 +37,15 @@ pub fn quant_bpp(quant: &str) -> f64 {
         "GPTQ-Int8" => 1.0,
         _ => 0.58,
     }
+}
+
+/// True for GGUF-style quant labels (`Q8_0`, `Q4_K_M`, ...), as opposed to
+/// native formats (`mlx-4bit`, `AWQ-4bit`, `nvfp4`, ...). Used to catch a
+/// `best_quant` that leaked llama.cpp's naming onto a model that isn't
+/// GGUF (issue #969, problem 3).
+pub fn is_gguf_quant_label(quant: &str) -> bool {
+    let upper = quant.to_uppercase();
+    upper.starts_with('Q') && upper.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
 }
 
 /// Speed multiplier for quantization (lower quant = faster inference).
@@ -744,7 +755,162 @@ pub fn matches_provider_filter(model: &LlmModel, mut matches: impl FnMut(&str) -
             .any(|source| matches(&source.provider))
 }
 
+/// Why a catalog entry is excluded from ranked fits (issue #969, problem 3).
+///
+/// The model stays in [`ModelDatabase`] either way — sanitization only
+/// gates `build_model_fits`, so a demoted row must stay inspectable rather
+/// than silently vanishing from the catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SanitizationReason {
+    /// A speculative-decoding draft head (EAGLE/DFlash/DSpark) cataloged as
+    /// if it were a standalone model.
+    SpecDecodeDraft,
+    /// The parameter count implied by the model's own name diverges from
+    /// the catalog's declared size by 4x or more.
+    SizeNameDivergence,
+    /// The declared `min_ram_gb` implies an implausible bits-per-parameter
+    /// figure for the declared parameter count (outside `[1.0, 33.0]`).
+    ImplausibleFootprint,
+}
+
+impl SanitizationReason {
+    /// Stable machine code for JSON/CLI consumers.
+    pub fn code(&self) -> &'static str {
+        match self {
+            SanitizationReason::SpecDecodeDraft => "spec_decode_draft",
+            SanitizationReason::SizeNameDivergence => "size_name_divergence",
+            SanitizationReason::ImplausibleFootprint => "implausible_footprint",
+        }
+    }
+}
+
+/// True if any hyphen/underscore/dot-delimited token in `basename` marks it
+/// as a speculative-decoding draft head rather than a standalone model.
+///
+/// Matches per-token against `^(eagle|dflash|dspark)\d*$` (case
+/// insensitive) so it never fires inside a larger word (e.g. it does not
+/// match "heretic" or "flashattention"). Deliberately excludes MTP: an
+/// `-MTP-` token alone is not a draft signal here, and this pattern must
+/// never be broadened to match it.
+fn is_speculative_decoding_draft_token(basename: &str) -> bool {
+    static DRAFT_TOKEN: OnceLock<Regex> = OnceLock::new();
+    let re = DRAFT_TOKEN
+        .get_or_init(|| Regex::new(r"(?i)^(eagle|dflash|dspark)\d*$").expect("valid regex"));
+    basename
+        .split(['-', '_', '.'])
+        .any(|token| !token.is_empty() && re.is_match(token))
+}
+
+/// Largest standalone `<number>B` parameter-count token found in `basename`,
+/// or `None` if the name carries no such token.
+///
+/// Ignores MoE active-expert markers (`A3B` in `Qwen3-30B-A3B`, meaning "3B
+/// active", not the model's total size) so those don't get compared against
+/// the total parameter count as if they were a competing size claim.
+fn name_derived_params_b(basename: &str) -> Option<f64> {
+    static SIZE_TOKEN: OnceLock<Regex> = OnceLock::new();
+    static ACTIVE_TOKEN: OnceLock<Regex> = OnceLock::new();
+    let size_re =
+        SIZE_TOKEN.get_or_init(|| Regex::new(r"(?i)^(\d+(?:\.\d+)?)b$").expect("valid regex"));
+    let active_re =
+        ACTIVE_TOKEN.get_or_init(|| Regex::new(r"(?i)^a\d+(?:\.\d+)?b$").expect("valid regex"));
+
+    basename
+        .split(['-', '_', '.', ' '])
+        .filter(|token| !active_re.is_match(token))
+        .filter_map(|token| {
+            size_re
+                .captures(token)
+                .and_then(|c| c[1].parse::<f64>().ok())
+        })
+        .fold(None, |acc, v| Some(acc.map_or(v, |a: f64| a.max(v))))
+}
+
 impl LlmModel {
+    /// If this catalog entry should be excluded from ranked fits, the
+    /// reason and a human-readable explanation. `None` for a clean entry.
+    ///
+    /// The model itself is never dropped from the catalog by this check —
+    /// callers that rank fits (`build_model_fits`) filter on
+    /// [`LlmModel::is_sanitization_demoted`] instead, so the row stays
+    /// inspectable (issue #969, problem 3).
+    pub fn sanitization_issue(&self) -> Option<(SanitizationReason, String)> {
+        let basename = self.name.rsplit('/').next().unwrap_or(&self.name);
+
+        if is_speculative_decoding_draft_token(basename) {
+            return Some((
+                SanitizationReason::SpecDecodeDraft,
+                format!(
+                    "'{}' looks like a speculative-decoding draft head (EAGLE/DFlash/DSpark \
+                     naming), not a standalone model — excluded from ranked fits",
+                    self.name
+                ),
+            ));
+        }
+
+        if let (Some(named_b), Some(actual_b)) =
+            (name_derived_params_b(basename), self.known_params_b())
+            && named_b > 0.0
+            && actual_b > 0.0
+        {
+            let ratio = (named_b / actual_b).max(actual_b / named_b);
+            if ratio >= 4.0 {
+                return Some((
+                    SanitizationReason::SizeNameDivergence,
+                    format!(
+                        "name implies ~{named_b:.1}B params but the catalog declares {actual_b:.1}B \
+                         ({ratio:.1}x divergence) — excluded from ranked fits"
+                    ),
+                ));
+            }
+        }
+
+        if let Some(bpp) = self.implied_bits_per_param()
+            && !(1.0..=33.0).contains(&bpp)
+        {
+            return Some((
+                SanitizationReason::ImplausibleFootprint,
+                format!(
+                    "declared min_ram_gb ({:.2} GB) implies {bpp:.2} bits/param at {:.1}B params, \
+                     outside the plausible [1, 33] range — excluded from ranked fits",
+                    self.min_ram_gb,
+                    self.params_b()
+                ),
+            ));
+        }
+
+        None
+    }
+
+    /// Convenience predicate over [`LlmModel::sanitization_issue`].
+    pub fn is_sanitization_demoted(&self) -> bool {
+        self.sanitization_issue().is_some()
+    }
+
+    /// Bits per declared parameter implied by `min_ram_gb`, or `None` when
+    /// the catalog doesn't record a trustworthy parameter count. A cheap
+    /// forward guard against entries like "117B model at 1.2GB" (issue
+    /// #969): real weights, at any quantization llmfit knows about, land
+    /// well inside `[1.0, 33.0]` bits/param.
+    fn implied_bits_per_param(&self) -> Option<f64> {
+        let params_b = self.known_params_b()?;
+        if params_b <= 0.0 {
+            return None;
+        }
+        let bytes = self.min_ram_gb * 1024.0_f64.powi(3);
+        Some(bytes * 8.0 / (params_b * 1_000_000_000.0))
+    }
+
+    /// True when the model's own repo name signals a native low-precision
+    /// format (NVFP4, MXFP4) rather than GGUF. These repos ship a single
+    /// upstream quantization in that format — a llama.cpp/GGUF quant
+    /// hierarchy entry like `Q8_0` never applies to them (issue #969,
+    /// problem 3).
+    pub fn is_native_low_precision_named(&self) -> bool {
+        let lower = self.name.to_lowercase();
+        lower.contains("nvfp4") || lower.contains("mxfp4")
+    }
+
     /// MLX models are Apple-only — they won't run on NVIDIA/AMD/Intel hardware.
     /// We detect them by the `-MLX-` suffix that's standard on HuggingFace
     /// (e.g. `Qwen3-8B-MLX-4bit`, `LFM2-1.2B-MLX-8bit`).
@@ -1891,6 +2057,215 @@ mod tests {
         assert!(matches_license_filter(&license, "bsd-3-clause,mit"));
         assert!(!matches_license_filter(&license, "cc-by-nc-4.0"));
         assert!(!matches_license_filter(&None, "mit"));
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Sanitization tests (issue #969, problem 3)
+    // ────────────────────────────────────────────────────────────────────
+
+    /// Minimal `LlmModel` builder for sanitization tests: only `name`,
+    /// `parameter_count`/`parameters_raw`, and `min_ram_gb` vary per case.
+    fn sanitization_test_model(
+        name: &str,
+        parameter_count: &str,
+        parameters_raw: Option<u64>,
+        min_ram_gb: f64,
+    ) -> LlmModel {
+        LlmModel {
+            name: name.to_string(),
+            provider: "test".to_string(),
+            parameter_count: parameter_count.to_string(),
+            parameters_raw,
+            min_ram_gb,
+            recommended_ram_gb: min_ram_gb * 1.5,
+            min_vram_gb: Some(min_ram_gb),
+            quantization: "Q4_K_M".to_string(),
+            context_length: 8192,
+            use_case: "General".to_string(),
+            is_moe: false,
+            num_experts: None,
+            active_experts: None,
+            active_parameters: None,
+            release_date: None,
+            gguf_sources: vec![],
+            capabilities: vec![],
+            languages: vec![],
+            format: ModelFormat::default(),
+            num_attention_heads: None,
+            num_key_value_heads: None,
+            num_hidden_layers: None,
+            head_dim: None,
+            attention_layout: None,
+            hidden_size: None,
+            moe_intermediate_size: None,
+            vocab_size: None,
+            shared_expert_intermediate_size: None,
+            architecture: None,
+            license: None,
+        }
+    }
+
+    #[test]
+    fn sanitization_flags_eagle_dflash_dspark_draft_tokens() {
+        // Real catalog examples (issue #969): tiny draft heads named after
+        // the much larger target model they speculate for.
+        for name in [
+            "yuhuili/EAGLE-LLaMA3-Instruct-70B",
+            "RedHatAI/Llama-3.3-70B-Instruct-speculator.eagle3",
+            "zenosai/MonkeyOCRv2-B-Parsing-DFlash",
+            "LiquidAI/LFM2.5-1.2B-Instruct-DSpark",
+            "z-lab/Qwen3.8-27B-DFlash2-MLXFast-Q4",
+        ] {
+            let model = sanitization_test_model(name, "3B", Some(3_000_000_000), 2.0);
+            let issue = model.sanitization_issue();
+            assert_eq!(
+                issue.map(|(reason, _)| reason),
+                Some(SanitizationReason::SpecDecodeDraft),
+                "expected '{name}' to be flagged as a spec-decode draft"
+            );
+            assert!(model.is_sanitization_demoted());
+        }
+    }
+
+    #[test]
+    fn sanitization_never_flags_mtp_alone() {
+        // MTP (multi-token-prediction head) is fused into the base
+        // checkpoint, not a standalone draft — must never match. Declared
+        // size matches the name-derived token so only the MTP token itself
+        // is under test, isolated from the size-divergence check.
+        for (name, parameter_count, parameters_raw, min_ram_gb) in [
+            (
+                "SC117/Ornith-1.0-35B-Heretic-MTP",
+                "35B",
+                35_000_000_000u64,
+                20.0,
+            ),
+            (
+                "crucible-labs/Ornith-1.0-35B-MTP",
+                "35B",
+                35_000_000_000,
+                20.0,
+            ),
+            (
+                "mlx-community/Qwen3.5-4B-MTP-4bit",
+                "4B",
+                4_000_000_000,
+                2.5,
+            ),
+        ] {
+            let model =
+                sanitization_test_model(name, parameter_count, Some(parameters_raw), min_ram_gb);
+            assert_eq!(
+                model.sanitization_issue().map(|(reason, _)| reason),
+                None,
+                "'{name}' must not be flagged by the MTP token alone"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitization_flags_size_name_divergence_without_draft_tokens() {
+        // No eagle/dflash/dspark token, but the name still claims a size
+        // 4x+ off from the catalog's declared parameter count.
+        let model = sanitization_test_model(
+            "acme/Llama-Clone-70B-Instruct",
+            "3.2B",
+            Some(3_200_000_000),
+            2.0,
+        );
+        assert_eq!(
+            model.sanitization_issue().map(|(reason, _)| reason),
+            Some(SanitizationReason::SizeNameDivergence)
+        );
+    }
+
+    #[test]
+    fn sanitization_ignores_moe_active_expert_marker() {
+        // "A3B" means 3B active experts, not a competing total-size claim —
+        // must not be compared against the declared 30.5B total.
+        let mut model =
+            sanitization_test_model("Qwen/Qwen3-30B-A3B", "30.5B", Some(30_500_000_000), 18.0);
+        model.is_moe = true;
+        model.num_experts = Some(128);
+        model.active_experts = Some(8);
+        assert_eq!(model.sanitization_issue(), None);
+    }
+
+    #[test]
+    fn sanitization_allows_close_size_match() {
+        // A name mentioning "8B" for an 8.2B model is normal rounding, not
+        // divergence.
+        let model = sanitization_test_model("Qwen/Qwen3-8B", "8.2B", Some(8_200_000_000), 5.0);
+        assert_eq!(model.sanitization_issue(), None);
+    }
+
+    #[test]
+    fn sanitization_flags_implausible_bits_per_param_footprint() {
+        // issue #969 example: a 117B model claiming 1.2 GB on disk
+        // (~0.08 bits/param) — physically impossible at any known quant.
+        let model =
+            sanitization_test_model("acme/impossible-117b", "117B", Some(117_000_000_000), 1.2);
+        assert_eq!(
+            model.sanitization_issue().map(|(reason, _)| reason),
+            Some(SanitizationReason::ImplausibleFootprint)
+        );
+    }
+
+    #[test]
+    fn sanitization_allows_plausible_footprint_across_quant_range() {
+        // 7B params at Q4_K_M (~0.58 bytes/param = ~4.6 bits/param) and at
+        // F16 (~2 bytes/param = 16 bits/param) both land inside [1, 33].
+        let q4 = sanitization_test_model("acme/plausible-7b-q4", "7B", Some(7_000_000_000), 4.5);
+        let f16 = sanitization_test_model("acme/plausible-7b-f16", "7B", Some(7_000_000_000), 14.0);
+        assert_eq!(q4.sanitization_issue(), None);
+        assert_eq!(f16.sanitization_issue(), None);
+    }
+
+    #[test]
+    fn sanitization_skips_divergence_and_footprint_checks_without_known_size() {
+        // No parameters_raw and an unparseable parameter_count: nothing to
+        // compare against, so neither check can fire.
+        let model = sanitization_test_model("acme/mystery-model", "Unknown", None, 4.0);
+        assert_eq!(model.known_params_b(), None);
+        assert_eq!(model.sanitization_issue(), None);
+    }
+
+    #[test]
+    fn sanitization_reason_codes_are_stable() {
+        assert_eq!(
+            SanitizationReason::SpecDecodeDraft.code(),
+            "spec_decode_draft"
+        );
+        assert_eq!(
+            SanitizationReason::SizeNameDivergence.code(),
+            "size_name_divergence"
+        );
+        assert_eq!(
+            SanitizationReason::ImplausibleFootprint.code(),
+            "implausible_footprint"
+        );
+    }
+
+    #[test]
+    fn is_native_low_precision_named_matches_nvfp4_and_mxfp4() {
+        let nvfp4 =
+            sanitization_test_model("nvidia/Qwen3-8B-NVFP4", "8B", Some(8_000_000_000), 5.0);
+        let mxfp4 =
+            sanitization_test_model("amd/MiniMax-M2.1-MXFP4", "10B", Some(10_000_000_000), 6.0);
+        let gguf = sanitization_test_model("acme/plain-7b", "7B", Some(7_000_000_000), 4.5);
+
+        assert!(nvfp4.is_native_low_precision_named());
+        assert!(mxfp4.is_native_low_precision_named());
+        assert!(!gguf.is_native_low_precision_named());
+    }
+
+    #[test]
+    fn is_gguf_quant_label_distinguishes_gguf_from_native_formats() {
+        assert!(is_gguf_quant_label("Q8_0"));
+        assert!(is_gguf_quant_label("Q4_K_M"));
+        assert!(!is_gguf_quant_label("mlx-4bit"));
+        assert!(!is_gguf_quant_label("AWQ-4bit"));
+        assert!(!is_gguf_quant_label("nvfp4"));
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/llmfit-core/src/models.rs
+++ b/llmfit-core/src/models.rs
@@ -1009,6 +1009,8 @@ impl LlmModel {
     /// per-token bandwidth. Captures the ratio of compute time to weight-read
     /// time for attention-sized matrix operations.
     /// Calibrated to K=3.2 from RX 6900 XT benchmarks across Q2_K, Q4_K_M, Q8_0.
+    /// The default for architectures without a fitted entry — see
+    /// `moe_tier1_fixed_bpp` in `fit.rs`.
     pub const MOE_FIXED_EFFECTIVE_BPP: f64 = 3.2;
 
     /// Decompose MoE per-token bandwidth into scalable (FFN) and fixed components.
@@ -1663,6 +1665,102 @@ fn load_embedded() -> Vec<LlmModel> {
     models
 }
 
+/// A published per-token active-parameter count, used to overrule a catalog
+/// figure that contradicts it.
+///
+/// `hf_models.json` derives `active_parameters` from each repo's
+/// `config.json`, and for the gpt-oss 120B geometry that derivation
+/// double-counts the SwiGLU expert projections: it records 9.31B where the
+/// model card publishes 5.1B. Active parameters are what the MoE decode
+/// estimate divides bandwidth by, so a 1.8x error there is a ~2x throughput
+/// error (issue #969, problem 2).
+///
+/// Matched on architecture plus expert geometry rather than repo name, so the
+/// dozens of gpt-oss-120b re-uploads and fine-tunes in the catalog are
+/// corrected alongside `openai/gpt-oss-120b` itself.
+struct PublishedMoeActive {
+    /// Lowercased HF `model_type` prefix the entry must carry.
+    architecture_prefix: &'static str,
+    num_experts: u32,
+    active_experts: u32,
+    /// Total parameters of the published model. An entry qualifies only if
+    /// its own total is within [`ACTIVE_PARAMS_TOTAL_TOLERANCE`] of this.
+    total_params: f64,
+    /// Active parameters per token, from the model card.
+    active_params: f64,
+}
+
+/// Published MoE active-parameter counts. Deliberately tiny: every entry
+/// overrules catalog data, so each one needs a citable source and a geometry
+/// specific enough that it cannot match a different model.
+const PUBLISHED_MOE_ACTIVE: &[PublishedMoeActive] = &[
+    // openai/gpt-oss-120b model card: 116.8B total, 5.1B active per token,
+    // 128 experts with 4 routed per token.
+    // https://huggingface.co/openai/gpt-oss-120b
+    //
+    // The 20B sibling (32 experts, 3.53B recorded vs 3.6B published) is
+    // within noise and deliberately has no entry here.
+    PublishedMoeActive {
+        architecture_prefix: "gpt_oss",
+        num_experts: 128,
+        active_experts: 4,
+        total_params: 116.8e9,
+        active_params: 5.1e9,
+    },
+];
+
+/// How far an entry's total parameter count may sit from the published
+/// figure and still count as the same model. Wide enough to cover re-uploads
+/// that round differently or add a few hundred million parameters
+/// (`gpt-oss-safeguard-120b`, 120.4B), narrow enough to leave pruned
+/// derivatives (`gpt-oss-120b-reap-48`, 45B) alone.
+const ACTIVE_PARAMS_TOTAL_TOLERANCE: f64 = 0.10;
+
+/// Below this ratio the catalog figure is treated as agreeing with the
+/// published one and left untouched, so the table only ever fires on entries
+/// that are actually wrong.
+const ACTIVE_PARAMS_DIVERGENCE: f64 = 1.2;
+
+/// Overrule `active_parameters` on entries whose catalog figure contradicts a
+/// published one. A no-op for every model not named by
+/// [`PUBLISHED_MOE_ACTIVE`].
+fn apply_published_moe_active(models: &mut [LlmModel]) {
+    for model in models.iter_mut() {
+        let Some(architecture) = model.architecture.as_deref() else {
+            continue;
+        };
+        let architecture = architecture.to_lowercase();
+        let (Some(num_experts), Some(active_experts), Some(current)) = (
+            model.num_experts,
+            model.active_experts,
+            model.active_parameters,
+        ) else {
+            continue;
+        };
+        let total = model.params_b() * 1e9;
+
+        for known in PUBLISHED_MOE_ACTIVE {
+            if !architecture.starts_with(known.architecture_prefix)
+                || num_experts != known.num_experts
+                || active_experts != known.active_experts
+            {
+                continue;
+            }
+            if (total - known.total_params).abs()
+                > known.total_params * ACTIVE_PARAMS_TOTAL_TOLERANCE
+            {
+                continue;
+            }
+            let current = current as f64;
+            let divergence = (current / known.active_params).max(known.active_params / current);
+            if divergence >= ACTIVE_PARAMS_DIVERGENCE {
+                model.active_parameters = Some(known.active_params as u64);
+            }
+            break;
+        }
+    }
+}
+
 /// Full path to the user's custom model overlay file, alongside the update
 /// cache (e.g. `~/.local/share/llmfit/custom_models.json` on Linux).
 /// The `LLMFIT_CUSTOM_MODELS` env var overrides the location.
@@ -1695,9 +1793,9 @@ impl ModelDatabase {
     /// Load only the compile-time embedded model list (no cache).
     /// Used internally by the updater to determine which models are already known.
     pub fn embedded() -> Self {
-        ModelDatabase {
-            models: load_embedded(),
-        }
+        let mut models = load_embedded();
+        apply_published_moe_active(&mut models);
+        ModelDatabase { models }
     }
 
     /// Load the embedded model list **and** merge user custom models and any
@@ -1738,6 +1836,11 @@ impl ModelDatabase {
                 models.push(cached);
             }
         }
+
+        // Last, so it also covers the custom overlay and the update cache —
+        // both carry the same derived `active_parameters` the embedded
+        // catalog does.
+        apply_published_moe_active(&mut models);
 
         ModelDatabase { models }
     }
@@ -4036,5 +4139,84 @@ mod tests {
                 m.name
             );
         }
+    }
+
+    /// The catalog derives 9.31B active parameters for the gpt-oss 120B
+    /// geometry where the model card publishes 5.1B; the derived figure is
+    /// what the MoE decode estimate divides bandwidth by, so it has to be
+    /// overruled at load (issue #969, problem 2).
+    #[test]
+    fn published_active_params_overrule_the_gpt_oss_120b_catalog_figure() {
+        let db = ModelDatabase::embedded();
+        let models = db.get_all_models();
+        let find = |name: &str| {
+            models
+                .iter()
+                .find(|m| m.name == name)
+                .unwrap_or_else(|| panic!("catalog is missing {name}"))
+        };
+
+        assert_eq!(
+            find("openai/gpt-oss-120b").active_parameters,
+            Some(5_100_000_000),
+            "the published 5.1B active figure must replace the derived one"
+        );
+        // Re-uploads and same-geometry siblings carry the same wrong figure,
+        // so the correction matches on geometry rather than repo name.
+        assert_eq!(
+            find("openai/gpt-oss-safeguard-120b").active_parameters,
+            Some(5_100_000_000)
+        );
+
+        // The 20B sibling's derived 3.53B already agrees with its published
+        // 3.6B, so nothing should touch it.
+        assert_eq!(
+            find("openai/gpt-oss-20b").active_parameters,
+            Some(3_529_365_271),
+            "a catalog figure that already agrees must be left alone"
+        );
+    }
+
+    /// The correction is keyed on expert geometry *and* total size, so a
+    /// pruned derivative — a genuinely different model that happens to share
+    /// the family name — keeps its own figure.
+    #[test]
+    fn published_active_params_leave_differently_sized_derivatives_alone() {
+        let mut models = vec![LlmModel {
+            name: "acme/gpt-oss-120b-reap-48".to_string(),
+            provider: "acme".to_string(),
+            parameter_count: "45.1B".to_string(),
+            parameters_raw: Some(45_132_360_192),
+            min_ram_gb: 25.2,
+            recommended_ram_gb: 42.0,
+            min_vram_gb: Some(25.2),
+            quantization: "Q4_K_M".to_string(),
+            context_length: 131_072,
+            use_case: "General".to_string(),
+            is_moe: true,
+            num_experts: Some(128),
+            active_experts: Some(4),
+            active_parameters: Some(3_600_000_000),
+            release_date: None,
+            gguf_sources: vec![],
+            capabilities: vec![],
+            languages: vec![],
+            format: ModelFormat::default(),
+            num_attention_heads: None,
+            num_key_value_heads: None,
+            num_hidden_layers: None,
+            head_dim: None,
+            attention_layout: None,
+            license: None,
+            hidden_size: None,
+            moe_intermediate_size: None,
+            vocab_size: None,
+            shared_expert_intermediate_size: None,
+            architecture: Some("gpt_oss".to_string()),
+        }];
+
+        apply_published_moe_active(&mut models);
+
+        assert_eq!(models[0].active_parameters, Some(3_600_000_000));
     }
 }

--- a/llmfit-core/tests/hardware_profiles.rs
+++ b/llmfit-core/tests/hardware_profiles.rs
@@ -1,0 +1,100 @@
+//! Gate the bundled hardware profiles: `data/hardware/*.json` is embedded by
+//! build.rs, and an invalid file there is dropped at load time — so without
+//! this test a malformed contribution would ship as a profile nobody can
+//! select, with no build failure to point at it.
+
+use jsonschema::Validator;
+use llmfit_core::hwprofile::HardwareProfile;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+fn hardware_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("data/hardware")
+}
+
+fn read_json(path: &Path) -> Value {
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    serde_json::from_str(&text).unwrap_or_else(|e| panic!("cannot parse {}: {e}", path.display()))
+}
+
+/// Every profile file, excluding the schema that lives alongside them.
+fn profile_paths() -> Vec<PathBuf> {
+    let dir = hardware_dir();
+    let entries =
+        std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()));
+    let mut paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("json"))
+        .filter(|path| path.file_stem().and_then(|s| s.to_str()) != Some("schema"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn validator() -> Validator {
+    let schema = read_json(&hardware_dir().join("schema.json"));
+    jsonschema::validator_for(&schema)
+        .expect("schema itself is invalid — check llmfit-core/data/hardware/schema.json")
+}
+
+#[test]
+fn bundled_profiles_match_schema() {
+    let validator = validator();
+    let paths = profile_paths();
+    assert!(paths.len() >= 2, "expected at least two seed profiles");
+
+    for path in paths {
+        let data = read_json(&path);
+        let errors: Vec<String> = validator
+            .iter_errors(&data)
+            .take(30)
+            .map(|e| format!("  [{}]  {}", e.instance_path(), e))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "{}: {} schema violation(s):\n{}",
+            path.display(),
+            errors.len(),
+            errors.join("\n")
+        );
+    }
+}
+
+#[test]
+fn bundled_profile_names_match_file_stems_and_validate_strictly() {
+    for path in profile_paths() {
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+        let profile =
+            HardwareProfile::parse(&text).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+        profile
+            .check_name_matches_stem(&path)
+            .unwrap_or_else(|e| panic!("{e}"));
+        profile
+            .validate_strict()
+            .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+    }
+}
+
+#[test]
+fn every_bundled_profile_is_embedded_and_selectable() {
+    let on_disk: Vec<String> = profile_paths()
+        .iter()
+        .filter_map(|path| path.file_stem().and_then(|s| s.to_str()).map(String::from))
+        .collect();
+    let embedded: Vec<String> = llmfit_core::hwprofile::embedded()
+        .iter()
+        .map(|profile| profile.name.clone())
+        .collect();
+
+    assert_eq!(
+        on_disk, embedded,
+        "build.rs embed drifted from data/hardware/"
+    );
+    for name in &on_disk {
+        llmfit_core::hwprofile::resolve(name)
+            .unwrap_or_else(|e| panic!("bundled profile {name} does not resolve: {e}"));
+    }
+}

--- a/llmfit-desktop/src/main.rs
+++ b/llmfit-desktop/src/main.rs
@@ -88,11 +88,10 @@ fn get_model_fits() -> Result<Vec<ModelFitInfo>, String> {
     let specs = SystemSpecs::detect();
     let db = ModelDatabase::new();
 
-    let mut fits: Vec<ModelFit> = db
-        .get_all_models()
-        .iter()
-        .map(|m| ModelFit::analyze(m, &specs))
-        .collect();
+    let mut fits: Vec<ModelFit> =
+        llmfit_core::analysis::rankable_models(db.get_all_models(), &specs)
+            .map(|m| ModelFit::analyze(m, &specs))
+            .collect();
 
     fits = llmfit_core::fit::rank_models_by_fit(fits);
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -132,7 +132,7 @@ pub fn display_model_fits(fits: &[ModelFit]) {
                     None => format!("{:.1}", fit.estimated_tps),
                 },
                 quant: display_best_quant(fit).to_string(),
-                confidence: fit.estimate_confidence.label().to_string(),
+                confidence: fit.effective_estimate_confidence().label().to_string(),
                 runtime: fit.runtime_text().to_string(),
                 mode: fit.run_mode_text().to_string(),
                 mem_use: format!("{:.1}%", fit.utilization_pct),
@@ -593,7 +593,10 @@ fn display_estimate_basis(fit: &ModelFit) {
     }
 
     println!("{}", "Estimate Basis:".bold().underline());
-    println!("  Confidence: {}", fit.estimate_confidence.label());
+    println!(
+        "  Confidence: {}",
+        fit.effective_estimate_confidence().label()
+    );
 
     if basis.method == "unsupported" || fit.estimated_tps <= 0.0 {
         println!();
@@ -1218,7 +1221,7 @@ mod tests {
         // issue #969's additive fields must pass through from the shared
         // envelope untouched.
         let mut fit = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
-        fit.estimate_confidence = llmfit_core::EstimateConfidence::Calibrated;
+        fit.estimate_basis.local_calibration = Some(1.2);
         fit.prefill_tps = Some(500.0);
         fit.ttft_ms = Some(16.0);
 

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -24,6 +24,8 @@ struct ModelRow {
     tps: String,
     #[tabled(rename = "Quant")]
     quant: String,
+    #[tabled(rename = "Confidence")]
+    confidence: String,
     #[tabled(rename = "Runtime")]
     runtime: String,
     #[tabled(rename = "Mode")]
@@ -85,6 +87,7 @@ pub fn display_all_models(models: &[LlmModel], sort: SortColumn) {
             score: "-".to_string(),
             tps: "-".to_string(),
             quant: m.quantization.clone(),
+            confidence: "-".to_string(),
             runtime: "-".to_string(),
             mode: "-".to_string(),
             mem_use: "-".to_string(),
@@ -128,7 +131,8 @@ pub fn display_model_fits(fits: &[ModelFit]) {
                     Some(m) => format!("{:.1} ✓", m.tok_s),
                     None => format!("{:.1}", fit.estimated_tps),
                 },
-                quant: fit.best_quant.clone(),
+                quant: display_best_quant(fit).to_string(),
+                confidence: fit.estimate_confidence.label().to_string(),
                 runtime: fit.runtime_text().to_string(),
                 mode: fit.run_mode_text().to_string(),
                 mem_use: format!("{:.1}%", fit.utilization_pct),
@@ -161,7 +165,7 @@ pub fn display_model_detail(fit: &ModelFit) {
     println!("{}: {}", "Provider".bold(), fit.model.provider);
     println!("{}: {}", "Parameters".bold(), fit.model.parameter_count);
     println!("{}: {}", "Quantization".bold(), fit.model.quantization);
-    println!("{}: {}", "Best Quant".bold(), fit.best_quant);
+    println!("{}: {}", "Best Quant".bold(), display_best_quant(fit));
     println!(
         "{}: {} tokens",
         "Context Length".bold(),
@@ -208,7 +212,7 @@ pub fn display_model_detail(fit: &ModelFit) {
     println!(
         "  Disk (est): {:.1} GB (at {})",
         fit.model.estimate_disk_gb(&fit.best_quant),
-        fit.best_quant
+        display_best_quant(fit)
     );
     let quants: &[&str] = if fit.best_quant.starts_with("mlx") {
         &["mlx-8bit", "mlx-4bit"]
@@ -283,9 +287,13 @@ pub fn display_model_detail(fit: &ModelFit) {
         println!();
     }
 
-    if !fit.notes.is_empty() {
+    let mut notes: Vec<String> = fit.notes.clone();
+    if let Some(note) = crate::serve_shared::best_quant_mismatch_note(fit) {
+        notes.push(note);
+    }
+    if !notes.is_empty() {
         println!("{}", "Notes:".bold().underline());
-        for note in &fit.notes {
+        for note in &notes {
             println!("  {}", note);
         }
         println!();
@@ -469,6 +477,7 @@ pub fn display_search_results(models: &[&LlmModel], query: &str) {
             score: "-".to_string(),
             tps: "-".to_string(),
             quant: m.quantization.clone(),
+            confidence: "-".to_string(),
             runtime: "-".to_string(),
             mode: "-".to_string(),
             mem_use: "-".to_string(),
@@ -549,9 +558,6 @@ pub fn display_json_fits_with_llamacpp(specs: &SystemSpecs, fits: &[ModelFit]) {
 /// Reproducibility ask from issue #292: no number without its inputs.
 fn display_estimate_basis(fit: &ModelFit) {
     let basis = &fit.estimate_basis;
-    if basis.method == "unsupported" || fit.estimated_tps <= 0.0 {
-        return;
-    }
 
     if let Some(m) = &fit.measured_tps {
         match m.source {
@@ -587,6 +593,13 @@ fn display_estimate_basis(fit: &ModelFit) {
     }
 
     println!("{}", "Estimate Basis:".bold().underline());
+    println!("  Confidence: {}", fit.estimate_confidence.label());
+
+    if basis.method == "unsupported" || fit.estimated_tps <= 0.0 {
+        println!();
+        return;
+    }
+
     if let Some(c) = basis.local_calibration {
         println!(
             "  Calibrated x{:.2} from benchmark run(s) on this exact hardware \
@@ -620,10 +633,23 @@ fn display_estimate_basis(fit: &ModelFit) {
         }
     }
     println!(
-        "  Models single-request generation at ctx <= {} tokens; prompt processing",
+        "  Models single-request generation at ctx <= {} tokens.",
         basis.assumed_context
     );
-    println!("  (prefill/TTFT) is not estimated. Baseline error band is roughly +/-30%.");
+    match (fit.prefill_tps, fit.ttft_ms) {
+        (Some(prefill), Some(ttft)) => {
+            println!(
+                "  Prefill (est.): ~{:.0} tok/s -> ~{:.0} ms time-to-first-token at {} prompt tokens",
+                prefill, ttft, fit.effective_context_length
+            );
+        }
+        _ => {
+            println!(
+                "  Prompt processing (prefill/TTFT) is not estimated for this model/hardware."
+            );
+        }
+    }
+    println!("  Baseline error band is roughly +/-30%.");
     println!("{}", "  Verify on this machine:".bold());
     println!(
         "    llmfit bench \"{}\"    (against a running provider)",
@@ -776,6 +802,14 @@ pub fn display_json_diff_fits(specs: &SystemSpecs, fits: &[ModelFit]) {
 
 fn system_json(specs: &SystemSpecs) -> serde_json::Value {
     crate::serve_shared::system_json(specs)
+}
+
+/// `fit.best_quant` for CLI display, cleared to an em dash when it's a
+/// GGUF-style label that doesn't apply to a native NVFP4/MXFP4-named repo
+/// (issue #969, problem 3). Mirrors `serve_shared::sanitized_best_quant`,
+/// the JSON-facing version of the same check.
+fn display_best_quant(fit: &ModelFit) -> &str {
+    crate::serve_shared::sanitized_best_quant(fit).unwrap_or("\u{2014}")
 }
 
 /// CLI `fit --json` envelope: the shared serializer plus this frontend's legacy
@@ -1058,6 +1092,9 @@ mod tests {
             usable_context: 8_192,
             estimate_basis: Default::default(),
             measured_tps: None,
+            estimate_confidence: llmfit_core::EstimateConfidence::Estimated,
+            prefill_tps: None,
+            ttft_ms: None,
         }
     }
 
@@ -1173,5 +1210,39 @@ mod tests {
 
         assert_eq!(json["context_length"], 131_072);
         assert_eq!(json["effective_context_length"], 8_192);
+    }
+
+    #[test]
+    fn cli_json_carries_confidence_and_prefill_fields_through_unchanged() {
+        // The CLI overlay only rewrites fit_level/run_mode/runtime/capabilities;
+        // issue #969's additive fields must pass through from the shared
+        // envelope untouched.
+        let mut fit = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
+        fit.estimate_confidence = llmfit_core::EstimateConfidence::Calibrated;
+        fit.prefill_tps = Some(500.0);
+        fit.ttft_ms = Some(16.0);
+
+        let json = fit_to_json(&fit);
+
+        assert_eq!(json["estimate_confidence"], "calibrated");
+        assert_eq!(json["estimate_confidence_label"], "calibrated");
+        assert_eq!(json["prefill_tps"], 500.0);
+        assert_eq!(json["ttft_ms"], 16.0);
+    }
+
+    #[test]
+    fn display_best_quant_clears_gguf_label_for_native_low_precision_named_model() {
+        let mut fit = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
+        fit.model.name = "nvidia/Qwen3-8B-NVFP4".to_string();
+        fit.best_quant = "Q8_0".to_string();
+
+        assert_eq!(display_best_quant(&fit), "\u{2014}");
+    }
+
+    #[test]
+    fn display_best_quant_keeps_label_for_plain_gguf_model() {
+        let fit = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
+
+        assert_eq!(display_best_quant(&fit), "Q4_K_M");
     }
 }

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -18,8 +18,9 @@ use std::thread;
 use std::time::Duration;
 
 use llmfit_core::bench;
-use llmfit_core::fit::{ModelFit, SortColumn, backend_compatible};
+use llmfit_core::fit::{CalcConfig, ModelFit, SortColumn, backend_compatible};
 use llmfit_core::hardware::SystemSpecs;
+use llmfit_core::hwprofile::HardwareProfile;
 use llmfit_core::models::{ModelDatabase, matches_provider_filter};
 use llmfit_core::plan::{PlanRequest, estimate_model_plan, resolve_model_selector};
 use llmfit_core::quality;
@@ -106,6 +107,11 @@ GLOBAL FLAGS:
   --memory <SIZE>    Override GPU VRAM (e.g. \"32G\", \"32000M\", \"1.5T\").
   --ram <SIZE>       Override system RAM (e.g. \"64G\", \"128000M\").
   --cpu-cores <N>    Override detected CPU core count.
+  --profile <NAME>   Score against a whole hardware profile (name or path to a
+                     profile JSON) instead of this machine. Sets capacity,
+                     unified memory, and the bandwidth/compute figures the
+                     throughput estimate needs. Conflicts with --memory,
+                     --ram, and --cpu-cores. See `llmfit hardware list`.
   --max-context N    Cap context length for memory estimation (tokens).
                      Falls back to OLLAMA_CONTEXT_LENGTH env var if unset.
 
@@ -164,6 +170,14 @@ struct Cli {
     #[arg(long, value_name = "CORES", value_parser = parse_positive_usize)]
     cpu_cores: Option<usize>,
 
+    /// Score models against a hardware profile instead of this machine:
+    /// a profile name (see `llmfit hardware list`) or a path to a profile
+    /// JSON file. A profile describes a whole machine — capacity, unified
+    /// memory, memory bandwidth, fp16 throughput — so it replaces the
+    /// single-field overrides rather than combining with them.
+    #[arg(long, value_name = "NAME|PATH", conflicts_with_all = ["memory", "ram", "cpu_cores"])]
+    profile: Option<String>,
+
     /// Cap context length used for memory estimation (tokens).
     /// Falls back to OLLAMA_CONTEXT_LENGTH if not set.
     #[arg(long, value_name = "TOKENS", value_parser = clap::value_parser!(u32).range(1..))]
@@ -210,6 +224,42 @@ AGENT USAGE:
   JSON output fields: { system: { cpu, ram_gb, gpu_name, gpu_vram_gb,
   gpu_backend, unified_memory, os } }")]
     System,
+
+    /// List, inspect, and validate hardware profiles
+    #[command(long_about = "\
+List, inspect, and validate hardware profiles.
+
+A hardware profile names a whole machine — memory capacity, unified-memory
+topology, memory bandwidth, and fp16 matmul throughput — so `--profile` can
+score models against hardware you don't have without a pile of single-field
+overrides. Bundled profiles are embedded in the binary; user profiles live in
+the directory printed by `llmfit hardware path` and shadow a bundled profile
+of the same name.
+
+PRECONDITIONS:
+  None. `show` also reports what the profile would change on this machine,
+  which runs hardware detection.
+
+SIDE EFFECTS:
+  None — read-only. No directory is created.
+
+EXIT CODES:
+  0  Success
+  1  Unknown profile, unreadable file, or a validation failure
+
+AGENT USAGE:
+  llmfit hardware list --json
+  llmfit hardware show ryzen-ai-max-plus-395 --json
+  llmfit hardware validate ./my-box.json --json
+  llmfit hardware path --json
+
+  `list --json` fields: { profiles: [{ name, origin, total_ram_gb,
+  unified_memory, gpu_memory_bandwidth_gbps, ddr_bandwidth_gbps,
+  gpu_compute_tflops_fp16, calibration_entries }], errors: [{ path, error }] }")]
+    Hardware {
+        #[command(subcommand)]
+        action: HardwareAction,
+    },
 
     /// Print a hardware diagnostic report for bug reports
     #[command(long_about = "\
@@ -847,17 +897,94 @@ AGENT USAGE:
     },
 }
 
+#[derive(Subcommand)]
+enum HardwareAction {
+    /// List every selectable profile (bundled and user)
+    List,
+
+    /// Show one profile's fields and what it would change on this machine
+    Show {
+        /// Profile name or path to a profile JSON file
+        #[arg(value_name = "NAME|PATH")]
+        profile: String,
+    },
+
+    /// Strictly validate profile files (unknown keys are errors)
+    Validate {
+        /// Profile JSON files to check
+        #[arg(value_name = "PATH", required = true, num_args = 1..)]
+        paths: Vec<std::path::PathBuf>,
+    },
+
+    /// Print the directory scanned for user profiles
+    Path,
+}
+
 /// Bundled hardware override options from CLI flags.
 pub(crate) struct HardwareOverrides {
     pub memory: Option<String>,
     pub ram: Option<String>,
     pub cpu_cores: Option<usize>,
+    /// Raw `--profile` selector (name or path), resolved by [`detect_specs`].
+    pub profile: Option<String>,
+}
+
+impl HardwareOverrides {
+    /// No overrides — hardware exactly as detected.
+    pub(crate) fn none() -> Self {
+        Self {
+            memory: None,
+            ram: None,
+            cpu_cores: None,
+            profile: None,
+        }
+    }
 }
 
 /// Detect system specs with optional hardware overrides.
-/// RAM override is applied before GPU VRAM so that `--memory` takes precedence
-/// on unified-memory systems where `--ram` would also update VRAM.
+///
+/// See [`detect_specs_and_config`] when the caller runs fit analysis: a
+/// hardware profile also carries the bandwidth and efficiency figures the
+/// throughput estimate needs, and those live on `CalcConfig`, not on specs.
 pub(crate) fn detect_specs(overrides: &HardwareOverrides) -> SystemSpecs {
+    detect_specs_and_config(overrides).0
+}
+
+/// Detect system specs, plus the calculation parameters `--profile` implies.
+///
+/// The config is `None` unless a profile was given, so callers without one keep
+/// the estimator defaults.
+///
+/// RAM override is applied before GPU VRAM so that `--memory` takes precedence
+/// on unified-memory systems where `--ram` would also update VRAM. A profile is
+/// applied last; it conflicts with the single-field overrides, so it never
+/// competes with them.
+///
+/// An unresolvable `--profile` exits instead of warning like the size
+/// overrides do: a profile that quietly failed to load would score every model
+/// against the wrong machine, and the numbers would look perfectly plausible.
+pub(crate) fn detect_specs_and_config(
+    overrides: &HardwareOverrides,
+) -> (SystemSpecs, Option<CalcConfig>) {
+    let mut specs = detect_specs_from_size_overrides(overrides);
+
+    let Some(selector) = overrides.profile.as_deref() else {
+        return (specs, None);
+    };
+
+    let loaded = match llmfit_core::hwprofile::resolve(selector) {
+        Ok(loaded) => loaded,
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            std::process::exit(1);
+        }
+    };
+    let mut config = CalcConfig::default();
+    specs = loaded.profile.apply(specs, &mut config);
+    (specs, Some(config))
+}
+
+fn detect_specs_from_size_overrides(overrides: &HardwareOverrides) -> SystemSpecs {
     let mut specs = SystemSpecs::detect();
 
     if let Some(ram_str) = &overrides.ram {
@@ -943,6 +1070,7 @@ fn is_readonly_subcommand(command: &Commands) -> bool {
         command,
         Commands::System
             | Commands::Doctor
+            | Commands::Hardware { .. }
             | Commands::Info { .. }
             | Commands::Diff { .. }
             | Commands::Plan { .. }
@@ -1020,6 +1148,9 @@ fn ensure_dashboard_available(
     if let Some(cores) = overrides.cpu_cores {
         command.arg("--cpu-cores").arg(cores.to_string());
     }
+    if let Some(profile) = &overrides.profile {
+        command.arg("--profile").arg(profile);
+    }
     if let Some(ctx) = context_limit {
         command.arg("--max-context").arg(ctx.to_string());
     }
@@ -1070,6 +1201,303 @@ fn ensure_dashboard_available(
     Some(DashboardGuard { child })
 }
 
+// ── hardware profiles ──────────────────────────────────────────────────────
+
+/// Validate one profile file the way `llmfit hardware validate` should:
+/// strictly. Loading tolerates unknown keys so a profile written for a newer
+/// llmfit still works, which means a typo'd key silently does nothing — this is
+/// where the user finds out.
+fn validate_profile_file(path: &std::path::Path) -> Result<HardwareProfile, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    let profile = HardwareProfile::parse(&text)?;
+    profile.validate_strict()?;
+    profile.check_name_matches_stem(path)?;
+    Ok(profile)
+}
+
+fn format_gb(value: f64) -> String {
+    format!("{:.0} GB", value)
+}
+
+fn profile_row_json(loaded: &llmfit_core::hwprofile::LoadedProfile) -> serde_json::Value {
+    let hw = &loaded.profile.hardware;
+    serde_json::json!({
+        "name": loaded.profile.name,
+        "origin": loaded.origin.label(),
+        "total_ram_gb": hw.total_ram_gb,
+        "unified_memory": hw.unified_memory,
+        "gpu_memory_bandwidth_gbps": hw.gpu_memory_bandwidth_gbps,
+        "ddr_bandwidth_gbps": hw.ddr_bandwidth_gbps,
+        "gpu_compute_tflops_fp16": hw.gpu_compute_tflops_fp16,
+        "calibration_entries": loaded.profile.calibration.len(),
+    })
+}
+
+fn run_hardware(action: HardwareAction, json: bool) -> Result<(), String> {
+    match action {
+        HardwareAction::List => {
+            let catalog = llmfit_core::hwprofile::catalog();
+            if json {
+                let payload = serde_json::json!({
+                    "profiles": catalog.profiles.iter().map(profile_row_json).collect::<Vec<_>>(),
+                    "errors": catalog
+                        .errors
+                        .iter()
+                        .map(|(path, error)| serde_json::json!({
+                            "path": path.display().to_string(),
+                            "error": error,
+                        }))
+                        .collect::<Vec<_>>(),
+                });
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&payload)
+                        .map_err(|e| format!("JSON serialization failed: {e}"))?
+                );
+                return Ok(());
+            }
+
+            println!("\n=== Hardware profiles ===");
+            println!(
+                "{:<26} {:>9} {:>8} {:>11} {:>13}  {}",
+                "NAME", "RAM", "UNIFIED", "GPU BW", "FP16 TFLOP/S", "SOURCE"
+            );
+            for loaded in &catalog.profiles {
+                let hw = &loaded.profile.hardware;
+                println!(
+                    "{:<26} {:>9} {:>8} {:>11} {:>13}  {}",
+                    loaded.profile.name,
+                    format_gb(hw.total_ram_gb),
+                    if hw.unified_memory { "yes" } else { "no" },
+                    hw.gpu_memory_bandwidth_gbps
+                        .map(|b| format!("{b:.0} GB/s"))
+                        .unwrap_or_else(|| "-".to_string()),
+                    hw.gpu_compute_tflops_fp16
+                        .map(|t| format!("{t:.1}"))
+                        .unwrap_or_else(|| "-".to_string()),
+                    loaded.origin.label(),
+                );
+            }
+            if catalog.profiles.is_empty() {
+                println!("(none)");
+            }
+            for (path, error) in &catalog.errors {
+                eprintln!("Warning: ignoring {}: {}", path.display(), error);
+            }
+            println!("\nScore models against one with: llmfit --profile <NAME> fit");
+            Ok(())
+        }
+
+        HardwareAction::Show { profile } => {
+            let loaded = llmfit_core::hwprofile::resolve(&profile)?;
+            let hw = &loaded.profile.hardware;
+
+            // What the profile means for *this* host: capacity is absolute, but
+            // the bandwidth actually used still goes through the same
+            // resolution order the estimator uses, so an unset profile field
+            // falls back to the detected GPU rather than reading as zero.
+            let mut config = CalcConfig::default();
+            let specs = loaded
+                .profile
+                .apply(detect_specs(&HardwareOverrides::none()), &mut config);
+            let effective_bandwidth = llmfit_core::fit::resolve_gpu_bandwidth(&specs, &config);
+
+            if json {
+                let payload = serde_json::json!({
+                    "profile": loaded.profile,
+                    "origin": loaded.origin.label(),
+                    "effective": {
+                        "total_ram_gb": specs.total_ram_gb,
+                        "unified_memory": specs.unified_memory,
+                        "gpu_vram_gb": specs.total_gpu_vram_gb,
+                        "gpu_bandwidth_gbps": effective_bandwidth,
+                        "efficiency": config.efficiency,
+                    },
+                    "calibration_applied": false,
+                });
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&payload)
+                        .map_err(|e| format!("JSON serialization failed: {e}"))?
+                );
+                return Ok(());
+            }
+
+            println!("\n=== Hardware profile: {} ===", loaded.profile.name);
+            println!("Source:                {}", loaded.origin.label());
+            println!("Schema version:        {}", loaded.profile.schema_version);
+            if let Some(matcher) = &loaded.profile.matcher {
+                println!(
+                    "Describes GPU:         {} (provenance only — profiles are never auto-selected)",
+                    matcher.gpu_name_contains
+                );
+            }
+
+            println!("\nHardware");
+            println!("  Total RAM:           {:.2} GB", hw.total_ram_gb);
+            println!(
+                "  Unified memory:      {}",
+                if hw.unified_memory { "yes" } else { "no" }
+            );
+            match hw.gpu_memory_bandwidth_gbps {
+                Some(bw) => println!("  GPU bandwidth:       {bw:.0} GB/s"),
+                None => println!("  GPU bandwidth:       not set (detected GPU is used)"),
+            }
+            match hw.ddr_bandwidth_gbps {
+                Some(bw) => println!("  DDR bandwidth:       {bw:.0} GB/s"),
+                None => println!("  DDR bandwidth:       not set (measured or 50 GB/s fallback)"),
+            }
+            match hw.gpu_compute_tflops_fp16 {
+                Some(tflops) => println!("  GPU fp16 throughput: {tflops:.1} TFLOP/s"),
+                None => {
+                    println!("  GPU fp16 throughput: not set (prefill and TTFT report null)")
+                }
+            }
+
+            if let Some(est) = &loaded.profile.estimation {
+                println!("\nEstimation");
+                if let Some(efficiency) = est.efficiency {
+                    println!("  Bandwidth efficiency: {efficiency:.2}");
+                }
+                if let Some(factors) = &est.run_mode_factors {
+                    for (label, value) in [
+                        ("gpu", factors.gpu),
+                        ("tensor_parallel", factors.tensor_parallel),
+                        ("moe_offload", factors.moe_offload),
+                        ("cpu_offload", factors.cpu_offload),
+                        ("cpu_only", factors.cpu_only),
+                    ] {
+                        if let Some(value) = value {
+                            println!("  Run mode {label:<16} x{value:.2}");
+                        }
+                    }
+                }
+            }
+
+            if !loaded.profile.calibration.is_empty() {
+                println!(
+                    "\nCalibration ({} entr{}, recorded but not applied in schema version {})",
+                    loaded.profile.calibration.len(),
+                    if loaded.profile.calibration.len() == 1 {
+                        "y"
+                    } else {
+                        "ies"
+                    },
+                    llmfit_core::hwprofile::SCHEMA_VERSION
+                );
+                for entry in &loaded.profile.calibration {
+                    println!(
+                        "  {} {} {} — {:.1} tok/s{}",
+                        entry.model,
+                        entry.quant.as_deref().unwrap_or("-"),
+                        entry.run_mode.as_deref().unwrap_or("-"),
+                        entry.measured_tps,
+                        entry
+                            .source
+                            .as_deref()
+                            .map(|s| format!(" ({s})"))
+                            .unwrap_or_default(),
+                    );
+                }
+            }
+
+            println!("\nOn this machine");
+            println!("  RAM:                 {:.2} GB", specs.total_ram_gb);
+            match specs.total_gpu_vram_gb {
+                Some(vram) => println!("  VRAM pool:           {vram:.2} GB"),
+                None => println!("  VRAM pool:           none detected"),
+            }
+            match effective_bandwidth {
+                Some(bw) => println!("  GPU bandwidth used:  {bw:.0} GB/s"),
+                None => println!("  GPU bandwidth used:  unknown (per-backend fallback)"),
+            }
+            if !hw.unified_memory {
+                println!("  Note: profiles carry no VRAM figure, so VRAM stays as detected here.");
+            }
+            println!();
+            Ok(())
+        }
+
+        HardwareAction::Validate { paths } => {
+            let results: Vec<(std::path::PathBuf, Result<HardwareProfile, String>)> = paths
+                .into_iter()
+                .map(|path| {
+                    let result = validate_profile_file(&path);
+                    (path, result)
+                })
+                .collect();
+            let failed = results.iter().filter(|(_, r)| r.is_err()).count();
+
+            if json {
+                let payload = serde_json::json!({
+                    "ok": failed == 0,
+                    "results": results
+                        .iter()
+                        .map(|(path, result)| match result {
+                            Ok(profile) => serde_json::json!({
+                                "path": path.display().to_string(),
+                                "ok": true,
+                                "name": profile.name,
+                            }),
+                            Err(error) => serde_json::json!({
+                                "path": path.display().to_string(),
+                                "ok": false,
+                                "error": error,
+                            }),
+                        })
+                        .collect::<Vec<_>>(),
+                });
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&payload)
+                        .map_err(|e| format!("JSON serialization failed: {e}"))?
+                );
+            } else {
+                for (path, result) in &results {
+                    match result {
+                        Ok(profile) => println!("ok    {} ({})", path.display(), profile.name),
+                        Err(error) => println!("FAIL  {}: {}", path.display(), error),
+                    }
+                }
+            }
+
+            if failed > 0 {
+                return Err(format!(
+                    "{failed} of {} profile file(s) failed validation",
+                    results.len()
+                ));
+            }
+            Ok(())
+        }
+
+        HardwareAction::Path => {
+            let dir = llmfit_core::hwprofile::user_profile_dir()
+                .ok_or_else(|| "cannot determine the user profile directory".to_string())?;
+            let exists = dir.is_dir();
+            if json {
+                let payload = serde_json::json!({
+                    "path": dir.display().to_string(),
+                    "exists": exists,
+                });
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&payload)
+                        .map_err(|e| format!("JSON serialization failed: {e}"))?
+                );
+            } else {
+                println!("{}", dir.display());
+                if !exists {
+                    eprintln!(
+                        "(directory does not exist yet — create it and drop <name>.json profiles in)"
+                    );
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
 fn run_fit(
     perfect: bool,
     tool_use: bool,
@@ -1081,7 +1509,7 @@ fn run_fit(
     overrides: &HardwareOverrides,
     context_limit: Option<u32>,
 ) {
-    let specs = detect_specs(overrides);
+    let (specs, config) = detect_specs_and_config(overrides);
     let db = ModelDatabase::new();
 
     if !json && !csv {
@@ -1096,8 +1524,18 @@ fn run_fit(
         .filter(|m| !backend_compatible(m, &specs))
         .count();
 
-    let mut fits =
-        llmfit_core::analysis::build_model_fits(&db, &specs, &installed, context_limit, None);
+    let mut fits = match config {
+        Some(config) => llmfit_core::analysis::build_model_fits_with_config(
+            &db,
+            &specs,
+            &installed,
+            context_limit,
+            config,
+        ),
+        None => {
+            llmfit_core::analysis::build_model_fits(&db, &specs, &installed, context_limit, None)
+        }
+    };
 
     if perfect {
         fits.retain(|f| f.fit_level == llmfit_core::fit::FitLevel::Perfect);
@@ -1407,7 +1845,7 @@ fn run_recommend(
     overrides: &HardwareOverrides,
     context_limit: Option<u32>,
 ) {
-    let specs = detect_specs(overrides);
+    let (specs, config) = detect_specs_and_config(overrides);
     let db = ModelDatabase::new();
 
     // Parse --force-runtime into an InferenceRuntime if provided
@@ -1428,8 +1866,30 @@ fn run_recommend(
 
     let installed = llmfit_core::analysis::InstalledIndex::detect_all();
 
-    let mut fits =
-        llmfit_core::analysis::build_model_fits(&db, &specs, &installed, context_limit, forced_rt);
+    // A forced runtime and a profile's `CalcConfig` cannot both reach
+    // `ModelFit` today, so refuse the combination rather than silently
+    // dropping one of them (see `build_model_fits_with_config`).
+    if config.is_some() && forced_rt.is_some() {
+        eprintln!("Error: --profile cannot be combined with --force-runtime yet");
+        std::process::exit(1);
+    }
+
+    let mut fits = match config {
+        Some(config) => llmfit_core::analysis::build_model_fits_with_config(
+            &db,
+            &specs,
+            &installed,
+            context_limit,
+            config,
+        ),
+        None => llmfit_core::analysis::build_model_fits(
+            &db,
+            &specs,
+            &installed,
+            context_limit,
+            forced_rt,
+        ),
+    };
 
     // Filter by minimum fit level
     let min_level = match min_fit.to_lowercase().as_str() {
@@ -2775,6 +3235,7 @@ fn main() {
         memory: cli.memory,
         ram: cli.ram,
         cpu_cores: cli.cpu_cores,
+        profile: cli.profile,
     };
     let auto_dashboard = !cli.no_dashboard
         && (cli.tui
@@ -2816,6 +3277,13 @@ fn main() {
                     "{}",
                     llmfit_core::doctor::collect_diagnostics(env!("CARGO_PKG_VERSION"))
                 );
+            }
+
+            Commands::Hardware { action } => {
+                if let Err(err) = run_hardware(action, cli.json) {
+                    eprintln!("Error: {}", err);
+                    std::process::exit(1);
+                }
             }
 
             Commands::Claim {
@@ -2922,7 +3390,7 @@ fn main() {
 
             Commands::Info { model } => {
                 let db = ModelDatabase::new();
-                let specs = detect_specs(&overrides);
+                let (specs, config) = detect_specs_and_config(&overrides);
                 let models = db.get_all_models();
 
                 let idx = match find_name_index_by_selector(models, &model, |m| m.name.as_str()) {
@@ -2933,8 +3401,15 @@ fn main() {
                     }
                 };
 
-                let mut fit =
-                    ModelFit::analyze_with_context_limit(&models[idx], &specs, context_limit);
+                let mut fit = match config {
+                    Some(mut config) => {
+                        config.context_cap = context_limit.or(config.context_cap);
+                        ModelFit::analyze_with_config(&models[idx], &specs, config)
+                    }
+                    None => {
+                        ModelFit::analyze_with_context_limit(&models[idx], &specs, context_limit)
+                    }
+                };
                 fit.measured_tps = llmfit_core::benchmarks::measured_tps_for(
                     &specs,
                     &fit.model.name,
@@ -3237,6 +3712,9 @@ mod tests {
             usable_context: 8192,
             estimate_basis: Default::default(),
             measured_tps: None,
+            estimate_confidence: llmfit_core::fit::EstimateConfidence::Estimated,
+            prefill_tps: None,
+            ttft_ms: None,
         }
     }
 

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -18,11 +18,11 @@ use std::thread;
 use std::time::Duration;
 
 use llmfit_core::bench;
-use llmfit_core::fit::{CalcConfig, ModelFit, SortColumn, backend_compatible};
+use llmfit_core::fit::{CalcConfig, ModelFit, SortColumn};
 use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::hwprofile::HardwareProfile;
 use llmfit_core::models::{ModelDatabase, matches_provider_filter};
-use llmfit_core::plan::{PlanRequest, estimate_model_plan, resolve_model_selector};
+use llmfit_core::plan::{PlanRequest, estimate_model_plan_with_config, resolve_model_selector};
 use llmfit_core::quality;
 use llmfit_core::share;
 
@@ -175,6 +175,7 @@ struct Cli {
     /// JSON file. A profile describes a whole machine — capacity, unified
     /// memory, memory bandwidth, fp16 throughput — so it replaces the
     /// single-field overrides rather than combining with them.
+    /// Rejected by `doctor`, which reports this machine's own detection.
     #[arg(long, value_name = "NAME|PATH", conflicts_with_all = ["memory", "ram", "cpu_cores"])]
     profile: Option<String>,
 
@@ -272,6 +273,8 @@ reproduced — and turned into regression tests — from the report alone.
 
 PRECONDITIONS:
   None. Missing tools are reported as unavailable, which is itself useful.
+  --profile is rejected: this report describes the machine it runs on. Use
+  `llmfit hardware show <NAME>` to inspect a profile.
 
 SIDE EFFECTS:
   None — read-only. Output contains hardware model names and driver info
@@ -1518,11 +1521,7 @@ fn run_fit(
 
     let installed = llmfit_core::analysis::InstalledIndex::detect_all();
 
-    let hidden: usize = db
-        .get_all_models()
-        .iter()
-        .filter(|m| !backend_compatible(m, &specs))
-        .count();
+    let hidden = llmfit_core::analysis::backend_hidden_count(db.get_all_models(), &specs);
 
     let mut fits = match config {
         Some(config) => llmfit_core::analysis::build_model_fits_with_config(
@@ -1665,15 +1664,20 @@ fn run_diff(
         std::process::exit(1);
     }
 
-    let specs = detect_specs(overrides);
+    let (specs, config) = detect_specs_and_config(overrides);
     let db = ModelDatabase::new();
 
-    let mut fits: Vec<ModelFit> = db
-        .get_all_models()
-        .iter()
-        .filter(|m| backend_compatible(m, &specs))
-        .map(|m| ModelFit::analyze_with_context_limit(m, &specs, context_limit))
-        .collect();
+    let mut fits: Vec<ModelFit> =
+        llmfit_core::analysis::rankable_models(db.get_all_models(), &specs)
+            .map(|m| {
+                llmfit_core::analysis::analyze_with_optional_config(
+                    m,
+                    &specs,
+                    context_limit,
+                    config.as_ref(),
+                )
+            })
+            .collect();
 
     fits.retain(|f| fit_matches_filter(f, fit_filter));
     fits = llmfit_core::fit::rank_models_by_fit_opts_col(fits, false, sort);
@@ -1755,8 +1759,8 @@ fn run_tui_inner(
     draw_boot_screen(&mut terminal, "Detecting system hardware...")?;
 
     // Create app state (provider detection runs in background threads)
-    let specs = detect_specs(overrides);
-    let mut app = tui_app::App::with_specs_and_context(specs, context_limit);
+    let (specs, config) = detect_specs_and_config(overrides);
+    let mut app = tui_app::App::with_specs_context_and_config(specs, context_limit, config);
     if api_key.is_some() {
         app.bench_api_key = api_key;
     }
@@ -2474,7 +2478,7 @@ fn run_plan(
     overrides: &HardwareOverrides,
 ) -> Result<(), String> {
     let db = ModelDatabase::new();
-    let specs = detect_specs(overrides);
+    let (specs, config) = detect_specs_and_config(overrides);
     let model = resolve_model_selector(db.get_all_models(), model_selector)?;
 
     let kv_quant = match kv_quant {
@@ -2502,7 +2506,15 @@ fn run_plan(
         target_tps,
         kv_quant,
     };
-    let plan = estimate_model_plan(model, &request, &specs)?;
+    // A profile's bandwidth and efficiency are what separate one machine's
+    // plan from another's; the default config would report this host's
+    // numbers under the profile's name (issue #969).
+    let plan = estimate_model_plan_with_config(
+        model,
+        &request,
+        &specs,
+        &config.unwrap_or_else(CalcConfig::default),
+    )?;
 
     if json {
         display::display_json_plan(&plan);
@@ -3273,6 +3285,17 @@ fn main() {
             }
 
             Commands::Doctor => {
+                // A diagnostic report is only useful if it describes the
+                // machine it was collected on, so a profile can't be honoured
+                // here — refuse instead of printing this host's detection under
+                // the profile's name (issue #969).
+                if overrides.profile.is_some() {
+                    eprintln!(
+                        "Error: --profile cannot be used with `doctor`; it reports what this \
+                         machine detects. Use `llmfit hardware show <NAME>` to inspect a profile."
+                    );
+                    std::process::exit(1);
+                }
                 print!(
                     "{}",
                     llmfit_core::doctor::collect_diagnostics(env!("CARGO_PKG_VERSION"))
@@ -3401,15 +3424,12 @@ fn main() {
                     }
                 };
 
-                let mut fit = match config {
-                    Some(mut config) => {
-                        config.context_cap = context_limit.or(config.context_cap);
-                        ModelFit::analyze_with_config(&models[idx], &specs, config)
-                    }
-                    None => {
-                        ModelFit::analyze_with_context_limit(&models[idx], &specs, context_limit)
-                    }
-                };
+                let mut fit = llmfit_core::analysis::analyze_with_optional_config(
+                    &models[idx],
+                    &specs,
+                    context_limit,
+                    config.as_ref(),
+                );
                 fit.measured_tps = llmfit_core::benchmarks::measured_tps_for(
                     &specs,
                     &fit.model.name,

--- a/llmfit-tui/src/mcp_server.rs
+++ b/llmfit-tui/src/mcp_server.rs
@@ -1,10 +1,9 @@
 use llmfit_core::fit::{
-    FitLevel, InferenceRuntime, ModelFit, SortColumn, backend_compatible,
-    rank_models_by_fit_opts_col,
+    CalcConfig, FitLevel, InferenceRuntime, ModelFit, SortColumn, rank_models_by_fit_opts_col,
 };
 use llmfit_core::hardware::{GpuBackend, SystemSpecs};
 use llmfit_core::models::{LlmModel, ModelDatabase, UseCase};
-use llmfit_core::plan::{PlanRequest, estimate_model_plan};
+use llmfit_core::plan::{PlanRequest, estimate_model_plan_with_config};
 use llmfit_core::providers::{
     DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider, ModelProvider,
     OllamaProvider, RamaLamaProvider, VllmProvider,
@@ -75,6 +74,9 @@ pub struct LlmfitMcpServer {
     specs: SystemSpecs,
     models: Vec<LlmModel>,
     context_limit: Option<u32>,
+    /// Calculation parameters implied by `--profile`, or `None` when the
+    /// server describes the machine it runs on (issue #969).
+    calc_config: Option<CalcConfig>,
     node_name: String,
     tool_router: ToolRouter<Self>,
 }
@@ -88,12 +90,14 @@ impl LlmfitMcpServer {
         specs: SystemSpecs,
         models: Vec<LlmModel>,
         context_limit: Option<u32>,
+        calc_config: Option<CalcConfig>,
         node_name: String,
     ) -> Self {
         Self {
             specs,
             models,
             context_limit,
+            calc_config,
             node_name,
             tool_router: Self::tool_router(),
         }
@@ -219,7 +223,8 @@ impl LlmfitMcpServer {
             kv_quant: None,
         };
 
-        match estimate_model_plan(model, &request, &self.specs) {
+        let config = self.calc_config.clone().unwrap_or_default();
+        match estimate_model_plan_with_config(model, &request, &self.specs, &config) {
             Ok(estimate) => {
                 serde_json::to_string_pretty(&serde_json::json!(estimate)).unwrap_or_default()
             }
@@ -333,14 +338,17 @@ impl LlmfitMcpServer {
 impl LlmfitMcpServer {
     fn analyze_all(&self) -> Vec<ModelFit> {
         let is_apple_silicon = self.specs.backend == GpuBackend::Metal && self.specs.unified_memory;
-        let mut fits: Vec<ModelFit> = self
-            .models
-            .iter()
-            .filter(|m| backend_compatible(m, &self.specs))
-            .map(|m| {
-                ModelFit::analyze_with_forced_runtime(m, &self.specs, self.context_limit, None)
-            })
-            .collect();
+        let mut fits: Vec<ModelFit> =
+            llmfit_core::analysis::rankable_models(&self.models, &self.specs)
+                .map(|m| {
+                    llmfit_core::analysis::analyze_with_optional_config(
+                        m,
+                        &self.specs,
+                        self.context_limit,
+                        self.calc_config.as_ref(),
+                    )
+                })
+                .collect();
 
         if !is_apple_silicon {
             fits.retain(|f| !f.model.is_mlx_only());
@@ -370,7 +378,7 @@ pub fn run_mcp_server(
     overrides: &super::HardwareOverrides,
     context_limit: Option<u32>,
 ) -> Result<(), String> {
-    let specs = super::detect_specs(overrides);
+    let (specs, calc_config) = super::detect_specs_and_config(overrides);
     let db = ModelDatabase::new();
     let models = db.get_all_models().clone();
     let node_name = std::env::var("HOSTNAME")
@@ -378,7 +386,7 @@ pub fn run_mcp_server(
         .filter(|v| !v.trim().is_empty())
         .unwrap_or_else(|| "unknown-node".to_string());
 
-    let server = LlmfitMcpServer::new(specs, models, context_limit, node_name);
+    let server = LlmfitMcpServer::new(specs, models, context_limit, calc_config, node_name);
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -459,12 +467,88 @@ mod tests {
     use serde_json::Value;
 
     fn test_server() -> LlmfitMcpServer {
+        server_with(SystemSpecs::detect(), None)
+    }
+
+    fn server_with(specs: SystemSpecs, calc_config: Option<CalcConfig>) -> LlmfitMcpServer {
         LlmfitMcpServer::new(
-            SystemSpecs::detect(),
+            specs,
             ModelDatabase::new().get_all_models().clone(),
             None,
+            calc_config,
             "test-node".to_string(),
         )
+    }
+
+    /// A fixed 128 GB unified-memory box, so estimator assertions don't depend
+    /// on whatever hardware the test happens to run on.
+    fn unified_specs() -> SystemSpecs {
+        SystemSpecs {
+            total_ram_gb: 128.0,
+            available_ram_gb: 120.0,
+            total_cpu_cores: 16,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: true,
+            gpu_vram_gb: Some(128.0),
+            total_gpu_vram_gb: Some(128.0),
+            gpu_available_gb: None,
+            gpu_name: Some("Test Unified GPU".to_string()),
+            gpu_count: 1,
+            unified_memory: true,
+            backend: GpuBackend::Rocm,
+            gpus: vec![],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        }
+    }
+
+    /// MCP clients rank from `analyze_all`, so the sanitization gate has to
+    /// hold here too — an agent must not be handed a speculative-decoding
+    /// draft head that the CLI hides (issue #969, problem 3).
+    #[test]
+    fn analyze_all_excludes_sanitization_demoted_entries() {
+        let db = ModelDatabase::new();
+        let demoted: std::collections::HashSet<&str> = db
+            .get_all_models()
+            .iter()
+            .filter(|m| m.is_sanitization_demoted())
+            .map(|m| m.name.as_str())
+            .collect();
+        assert!(
+            !demoted.is_empty(),
+            "catalog has no demoted entries to hide"
+        );
+
+        let fits = server_with(unified_specs(), None).analyze_all();
+
+        assert!(!fits.is_empty(), "expected some ranked fits");
+        let leaked: Vec<&str> = fits
+            .iter()
+            .map(|f| f.model.name.as_str())
+            .filter(|name| demoted.contains(name))
+            .collect();
+        assert!(leaked.is_empty(), "demoted models reached MCP: {leaked:?}");
+    }
+
+    /// A profile's bandwidth has to reach the estimator, not just the reported
+    /// capacity, or MCP publishes this host's speeds under the profile's name.
+    #[test]
+    fn analyze_all_estimates_from_the_profile_config() {
+        let config = CalcConfig {
+            gpu_bandwidth_gbps_override: Some(777.0),
+            ..CalcConfig::default()
+        };
+
+        let bandwidths: Vec<f64> = server_with(unified_specs(), Some(config))
+            .analyze_all()
+            .iter()
+            .filter_map(|f| f.estimate_basis.gpu_bandwidth_gbps)
+            .collect();
+
+        assert!(
+            !bandwidths.is_empty() && bandwidths.iter().all(|bw| *bw == 777.0),
+            "every GPU-path estimate should use the profile bandwidth, got {bandwidths:?}"
+        );
     }
 
     #[test]

--- a/llmfit-tui/src/serve_api.rs
+++ b/llmfit-tui/src/serve_api.rs
@@ -9,12 +9,11 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use llmfit_core::fit::{
-    FitLevel, InferenceRuntime, ModelFit, SortColumn, backend_compatible,
-    rank_models_by_fit_opts_col,
+    CalcConfig, FitLevel, InferenceRuntime, ModelFit, SortColumn, rank_models_by_fit_opts_col,
 };
 use llmfit_core::hardware::{GpuBackend, SystemSpecs};
 use llmfit_core::models::{LlmModel, ModelDatabase, UseCase};
-use llmfit_core::plan::{PlanRequest, estimate_model_plan};
+use llmfit_core::plan::{PlanRequest, estimate_model_plan_with_config};
 use llmfit_core::providers::{
     DockerModelRunnerProvider, LlamaCppProvider, LmStudioProvider, MlxProvider, ModelProvider,
     OllamaProvider, PullEvent, VllmProvider,
@@ -34,6 +33,11 @@ struct AppState {
     specs: SystemSpecs,
     models: Vec<LlmModel>,
     context_limit: Option<u32>,
+    /// Calculation parameters implied by `--profile`, or `None` when the
+    /// server describes the machine it runs on. Applied to every fit and plan
+    /// so the API can't report this host's speeds under a profile's capacity
+    /// (issue #969).
+    calc_config: Option<CalcConfig>,
     active_download: tokio::sync::RwLock<Option<ActiveDownload>>,
     download_counter: std::sync::atomic::AtomicU32,
 }
@@ -145,7 +149,7 @@ pub fn run_serve(
     overrides: &super::HardwareOverrides,
     context_limit: Option<u32>,
 ) -> Result<(), String> {
-    let specs = super::detect_specs(overrides);
+    let (specs, calc_config) = super::detect_specs_and_config(overrides);
     let db = ModelDatabase::new();
     let all_models = db.get_all_models().clone();
 
@@ -160,6 +164,7 @@ pub fn run_serve(
         specs,
         models: all_models,
         context_limit,
+        calc_config,
         active_download: tokio::sync::RwLock::new(None),
         download_counter: std::sync::atomic::AtomicU32::new(0),
     });
@@ -747,7 +752,8 @@ async fn plan_estimate(
     };
     let specs = effective_specs(&state.specs, &overrides)?;
 
-    match estimate_model_plan(model, &request, &specs) {
+    let config = state.calc_config.clone().unwrap_or_default();
+    match estimate_model_plan_with_config(model, &request, &specs, &config) {
         Ok(estimate) => Ok(Json(serde_json::json!(estimate))),
         Err(e) => Err(ApiError::bad_request(e)),
     }
@@ -766,11 +772,25 @@ fn filtered_fits(
 
     let context_limit = query.max_context.or(state.context_limit);
     let forced_rt = parse_force_runtime(query.force_runtime.as_deref())?;
-    let mut fits: Vec<ModelFit> = state
-        .models
-        .iter()
-        .filter(|m| backend_compatible(m, specs))
-        .map(|m| ModelFit::analyze_with_forced_runtime(m, specs, context_limit, forced_rt))
+    // Same restriction the CLI applies: `ModelFit` has no entry point that
+    // takes both a forced runtime and a `CalcConfig`, so a server started
+    // under `--profile` refuses `force_runtime` rather than dropping one of
+    // them (issue #969).
+    if state.calc_config.is_some() && forced_rt.is_some() {
+        return Err(ApiError::bad_request(
+            "force_runtime is not supported while this server is running under --profile",
+        ));
+    }
+    let mut fits: Vec<ModelFit> = llmfit_core::analysis::rankable_models(&state.models, specs)
+        .map(|m| match state.calc_config.as_ref() {
+            Some(config) => llmfit_core::analysis::analyze_with_optional_config(
+                m,
+                specs,
+                context_limit,
+                Some(config),
+            ),
+            None => ModelFit::analyze_with_forced_runtime(m, specs, context_limit, forced_rt),
+        })
         .collect();
 
     let is_apple_silicon = specs.backend == GpuBackend::Metal && specs.unified_memory;
@@ -1012,16 +1032,43 @@ mod tests {
     use tower::ServiceExt;
 
     fn test_state() -> Arc<AppState> {
+        state_with(SystemSpecs::detect(), None)
+    }
+
+    fn state_with(specs: SystemSpecs, calc_config: Option<CalcConfig>) -> Arc<AppState> {
         let db = ModelDatabase::new();
         Arc::new(AppState {
             node_name: "test-node".to_string(),
             os: "test-os".to_string(),
-            specs: SystemSpecs::detect(),
+            specs,
             models: db.get_all_models().clone(),
             context_limit: None,
+            calc_config,
             active_download: tokio::sync::RwLock::new(None),
             download_counter: std::sync::atomic::AtomicU32::new(0),
         })
+    }
+
+    /// A fixed 128 GB unified-memory box, so estimator assertions don't depend
+    /// on whatever hardware the test happens to run on.
+    fn unified_specs() -> SystemSpecs {
+        SystemSpecs {
+            total_ram_gb: 128.0,
+            available_ram_gb: 120.0,
+            total_cpu_cores: 16,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: true,
+            gpu_vram_gb: Some(128.0),
+            total_gpu_vram_gb: Some(128.0),
+            gpu_available_gb: None,
+            gpu_name: Some("Test Unified GPU".to_string()),
+            gpu_count: 1,
+            unified_memory: true,
+            backend: GpuBackend::Rocm,
+            gpus: vec![],
+            cluster_mode: false,
+            cluster_node_count: 0,
+        }
     }
 
     fn test_router() -> Router {
@@ -1209,6 +1256,118 @@ mod tests {
                 .unwrap();
 
             assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        });
+    }
+
+    async fn json_body(response: Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// The API ranks models too, so it has to inherit the same sanitization
+    /// gate as the CLI — an MCP or dashboard client must not be offered a
+    /// speculative-decoding draft head the CLI hides (issue #969, problem 3).
+    #[test]
+    fn models_endpoint_excludes_sanitization_demoted_entries() {
+        let db = ModelDatabase::new();
+        let demoted: std::collections::HashSet<String> = db
+            .get_all_models()
+            .iter()
+            .filter(|m| m.is_sanitization_demoted())
+            .map(|m| m.name.clone())
+            .collect();
+        assert!(
+            !demoted.is_empty(),
+            "catalog has no demoted entries to hide"
+        );
+
+        run_async(async {
+            let router = build_router(state_with(unified_specs(), None));
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/v1/models?limit=100000&include_too_tight=true&min_fit=marginal")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let value = json_body(response).await;
+            let returned: Vec<&str> = value["models"]
+                .as_array()
+                .expect("models array")
+                .iter()
+                .filter_map(|m| m["name"].as_str())
+                .collect();
+            assert!(!returned.is_empty(), "expected some ranked models");
+            let leaked: Vec<&&str> = returned
+                .iter()
+                .filter(|name| demoted.contains(**name))
+                .collect();
+            assert!(
+                leaked.is_empty(),
+                "demoted models reached the API: {leaked:?}"
+            );
+        });
+    }
+
+    /// `force_runtime` and a profile's `CalcConfig` cannot both reach
+    /// `ModelFit`, so a profile-backed server refuses the combination the same
+    /// way the CLI does rather than silently dropping the profile.
+    #[test]
+    fn force_runtime_is_refused_while_serving_under_a_profile() {
+        run_async(async {
+            let router = build_router(state_with(unified_specs(), Some(CalcConfig::default())));
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/v1/models?limit=1&force_runtime=llamacpp")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        });
+    }
+
+    /// A profile's bandwidth has to reach the estimator, not just the reported
+    /// capacity: without it the API would publish this host's speeds under the
+    /// profile's name (issue #969).
+    #[test]
+    fn profile_bandwidth_reaches_the_models_endpoint_estimates() {
+        run_async(async {
+            let config = CalcConfig {
+                gpu_bandwidth_gbps_override: Some(777.0),
+                ..CalcConfig::default()
+            };
+            let router = build_router(state_with(unified_specs(), Some(config)));
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/v1/models?limit=50")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let value = json_body(response).await;
+            let bandwidths: Vec<f64> = value["models"]
+                .as_array()
+                .expect("models array")
+                .iter()
+                .filter_map(|m| m.pointer("/estimate_basis/gpu_bandwidth_gbps"))
+                .filter_map(serde_json::Value::as_f64)
+                .collect();
+            assert!(
+                !bandwidths.is_empty() && bandwidths.iter().all(|bw| *bw == 777.0),
+                "expected every GPU-path estimate to use the profile bandwidth, got {bandwidths:?}"
+            );
         });
     }
 }

--- a/llmfit-tui/src/serve_shared.rs
+++ b/llmfit-tui/src/serve_shared.rs
@@ -34,7 +34,12 @@ pub fn system_json(specs: &SystemSpecs) -> serde_json::Value {
 }
 
 pub fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
-    serde_json::json!({
+    let mut notes = fit.notes.clone();
+    if let Some(note) = best_quant_mismatch_note(fit) {
+        notes.push(note);
+    }
+
+    let mut value = serde_json::json!({
         "name": fit.model.name,
         "provider": fit.model.provider,
         "parameter_count": fit.model.parameter_count,
@@ -60,13 +65,13 @@ pub fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "estimated_tps": round1(fit.estimated_tps),
         "runtime": runtime_code(fit.runtime),
         "runtime_label": fit.runtime_text(),
-        "best_quant": fit.best_quant,
+        "best_quant": sanitized_best_quant(fit),
         "memory_required_gb": round2(fit.memory_required_gb),
         "memory_available_gb": round2(fit.memory_available_gb),
         "moe_offloaded_gb": fit.moe_offloaded_gb.map(round2),
         "total_memory_gb": round2(fit.memory_required_gb + fit.moe_offloaded_gb.unwrap_or(0.0)),
         "utilization_pct": round1(fit.utilization_pct),
-        "notes": fit.notes,
+        "notes": notes,
         "gguf_sources": fit.model.gguf_sources,
         "capabilities": fit.model.capabilities,
         "capability_ids": fit.model.capabilities,
@@ -78,7 +83,63 @@ pub fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
         "estimate_basis": fit.estimate_basis,
         "verify_command": generate_llamabench_command(fit),
         "measured_tps": fit.measured_tps,
-    })
+    });
+
+    // Inserted separately rather than folded into the json! call above: that
+    // macro hits rustc's default recursion limit once the object grows this
+    // wide (issue #969 added these three keys on top of an already-large
+    // envelope).
+    let obj = value
+        .as_object_mut()
+        .expect("fit_to_json returns an object");
+    obj.insert(
+        "estimate_confidence".to_string(),
+        serde_json::json!(fit.estimate_confidence.code()),
+    );
+    obj.insert(
+        "estimate_confidence_label".to_string(),
+        serde_json::json!(fit.estimate_confidence.label()),
+    );
+    obj.insert(
+        "prefill_tps".to_string(),
+        serde_json::json!(fit.prefill_tps.map(round1)),
+    );
+    obj.insert(
+        "ttft_ms".to_string(),
+        serde_json::json!(fit.ttft_ms.map(round1)),
+    );
+
+    value
+}
+
+/// `fit.best_quant`, unless it's a GGUF-style label (`Q8_0`, `Q4_K_M`, ...)
+/// attached to a model whose own repo name declares a native low-precision
+/// format (NVFP4/MXFP4) that GGUF quant strings don't apply to. `None`
+/// means "not meaningful for this model", not "no quant chosen" (issue
+/// #969, problem 3).
+pub fn sanitized_best_quant(fit: &ModelFit) -> Option<&str> {
+    if fit.model.is_native_low_precision_named()
+        && llmfit_core::models::is_gguf_quant_label(&fit.best_quant)
+    {
+        None
+    } else {
+        Some(fit.best_quant.as_str())
+    }
+}
+
+/// Explanatory note for a cleared `best_quant`, or `None` when nothing was
+/// cleared. Appended to the displayed notes list rather than the
+/// fit-analysis `fit.notes` vec, since this is a presentation-layer
+/// clarification shared by the JSON envelope and the CLI detail pane.
+pub(crate) fn best_quant_mismatch_note(fit: &ModelFit) -> Option<String> {
+    if sanitized_best_quant(fit).is_some() {
+        return None;
+    }
+    Some(format!(
+        "best_quant cleared: '{}' is a native NVFP4/MXFP4 repo, so the GGUF quant label '{}' \
+         does not apply",
+        fit.model.name, fit.best_quant
+    ))
 }
 
 pub fn fit_level_code(fit_level: FitLevel) -> &'static str {
@@ -144,7 +205,76 @@ pub fn round2(v: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use llmfit_core::EstimateConfidence;
+    use llmfit_core::fit::{EstimateBasis, ScoreComponents};
     use llmfit_core::hardware::{GpuBackend, GpuInfo};
+    use llmfit_core::models::{LlmModel, ModelFormat, UseCase};
+
+    /// Minimal `ModelFit` for tests that only care about a few fields —
+    /// `name`, `best_quant`, `estimate_confidence`, `prefill_tps`, `ttft_ms`.
+    fn mock_fit(name: &str, best_quant: &str) -> ModelFit {
+        ModelFit {
+            model: LlmModel {
+                name: name.to_string(),
+                provider: "test".to_string(),
+                parameter_count: "7B".to_string(),
+                parameters_raw: Some(7_000_000_000),
+                min_ram_gb: 4.5,
+                recommended_ram_gb: 8.0,
+                min_vram_gb: Some(4.5),
+                quantization: "Q4_K_M".to_string(),
+                context_length: 8192,
+                use_case: "General".to_string(),
+                is_moe: false,
+                num_experts: None,
+                active_experts: None,
+                active_parameters: None,
+                release_date: None,
+                gguf_sources: vec![],
+                capabilities: vec![],
+                languages: vec![],
+                format: ModelFormat::default(),
+                num_attention_heads: None,
+                num_key_value_heads: None,
+                num_hidden_layers: None,
+                head_dim: None,
+                attention_layout: None,
+                license: None,
+                hidden_size: None,
+                moe_intermediate_size: None,
+                vocab_size: None,
+                shared_expert_intermediate_size: None,
+                architecture: None,
+            },
+            fit_level: FitLevel::Good,
+            run_mode: RunMode::Gpu,
+            memory_required_gb: 4.5,
+            memory_available_gb: 16.0,
+            utilization_pct: 28.1,
+            notes: vec![],
+            moe_offloaded_gb: None,
+            score: 80.0,
+            score_components: ScoreComponents {
+                quality: 80.0,
+                speed: 80.0,
+                fit: 80.0,
+                context: 80.0,
+            },
+            estimated_tps: 30.0,
+            best_quant: best_quant.to_string(),
+            use_case: UseCase::General,
+            runtime: InferenceRuntime::LlamaCpp,
+            installed: false,
+            fits_with_turboquant: false,
+            effective_context_length: 8_192,
+            usable_context: 8_192,
+            estimate_basis: EstimateBasis::default(),
+            measured_tps: None,
+            estimate_confidence: EstimateConfidence::Estimated,
+            prefill_tps: None,
+            ttft_ms: None,
+        }
+    }
 
     fn specs_with_gpu(name: &str) -> SystemSpecs {
         SystemSpecs {
@@ -228,11 +358,111 @@ mod tests {
             "estimate_basis",
             "verify_command",
             "measured_tps",
+            // issue #969: confidence label + prefill/TTFT, additive on top
+            // of the #759 envelope.
+            "estimate_confidence",
+            "estimate_confidence_label",
+            "prefill_tps",
+            "ttft_ms",
         ] {
             assert!(
                 json.get(key).is_some(),
                 "shared envelope is missing `{key}`"
             );
         }
+    }
+
+    #[test]
+    fn fit_json_serializes_estimate_confidence_code_and_label() {
+        for (confidence, code, label) in [
+            (
+                EstimateConfidence::MeasuredLocal,
+                "measured_local",
+                "measured (this machine)",
+            ),
+            (
+                EstimateConfidence::MeasuredCommunity,
+                "measured_community",
+                "measured (community)",
+            ),
+            (EstimateConfidence::Calibrated, "calibrated", "calibrated"),
+            (EstimateConfidence::Estimated, "estimated", "estimated"),
+            (
+                EstimateConfidence::Unsupported,
+                "unsupported",
+                "unsupported — no basis",
+            ),
+        ] {
+            let mut fit = mock_fit("test/model-7b", "Q4_K_M");
+            fit.estimate_confidence = confidence;
+
+            let json = fit_to_json(&fit);
+
+            assert_eq!(json["estimate_confidence"], code);
+            assert_eq!(json["estimate_confidence_label"], label);
+        }
+    }
+
+    #[test]
+    fn fit_json_prefill_and_ttft_are_null_when_not_estimated() {
+        let fit = mock_fit("test/model-7b", "Q4_K_M");
+        assert_eq!(fit.prefill_tps, None);
+        assert_eq!(fit.ttft_ms, None);
+
+        let json = fit_to_json(&fit);
+
+        assert!(json["prefill_tps"].is_null(), "expected null, not 0.0");
+        assert!(json["ttft_ms"].is_null(), "expected null, not 0.0");
+    }
+
+    #[test]
+    fn fit_json_prefill_and_ttft_carry_values_when_estimated() {
+        let mut fit = mock_fit("test/model-7b", "Q4_K_M");
+        fit.prefill_tps = Some(1234.56);
+        fit.ttft_ms = Some(78.9);
+
+        let json = fit_to_json(&fit);
+
+        assert_eq!(json["prefill_tps"], round1(1234.56));
+        assert_eq!(json["ttft_ms"], round1(78.9));
+    }
+
+    #[test]
+    fn best_quant_clears_gguf_label_on_native_low_precision_named_model() {
+        let fit = mock_fit("nvidia/Qwen3-8B-NVFP4", "Q8_0");
+
+        assert_eq!(sanitized_best_quant(&fit), None);
+
+        let json = fit_to_json(&fit);
+        assert!(json["best_quant"].is_null());
+        let notes: Vec<String> = json["notes"]
+            .as_array()
+            .expect("notes is an array")
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert!(
+            notes.iter().any(|n| n.contains("best_quant cleared")),
+            "expected a mismatch note, got: {notes:?}"
+        );
+    }
+
+    #[test]
+    fn best_quant_keeps_gguf_label_for_plain_gguf_model() {
+        let fit = mock_fit("acme/plain-7b-GGUF", "Q4_K_M");
+
+        assert_eq!(sanitized_best_quant(&fit), Some("Q4_K_M"));
+
+        let json = fit_to_json(&fit);
+        assert_eq!(json["best_quant"], "Q4_K_M");
+    }
+
+    #[test]
+    fn best_quant_keeps_native_label_for_low_precision_named_model() {
+        // MXFP4/NVFP4-named model whose best_quant is already a native
+        // label (e.g. picked via the MLX hierarchy) — nothing to clear.
+        let fit = mock_fit("amd/MiniMax-M2.1-MXFP4", "mlx-4bit");
+
+        assert_eq!(sanitized_best_quant(&fit), Some("mlx-4bit"));
     }
 }

--- a/llmfit-tui/src/serve_shared.rs
+++ b/llmfit-tui/src/serve_shared.rs
@@ -92,13 +92,18 @@ pub fn fit_to_json(fit: &ModelFit) -> serde_json::Value {
     let obj = value
         .as_object_mut()
         .expect("fit_to_json returns an object");
+    // Derived here rather than read off the fit: `measured_tps` is attached
+    // after analysis, and a producer that skipped
+    // `refresh_estimate_confidence` would otherwise ship "estimated" in the
+    // same object as a measured tok/s figure (issue #969).
+    let confidence = fit.effective_estimate_confidence();
     obj.insert(
         "estimate_confidence".to_string(),
-        serde_json::json!(fit.estimate_confidence.code()),
+        serde_json::json!(confidence.code()),
     );
     obj.insert(
         "estimate_confidence_label".to_string(),
-        serde_json::json!(fit.estimate_confidence.label()),
+        serde_json::json!(confidence.label()),
     );
     obj.insert(
         "prefill_tps".to_string(),
@@ -372,35 +377,95 @@ mod tests {
         }
     }
 
+    /// Drives the confidence through the fields it is derived from, rather
+    /// than by assigning the enum: the envelope re-derives at serialize time,
+    /// so those fields are what an API consumer's label actually depends on.
     #[test]
     fn fit_json_serializes_estimate_confidence_code_and_label() {
-        for (confidence, code, label) in [
+        use llmfit_core::benchmarks::{MeasuredSource, MeasuredTps};
+
+        let measured = |source| {
+            Some(MeasuredTps {
+                tok_s: 42.0,
+                sample_count: 3,
+                hardware_label: "test".to_string(),
+                source,
+            })
+        };
+
+        for (measured_tps, basis, code, label) in [
             (
-                EstimateConfidence::MeasuredLocal,
+                measured(MeasuredSource::LocalBench),
+                EstimateBasis::default(),
                 "measured_local",
                 "measured (this machine)",
             ),
             (
-                EstimateConfidence::MeasuredCommunity,
+                measured(MeasuredSource::Community),
+                EstimateBasis::default(),
                 "measured_community",
                 "measured (community)",
             ),
-            (EstimateConfidence::Calibrated, "calibrated", "calibrated"),
-            (EstimateConfidence::Estimated, "estimated", "estimated"),
             (
-                EstimateConfidence::Unsupported,
+                None,
+                EstimateBasis {
+                    local_calibration: Some(1.2),
+                    ..EstimateBasis::default()
+                },
+                "calibrated",
+                "calibrated",
+            ),
+            (
+                None,
+                EstimateBasis {
+                    method: "gpu_bandwidth_roofline".to_string(),
+                    ..EstimateBasis::default()
+                },
+                "estimated",
+                "estimated",
+            ),
+            (
+                None,
+                EstimateBasis {
+                    method: llmfit_core::fit::UNSUPPORTED_METHOD.to_string(),
+                    ..EstimateBasis::default()
+                },
                 "unsupported",
                 "unsupported — no basis",
             ),
         ] {
             let mut fit = mock_fit("test/model-7b", "Q4_K_M");
-            fit.estimate_confidence = confidence;
+            fit.measured_tps = measured_tps;
+            fit.estimate_basis = basis;
 
             let json = fit_to_json(&fit);
 
             assert_eq!(json["estimate_confidence"], code);
             assert_eq!(json["estimate_confidence_label"], label);
         }
+    }
+
+    /// The envelope must not trust `fit.estimate_confidence`: it is stale for
+    /// any producer that attached `measured_tps` without calling
+    /// `refresh_estimate_confidence`, and "estimated" alongside a measured
+    /// tok/s figure is exactly the contradiction API and MCP consumers can't
+    /// see through (issue #969).
+    #[test]
+    fn fit_json_derives_confidence_instead_of_trusting_a_stale_field() {
+        let mut fit = mock_fit("test/model-7b", "Q4_K_M");
+        fit.measured_tps = Some(llmfit_core::benchmarks::MeasuredTps {
+            tok_s: 42.0,
+            sample_count: 3,
+            hardware_label: "this machine".to_string(),
+            source: llmfit_core::benchmarks::MeasuredSource::LocalBench,
+        });
+        // Deliberately left at the pre-measurement value.
+        assert_eq!(fit.estimate_confidence, EstimateConfidence::Estimated);
+
+        let json = fit_to_json(&fit);
+
+        assert_eq!(json["estimate_confidence"], "measured_local");
+        assert_eq!(json["estimate_confidence_label"], "measured (this machine)");
     }
 
     #[test]

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -1,4 +1,4 @@
-use llmfit_core::fit::{CalcConfig, FitLevel, ModelFit, SortColumn, backend_compatible};
+use llmfit_core::fit::{CalcConfig, FitLevel, ModelFit, SortColumn};
 use llmfit_core::hardware::SystemSpecs;
 use llmfit_core::models::{Capability, LlmModel, ModelDatabase, UseCase, matches_provider_filter};
 use llmfit_core::plan::{PlanEstimate, PlanRequest, estimate_model_plan_with_config};
@@ -1024,6 +1024,10 @@ pub struct App {
 
     // Advanced Configuration
     pub calc_config: CalcConfig,
+    /// What "reset" in the advanced-config editor goes back to: the config the
+    /// app was started with, so a `--profile` run resets to the profile rather
+    /// than to this host's defaults (issue #969).
+    calc_config_baseline: CalcConfig,
     pub adv_config_field: AdvConfigField,
     pub adv_config_cursor_position: usize,
     pub adv_config_dirty: bool,
@@ -1122,7 +1126,17 @@ pub struct App {
 }
 
 impl App {
-    pub fn with_specs_and_context(specs: SystemSpecs, context_limit: Option<u32>) -> Self {
+    /// Start the TUI with the calculation parameters a `--profile` implies.
+    ///
+    /// `profile_config` seeds [`App::calc_config`], so the opening sweep, every
+    /// rebuild, and the plan view all estimate against the profile's bandwidth
+    /// and efficiency instead of this host's (issue #969). `None` keeps the
+    /// estimator defaults, which is what the advanced-config editor starts from.
+    pub fn with_specs_context_and_config(
+        specs: SystemSpecs,
+        context_limit: Option<u32>,
+        profile_config: Option<CalcConfig>,
+    ) -> Self {
         let real_specs = specs.clone();
         let db = ModelDatabase::new();
 
@@ -1244,11 +1258,10 @@ impl App {
         }
 
         // Track how many we're skipping so the UI can surface it.
-        let backend_hidden_count = db
-            .get_all_models()
-            .iter()
-            .filter(|m| !backend_compatible(m, &specs))
-            .count();
+        let backend_hidden_count =
+            llmfit_core::analysis::backend_hidden_count(db.get_all_models(), &specs);
+
+        let calc_config = profile_config.unwrap_or_default();
 
         // Only analyze models that can actually run on this hardware.
         // Measured sources, most trustworthy first: your own runs, llmfit
@@ -1256,25 +1269,28 @@ impl App {
         let local_index = llmfit_core::share::LocalBenchIndex::load(&specs);
         let community_index = llmfit_core::benchmarks::CommunityBenchIndex::for_specs(&specs);
         let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&specs);
-        let mut all_fits: Vec<ModelFit> = db
-            .get_all_models()
-            .iter()
-            .filter(|m| backend_compatible(m, &specs))
-            .map(|m| {
-                let mut fit = ModelFit::analyze_with_context_limit(m, &specs, context_limit);
-                fit.installed = installed.is_installed(m);
-                fit.measured_tps = local_index
-                    .as_ref()
-                    .and_then(|idx| idx.lookup(&m.name))
-                    .or_else(|| community_index.as_ref().and_then(|idx| idx.lookup(&m.name)))
-                    .or_else(|| {
-                        measured_index
-                            .as_ref()
-                            .and_then(|idx| idx.lookup(&m.name, &fit.best_quant))
-                    });
-                fit
-            })
-            .collect();
+        let mut all_fits: Vec<ModelFit> =
+            llmfit_core::analysis::rankable_models(db.get_all_models(), &specs)
+                .map(|m| {
+                    let mut fit = llmfit_core::analysis::analyze_with_optional_config(
+                        m,
+                        &specs,
+                        context_limit,
+                        Some(&calc_config),
+                    );
+                    fit.installed = installed.is_installed(m);
+                    fit.measured_tps = local_index
+                        .as_ref()
+                        .and_then(|idx| idx.lookup(&m.name))
+                        .or_else(|| community_index.as_ref().and_then(|idx| idx.lookup(&m.name)))
+                        .or_else(|| {
+                            measured_index
+                                .as_ref()
+                                .and_then(|idx| idx.lookup(&m.name, &fit.best_quant))
+                        });
+                    fit
+                })
+                .collect();
 
         // Calibrate formula estimates from the user's own benchmark runs.
         llmfit_core::analysis::apply_local_calibration(&mut all_fits);
@@ -1549,19 +1565,34 @@ impl App {
             context_limit,
             theme: Theme::load(),
             backend_hidden_count,
-            // Advanced configuration defaults
-            calc_config: CalcConfig::default(),
+            // Advanced configuration: seeded from `--profile` when given,
+            // otherwise the estimator defaults. The popup re-reads every input
+            // from `calc_config` when it opens.
+            adv_config_efficiency_input: format!("{:.2}", calc_config.efficiency),
+            adv_config_eff_factor_gpu: format!("{:.2}", calc_config.run_mode_factors.gpu),
+            adv_config_eff_factor_cpu_offload: format!(
+                "{:.2}",
+                calc_config.run_mode_factors.cpu_offload
+            ),
+            adv_config_eff_factor_moe: format!("{:.2}", calc_config.run_mode_factors.moe_offload),
+            adv_config_eff_factor_tp: format!(
+                "{:.2}",
+                calc_config.run_mode_factors.tensor_parallel
+            ),
+            adv_config_eff_factor_cpu_only: format!("{:.2}", calc_config.run_mode_factors.cpu_only),
+            adv_config_context_cap_input: match calc_config.context_cap {
+                Some(cap) => cap.to_string(),
+                None => String::new(),
+            },
+            adv_config_ddr_bandwidth_input: match calc_config.ddr_bandwidth_gbps {
+                Some(bw) => format!("{bw:.0}"),
+                None => String::new(),
+            },
+            calc_config_baseline: calc_config.clone(),
+            calc_config,
             adv_config_field: AdvConfigField::Efficiency,
             adv_config_cursor_position: 0,
             adv_config_dirty: false,
-            adv_config_efficiency_input: "0.55".to_string(),
-            adv_config_eff_factor_gpu: "1.0".to_string(),
-            adv_config_eff_factor_cpu_offload: "0.5".to_string(),
-            adv_config_eff_factor_moe: "0.8".to_string(),
-            adv_config_eff_factor_tp: "0.9".to_string(),
-            adv_config_eff_factor_cpu_only: "0.3".to_string(),
-            adv_config_context_cap_input: String::new(), // empty = use default
-            adv_config_ddr_bandwidth_input: String::new(), // empty = auto-detect
             // Filter popup defaults
             filter_field: FilterPopupField::ParamsMin,
             filter_cursor_position: 0,
@@ -3709,25 +3740,27 @@ impl App {
         self.rebuild_fits();
     }
 
-    /// Re-evaluate all model fits against current `self.specs`, preserving
-    /// installed status and filter selections.
+    /// Re-evaluate all model fits against current `self.specs` and
+    /// `self.calc_config`, preserving installed status and filter selections.
+    ///
+    /// Always goes through `calc_config`, so a rebuild triggered by hardware
+    /// simulation can't quietly drop the `--profile` or advanced-config
+    /// parameters the visible numbers were built from (issue #969).
     fn rebuild_fits(&mut self) {
         let db = ModelDatabase::new();
 
-        self.backend_hidden_count = db
-            .get_all_models()
-            .iter()
-            .filter(|m| !backend_compatible(m, &self.specs))
-            .count();
+        self.backend_hidden_count =
+            llmfit_core::analysis::backend_hidden_count(db.get_all_models(), &self.specs);
 
         let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&self.specs);
-        self.all_fits = db
-            .get_all_models()
-            .iter()
-            .filter(|m| backend_compatible(m, &self.specs))
+        self.all_fits = llmfit_core::analysis::rankable_models(db.get_all_models(), &self.specs)
             .map(|m| {
-                let mut fit =
-                    ModelFit::analyze_with_context_limit(m, &self.specs, self.context_limit);
+                let mut fit = llmfit_core::analysis::analyze_with_optional_config(
+                    m,
+                    &self.specs,
+                    self.context_limit,
+                    Some(&self.calc_config),
+                );
                 fit.installed = self.installed.is_installed(m);
                 fit.measured_tps = measured_index
                     .as_ref()
@@ -4037,7 +4070,7 @@ impl App {
     }
 
     pub fn reset_advanced_config(&mut self) {
-        self.calc_config = CalcConfig::default();
+        self.calc_config = self.calc_config_baseline.clone();
         self.rebuild_fits_with_config();
         // Refresh input fields to show defaults
         self.open_advanced_config_popup();
@@ -4160,37 +4193,9 @@ impl App {
         self.input_mode = InputMode::Normal;
     }
 
-    /// Rebuild fits using the custom calc_config
+    /// Rebuild fits after the advanced-config editor changed `calc_config`.
     fn rebuild_fits_with_config(&mut self) {
-        let db = ModelDatabase::new();
-
-        self.backend_hidden_count = db
-            .get_all_models()
-            .iter()
-            .filter(|m| !backend_compatible(m, &self.specs))
-            .count();
-
-        let measured_index = llmfit_core::benchmarks::MeasuredTpsIndex::for_specs(&self.specs);
-        self.all_fits = db
-            .get_all_models()
-            .iter()
-            .filter(|m| backend_compatible(m, &self.specs))
-            .map(|m| {
-                let mut fit =
-                    ModelFit::analyze_with_config(m, &self.specs, self.calc_config.clone());
-                fit.installed = self.installed.is_installed(m);
-                fit.measured_tps = measured_index
-                    .as_ref()
-                    .and_then(|idx| idx.lookup(&m.name, &fit.best_quant));
-                fit
-            })
-            .collect();
-
-        self.all_fits = llmfit_core::fit::rank_models_by_fit(self.all_fits.drain(..).collect());
-        self.selected_row = 0;
-        self.compare_models.clear();
-        self.compare_mark_model = None;
-        self.apply_filters();
+        self.rebuild_fits();
     }
 
     pub fn toggle_installed_first(&mut self) {
@@ -5188,7 +5193,7 @@ mod tests {
     use llmfit_core::models::{GgufSource, LlmModel, ModelFormat, UseCase};
 
     fn test_app() -> App {
-        App::with_specs_and_context(
+        App::with_specs_context_and_config(
             SystemSpecs {
                 total_ram_gb: 16.0,
                 available_ram_gb: 12.0,
@@ -5207,7 +5212,92 @@ mod tests {
                 cluster_node_count: 0,
             },
             None,
+            None,
         )
+    }
+
+    /// A 128 GB unified box, so estimator assertions don't depend on whatever
+    /// hardware the test happens to run on.
+    fn unified_specs() -> SystemSpecs {
+        SystemSpecs {
+            total_ram_gb: 128.0,
+            available_ram_gb: 120.0,
+            total_cpu_cores: 16,
+            cpu_name: "Test CPU".to_string(),
+            has_gpu: true,
+            gpu_vram_gb: Some(128.0),
+            total_gpu_vram_gb: Some(128.0),
+            gpu_available_gb: None,
+            gpu_name: Some("Test Unified GPU".to_string()),
+            gpu_count: 1,
+            unified_memory: true,
+            backend: GpuBackend::Rocm,
+            gpus: Vec::new(),
+            cluster_mode: false,
+            cluster_node_count: 0,
+        }
+    }
+
+    /// The TUI builds its own sweep, so the sanitization gate has to hold here
+    /// too rather than only in the CLI's `build_fits` (issue #969, problem 3).
+    #[test]
+    fn tui_sweep_excludes_sanitization_demoted_entries() {
+        let db = ModelDatabase::new();
+        let demoted: std::collections::HashSet<&str> = db
+            .get_all_models()
+            .iter()
+            .filter(|m| m.is_sanitization_demoted())
+            .map(|m| m.name.as_str())
+            .collect();
+        assert!(
+            !demoted.is_empty(),
+            "catalog has no demoted entries to hide"
+        );
+
+        let app = App::with_specs_context_and_config(unified_specs(), None, None);
+
+        assert!(!app.all_fits.is_empty(), "expected some ranked fits");
+        let leaked: Vec<&str> = app
+            .all_fits
+            .iter()
+            .map(|f| f.model.name.as_str())
+            .filter(|name| demoted.contains(name))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "demoted models reached the TUI: {leaked:?}"
+        );
+    }
+
+    /// Startup under `--profile` has to seed the estimator config, not just the
+    /// reported capacity, and the advanced-config reset has to return to that
+    /// profile rather than to the generic defaults (issue #969).
+    #[test]
+    fn profile_config_seeds_the_sweep_and_the_advanced_config_reset() {
+        let config = CalcConfig {
+            gpu_bandwidth_gbps_override: Some(777.0),
+            ..CalcConfig::default()
+        };
+        let mut app =
+            App::with_specs_context_and_config(unified_specs(), None, Some(config.clone()));
+
+        let bandwidths: Vec<f64> = app
+            .all_fits
+            .iter()
+            .filter_map(|f| f.estimate_basis.gpu_bandwidth_gbps)
+            .collect();
+        assert!(
+            !bandwidths.is_empty() && bandwidths.iter().all(|bw| *bw == 777.0),
+            "every GPU-path estimate should use the profile bandwidth, got {bandwidths:?}"
+        );
+
+        app.calc_config.gpu_bandwidth_gbps_override = Some(100.0);
+        app.reset_advanced_config();
+
+        assert_eq!(
+            app.calc_config.gpu_bandwidth_gbps_override, config.gpu_bandwidth_gbps_override,
+            "reset should return to the profile, not to CalcConfig::default()"
+        );
     }
 
     fn test_model(name: &str) -> LlmModel {

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -5272,6 +5272,9 @@ mod tests {
             usable_context: 8192,
             estimate_basis: Default::default(),
             measured_tps: None,
+            estimate_confidence: llmfit_core::EstimateConfidence::Estimated,
+            prefill_tps: None,
+            ttft_ms: None,
         }
     }
 
@@ -5593,6 +5596,15 @@ mod tests {
         app.filter_params_max_input.clear();
         app.filter_mem_pct_min_input.clear();
         app.filter_mem_pct_max_input.clear();
+        // Persisted use-case / provider toggles load from the real config dir
+        // and can zero out filtered_fits under a developer machine. Reset them
+        // so unit tests don't depend on ~/.config/llmfit/filters.json.
+        for selected in &mut app.selected_use_cases {
+            *selected = true;
+        }
+        for selected in &mut app.selected_providers {
+            *selected = true;
+        }
     }
 
     #[test]

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -791,7 +791,7 @@ mod tests {
     use llmfit_core::hardware::{GpuBackend, SystemSpecs};
 
     fn plan_mode_app() -> App {
-        let mut app = App::with_specs_and_context(
+        let mut app = App::with_specs_context_and_config(
             SystemSpecs {
                 total_ram_gb: 16.0,
                 available_ram_gb: 12.0,
@@ -809,6 +809,7 @@ mod tests {
                 cluster_mode: false,
                 cluster_node_count: 0,
             },
+            None,
             None,
         );
         app.input_mode = InputMode::Plan;

--- a/llmfit-tui/tests/hardware_profiles_cli.rs
+++ b/llmfit-tui/tests/hardware_profiles_cli.rs
@@ -1,0 +1,424 @@
+//! `llmfit hardware` and the global `--profile` flag.
+//!
+//! Every test points `LLMFIT_HARDWARE_PROFILES` at a scratch directory so a
+//! developer's own profiles can't change the result.
+
+use assert_cmd::Command;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+/// A profile file with a bandwidth no real GPU reports, so an assertion can
+/// prove the value came from the profile and not from detection.
+const UNIFIED_PROFILE: &str = r#"{
+  "schema_version": 1,
+  "name": "test-unified",
+  "hardware": {
+    "total_ram_gb": 128.0,
+    "unified_memory": true,
+    "gpu_memory_bandwidth_gbps": 777.0,
+    "gpu_compute_tflops_fp16": 42.0
+  },
+  "estimation": { "efficiency": 0.5 },
+  "calibration": [{ "model": "openai/gpt-oss-120b", "measured_tps": 50.0 }]
+}"#;
+
+fn scratch_dir(tag: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("llmfit-cli-hwprofile-{}-{tag}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+fn llmfit(profiles_dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("llmfit").expect("failed to locate llmfit test binary");
+    cmd.env("LLMFIT_HARDWARE_PROFILES", profiles_dir);
+    cmd
+}
+
+fn json_of(output: Vec<u8>) -> Value {
+    serde_json::from_slice(&output).expect("command did not emit valid JSON")
+}
+
+#[test]
+fn hardware_list_json_reports_bundled_profiles() {
+    let dir = scratch_dir("list");
+    let output = llmfit(&dir)
+        .args(["--json", "hardware", "list"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json = json_of(output);
+    let profiles = json
+        .get("profiles")
+        .and_then(Value::as_array)
+        .expect("list --json missing profiles array");
+    assert!(
+        profiles.len() >= 2,
+        "expected the bundled seed profiles, got {}",
+        profiles.len()
+    );
+    assert!(
+        json.get("errors")
+            .and_then(Value::as_array)
+            .is_some_and(|e| e.is_empty()),
+        "an empty profile directory should report no errors"
+    );
+
+    let unified = profiles
+        .iter()
+        .find(|p| p.get("name").and_then(Value::as_str) == Some("ryzen-ai-max-plus-395"))
+        .expect("the 256 GB/s-class unified seed profile should be listed");
+    assert_eq!(
+        unified
+            .get("gpu_memory_bandwidth_gbps")
+            .and_then(Value::as_f64),
+        Some(256.0)
+    );
+    assert_eq!(
+        unified.get("unified_memory").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        unified.get("origin").and_then(Value::as_str),
+        Some("bundled")
+    );
+
+    assert!(
+        profiles
+            .iter()
+            .any(|p| p.get("unified_memory").and_then(Value::as_bool) == Some(false)),
+        "expected a discrete-GPU seed profile too"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn hardware_list_reports_unloadable_user_files_instead_of_hiding_them() {
+    let dir = scratch_dir("list-errors");
+    std::fs::write(dir.join("broken.json"), "{ not json").expect("write broken profile");
+
+    let output = llmfit(&dir)
+        .args(["--json", "hardware", "list"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json = json_of(output);
+    let errors = json
+        .get("errors")
+        .and_then(Value::as_array)
+        .expect("list --json missing errors array");
+    assert_eq!(errors.len(), 1, "the broken file should be reported");
+    assert!(
+        errors[0]
+            .get("path")
+            .and_then(Value::as_str)
+            .is_some_and(|p| p.ends_with("broken.json"))
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn hardware_show_json_reports_effective_bandwidth_and_unapplied_calibration() {
+    let dir = scratch_dir("show");
+    std::fs::write(dir.join("test-unified.json"), UNIFIED_PROFILE).expect("write profile");
+
+    let output = llmfit(&dir)
+        .args(["--json", "hardware", "show", "test-unified"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json = json_of(output);
+    let effective = json
+        .get("effective")
+        .and_then(Value::as_object)
+        .expect("show --json missing effective object");
+    assert_eq!(
+        effective.get("gpu_bandwidth_gbps").and_then(Value::as_f64),
+        Some(777.0),
+        "the profile's bandwidth must win over the detected GPU"
+    );
+    assert_eq!(
+        effective.get("total_ram_gb").and_then(Value::as_f64),
+        Some(128.0)
+    );
+    assert_eq!(
+        effective.get("unified_memory").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        effective.get("efficiency").and_then(Value::as_f64),
+        Some(0.5)
+    );
+    assert_eq!(
+        json.get("calibration_applied").and_then(Value::as_bool),
+        Some(false),
+        "schema version 1 records calibration without applying it"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn hardware_show_rejects_an_unknown_profile() {
+    let dir = scratch_dir("show-unknown");
+    llmfit(&dir)
+        .args(["hardware", "show", "no-such-profile"])
+        .assert()
+        .failure();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn hardware_validate_rejects_unknown_keys_and_stem_mismatch() {
+    let dir = scratch_dir("validate");
+    let good = dir.join("test-unified.json");
+    std::fs::write(&good, UNIFIED_PROFILE).expect("write profile");
+    let typo = dir.join("typo.json");
+    std::fs::write(
+        &typo,
+        r#"{ "schema_version": 1, "name": "typo",
+             "hardware": { "total_ram_gb": 64.0, "unified_memory": false,
+                           "gpu_bandwith_gbps": 900 } }"#,
+    )
+    .expect("write typo profile");
+    let mismatch = dir.join("wrong-stem.json");
+    std::fs::write(&mismatch, UNIFIED_PROFILE).expect("write mismatched profile");
+
+    llmfit(&dir)
+        .args(["hardware", "validate"])
+        .arg(&good)
+        .assert()
+        .success();
+
+    let output = llmfit(&dir)
+        .args(["--json", "hardware", "validate"])
+        .arg(&good)
+        .arg(&typo)
+        .arg(&mismatch)
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json = json_of(output);
+    assert_eq!(json.get("ok").and_then(Value::as_bool), Some(false));
+    let results = json
+        .get("results")
+        .and_then(Value::as_array)
+        .expect("validate --json missing results array");
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].get("ok").and_then(Value::as_bool), Some(true));
+    assert!(
+        results[1]
+            .get("error")
+            .and_then(Value::as_str)
+            .is_some_and(|e| e.contains("gpu_bandwith_gbps")),
+        "a misspelled key must be named in the error: {:?}",
+        results[1]
+    );
+    assert!(
+        results[2]
+            .get("error")
+            .and_then(Value::as_str)
+            .is_some_and(|e| e.contains("file stem")),
+        "a name/stem mismatch must be rejected: {:?}",
+        results[2]
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn hardware_validate_requires_a_path() {
+    let dir = scratch_dir("validate-noargs");
+    llmfit(&dir)
+        .args(["hardware", "validate"])
+        .assert()
+        .failure();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn hardware_path_json_reports_the_user_directory() {
+    let dir = scratch_dir("path");
+    let output = llmfit(&dir)
+        .args(["--json", "hardware", "path"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json = json_of(output);
+    assert_eq!(
+        json.get("path").and_then(Value::as_str),
+        Some(dir.to_str().expect("utf-8 scratch path"))
+    );
+    assert_eq!(json.get("exists").and_then(Value::as_bool), Some(true));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn profile_conflicts_with_the_single_field_overrides() {
+    let dir = scratch_dir("conflicts");
+    for conflicting in [
+        vec!["--memory", "8G"],
+        vec!["--ram", "16G"],
+        vec!["--cpu-cores", "4"],
+    ] {
+        llmfit(&dir)
+            .args(["--profile", "nvidia-rtx-4090"])
+            .args(&conflicting)
+            .args(["--json", "system"])
+            .assert()
+            .failure();
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn profile_replaces_detected_hardware_in_the_fit_sweep() {
+    let dir = scratch_dir("fit");
+    std::fs::write(dir.join("test-unified.json"), UNIFIED_PROFILE).expect("write profile");
+
+    let output = llmfit(&dir)
+        .args([
+            "--no-dashboard",
+            "--json",
+            "--profile",
+            "test-unified",
+            "fit",
+            "--limit",
+            "10",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json = json_of(output);
+    assert_eq!(
+        json.pointer("/system/total_ram_gb").and_then(Value::as_f64),
+        Some(128.0),
+        "the profile's capacity should replace the detected pool"
+    );
+    assert_eq!(
+        json.pointer("/system/unified_memory")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let models = json
+        .get("models")
+        .and_then(Value::as_array)
+        .expect("fit --json missing models array");
+    assert!(
+        !models.is_empty(),
+        "a 128 GB machine should fit some models"
+    );
+
+    let bandwidths: Vec<f64> = models
+        .iter()
+        .filter_map(|m| m.pointer("/estimate_basis/gpu_bandwidth_gbps"))
+        .filter_map(Value::as_f64)
+        .collect();
+    assert!(
+        !bandwidths.is_empty(),
+        "a unified profile should put at least one model on the GPU path"
+    );
+    assert!(
+        bandwidths.iter().all(|bw| *bw == 777.0),
+        "every GPU-path estimate should use the profile bandwidth, got {bandwidths:?}"
+    );
+    assert!(
+        models
+            .iter()
+            .filter_map(|m| m.pointer("/estimate_basis/efficiency"))
+            .filter_map(Value::as_f64)
+            .all(|eff| eff == 0.5),
+        "the profile's efficiency should reach the estimator"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn profile_reads_a_path_selector() {
+    let dir = scratch_dir("fit-path");
+    let path = dir.join("test-unified.json");
+    std::fs::write(&path, UNIFIED_PROFILE).expect("write profile");
+
+    // Point the user directory elsewhere: the profile must be found through the
+    // path alone, not through name lookup.
+    let empty = scratch_dir("fit-path-empty");
+    let output = llmfit(&empty)
+        .args(["--no-dashboard", "--json", "--profile"])
+        .arg(&path)
+        .args(["fit", "--limit", "1"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json = json_of(output);
+    assert_eq!(
+        json.pointer("/system/total_ram_gb").and_then(Value::as_f64),
+        Some(128.0)
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&empty);
+}
+
+#[test]
+fn unknown_profile_fails_instead_of_falling_back_to_detection() {
+    let dir = scratch_dir("unknown");
+    llmfit(&dir)
+        .args([
+            "--no-dashboard",
+            "--json",
+            "--profile",
+            "no-such-profile",
+            "fit",
+        ])
+        .assert()
+        .failure();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn profile_with_force_runtime_is_refused_rather_than_half_applied() {
+    let dir = scratch_dir("force-runtime");
+    std::fs::write(dir.join("test-unified.json"), UNIFIED_PROFILE).expect("write profile");
+
+    llmfit(&dir)
+        .args([
+            "--no-dashboard",
+            "--json",
+            "--profile",
+            "test-unified",
+            "recommend",
+            "--force-runtime",
+            "llamacpp",
+        ])
+        .assert()
+        .failure();
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/llmfit-tui/tests/hardware_profiles_cli.rs
+++ b/llmfit-tui/tests/hardware_profiles_cli.rs
@@ -22,6 +22,20 @@ const UNIFIED_PROFILE: &str = r#"{
   "calibration": [{ "model": "openai/gpt-oss-120b", "measured_tps": 50.0 }]
 }"#;
 
+/// `UNIFIED_PROFILE` with twice the bandwidth and nothing else changed, so a
+/// difference between the two can only have come from the estimator config.
+const UNIFIED_PROFILE_FAST: &str = r#"{
+  "schema_version": 1,
+  "name": "test-unified-fast",
+  "hardware": {
+    "total_ram_gb": 128.0,
+    "unified_memory": true,
+    "gpu_memory_bandwidth_gbps": 1554.0,
+    "gpu_compute_tflops_fp16": 42.0
+  },
+  "estimation": { "efficiency": 0.5 }
+}"#;
+
 fn scratch_dir(tag: &str) -> PathBuf {
     let dir =
         std::env::temp_dir().join(format!("llmfit-cli-hwprofile-{}-{tag}", std::process::id()));
@@ -399,6 +413,78 @@ fn unknown_profile_fails_instead_of_falling_back_to_detection() {
         ])
         .assert()
         .failure();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `plan` used to build its estimate from `CalcConfig::default()`, so it
+/// reported this host's speed under the profile's name. Capacity is identical
+/// across both profiles here, which leaves the profile's bandwidth as the only
+/// possible source of the difference (issue #969).
+#[test]
+fn plan_estimates_from_the_profile_bandwidth_not_the_default_config() {
+    let dir = scratch_dir("plan");
+    std::fs::write(dir.join("test-unified.json"), UNIFIED_PROFILE).expect("write profile");
+    std::fs::write(dir.join("test-unified-fast.json"), UNIFIED_PROFILE_FAST)
+        .expect("write fast profile");
+
+    let plan_tps = |profile: Option<&str>| -> f64 {
+        let mut cmd = llmfit(&dir);
+        cmd.args(["--no-dashboard", "--json"]);
+        if let Some(name) = profile {
+            cmd.args(["--profile", name]);
+        }
+        let output = cmd
+            .args(["plan", "openai/gpt-oss-120b", "--context", "8192"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        json_of(output)
+            .pointer("/current/estimated_tps")
+            .and_then(Value::as_f64)
+            .expect("plan --json missing current.estimated_tps")
+    };
+
+    let baseline = plan_tps(Some("test-unified"));
+    let doubled = plan_tps(Some("test-unified-fast"));
+    let detected = plan_tps(None);
+
+    assert!(
+        (doubled / baseline - 2.0).abs() < 0.05,
+        "doubling only the profile bandwidth should roughly double a \
+         memory-bound plan estimate, got {baseline:.1} then {doubled:.1} tok/s"
+    );
+    assert!(
+        (baseline - detected).abs() > f64::EPSILON,
+        "a 777 GB/s profile should not reproduce the detected machine's \
+         plan estimate ({detected:.1} tok/s)"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `doctor` diagnoses the machine it runs on, so a profile can only make its
+/// output a lie. Silently ignoring the flag was the previous behaviour.
+#[test]
+fn doctor_refuses_a_profile_rather_than_ignoring_it() {
+    let dir = scratch_dir("doctor");
+    std::fs::write(dir.join("test-unified.json"), UNIFIED_PROFILE).expect("write profile");
+
+    let output = llmfit(&dir)
+        .args(["--no-dashboard", "--profile", "test-unified", "doctor"])
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+
+    let stderr = String::from_utf8_lossy(&output);
+    assert!(
+        stderr.contains("--profile") && stderr.contains("doctor"),
+        "the refusal should name the flag and the subcommand, got: {stderr}"
+    );
+
     let _ = std::fs::remove_dir_all(&dir);
 }
 


### PR DESCRIPTION
## What this PR does

Lets you score models against a **named machine** (RAM, unified vs discrete, bandwidth, optional FP16 TFLOPS) instead of only the host you are on — including hardware you do not own yet.

Also tightens MoE estimates, adds a confidence label on every fit JSON row, and keeps draft draft-model families out of ranked fits.

Closes #969

---

## How it works (spin up the CLI)

**1. List what ships in the binary**

```sh
llmfit hardware list
llmfit hardware show ryzen-ai-max-plus-395
```

**2. Score against that machine**

```sh
llmfit --profile ryzen-ai-max-plus-395 fit -n 10
llmfit --profile ryzen-ai-max-plus-395 plan openai/gpt-oss-120b
```

**3. Simulate anything else (unreleased SKU, custom box)**

Write a small JSON profile → validate → pass `--profile` by name or path. Full step-by-step:

📘 **[Walkthrough: Hardware profiles](https://github.com/saman-mb/llmfit/blob/feat/issue-969-hardware-profiles/docs/cli.md#hardware-profiles)**  
(also linked from [`llmfit-core/data/hardware/README.md`](https://github.com/saman-mb/llmfit/blob/feat/issue-969-hardware-profiles/llmfit-core/data/hardware/README.md))

Quick taste:

```sh
# one-off file
llmfit --profile ./my-box.json fit --json

# or install under the user dir and use the name forever
llmfit hardware path    # drop <name>.json here
llmfit hardware validate ~/.local/share/llmfit/hardware/my-box.json
llmfit --profile my-box fit -n 20
```

`--profile` replaces `--memory` / `--ram` / `--cpu-cores` (do not mix). Bundled seeds: `ryzen-ai-max-plus-395`, `apple-m3-max-128gb`, `nvidia-rtx-4090`.

---

## What else changed (same PR)

| Area | Behavior |
| --- | --- |
| Fit verdict | Still Perfect / Great / OK / Poor from memory headroom; Perfect still needs GPU |
| MoE | Per-arch Tier-1/Tier-2 constants (`gpt-oss`, DeepSeek-class); default path unchanged for other arches |
| Bandwidth | Single resolve path; profile BW drives `estimated_tps` and `estimate_basis.gpu_bandwidth_gbps` |
| Prefill / TTFT | Only when the profile sets FP16 TFLOPS; otherwise honest `null` |
| Confidence | Every fit JSON row gets `estimate_confidence` (+ label) |
| Catalog | EAGLE / DFlash / DSpark drafts out of ranked fits; `-MTP-` kept |

---

## Reviewer smoke (copy-paste)

```sh
llmfit hardware list
llmfit --profile ryzen-ai-max-plus-395 plan --quant Q4_K_M openai/gpt-oss-120b
# expect ~50 tok/s

llmfit --profile ryzen-ai-max-plus-395 fit --json -n 5 \
  | jq '.[0] | {name, estimated_tps, estimate_confidence, estimate_basis}'
```

---

## Real-world check

Installed this branch’s release binary and re-ran the Apple Silicon pre-order matrix **without** post-scaling tok/s by detector bandwidth (the old workaround).

- Companion branch (not on that repo’s `main` yet):  
  [`saman-mb/mac-studio-m5-analysis` @ `feat/llmfit-969-hardware-profiles`](https://github.com/saman-mb/mac-studio-m5-analysis/tree/feat/llmfit-969-hardware-profiles)
- 13/13 SKU dumps; each dump’s BW matched the profile (153–1200 GB/s)
- Example `openai/gpt-oss-120b`: 153 GB/s → 29.9 tok/s · 614 → 56.3 · 1200 → 176.4

---

## Tests / follow-ups

- [x] `cargo test -p llmfit-core` / `cargo test -p llmfit`
- [x] Greptile pass on prior head; docs commit is additive
- [ ] CI on this fork PR (needs maintainer “Approve and run workflows”)
- Follow-ups: [#972](https://github.com/AlexsJones/llmfit/issues/972) accuracy CI · [#973](https://github.com/AlexsJones/llmfit/issues/973) MXFP4 · [#974](https://github.com/AlexsJones/llmfit/issues/974) TUI confidence
- Schema v1: `calibration[]` stored, not applied; no `--profile` + `--force-runtime`; discrete profiles do not set VRAM independently
- Untrusted profile paths → recommend `/harden` before merge