### PR TITLE
fix(docker): build each platform natively instead of cross-compiling under QEMU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,3 @@
-# Global ARG scope for multi-arch build options
-ARG BUILDPLATFORM=linux/amd64
-ARG TARGETPLATFORM
-ARG TARGETARCH
-
 # =========================================================
 # STAGE 1: Build Web UI Static Assets
 # =========================================================
@@ -24,24 +19,19 @@ RUN npm run build
 # against symbols the bookworm runtime (glibc 2.36) does not provide, so the
 # binary fails to start with "GLIBC_2.39 not found". Keep both stages on the
 # same release so the linked glibc is always available at runtime.
-FROM --platform=$BUILDPLATFORM rust:1.95-slim-bookworm AS rust-builder
+#
+# Each platform is built natively: the Docker workflow runs one job per
+# platform on a matching runner, so the builder image is always the host's
+# own architecture. Do not pin `--platform=$BUILDPLATFORM` here. Declaring
+# BUILDPLATFORM with a default overrode the value buildx supplies, which
+# pulled the amd64 toolchain onto the arm64 runner and ran rustc under QEMU
+# user-mode emulation, where it segfaults (v1.1.13 release failure).
+FROM rust:1.95-slim-bookworm AS rust-builder
 
-ARG BUILDPLATFORM
-ARG TARGETPLATFORM
-ARG TARGETARCH
-
-# Install cross-compilers for both directions (x86_64 -> aarch64 and aarch64 -> x86_64)
-# in the builder stage
+# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libssl-dev \
-    build-essential \
-    gcc-aarch64-linux-gnu \
-    g++-aarch64-linux-gnu \
-    libc6-dev-arm64-cross \
-    gcc-x86-64-linux-gnu \
-    g++-x86-64-linux-gnu \
-    libc6-dev-amd64-cross \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
@@ -58,30 +48,8 @@ COPY llmfit-desktop/ ./llmfit-desktop/
 # Copy built frontend dist into workspace so rust-embed includes it at compile-time
 COPY --from=web-builder /app/llmfit-web/dist ./llmfit-web/dist
 
-# Multi-arch compilation handling cross builds between amd64 and arm64 host platforms
-RUN case "${TARGETPLATFORM}" in \
-        "linux/amd64") \
-            RUST_TARGET="x86_64-unknown-linux-gnu" ;; \
-        "linux/arm64") \
-            RUST_TARGET="aarch64-unknown-linux-gnu" ;; \
-        *) \
-            RUST_TARGET="$(rustc -vV | sed -n 's/host: //p')" ;; \
-    esac && \
-    if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]; then \
-        rustup target add "$RUST_TARGET" && \
-        if [ "$TARGETARCH" = "arm64" ]; then \
-            CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-            cargo build --release -p llmfit --target "$RUST_TARGET"; \
-        elif [ "$TARGETARCH" = "amd64" ]; then \
-            CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
-            cargo build --release -p llmfit --target "$RUST_TARGET"; \
-        else \
-            cargo build --release -p llmfit --target "$RUST_TARGET"; \
-        fi && \
-        cp "target/${RUST_TARGET}/release/llmfit" target/release/llmfit; \
-    else \
-        cargo build --release -p llmfit; \
-    fi
+# Build the release binary for the host architecture
+RUN cargo build --release -p llmfit
 
 # =========================================================
 # STAGE 3: Unified Runtime Container


### PR DESCRIPTION
## Summary

The v1.1.13 Docker release failed on the arm64 job ([run](https://github.com/AlexsJones/llmfit/actions/runs/33756633131/job/100652540903)) with:

```
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
error: process didn't exit successfully:
  `/usr/local/rustup/toolchains/1.95.0-x86_64-unknown-linux-gnu/bin/rustc -vV` (signal: 11, SIGSEGV)
```

The Dockerfile from #911 declares `ARG BUILDPLATFORM=linux/amd64` at global scope. Giving the built-in `BUILDPLATFORM` a default overrides the value buildx sets automatically, so `FROM --platform=$BUILDPLATFORM rust:1.95-slim-bookworm` pinned the builder stage to the amd64 image even on the native `ubuntu-24.04-arm` runner. buildkit ran that stage under QEMU user-mode emulation, and rustc crashed before the cross-compile branch could do anything. The amd64 job passed because host and target matched.

The Docker workflow already runs one job per platform on a matching runner and merges digests into the manifest, so the cross-compile path is dead weight. This PR drops the platform pin, the global ARGs, the cross-compiler packages and the target-selection script. The builder stage is the host architecture again and runs `cargo build --release -p llmfit`, as it did before #911. The bookworm glibc pinning is unchanged.

## Test plan
- [x] `podman build --no-cache .` on x86_64 from this branch succeeds; the image reports `llmfit 1.1.13` and `system` runs
- [ ] After merge, re-run the Docker workflow via `workflow_dispatch` with tag `v1.1.13` and confirm both platform jobs plus the merge job pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136RnscU6pYGzbp2rvg4dkZ
