### PR TITLE
bench: community results for nvidia-geforce-gtx-1650-with-max-q-design

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788288178-ed642883.json
+++ b/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788288178-ed642883.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce GTX 1650 with Max-Q Design",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.84,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 61045.75,
+      "avgTps": 5.15,
+      "avgTtftMs": 2660.12,
+      "maxTps": 5.35,
+      "minTps": 4.95,
+      "model": "gemma4:26b",
+      "numRuns": 2,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788300600,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788294775-acb4f25f.json
+++ b/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788294775-acb4f25f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce GTX 1650 with Max-Q Design",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.84,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 154.5,
+      "avgTotalMs": 12039.52,
+      "avgTps": 15.12,
+      "avgTtftMs": 581.11,
+      "maxTps": 17.29,
+      "minTps": 12.95,
+      "model": "qwen2.5:3b-instruct-q6_k",
+      "numRuns": 2,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788300600,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788295253-fdd4c24b.json
+++ b/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788295253-fdd4c24b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce GTX 1650 with Max-Q Design",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.84,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 243.0,
+      "avgTotalMs": 72773.33,
+      "avgTps": 3.58,
+      "avgTtftMs": 4579.41,
+      "maxTps": 3.63,
+      "minTps": 3.53,
+      "model": "deepseek-r1:8b",
+      "numRuns": 2,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788300600,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788295458-643d1c43.json
+++ b/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788295458-643d1c43.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce GTX 1650 with Max-Q Design",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.84,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 169.0,
+      "avgTotalMs": 4627.77,
+      "avgTps": 39.5,
+      "avgTtftMs": 274.71,
+      "maxTps": 40.18,
+      "minTps": 38.81,
+      "model": "qwen2.5:3b-instruct-q4_k_m",
+      "numRuns": 2,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788300600,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788295883-66bebfb6.json
+++ b/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788295883-66bebfb6.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce GTX 1650 with Max-Q Design",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.84,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 63176.77,
+      "avgTps": 5.18,
+      "avgTtftMs": 4332.36,
+      "maxTps": 5.8,
+      "minTps": 4.56,
+      "model": "gemma4:26b",
+      "numRuns": 2,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788300600,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788295921-aeb17104.json
+++ b/llmfit-core/data/community/nvidia-geforce-gtx-1650-with-max-q-design/1788295921-aeb17104.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce GTX 1650 with Max-Q Design",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.84,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 149.5,
+      "avgTotalMs": 4762.46,
+      "avgTps": 34.65,
+      "avgTtftMs": 394.33,
+      "maxTps": 35.17,
+      "minTps": 34.13,
+      "model": "qwen2.5:3b-instruct-q4_k_m",
+      "numRuns": 2,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788300600,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| gemma4:26b | ollama | 5.2 | 2660.1 |
| qwen2.5:3b-instruct-q6_k | ollama | 15.1 | 581.1 |
| deepseek-r1:8b | ollama | 3.6 | 4579.4 |
| qwen2.5:3b-instruct-q4_k_m | ollama | 39.5 | 274.7 |
| gemma4:26b | ollama | 5.2 | 4332.4 |
| qwen2.5:3b-instruct-q4_k_m | ollama | 34.6 | 394.3 |

_Submitted without the `gh` CLI via the GitHub device flow._
