### PR TITLE
bench: community results for intel-coffeelake-s-gt2-uhd-graphics-630-integrated

### DIFF
--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788303805-a32bbe34.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788303805-a32bbe34.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 214.0,
+      "avgTotalMs": 32662.58,
+      "avgTps": 7.01,
+      "avgTtftMs": 636.51,
+      "maxTps": 7.66,
+      "minTps": 5.95,
+      "model": "qwen2.5:3b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788320075,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788304560-904ca957.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788304560-904ca957.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 161.67,
+      "avgTotalMs": 44055.92,
+      "avgTps": 3.78,
+      "avgTtftMs": 1487.56,
+      "maxTps": 3.99,
+      "minTps": 3.59,
+      "model": "qwen2.5-coder:7b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788320075,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788307440-cb19947c.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788307440-cb19947c.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 220.67,
+      "avgTotalMs": 39728.74,
+      "avgTps": 5.98,
+      "avgTtftMs": 884.93,
+      "maxTps": 6.49,
+      "minTps": 5.66,
+      "model": "gemma3:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788320075,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788307781-a65d2ea0.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788307781-a65d2ea0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 245.67,
+      "avgTotalMs": 42570.62,
+      "avgTps": 5.9,
+      "avgTtftMs": 919.45,
+      "maxTps": 6.02,
+      "minTps": 5.69,
+      "model": "qwen3:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788320075,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309065-091de24d.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309065-091de24d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 198.67,
+      "avgTotalMs": 50977.81,
+      "avgTps": 3.99,
+      "avgTtftMs": 1279.89,
+      "maxTps": 4.11,
+      "minTps": 3.88,
+      "model": "huihui_ai/qwen2.5-1m-abliterated:7b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788320075,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309337-0f68971f.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309337-0f68971f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 197.33,
+      "avgTotalMs": 15700.34,
+      "avgTps": 13.36,
+      "avgTtftMs": 255.74,
+      "maxTps": 14.19,
+      "minTps": 12.77,
+      "model": "llama3.2:1b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788320075,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309384-45601290.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309384-45601290.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 181.0,
+      "avgTotalMs": 14209.64,
+      "avgTps": 12.81,
+      "avgTtftMs": 223.51,
+      "maxTps": 13.55,
+      "minTps": 11.7,
+      "model": "qwen2.5:1.5b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788320075,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309433-ab6592e9.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309433-ab6592e9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 195.0,
+      "avgTotalMs": 14829.44,
+      "avgTps": 14.84,
+      "avgTtftMs": 338.31,
+      "maxTps": 16.19,
+      "minTps": 13.07,
+      "model": "gemma3:1b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788320075,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309959-a9b77926.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788309959-a9b77926.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 219.33,
+      "avgTotalMs": 9759.63,
+      "avgTps": 23.01,
+      "avgTtftMs": 349.19,
+      "maxTps": 24.16,
+      "minTps": 21.49,
+      "model": "granite3.1-moe:3b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788320075,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen2.5:3b | ollama | 7.0 | 636.5 |
| qwen2.5-coder:7b | ollama | 3.8 | 1487.6 |
| gemma3:4b | ollama | 6.0 | 884.9 |
| qwen3:4b | ollama | 5.9 | 919.5 |
| huihui_ai/qwen2.5-1m-abliterated:7b | ollama | 4.0 | 1279.9 |
| llama3.2:1b | ollama | 13.4 | 255.7 |
| qwen2.5:1.5b | ollama | 12.8 | 223.5 |
| gemma3:1b | ollama | 14.8 | 338.3 |
| granite3.1-moe:3b | ollama | 23.0 | 349.2 |

_Submitted without the `gh` CLI via the GitHub device flow._
