### PR TITLE
feat(concurrency): concurrent-session capacity estimator (#140)

### DIFF
--- a/llmfit-core/src/concurrency.rs
+++ b/llmfit-core/src/concurrency.rs
@@ -1,0 +1,496 @@
+//! Concurrent-session capacity estimation (issue #140).
+//!
+//! Answers "how many simultaneous inference sessions of this model fit in the
+//! memory pool at a given context length" — the server-planning counterpart to
+//! [`crate::fit::ModelFit::usable_context`], which solves the same memory
+//! balance for tokens instead of sessions. Model weights and the fixed runtime
+//! overhead are resident once; each concurrent session adds one KV cache at the
+//! chosen context:
+//!
+//! ```text
+//! sessions(ctx) = floor( (pool - weights_resident) / kv_cache(ctx) )
+//! ```
+//!
+//! `kv_cache(ctx)` is GQA- and layout-aware via
+//! [`crate::models::LlmModel::kv_cache_gb`]; `weights_resident` is the weight
+//! actually held in the pool for the run mode: the full model
+//! ([`crate::models::LlmModel::estimate_memory_gb`] at context 0, weights plus
+//! one-time overhead, no KV) for a resident model, or only the active experts
+//! under MoE offload. This is a memory-capacity ceiling, not a throughput
+//! figure: it says how many sessions can be *resident*, not how fast they run
+//! under concurrent load.
+
+use serde::Serialize;
+
+use crate::fit::RunMode;
+use crate::models::{KvQuant, LlmModel};
+
+/// Default context ladder reported when no explicit context is given: 4k to
+/// 256k, doubling. Makes the memory-versus-context trade-off visible at a
+/// glance (a model that hosts many sessions at 8k but only one at 128k is the
+/// common real case).
+pub const DEFAULT_CONTEXT_LADDER: [u32; 7] =
+    [4_096, 8_192, 16_384, 32_768, 65_536, 131_072, 262_144];
+
+/// Concurrency at one context length.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ConcurrencySlot {
+    /// Context requested for this rung.
+    pub requested_context: u32,
+    /// Context actually used, clamped to the effective ceiling (the native
+    /// window, or the smaller `--max-context` cap).
+    pub effective_context: u32,
+    /// True when `requested_context` exceeded the effective ceiling (the native
+    /// window, or the smaller `--max-context` cap) and was clamped down.
+    pub clamped: bool,
+    /// KV cache size for a single session at `effective_context`, in GB.
+    pub per_session_kv_gb: f64,
+    /// Maximum concurrent sessions that fit alongside the resident weights.
+    pub max_sessions: u32,
+}
+
+/// Full concurrency estimate for one model against one memory pool.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ConcurrencyEstimate {
+    /// Memory pool the sessions share, in GB.
+    pub pool_gb: f64,
+    /// Resident weight held in the pool, in GB: the full model plus one-time
+    /// runtime overhead, or only the active experts under MoE offload.
+    pub weights_resident_gb: f64,
+    /// Pool left for KV caches after the resident weights, in GB.
+    pub kv_budget_gb: f64,
+    /// Coarse per-session recurrent-state estimate (GB) for hybrid SSM models,
+    /// added to each session on top of its KV cache. Zero for pure attention
+    /// models. See [`crate::models::LlmModel::recurrent_state_estimate_gb`].
+    pub per_session_recurrent_gb: f64,
+    /// Weight quantization the estimate assumes.
+    pub quant: String,
+    /// KV cache element representation the estimate assumes.
+    pub kv_quant: KvQuant,
+    /// Model's native context window.
+    pub native_context: u32,
+    /// One entry per requested context length.
+    pub ladder: Vec<ConcurrencySlot>,
+}
+
+impl ConcurrencyEstimate {
+    /// Largest ladder rung (by effective context) that still fits at least
+    /// `users` concurrent sessions, if any.
+    pub fn max_context_for(&self, users: u32) -> Option<u32> {
+        self.ladder
+            .iter()
+            .filter(|s| s.max_sessions >= users)
+            .map(|s| s.effective_context)
+            .max()
+    }
+}
+
+/// Estimate concurrent-session capacity for `model` sharing a `pool_gb` memory
+/// pool, at each context length in `contexts`.
+///
+/// `pool_gb` is the pool the model actually runs from (for a GPU-resident model
+/// this is [`crate::fit::ModelFit::memory_available_gb`]); `quant` is the weight
+/// quantization; `kv` the KV cache representation; `run_mode` selects how the
+/// resident weight is charged (full weight, or only the active experts under MoE
+/// offload). Contexts above the effective ceiling (the native window, further
+/// capped by `context_cap` / `--max-context` when set) are clamped down to it,
+/// while `requested_context` keeps the asked value, mirroring `usable_context`.
+pub fn estimate_concurrency(
+    model: &LlmModel,
+    pool_gb: f64,
+    quant: &str,
+    kv: KvQuant,
+    contexts: &[u32],
+    run_mode: RunMode,
+    context_cap: Option<u32>,
+) -> ConcurrencyEstimate {
+    // Weights and fixed runtime overhead are resident once (KV at context 0 is
+    // zero). A fully-resident model charges its full weight to the pool, but
+    // under MoE offload only the active experts sit in the VRAM pool (inactive
+    // experts are offloaded to system RAM), so charging the full weight there
+    // wrongly zeroes the KV budget and reports zero sessions (issue #999). Each
+    // session then adds one kv_cache_gb(ctx) on top.
+    let weights_resident_gb = match run_mode {
+        RunMode::MoeOffload => model
+            .moe_active_vram_gb_at(quant)
+            .unwrap_or_else(|| model.estimate_memory_gb(quant, 0)),
+        _ => model.estimate_memory_gb(quant, 0),
+    };
+    let kv_budget_gb = (pool_gb - weights_resident_gb).max(0.0);
+    let native_context = model.context_length;
+    // Requested contexts are clamped to the effective ceiling: the native window,
+    // further capped by context_cap (--max-context) when set. requested_context
+    // keeps the asked value and `clamped` marks any rung the ceiling reduced, so
+    // JSON consumers keep the requested-vs-effective distinction (issue #999).
+    let effective_ceiling = context_cap.map_or(native_context, |cap| cap.min(native_context));
+    // Hybrid SSM / linear-attention models keep a fixed-size recurrent state per
+    // sequence, so each concurrent session costs its KV cache plus this
+    // (context-independent) estimate. Zero for pure attention models.
+    let per_session_recurrent_gb = model.recurrent_state_estimate_gb();
+
+    let ladder = contexts
+        .iter()
+        .map(|&requested| {
+            let effective_context = requested.min(effective_ceiling);
+            let per_session_kv_gb = model.kv_cache_gb(effective_context, kv);
+            let per_session_total_gb = per_session_kv_gb + per_session_recurrent_gb;
+            let max_sessions = if per_session_total_gb > f64::EPSILON {
+                // Clamp before the cast: a near-zero per-session cost (a
+                // degenerate tiny model) could otherwise overflow u32.
+                (kv_budget_gb / per_session_total_gb)
+                    .floor()
+                    .min(f64::from(u32::MAX)) as u32
+            } else {
+                0
+            };
+            ConcurrencySlot {
+                requested_context: requested,
+                effective_context,
+                clamped: requested > effective_ceiling,
+                per_session_kv_gb,
+                max_sessions,
+            }
+        })
+        .collect();
+
+    ConcurrencyEstimate {
+        pool_gb,
+        weights_resident_gb,
+        kv_budget_gb,
+        per_session_recurrent_gb,
+        quant: quant.to_string(),
+        kv_quant: kv,
+        native_context,
+        ladder,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fit::RunMode;
+    use crate::models::{self, LlmModel};
+
+    /// Synthetic MoE model: 30B total, 3B active, so full weight and active-
+    /// expert weight differ enough to expose the run-mode accounting without
+    /// owning the hardware.
+    fn moe_offload_model() -> LlmModel {
+        let mut m = calibrated_model(262_144);
+        m.is_moe = true;
+        m.num_experts = Some(128);
+        m.active_experts = Some(8);
+        m.parameters_raw = Some(30_000_000_000);
+        m.active_parameters = Some(3_000_000_000);
+        m
+    }
+
+    #[test]
+    fn moe_offload_charges_active_experts_not_full_weights() {
+        let m = moe_offload_model();
+        let quant = "Q4_K_M";
+        let full = m.estimate_memory_gb(quant, 0);
+        let active = m.moe_active_vram_gb_at(quant).unwrap();
+        assert!(
+            active < full,
+            "active-expert weight must be below full weight"
+        );
+        // Pool between the two: fits under offload, not if the full weight is
+        // charged to the VRAM pool.
+        let pool = (active + full) / 2.0;
+        let gpu =
+            estimate_concurrency(&m, pool, quant, KvQuant::Fp16, &[8_192], RunMode::Gpu, None);
+        let off = estimate_concurrency(
+            &m,
+            pool,
+            quant,
+            KvQuant::Fp16,
+            &[8_192],
+            RunMode::MoeOffload,
+            None,
+        );
+        assert_eq!(gpu.weights_resident_gb, full);
+        assert_eq!(off.weights_resident_gb, active);
+        // Full-weight charge zeroes the budget and reports no sessions...
+        assert_eq!(gpu.kv_budget_gb, 0.0);
+        assert_eq!(gpu.ladder[0].max_sessions, 0);
+        // ...active-expert charge leaves budget for real sessions.
+        assert!(off.kv_budget_gb > 0.0);
+        assert!(off.ladder[0].max_sessions > 0);
+    }
+
+    #[test]
+    fn context_cap_clamps_effective_but_preserves_requested() {
+        let m = calibrated_model(262_144);
+        let est = estimate_concurrency(
+            &m,
+            100.0,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &DEFAULT_CONTEXT_LADDER,
+            RunMode::Gpu,
+            Some(8_192),
+        );
+        // No rung reports a context above the cap.
+        assert!(est.ladder.iter().all(|s| s.effective_context <= 8_192));
+        // The requested value is preserved and the over-cap rung is marked.
+        let top = est
+            .ladder
+            .iter()
+            .find(|s| s.requested_context == 262_144)
+            .expect("ladder keeps the 256k request");
+        assert_eq!(top.effective_context, 8_192);
+        assert!(top.clamped);
+    }
+
+    /// Model with a precise-path KV cache calibrated so that fp16 KV at an 8192
+    /// context is exactly 1 GiB: 2 * 8 kv_heads * 128 head_dim * 2 bytes * 32
+    /// layers = 131072 bytes/token, * 8192 = 1_073_741_824 bytes = 1 GiB.
+    fn calibrated_model(context_length: u32) -> LlmModel {
+        LlmModel {
+            name: "Calibrated".to_string(),
+            provider: "Test".to_string(),
+            parameter_count: "7B".to_string(),
+            parameters_raw: Some(7_000_000_000),
+            min_ram_gb: 4.0,
+            recommended_ram_gb: 8.0,
+            min_vram_gb: Some(4.0),
+            quantization: "Q4_K_M".to_string(),
+            context_length,
+            use_case: "General".to_string(),
+            is_moe: false,
+            num_experts: None,
+            active_experts: None,
+            active_parameters: None,
+            release_date: None,
+            gguf_sources: vec![],
+            capabilities: vec![],
+            languages: vec![],
+            format: models::ModelFormat::default(),
+            num_attention_heads: Some(32),
+            num_key_value_heads: Some(8),
+            num_hidden_layers: Some(32),
+            head_dim: Some(128),
+            attention_layout: None,
+            license: None,
+            hidden_size: Some(4096),
+            moe_intermediate_size: None,
+            vocab_size: Some(32000),
+            shared_expert_intermediate_size: None,
+            architecture: None,
+        }
+    }
+
+    /// Hybrid SSM model: 64 layers, 16 full attention + 48 linear, hidden 5120,
+    /// matching the measured Qwen3.5 hybrid used to fit the recurrent estimate.
+    fn hybrid_ssm_model() -> LlmModel {
+        let mut m = calibrated_model(262_144);
+        m.num_hidden_layers = Some(64);
+        m.hidden_size = Some(5120);
+        m.attention_layout = Some(models::AttentionLayout {
+            full: 16,
+            linear: 48,
+        });
+        m
+    }
+
+    #[test]
+    fn recurrent_estimate_calibrated_to_measured_hybrid() {
+        let mib = hybrid_ssm_model().recurrent_state_estimate_gb() * 1024.0;
+        assert!(
+            (mib - 150.0).abs() < 10.0,
+            "recurrent state should be ~150 MiB, got {mib} MiB"
+        );
+        // Pure attention model (no linear layers) pays no recurrent state.
+        assert_eq!(calibrated_model(262_144).recurrent_state_estimate_gb(), 0.0);
+    }
+
+    #[test]
+    fn recurrent_state_reduces_hybrid_sessions() {
+        let hyb = hybrid_ssm_model();
+        let mut hyb_no_rec = hyb.clone();
+        hyb_no_rec.hidden_size = None; // forces recurrent estimate to 0, KV unchanged
+        let est = estimate_concurrency(
+            &hyb,
+            100.0,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &[8_192],
+            RunMode::Gpu,
+            None,
+        );
+        let est0 = estimate_concurrency(
+            &hyb_no_rec,
+            100.0,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &[8_192],
+            RunMode::Gpu,
+            None,
+        );
+        assert!(est.per_session_recurrent_gb > 0.0);
+        assert_eq!(est0.per_session_recurrent_gb, 0.0);
+        assert!(
+            est.ladder[0].max_sessions < est0.ladder[0].max_sessions,
+            "recurrent state must reduce concurrency: {} vs {}",
+            est.ladder[0].max_sessions,
+            est0.ladder[0].max_sessions
+        );
+    }
+
+    #[test]
+    fn kv_cache_is_calibrated_to_one_gib_at_8k() {
+        let m = calibrated_model(262_144);
+        assert!((m.kv_cache_gb(8_192, KvQuant::Fp16) - 1.0).abs() < 1e-9);
+        assert!((m.kv_cache_gb(16_384, KvQuant::Fp16) - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn budget_and_weights_are_consistent() {
+        let m = calibrated_model(262_144);
+        let pool = 100.0;
+        let est = estimate_concurrency(
+            &m,
+            pool,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &DEFAULT_CONTEXT_LADDER,
+            RunMode::Gpu,
+            None,
+        );
+        assert_eq!(est.weights_resident_gb, m.estimate_memory_gb("Q4_K_M", 0));
+        assert!((est.kv_budget_gb - (pool - est.weights_resident_gb)).abs() < 1e-9);
+        assert_eq!(est.ladder.len(), DEFAULT_CONTEXT_LADDER.len());
+    }
+
+    #[test]
+    fn sessions_match_budget_over_per_session_kv() {
+        let m = calibrated_model(262_144);
+        let est = estimate_concurrency(
+            &m,
+            100.0,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &DEFAULT_CONTEXT_LADDER,
+            RunMode::Gpu,
+            None,
+        );
+        let slot_8k = est
+            .ladder
+            .iter()
+            .find(|s| s.effective_context == 8_192)
+            .unwrap();
+        assert!((slot_8k.per_session_kv_gb - 1.0).abs() < 1e-9);
+        assert_eq!(slot_8k.max_sessions, est.kv_budget_gb.floor() as u32);
+    }
+
+    #[test]
+    fn more_context_never_fits_more_sessions() {
+        let m = calibrated_model(262_144);
+        let est = estimate_concurrency(
+            &m,
+            100.0,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &DEFAULT_CONTEXT_LADDER,
+            RunMode::Gpu,
+            None,
+        );
+        for w in est.ladder.windows(2) {
+            assert!(
+                w[1].max_sessions <= w[0].max_sessions,
+                "sessions must not grow as context grows: {} then {}",
+                w[0].max_sessions,
+                w[1].max_sessions
+            );
+        }
+    }
+
+    #[test]
+    fn contexts_above_native_window_are_clamped() {
+        let m = calibrated_model(16_384);
+        let est = estimate_concurrency(
+            &m,
+            100.0,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &DEFAULT_CONTEXT_LADDER,
+            RunMode::Gpu,
+            None,
+        );
+        let over = est
+            .ladder
+            .iter()
+            .find(|s| s.requested_context == 262_144)
+            .unwrap();
+        assert!(over.clamped);
+        assert_eq!(over.effective_context, 16_384);
+        let under = est
+            .ladder
+            .iter()
+            .find(|s| s.requested_context == 8_192)
+            .unwrap();
+        assert!(!under.clamped);
+        let native_rung = est
+            .ladder
+            .iter()
+            .find(|s| s.requested_context == 16_384)
+            .unwrap();
+        assert_eq!(over.max_sessions, native_rung.max_sessions);
+    }
+
+    #[test]
+    fn tiny_pool_yields_zero_sessions() {
+        let m = calibrated_model(262_144);
+        let est = estimate_concurrency(
+            &m,
+            0.1,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &DEFAULT_CONTEXT_LADDER,
+            RunMode::Gpu,
+            None,
+        );
+        assert_eq!(est.kv_budget_gb, 0.0);
+        assert!(est.ladder.iter().all(|s| s.max_sessions == 0));
+    }
+
+    #[test]
+    fn max_context_for_users_picks_largest_fitting_rung() {
+        let m = calibrated_model(262_144);
+        let est = estimate_concurrency(
+            &m,
+            100.0,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &DEFAULT_CONTEXT_LADDER,
+            RunMode::Gpu,
+            None,
+        );
+        let c1 = est.max_context_for(1).unwrap();
+        if let Some(c_many) = est.max_context_for(8) {
+            assert!(c_many <= c1);
+        }
+    }
+
+    #[test]
+    fn coarse_fallback_without_arch_metadata_still_estimates() {
+        let mut m = calibrated_model(262_144);
+        m.num_hidden_layers = None;
+        m.head_dim = None;
+        m.num_key_value_heads = None;
+        m.num_attention_heads = None;
+        let est = estimate_concurrency(
+            &m,
+            100.0,
+            "Q4_K_M",
+            KvQuant::Fp16,
+            &DEFAULT_CONTEXT_LADDER,
+            RunMode::Gpu,
+            None,
+        );
+        assert!(est.ladder.iter().any(|s| s.max_sessions > 0));
+        for w in est.ladder.windows(2) {
+            assert!(w[1].max_sessions <= w[0].max_sessions);
+        }
+    }
+}

--- a/llmfit-core/src/lib.rs
+++ b/llmfit-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod analysis;
 pub mod bench;
 pub mod benchmarks;
 pub mod claim;
+pub mod concurrency;
 pub mod doctor;
 pub mod fit;
 pub mod hardware;

--- a/llmfit-core/src/models.rs
+++ b/llmfit-core/src/models.rs
@@ -35,6 +35,8 @@ pub fn quant_bpp(quant: &str) -> f64 {
         "AWQ-8bit" => 1.0,
         "GPTQ-Int4" => 0.5,
         "GPTQ-Int8" => 1.0,
+        "AutoRound-4bit" => 0.5,
+        "AutoRound-8bit" => 1.0,
         _ => 0.58,
     }
 }
@@ -95,6 +97,61 @@ pub fn quant_bytes_per_param(quant: &str) -> f64 {
         "AWQ-8bit" | "GPTQ-Int8" | "AutoRound-8bit" => 1.0,
         _ => 0.5, // default to ~4-bit
     }
+}
+
+/// True when `quant` is a quantization label the memory-sizing path recognises
+/// exactly (case-sensitive). An unrecognised label silently takes the 0.58
+/// bytes/param fallback in [`quant_bpp`], which [`LlmModel::estimate_memory_gb`]
+/// and [`LlmModel::moe_active_vram_gb_at`] use for resident weights, so a caller
+/// that accepts a user-supplied quant should reject anything this returns false
+/// for rather than mis-sizing the model. Keep in sync with the arms of
+/// [`quant_bpp`].
+pub fn quant_is_recognized(quant: &str) -> bool {
+    matches!(
+        quant,
+        "F32"
+            | "F16"
+            | "BF16"
+            | "Q8_0"
+            | "Q6_K"
+            | "Q5_K_M"
+            | "Q4_K_M"
+            | "Q4_0"
+            | "Q3_K_M"
+            | "Q2_K"
+            | "UD-Q2_K_XL"
+            | "UD-Q2_K_L"
+            | "UD-Q2_K_M"
+            | "UD-Q2_K_S"
+            | "UD-Q3_K_XL"
+            | "UD-Q3_K_L"
+            | "UD-Q3_K_M"
+            | "UD-Q3_K_S"
+            | "UD-Q4_K_XL"
+            | "UD-Q4_K_L"
+            | "UD-Q4_K_M"
+            | "UD-Q4_K_S"
+            | "UD-Q5_K_XL"
+            | "UD-Q5_K_L"
+            | "UD-Q5_K_M"
+            | "UD-Q5_K_S"
+            | "UD-Q6_K_XL"
+            | "UD-Q6_K_L"
+            | "UD-Q6_K_M"
+            | "UD-Q6_K_S"
+            | "UD-Q8_K_XL"
+            | "UD-Q8_K_L"
+            | "UD-Q8_K_M"
+            | "UD-Q8_K_S"
+            | "mlx-4bit"
+            | "mlx-8bit"
+            | "AWQ-4bit"
+            | "AWQ-8bit"
+            | "GPTQ-Int4"
+            | "GPTQ-Int8"
+            | "AutoRound-4bit"
+            | "AutoRound-8bit"
+    )
 }
 
 /// Quality penalty for quantization (lower quant = lower quality).
@@ -1128,6 +1185,32 @@ impl LlmModel {
         baseline_fp16 * scale
     }
 
+    /// Coarse per-session recurrent-state estimate (GB) for hybrid SSM /
+    /// linear-attention models (Qwen3.5, Jamba, Mamba hybrids). The linear
+    /// layers keep a fixed-size state per sequence, independent of context, so
+    /// each concurrent session pays it on top of its KV cache. This is a
+    /// deliberately rough estimate for capacity planning, not an exact
+    /// accounting: linear_layers * hidden_size * C, with C fitted to a measured
+    /// Qwen3.5 hybrid (48 linear layers, hidden 5120 -> ~150 MiB per sequence).
+    /// Zero for pure attention models and when hidden_size is unknown.
+    pub fn recurrent_state_estimate_gb(&self) -> f64 {
+        let hidden = match self.hidden_size {
+            Some(h) => f64::from(h),
+            None => return 0.0,
+        };
+        let linear = self
+            .effective_attention_layout()
+            .map(|l| l.linear)
+            .unwrap_or(0);
+        if linear == 0 {
+            return 0.0;
+        }
+        // ~640 bytes per (linear layer x hidden unit), fitted to the measured
+        // hybrid above. Approximate by design.
+        const BYTES_PER_LAYER_HIDDEN: f64 = 640.0;
+        f64::from(linear) * hidden * BYTES_PER_LAYER_HIDDEN / 1_073_741_824.0
+    }
+
     /// Select the best quantization level that fits within a memory budget.
     /// Returns the quant name and estimated memory in GB, or None if nothing fits.
     pub fn best_quant_for_budget(&self, budget_gb: f64, ctx: u32) -> Option<(&'static str, f64)> {
@@ -1207,11 +1290,19 @@ impl LlmModel {
     /// For MoE models, compute estimated VRAM for active experts only.
     /// Returns None for dense models.
     pub fn moe_active_vram_gb(&self) -> Option<f64> {
+        self.moe_active_vram_gb_at(&self.quantization)
+    }
+
+    /// Active-expert VRAM at a specific quantization, for MoE models. Like
+    /// [`Self::moe_active_vram_gb`] but at `quant` rather than the model's own
+    /// quantization, which the concurrency estimator needs since it picks its
+    /// own quant. Returns None for dense models.
+    pub fn moe_active_vram_gb_at(&self, quant: &str) -> Option<f64> {
         if !self.is_moe {
             return None;
         }
         let active_params = self.active_parameters? as f64;
-        let bpp = self.quant_bpp();
+        let bpp = quant_bpp(quant);
         let size_gb = (active_params * bpp) / (1024.0 * 1024.0 * 1024.0);
         Some((size_gb * 1.1).max(0.5))
     }
@@ -2075,6 +2166,24 @@ fn infer_heads_from_name(name: &str, params_b: f64) -> (u32, u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn quant_is_recognized_matches_quant_bpp_labels() {
+        // Accepted: labels quant_bpp sizes without the fallback.
+        assert!(quant_is_recognized("Q8_0"));
+        assert!(quant_is_recognized("Q4_K_M"));
+        assert!(quant_is_recognized("F32"));
+        assert!(quant_is_recognized("mlx-4bit"));
+        assert!(quant_is_recognized("AWQ-8bit"));
+        assert!(quant_is_recognized("GPTQ-Int4"));
+        // Wrong case must not pass: sizing matches exact labels.
+        assert!(!quant_is_recognized("q8_0"));
+        assert!(!quant_is_recognized("bogus_quant"));
+        // AutoRound is sized by quant_bpp at the AWQ/GPTQ scale, so it is
+        // accepted rather than falling through to the 0.58 default.
+        assert!(quant_is_recognized("AutoRound-4bit"));
+        assert!(quant_is_recognized("AutoRound-8bit"));
+    }
 
     // ────────────────────────────────────────────────────────────────────
     // Custom model overlay tests

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -135,6 +135,10 @@ struct Cli {
     #[arg(short, long)]
     perfect: bool,
 
+    /// Default fit view: append a concurrent-session estimate per model (issue #140)
+    #[arg(long)]
+    concurrency: bool,
+
     /// Show only models with tool/function-call capability
     #[arg(long)]
     tool_use: bool,
@@ -419,6 +423,10 @@ AGENT USAGE:
         /// Sort column for fit output
         #[arg(long, value_enum, default_value_t = SortArg::Score)]
         sort: SortArg,
+
+        /// Append a concurrent-session estimate per model at its usable context (issue #140)
+        #[arg(long)]
+        concurrency: bool,
     },
 
     /// Search for specific models
@@ -545,6 +553,48 @@ AGENT USAGE:
   JSON output: PlanEstimate object with fields: model_name, context_length,
   quantization, weight_gb, kv_cache_gb, total_vram_gb, fits_in_vram,
   estimated_tps, recommended_gpu, notes.")]
+    /// Estimate concurrent-session capacity for a model (issue #140)
+    #[command(long_about = "\
+Estimate how many concurrent inference sessions of a model fit in the memory
+pool at a range of context lengths.
+
+Model weights and fixed runtime overhead are resident once; each concurrent
+session adds one KV cache at the chosen context, so:
+  sessions(ctx) = floor((pool - weights_resident) / kv_cache(ctx))
+The KV term is GQA- and layout-aware. This is a memory-capacity ceiling
+(sessions resident), not a throughput figure under concurrent load.
+
+PRECONDITIONS:
+  Requires hardware detection. Use --memory / --profile to model other hardware.
+
+SIDE EFFECTS:
+  None -- read-only.
+
+EXIT CODES:
+  0  Success
+  1  Unknown/ambiguous model or bad argument
+
+AGENT USAGE:
+  llmfit concurrency qwen2.5-32b --json
+  llmfit concurrency llama-3.1-8b --context 32768
+  llmfit concurrency mistral-7b --users 16")]
+    Concurrency {
+        /// Model selector (name or unique partial name)
+        model: String,
+        /// Weight quantization override (e.g. Q4_K_M, Q8_0). Defaults to the best fit.
+        #[arg(long)]
+        quant: Option<String>,
+        /// KV cache element representation (fp16, fp8, q8_0, q4_0, tq). Defaults to fp16.
+        #[arg(long, value_name = "KV")]
+        kv_quant: Option<String>,
+        /// Report a single context instead of the 4k-256k ladder (tokens).
+        #[arg(long, value_name = "TOKENS", value_parser = clap::value_parser!(u32).range(1..))]
+        context: Option<u32>,
+        /// Also report the largest context that fits this many concurrent sessions.
+        #[arg(long, value_name = "N", value_parser = clap::value_parser!(u32).range(1..))]
+        users: Option<u32>,
+    },
+
     Plan {
         /// Model selector (name or unique partial name)
         model: String,
@@ -1158,6 +1208,7 @@ fn is_readonly_subcommand(command: &Commands) -> bool {
             | Commands::Plan { .. }
             | Commands::Recommend { .. }
             | Commands::Fit { .. }
+            | Commands::Concurrency { .. }
             | Commands::Search { .. }
             | Commands::HfSearch { .. }
             | Commands::List { .. }
@@ -1590,6 +1641,7 @@ fn run_fit(
     csv: bool,
     overrides: &HardwareOverrides,
     context_limit: Option<u32>,
+    concurrency: bool,
 ) {
     let (specs, config) = detect_specs_and_config(overrides);
     let db = ModelDatabase::new();
@@ -1656,6 +1708,9 @@ fn run_fit(
             );
         }
         display::display_model_fits(&fits);
+        if concurrency {
+            print_concurrency_section(&fits, context_limit);
+        }
     }
 }
 
@@ -2621,6 +2676,187 @@ fn run_plan(
     Ok(())
 }
 
+fn fmt_context_short(tokens: u32) -> String {
+    if tokens % 1024 == 0 {
+        format!("{}k", tokens / 1024)
+    } else {
+        tokens.to_string()
+    }
+}
+
+/// Format a per-session memory figure for the capacity tables. Uses GB at two
+/// decimals at or above 0.01 GB, and MiB below that, so a sub-10-MiB KV cache
+/// (tiny models or short contexts) does not render as "0.00 GB" beside a large
+/// session count.
+fn fmt_gb_per_session(gb: f64) -> String {
+    if gb >= 0.01 {
+        format!("{gb:.2} GB")
+    } else {
+        format!("{:.1} MiB", gb * 1024.0)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_concurrency(
+    model_selector: &str,
+    quant: Option<String>,
+    kv_quant: Option<String>,
+    context: Option<u32>,
+    users: Option<u32>,
+    json: bool,
+    overrides: &HardwareOverrides,
+    context_limit: Option<u32>,
+) -> Result<(), String> {
+    if let Some(q) = quant.as_deref()
+        && !llmfit_core::models::quant_is_recognized(q)
+    {
+        return Err(format!(
+            "Unrecognized --quant '{q}'. Expected a known label such as Q4_K_M, Q6_K, Q8_0, or mlx-4bit (case-sensitive)."
+        ));
+    }
+    let db = ModelDatabase::new();
+    let (specs, _config) = detect_specs_and_config(overrides);
+    let model = resolve_model_selector(db.get_all_models(), model_selector)?;
+
+    let kv = match kv_quant {
+        Some(s) => llmfit_core::models::KvQuant::parse(&s).ok_or_else(|| {
+            format!(
+                "Unsupported --kv-quant '{}'. Valid: fp16, fp8, q8_0, q4_0, tq",
+                s
+            )
+        })?,
+        None => llmfit_core::models::KvQuant::Fp16,
+    };
+
+    let fit = ModelFit::analyze_with_context_limit(model, &specs, context_limit);
+    let quant = quant.unwrap_or_else(|| fit.best_quant.clone());
+    let pool = fit.memory_available_gb;
+
+    // Requested contexts stay as asked; estimate_concurrency clamps each to the
+    // effective ceiling (native window, and context_limit if set) while keeping
+    // the requested value and marking clamped rungs, so a global cap does not
+    // corrupt the structured requested-vs-effective metadata.
+    let contexts: Vec<u32> = match context {
+        Some(c) => vec![c],
+        None => llmfit_core::concurrency::DEFAULT_CONTEXT_LADDER.to_vec(),
+    };
+
+    let est = llmfit_core::concurrency::estimate_concurrency(
+        &fit.model,
+        pool,
+        &quant,
+        kv,
+        &contexts,
+        fit.run_mode,
+        context_limit,
+    );
+
+    if json {
+        let payload = serde_json::json!({
+            "model": fit.model.name,
+            "run_mode": format!("{:?}", fit.run_mode),
+            "fit_level": format!("{:?}", fit.fit_level),
+            "target_users": users,
+            "max_context_for_target": users.and_then(|u| est.max_context_for(u)),
+            "estimate": est,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload).map_err(|e| e.to_string())?
+        );
+        return Ok(());
+    }
+
+    specs.display();
+    println!();
+    println!("Concurrent-session capacity - {}", fit.model.name);
+    println!(
+        "  pool {:.1} GB | weights+overhead {:.1} GB resident | {:.1} GB for KV | quant {} | KV {}",
+        est.pool_gb,
+        est.weights_resident_gb,
+        est.kv_budget_gb,
+        est.quant,
+        est.kv_quant.label()
+    );
+    println!("  native context {}", fmt_context_short(est.native_context));
+    println!();
+    println!(
+        "  {:>9}  {:>5}  {:>13}  {:>8}",
+        "context", "clamp", "KV/session", "sessions"
+    );
+    let mut last_shown: Option<(u32, u32)> = None;
+    for slot in &est.ladder {
+        // Rungs above the native window all clamp to it and repeat the same
+        // row; print each distinct (context, sessions) pair once.
+        let key = (slot.effective_context, slot.max_sessions);
+        if last_shown == Some(key) {
+            continue;
+        }
+        last_shown = Some(key);
+        println!(
+            "  {:>9}  {:>5}  {:>13}  {:>8}",
+            fmt_context_short(slot.effective_context),
+            if slot.clamped { "clamp" } else { "" },
+            fmt_gb_per_session(slot.per_session_kv_gb),
+            slot.max_sessions
+        );
+    }
+    if let Some(u) = users {
+        println!();
+        match est.max_context_for(u) {
+            Some(c) => println!(
+                "  {} concurrent sessions fit up to a {} context.",
+                u,
+                fmt_context_short(c)
+            ),
+            None => println!(
+                "  {} concurrent sessions do not fit at any listed context.",
+                u
+            ),
+        }
+    }
+    println!();
+    println!("  Memory-capacity ceiling (sessions resident), not a throughput figure under load.");
+
+    Ok(())
+}
+
+fn print_concurrency_section(fits: &[ModelFit], context_limit: Option<u32>) {
+    if fits.is_empty() {
+        return;
+    }
+    println!();
+    // Clamp the reference context to a global cap so the density view never
+    // reports a context above --max-context / OLLAMA_CONTEXT_LENGTH.
+    let ref_ctx = context_limit.map_or(llmfit_core::fit::DEFAULT_ESTIMATION_CTX, |c| {
+        c.min(llmfit_core::fit::DEFAULT_ESTIMATION_CTX)
+    });
+    println!(
+        "Concurrent sessions at a {} context (fp16 KV, memory ceiling):",
+        fmt_context_short(ref_ctx)
+    );
+    for f in fits {
+        let est = llmfit_core::concurrency::estimate_concurrency(
+            &f.model,
+            f.memory_available_gb,
+            &f.best_quant,
+            llmfit_core::models::KvQuant::Fp16,
+            &[ref_ctx],
+            f.run_mode,
+            None,
+        );
+        let slot = &est.ladder[0];
+        println!(
+            "  {:<40} {:>4} @ {:>7}  ({}, {}/session)",
+            truncate_str(&f.model.name, 40),
+            slot.max_sessions,
+            fmt_context_short(slot.effective_context),
+            f.best_quant,
+            fmt_gb_per_session(slot.per_session_kv_gb)
+        );
+    }
+}
+
 // ── bench helpers ──────────────────────────────────────────────────────────
 
 fn target_info(target: &bench::BenchTarget) -> (&str, &str, &str) {
@@ -3466,6 +3702,7 @@ fn main() {
                 providers,
                 limit,
                 sort,
+                concurrency,
             } => {
                 run_fit(
                     perfect,
@@ -3477,6 +3714,7 @@ fn main() {
                     cli.csv,
                     &overrides,
                     context_limit,
+                    concurrency,
                 );
             }
 
@@ -3561,6 +3799,28 @@ fn main() {
                     &overrides,
                     context_limit,
                 );
+            }
+
+            Commands::Concurrency {
+                model,
+                quant,
+                kv_quant,
+                context,
+                users,
+            } => {
+                if let Err(err) = run_concurrency(
+                    &model,
+                    quant,
+                    kv_quant,
+                    context,
+                    users,
+                    cli.json,
+                    &overrides,
+                    context_limit,
+                ) {
+                    eprintln!("Error: {}", err);
+                    std::process::exit(1);
+                }
             }
 
             Commands::Plan {
@@ -3759,6 +4019,7 @@ fn main() {
             cli.csv,
             &overrides,
             context_limit,
+            cli.concurrency,
         );
         return;
     }
@@ -3955,6 +4216,15 @@ mod tests {
         assert_eq!(truncate_str("🚀 hello", 4), "🚀 h…");
         // Exact max length — no truncation
         assert_eq!(truncate_str("abc", 3), "abc");
+    }
+
+    #[test]
+    fn fmt_gb_per_session_keeps_small_values_visible() {
+        assert_eq!(fmt_gb_per_session(1.5), "1.50 GB");
+        assert_eq!(fmt_gb_per_session(0.01), "0.01 GB");
+        // Sub-10-MiB values must stay visible, not collapse to "0.00 GB".
+        assert_eq!(fmt_gb_per_session(0.0006), "0.6 MiB");
+        assert_eq!(fmt_gb_per_session(0.0), "0.0 MiB");
     }
 
     #[test]

--- a/llmfit-tui/tests/cli_smoke.rs
+++ b/llmfit-tui/tests/cli_smoke.rs
@@ -427,3 +427,73 @@ fn llama_cpp_path_flag_works_with_help() {
         .assert()
         .success();
 }
+
+#[test]
+fn concurrency_users_parser_rejects_zero() {
+    // Regression for PR #999 review: --users must be rejected at the CLI
+    // boundary when zero, not treated as a target that any context satisfies.
+    Command::cargo_bin("llmfit")
+        .expect("failed to locate llmfit test binary")
+        .args(["concurrency", "llama-3.1-8b", "--users", "0"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn concurrency_context_parser_rejects_zero() {
+    // Regression for PR #999 review: --context must be rejected at the CLI
+    // boundary when zero, not emitted as a zero-context ladder row.
+    Command::cargo_bin("llmfit")
+        .expect("failed to locate llmfit test binary")
+        .args(["concurrency", "llama-3.1-8b", "--context", "0"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn concurrency_rejects_unrecognized_quant() {
+    // Greptile P1: an unknown or mis-cased --quant must be rejected, not sized
+    // silently as Q4 with the requested label echoed back.
+    Command::cargo_bin("llmfit")
+        .expect("failed to locate llmfit test binary")
+        .args(["concurrency", "any-model", "--quant", "q8_0"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn concurrency_honors_global_context_cap() {
+    // Greptile P1: --max-context must clamp the concurrency ladder, not only the
+    // preliminary fit analysis.
+    let v = run_json_command(&[
+        "--memory",
+        "24",
+        "--max-context",
+        "8192",
+        "concurrency",
+        "Qwen/Qwen3-8B",
+        "--json",
+    ]);
+    let ladder = v["estimate"]["ladder"]
+        .as_array()
+        .expect("JSON output missing estimate.ladder");
+    assert!(!ladder.is_empty());
+    for slot in ladder {
+        let eff = slot["effective_context"]
+            .as_u64()
+            .expect("effective_context");
+        assert!(
+            eff <= 8192,
+            "ladder reports context {eff} above the 8192 cap"
+        );
+    }
+    // Requested values are preserved and over-cap rungs are marked clamped, so
+    // the cap does not corrupt the structured requested-vs-effective metadata.
+    assert!(
+        ladder
+            .iter()
+            .any(|s| s["requested_context"].as_u64().unwrap_or(0) > 8192
+                && s["clamped"].as_bool().unwrap_or(false)),
+        "expected an over-cap rung kept as requested and marked clamped"
+    );
+}


### PR DESCRIPTION
**Summary**
Adds a concurrent-session capacity estimate: how many simultaneous inference sessions of a model fit in a memory pool at a given context. It is the server planning counterpart to `usable_context`.

**Approach**
`sessions(ctx) = floor((pool - weights_resident) / per_session(ctx))`. `weights_resident` is the weight held in the pool for the run mode: `estimate_memory_gb(quant, 0)` (weights plus one time overhead) for a resident model, or only the active experts (`moe_active_vram_gb_at`) under MoE offload, so an offloaded MoE no longer reports zero sessions. `per_session` is the GQA and layout aware KV cache, plus a per session recurrent state term for hybrids (see below). Contexts run a doubling ladder (4k to 256k) or a single `--context`, clamped to the effective ceiling (native window, further capped by `--max-context` / `OLLAMA_CONTEXT_LENGTH`); `requested_context` keeps the asked value and `clamped` marks any rung the ceiling reduced.

**Two surfaces**
- `fit --concurrency` (and the global `--concurrency` default view): a density section under the fit table, at a fixed estimation context.
- `llmfit concurrency <model>`: `--quant`, `--kv-quant`, `--context`, `--users`, `--json`.

**Validation (measured)**
The KV term was checked against llama.cpp `llama_kv_cache` self size on an RX 7900 XT: exact match at 8k (512 MiB) and 16k (1024 MiB) on a hybrid Qwen3.5 class model (16 full attention of 64 layers, head_dim 256, 4 KV heads).

**Hybrid SSM handling**
Hybrid SSM and linear attention models hold a fixed size recurrent state per sequence (measured about 150 MiB), context independent, so it is charged per session rather than once. It is modeled as a coarse `linear_layers * hidden_size * C` estimate (C fitted to the measured hybrid), deliberately approximate, and zero for pure attention models. This corrects a concurrency overcount (about 23% at 8k) for those architectures.

**Quantization**
`--quant` is validated against the labels `quant_bpp` sizes, so an unknown or mis-cased value is rejected instead of silently falling to the 0.58 default. `quant_bpp` gains `AutoRound-4bit` (0.5) and `AutoRound-8bit` (1.0) at the AWQ/GPTQ scale, which also corrects fit's sizing of those models.

**Tests**
Hermetic: KV calibration, ladder monotonicity, native window clamp, tiny pool zero, coarse fallback without arch metadata, recurrent term calibration (about 150 MiB), recurrent reduces hybrid concurrency, a synthetic MoE fixture showing active-expert residency keeps sessions where full weight yields zero, and a context cap that clamps `effective_context` while preserving `requested_context`. CLI: `--users 0` and `--context 0` rejected at the parse boundary, unrecognized `--quant` rejected, `--max-context` honored by the ladder, and per-session formatting keeps sub-10-MiB values visible. `fmt` and `clippy` clean.

**Display**
The capacity table collapses ladder rungs that clamp to the same (context, sessions) pair, and formats per-session memory in MiB below 0.01 GB so small caches do not render as `0.00 GB`. JSON output and the estimate are unchanged.

**Limitations**
The recurrent term is an estimate, not exact per tensor accounting, and it only fires when a hybrid's layout resolves linear layers and `hidden_size` is known. SSM dims are not yet in the catalog. Under MoE offload, concurrency charges only the active experts, inheriting fit's own offload accounting (`moe_memory_for_quant`); fixed weights (attention, router, embeddings, shared experts) are not charged separately.

Closes #140