### PR TITLE
bench: community results for amd-gpu

### DIFF
--- a/llmfit-core/data/community/amd-gpu/1788085386-4f91f4d5.json
+++ b/llmfit-core/data/community/amd-gpu/1788085386-4f91f4d5.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 7840U w/ Radeon 780M Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "AMD GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 2,
+    "os": "linux",
+    "ramGb": 14.9,
+    "unifiedMemory": false,
+    "vramGb": 0.5
+  },
+  "results": [
+    {
+      "avgOutputTokens": 249.67,
+      "avgTotalMs": 5871.45,
+      "avgTps": 42.74,
+      "avgTtftMs": null,
+      "maxTps": 43.74,
+      "minTps": 41.74,
+      "model": "Qwen3-1.7B-Sushi-Coder.Q8_0.gguf",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788085386,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.11"
+  }
+}

--- a/llmfit-core/data/community/amd-gpu/1788086609-e586ba26.json
+++ b/llmfit-core/data/community/amd-gpu/1788086609-e586ba26.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 7840U w/ Radeon 780M Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "AMD GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 2,
+    "os": "linux",
+    "ramGb": 14.9,
+    "unifiedMemory": false,
+    "vramGb": 0.5
+  },
+  "results": [
+    {
+      "avgOutputTokens": 214.67,
+      "avgTotalMs": 8506.95,
+      "avgTps": 25.26,
+      "avgTtftMs": null,
+      "maxTps": 25.33,
+      "minTps": 25.12,
+      "model": "Qwen2.5-Coder-3B-Q8_0.gguf",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788086609,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.11"
+  }
+}

--- a/llmfit-core/data/community/amd-gpu/1788088672-2f9f0c07.json
+++ b/llmfit-core/data/community/amd-gpu/1788088672-2f9f0c07.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 7840U w/ Radeon 780M Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "AMD GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 2,
+    "os": "linux",
+    "ramGb": 14.9,
+    "unifiedMemory": false,
+    "vramGb": 0.5
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 15636.91,
+      "avgTps": 19.19,
+      "avgTtftMs": null,
+      "maxTps": 19.25,
+      "minTps": 19.13,
+      "model": "F2LLM-v2-4B.Q8_0.gguf",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788088672,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.11"
+  }
+}

--- a/llmfit-core/data/community/amd-gpu/1788089395-655ea961.json
+++ b/llmfit-core/data/community/amd-gpu/1788089395-655ea961.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 7840U w/ Radeon 780M Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "AMD GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 2,
+    "os": "linux",
+    "ramGb": 14.9,
+    "unifiedMemory": false,
+    "vramGb": 0.5
+  },
+  "results": [
+    {
+      "avgOutputTokens": 229.33,
+      "avgTotalMs": 11306.95,
+      "avgTps": 20.33,
+      "avgTtftMs": null,
+      "maxTps": 20.48,
+      "minTps": 20.19,
+      "model": "lexi-coder-v4.3.Q8_0.gguf",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788089395,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.11"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| Qwen3-1.7B-Sushi-Coder.Q8_0.gguf | llamacpp | 42.7 | — |

_Submitted without the `gh` CLI via the GitHub device flow._
