### PR TITLE
bench: community results for nvidia-geforce-rtx-4070-ti

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-rtx-4070-ti/1788252236-725d0265.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-4070-ti/1788252236-725d0265.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i5-13600KF",
+    "cpuCores": 20,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 4070 Ti",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 12,
+    "os": "windows",
+    "ramGb": 31.8,
+    "unifiedMemory": false,
+    "vramGb": 11.99
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 4661.85,
+      "avgTps": 66.16,
+      "avgTtftMs": 99.39,
+      "maxTps": 67.23,
+      "minTps": 64.27,
+      "model": "qwen3.5-9b-64k:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788252569,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-4070-ti/1788252329-b220d0fb.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-4070-ti/1788252329-b220d0fb.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i5-13600KF",
+    "cpuCores": 20,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 4070 Ti",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 12,
+    "os": "windows",
+    "ramGb": 31.8,
+    "unifiedMemory": false,
+    "vramGb": 11.99
+  },
+  "results": [
+    {
+      "avgOutputTokens": 180.33,
+      "avgTotalMs": 14716.68,
+      "avgTps": 12.7,
+      "avgTtftMs": 455.82,
+      "maxTps": 12.73,
+      "minTps": 12.65,
+      "model": "qwen3.8-27b-iq3xxs-64k:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788252569,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen3.5-9b-64k:latest | ollama | 66.2 | 99.4 |
| qwen3.8-27b-iq3xxs-64k:latest | ollama | 12.7 | 455.8 |

_Submitted without the `gh` CLI via the GitHub device flow._
