### PR TITLE
fix(quality): disable Ollama thinking for benchmarks

### DIFF
--- a/llmfit-core/src/quality.rs
+++ b/llmfit-core/src/quality.rs
@@ -172,6 +172,24 @@ pub struct InferenceResponse {
     pub wall_time_sec: f64,
 }
 
+fn ollama_request_body(
+    model: &str,
+    prompt: &str,
+    max_tokens: u32,
+    temperature: f64,
+) -> serde_json::Value {
+    serde_json::json!({
+        "model": model,
+        "prompt": prompt,
+        "stream": false,
+        "think": false,
+        "options": {
+            "num_predict": max_tokens,
+            "temperature": temperature,
+        }
+    })
+}
+
 pub fn quality_ollama_generate(
     url: &str,
     model: &str,
@@ -179,15 +197,7 @@ pub fn quality_ollama_generate(
     max_tokens: u32,
     temperature: f64,
 ) -> Result<InferenceResponse, String> {
-    let body = serde_json::json!({
-        "model": model,
-        "prompt": prompt,
-        "stream": false,
-        "options": {
-            "num_predict": max_tokens,
-            "temperature": temperature,
-        }
-    });
+    let body = ollama_request_body(model, prompt, max_tokens, temperature);
 
     let start = Instant::now();
     let resp = ureq::post(url)
@@ -773,6 +783,26 @@ mod tests {
         }];
         // Negative score clamped to 0
         assert!((evaluate_response("bad", &rules) - 0.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn ollama_quality_requests_disable_thinking() {
+        let body = ollama_request_body("test-model", "Return JSON", 128, 0.3);
+
+        assert_eq!(body["think"], false);
+        assert_eq!(body["options"]["num_predict"], 128);
+    }
+
+    #[test]
+    fn empty_quality_response_does_not_match_scoring_rules() {
+        let rules = vec![ScoringRule {
+            pattern: "expected answer".to_string(),
+            weight: 10,
+            negate: false,
+            case_insensitive: false,
+        }];
+
+        assert_eq!(evaluate_response("", &rules), 0.0);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #960

## Summary

Ollama models with thinking enabled by default can consume the entire `num_predict` budget in reasoning, leaving an empty `response` for quality benchmarks. This resubmits the focused fix from #968 after that pull request was closed without merging.

- Send `"think": false` for Ollama quality benchmark requests.
- Keep request construction in a small helper so the payload is directly testable.
- Add regression coverage for the request flag and empty-response scoring behavior.

## Implementation

The Ollama quality path now explicitly disables thinking while preserving the existing prompt, token, temperature, and non-streaming request settings. OpenAI-compatible reasoning controls remain outside this focused fix.

## Validation

- `cargo test -p llmfit-core --quiet` — 590 passed, 0 failed, 1 ignored; integration suites: 6 passed and 2 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy -p llmfit-core --all-targets` — passed with existing warnings
- `git diff --check` — passed

The strict `cargo clippy ... -- -D warnings` variant remains blocked by pre-existing warnings outside this change, including the existing `manual_clamp` warning in `quality.rs`.

## Compatibility

This changes only Ollama quality benchmark requests and makes their behavior deterministic for models that enable thinking by default. It does not change the public API or OpenAI-compatible provider behavior.
