### PR TITLE
Fix Score sort direction floating unrunnable models to the top

### DIFF
--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -1141,6 +1141,28 @@ pub fn rank_models_by_fit_opts_col(
     installed_first: bool,
     sort_column: SortColumn,
 ) -> Vec<ModelFit> {
+    rank_models_by_fit_opts_col_dir(models, installed_first, sort_column, false)
+}
+
+/// Like [`rank_models_by_fit_opts_col`] with an explicit sort direction.
+///
+/// `ascending = false` keeps each column's default direction (Score, tok/s,
+/// Params, Mem%, Ctx: best value first; Date: newest first; UseCase,
+/// Provider: A→Z). `ascending = true` reverses only the sort key — installed
+/// models stay first (when requested) and TooTight entries stay last in both
+/// directions, so toggling direction cannot float unrunnable models to the
+/// top of the list.
+pub fn rank_models_by_fit_opts_col_dir(
+    models: Vec<ModelFit>,
+    installed_first: bool,
+    sort_column: SortColumn,
+    ascending: bool,
+) -> Vec<ModelFit> {
+    // Applies the requested direction to a key comparison that is written in
+    // the column's default (descending-best-first) orientation.
+    let dir = |cmp: std::cmp::Ordering| {
+        if ascending { cmp.reverse() } else { cmp }
+    };
     let mut ranked = models;
     ranked.sort_by(|a, b| {
         // Installed-first: if toggled, installed models sort above non-installed
@@ -1161,61 +1183,66 @@ pub fn rank_models_by_fit_opts_col(
             _ => {}
         }
 
-        // Sort by selected column
+        // Sort by selected column. Each arm compares in the column's default
+        // orientation; `dir` flips it when ascending was requested.
         match sort_column {
-            SortColumn::Score => b
+            SortColumn::Score => dir(b
                 .score
                 .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal),
+                .unwrap_or(std::cmp::Ordering::Equal)),
             SortColumn::Tps => {
                 let cmp = b
                     .estimated_tps
                     .partial_cmp(&a.estimated_tps)
                     .unwrap_or(std::cmp::Ordering::Equal);
                 if cmp == std::cmp::Ordering::Equal {
-                    b.score
+                    dir(b
+                        .score
                         .partial_cmp(&a.score)
-                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .unwrap_or(std::cmp::Ordering::Equal))
                 } else {
-                    cmp
+                    dir(cmp)
                 }
             }
             SortColumn::Params => {
                 let a_params = a.model.params_b();
                 let b_params = b.model.params_b();
-                b_params
+                dir(b_params
                     .partial_cmp(&a_params)
-                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .unwrap_or(std::cmp::Ordering::Equal))
             }
-            SortColumn::MemPct => b
+            SortColumn::MemPct => dir(b
                 .utilization_pct
                 .partial_cmp(&a.utilization_pct)
-                .unwrap_or(std::cmp::Ordering::Equal),
+                .unwrap_or(std::cmp::Ordering::Equal)),
             // Sort by the context that actually fits on this machine, not the
             // advertised window — that's the number that constrains real work
             // (issue #621). Native window breaks ties.
-            SortColumn::Ctx => b
+            SortColumn::Ctx => dir(b
                 .usable_context
                 .cmp(&a.usable_context)
-                .then(b.model.context_length.cmp(&a.model.context_length)),
+                .then(b.model.context_length.cmp(&a.model.context_length))),
             SortColumn::ReleaseDate => {
                 let a_date = a.model.release_date.as_deref().unwrap_or("");
                 let b_date = b.model.release_date.as_deref().unwrap_or("");
                 match (a_date.is_empty(), b_date.is_empty()) {
-                    (true, false) => std::cmp::Ordering::Greater, // no date = last
+                    // No date stays last in both directions — it is a
+                    // "missing value", not a sortable key.
+                    (true, false) => std::cmp::Ordering::Greater,
                     (false, true) => std::cmp::Ordering::Less,
-                    (true, true) => b
+                    (true, true) => dir(b
                         .score
                         .partial_cmp(&a.score)
-                        .unwrap_or(std::cmp::Ordering::Equal),
+                        .unwrap_or(std::cmp::Ordering::Equal)),
                     (false, false) => {
-                        let cmp = b_date.cmp(a_date); // descending = newest first
+                        let cmp = b_date.cmp(a_date); // default = newest first
                         if cmp == std::cmp::Ordering::Equal {
-                            b.score
+                            dir(b
+                                .score
                                 .partial_cmp(&a.score)
-                                .unwrap_or(std::cmp::Ordering::Equal)
+                                .unwrap_or(std::cmp::Ordering::Equal))
                         } else {
-                            cmp
+                            dir(cmp)
                         }
                     }
                 }
@@ -1224,11 +1251,12 @@ pub fn rank_models_by_fit_opts_col(
                 let cmp = a.use_case.label().cmp(b.use_case.label());
                 if cmp == std::cmp::Ordering::Equal {
                     // Secondary sort by score within same use case
-                    b.score
+                    dir(b
+                        .score
                         .partial_cmp(&a.score)
-                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .unwrap_or(std::cmp::Ordering::Equal))
                 } else {
-                    cmp
+                    dir(cmp)
                 }
             }
             SortColumn::Provider => {
@@ -1238,11 +1266,12 @@ pub fn rank_models_by_fit_opts_col(
                     .to_lowercase()
                     .cmp(&b.model.provider.to_lowercase());
                 if cmp == std::cmp::Ordering::Equal {
-                    b.score
+                    dir(b
+                        .score
                         .partial_cmp(&a.score)
-                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .unwrap_or(std::cmp::Ordering::Equal))
                 } else {
-                    cmp
+                    dir(cmp)
                 }
             }
         }
@@ -2670,6 +2699,40 @@ mod tests {
             for f in &ranked[pos..] {
                 assert_eq!(f.fit_level, FitLevel::TooTight);
             }
+        }
+    }
+
+    #[test]
+    fn test_ascending_sort_keeps_too_tight_last() {
+        // Toggling direction must flip only the sort key. The TUI used to
+        // reverse the whole ranked list, which floated TooTight models to the
+        // top whenever ascending was selected.
+        let model1 = test_model("7B", 4.0, Some(4.0));
+        let model2 = test_model("70B", 40.0, Some(40.0));
+        let model3 = test_model("13B", 8.0, Some(8.0));
+
+        let system = test_system(16.0, true, Some(10.0));
+
+        let fits = vec![
+            ModelFit::analyze(&model2, &system), // TooTight
+            ModelFit::analyze(&model1, &system),
+            ModelFit::analyze(&model3, &system),
+        ];
+
+        let ranked = rank_models_by_fit_opts_col_dir(fits, false, SortColumn::Score, true);
+
+        assert_eq!(ranked.last().unwrap().fit_level, FitLevel::TooTight);
+        let runnable: Vec<_> = ranked
+            .iter()
+            .filter(|f| f.fit_level != FitLevel::TooTight)
+            .collect();
+        for i in 0..runnable.len() - 1 {
+            assert!(
+                runnable[i].score <= runnable[i + 1].score,
+                "ascending score violated: {} then {}",
+                runnable[i].score,
+                runnable[i + 1].score
+            );
         }
     }
 

--- a/llmfit-tui/src/tui_app.rs
+++ b/llmfit-tui/src/tui_app.rs
@@ -4206,15 +4206,16 @@ impl App {
     /// Re-sort all_fits using current sort column and installed_first preference, then refilter.
     fn re_sort(&mut self) {
         let fits = std::mem::take(&mut self.all_fits);
-        let mut sorted = llmfit_core::fit::rank_models_by_fit_opts_col(
+        // Direction is applied to the sort key inside the core comparator so
+        // installed-first and TooTight-last hold in both directions — a plain
+        // `reverse()` here used to float unrunnable models to the top (and
+        // installed ones to the bottom) whenever ascending was toggled on.
+        self.all_fits = llmfit_core::fit::rank_models_by_fit_opts_col_dir(
             fits,
             self.installed_first,
             self.sort_column,
+            self.sort_ascending,
         );
-        if self.sort_ascending {
-            sorted.reverse();
-        }
-        self.all_fits = sorted;
         self.apply_filters();
     }
 
@@ -5372,6 +5373,66 @@ mod tests {
         }
     }
 
+    // ── sort direction regression ────────────────────────────────────
+
+    #[test]
+    fn score_sort_ascending_keeps_too_tight_last() {
+        let mut app = test_app();
+        clear_persisted_filters(&mut app);
+        app.all_fits = vec![
+            test_fit("a-high", FitLevel::Good, 90.0),
+            test_fit("b-tootight", FitLevel::TooTight, 10.0),
+            test_fit("c-mid", FitLevel::Good, 60.0),
+        ];
+        app.providers = vec!["Test".to_string()];
+        app.selected_providers = vec![true];
+        app.sort_column = SortColumn::Score;
+        app.sort_ascending = false;
+        app.re_sort();
+        let names: Vec<&str> = app
+            .filtered_fits
+            .iter()
+            .map(|&i| app.all_fits[i].model.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["a-high", "c-mid", "b-tootight"]);
+
+        // Toggle to ascending: runnable models flip, TooTight must stay last.
+        app.sort_ascending = true;
+        app.re_sort();
+        let names: Vec<&str> = app
+            .filtered_fits
+            .iter()
+            .map(|&i| app.all_fits[i].model.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["c-mid", "a-high", "b-tootight"]);
+    }
+
+    #[test]
+    fn score_sort_keeps_installed_first_in_both_directions() {
+        let mut app = test_app();
+        clear_persisted_filters(&mut app);
+        let mut installed_high = test_fit("a-installed", FitLevel::Good, 95.0);
+        installed_high.installed = true;
+        let not_installed_low = test_fit("b-remote", FitLevel::Good, 40.0);
+        app.all_fits = vec![not_installed_low, installed_high];
+        app.providers = vec!["Test".to_string()];
+        app.selected_providers = vec![true];
+        app.sort_column = SortColumn::Score;
+        app.installed_first = true;
+
+        // Descending: installed stays on top even though the remote model
+        // would never out-score it — but prove the pinning with the direction
+        // where the raw key order would bury it.
+        app.sort_ascending = true;
+        app.re_sort();
+        let names: Vec<&str> = app
+            .filtered_fits
+            .iter()
+            .map(|&i| app.all_fits[i].model.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["a-installed", "b-remote"]);
+    }
+
     // ── matched GGUF source attribution (issue #569) ─────────────────
 
     /// `Qwen/Qwen3-4B`-shaped entry: base model from one provider, GGUF quants
@@ -5690,13 +5751,23 @@ mod tests {
         app.filter_params_max_input.clear();
         app.filter_mem_pct_min_input.clear();
         app.filter_mem_pct_max_input.clear();
-        // Persisted use-case / provider toggles load from the real config dir
-        // and can zero out filtered_fits under a developer machine. Reset them
-        // so unit tests don't depend on ~/.config/llmfit/filters.json.
+        // Persisted use-case / provider / quant / run-mode / capability
+        // toggles load from the real config dir and can zero out
+        // filtered_fits under a developer machine. Reset them all so unit
+        // tests don't depend on ~/.config/llmfit/filters.json.
         for selected in &mut app.selected_use_cases {
             *selected = true;
         }
         for selected in &mut app.selected_providers {
+            *selected = true;
+        }
+        for selected in &mut app.selected_quants {
+            *selected = true;
+        }
+        for selected in &mut app.selected_run_modes {
+            *selected = true;
+        }
+        for selected in &mut app.selected_capabilities {
             *selected = true;
         }
     }


### PR DESCRIPTION
## Problem

In the TUI, toggling the **Score** column to ascending put models that cannot run on the system (`TooTight` fit) at the **top** of the list, and installed models at the bottom — the opposite of the documented invariants.

### Root cause

`App::re_sort()` implemented ascending sort by reversing the entire ranked vector:

```rust
if self.sort_ascending {
    sorted.reverse();
}
```

The core ranker guarantees two invariants *in addition* to the key order:

1. `TooTight` models always sort last, regardless of column
2. Installed models sort first (when `installed_first` is on)

Reversing the whole list flipped those pins along with the key. Since `sort_ascending` is persisted to `~/.config/llmfit/filters.json`, the broken order could also survive app restarts.

Reproduced with a test before the fix — toggling Score ascending produced:

```
["b-tootight", "c-mid", "a-high"]   // wrong
["c-mid", "a-high", "b-tootight"]   // expected
```

## Fix

- **`llmfit-core/src/fit.rs`**: add `rank_models_by_fit_opts_col_dir()`, which applies the direction *only to the sort key* inside the comparator (via a `dir()` helper), so installed-first and TooTight-last hold in both directions. "No release date" entries also stay last in both directions (missing value, not a key).
- The existing `rank_models_by_fit_opts_col()` delegates with the default direction, so **CLI, MCP, and Web API behavior are unchanged**.
- **`llmfit-tui/src/tui_app.rs`**: `re_sort()` now calls the direction-aware function instead of `reverse()`.
- Drive-by: `clear_persisted_filters()` didn't reset the quant / run-mode / capability toggles (which also load from `filters.json`), causing a pre-existing test failure on machines with a real filter config (`changing_search_query_resets_selection_to_top` failed on clean `main`). Now completed.

## Testing

- Added `score_sort_ascending_keeps_too_tight_last` and `score_sort_keeps_installed_first_in_both_directions` (TUI), plus `test_ascending_sort_keeps_too_tight_last` (core).
- Full suite green: 680 core + 102 TUI + integration tests, including the previously failing pre-existing test.
- `cargo fmt` / `cargo clippy` clean — no new warnings.
- CLI `fit` output re-verified as correctly score-sorted.