### PR TITLE
bench: community results for intel-raptor-lake-p-iris-xe-graphics-integrated

### DIFF
--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788615847-16a8beab.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788615847-16a8beab.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 1,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 140.0,
+      "avgTotalMs": 24085.62,
+      "avgTps": 6.45,
+      "avgTtftMs": 1749.04,
+      "maxTps": 6.45,
+      "minTps": 6.45,
+      "model": "qwen3-vl:2b",
+      "numRuns": 1,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788625494,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788615926-cbcc63b5.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788615926-cbcc63b5.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 181.0,
+      "avgTotalMs": 30681.35,
+      "avgTps": 6.38,
+      "avgTtftMs": 1792.31,
+      "maxTps": 6.38,
+      "minTps": 6.38,
+      "model": "qwen3-vl:2b",
+      "numRuns": 1,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788625494,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616145-972937a9.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616145-972937a9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 255.33,
+      "avgTotalMs": 42144.02,
+      "avgTps": 6.52,
+      "avgTtftMs": 2323.59,
+      "maxTps": 6.59,
+      "minTps": 6.47,
+      "model": "qwen3-vl:2b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788625494,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616233-c5ca7dda.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616233-c5ca7dda.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 128.0,
+      "avgTotalMs": 22658.29,
+      "avgTps": 6.43,
+      "avgTtftMs": 2136.39,
+      "maxTps": 6.43,
+      "minTps": 6.43,
+      "model": "qwen3-vl:2b",
+      "numRuns": 1,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788625494,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616313-dd73bf7a.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616313-dd73bf7a.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 142.0,
+      "avgTotalMs": 24169.7,
+      "avgTps": 6.53,
+      "avgTtftMs": 1860.51,
+      "maxTps": 6.53,
+      "minTps": 6.53,
+      "model": "qwen3-vl:2b",
+      "numRuns": 1,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788625494,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616409-b6898083.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616409-b6898083.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 51838.29,
+      "avgTps": 6.07,
+      "avgTtftMs": 1880.14,
+      "maxTps": 6.07,
+      "minTps": 6.07,
+      "model": "qwen3-vl:2b",
+      "numRuns": 1,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788625494,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616506-6d5f1ec3.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616506-6d5f1ec3.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 167.0,
+      "avgTotalMs": 28435.46,
+      "avgTps": 6.4,
+      "avgTtftMs": 1755.94,
+      "maxTps": 6.4,
+      "minTps": 6.4,
+      "model": "qwen3-vl:2b",
+      "numRuns": 1,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788625494,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616712-259c75d0.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788616712-259c75d0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 49913.08,
+      "avgTps": 6.39,
+      "avgTtftMs": 2387.1,
+      "maxTps": 6.42,
+      "minTps": 6.34,
+      "model": "qwen3-vl:2b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788625494,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788626088-847c41c5.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788626088-847c41c5.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 251.67,
+      "avgTotalMs": 81464.57,
+      "avgTps": 3.37,
+      "avgTtftMs": 5289.77,
+      "maxTps": 3.49,
+      "minTps": 3.29,
+      "model": "granite4.2:3b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788626429-ab21e745.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788626429-ab21e745.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 185.0,
+      "avgTotalMs": 78067.29,
+      "avgTps": 2.66,
+      "avgTtftMs": 8011.38,
+      "maxTps": 2.72,
+      "minTps": 2.62,
+      "model": "phi3:mini",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788626706-f813113a.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788626706-f813113a.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 145.67,
+      "avgTotalMs": 54840.31,
+      "avgTps": 2.95,
+      "avgTtftMs": 4381.54,
+      "maxTps": 3.03,
+      "minTps": 2.9,
+      "model": "phi4-mini:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788627189-45b0e05c.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788627189-45b0e05c.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 211.0,
+      "avgTotalMs": 83858.34,
+      "avgTps": 2.74,
+      "avgTtftMs": 5005.78,
+      "maxTps": 2.85,
+      "minTps": 2.67,
+      "model": "ministral-3:3b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788627707-a23fb202.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788627707-a23fb202.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 283.0,
+      "avgTotalMs": 111910.41,
+      "avgTps": 2.72,
+      "avgTtftMs": 6954.58,
+      "maxTps": 2.75,
+      "minTps": 2.69,
+      "model": "huihui_ai/qwen3.5-abliterated:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788628510-8c07f618.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788628510-8c07f618.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 296.67,
+      "avgTotalMs": 191599.47,
+      "avgTps": 1.65,
+      "avgTtftMs": 11027.12,
+      "maxTps": 1.66,
+      "minTps": 1.64,
+      "model": "qwen3:8b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788629456-65753740.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788629456-65753740.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 207837.5,
+      "avgTps": 1.55,
+      "avgTtftMs": 12885.44,
+      "maxTps": 1.57,
+      "minTps": 1.52,
+      "model": "huihui_ai/qwen3.5-abliterated:9b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788630394-e708115e.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788630394-e708115e.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 208068.19,
+      "avgTps": 1.55,
+      "avgTtftMs": 13032.85,
+      "maxTps": 1.55,
+      "minTps": 1.54,
+      "model": "metatron-qwen:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788631432-08871ec1.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788631432-08871ec1.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 297.33,
+      "avgTotalMs": 224852.42,
+      "avgTps": 1.39,
+      "avgTtftMs": 9926.11,
+      "maxTps": 1.4,
+      "minTps": 1.38,
+      "model": "deepseek-r1:8b-0528-qwen3-q8_0",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788632708-a89c0e7e.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788632708-a89c0e7e.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 81.0,
+      "avgTotalMs": 196776.31,
+      "avgTps": 0.47,
+      "avgTtftMs": 24275.21,
+      "maxTps": 0.47,
+      "minTps": 0.47,
+      "model": "phi4:latest",
+      "numRuns": 1,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788642097-4d0b1aa2.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788642097-4d0b1aa2.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 211.33,
+      "avgTotalMs": 32459.54,
+      "avgTps": 7.1,
+      "avgTtftMs": 2252.57,
+      "maxTps": 7.14,
+      "minTps": 7.08,
+      "model": "qwen2.5:1.5b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788642372-658f5bf7.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788642372-658f5bf7.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 198.67,
+      "avgTotalMs": 56104.04,
+      "avgTps": 3.89,
+      "avgTtftMs": 4108.12,
+      "maxTps": 3.96,
+      "minTps": 3.76,
+      "model": "qwen2.5-coder:3b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788643332-b0186686.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788643332-b0186686.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 290.0,
+      "avgTotalMs": 138546.96,
+      "avgTps": 2.27,
+      "avgTtftMs": 10228.89,
+      "maxTps": 2.29,
+      "minTps": 2.26,
+      "model": "nemotron-3-nano:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788644098-2c4f2e99.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788644098-2c4f2e99.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 2,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 121484.35,
+      "avgTps": 2.65,
+      "avgTtftMs": 7155.66,
+      "maxTps": 2.72,
+      "minTps": 2.58,
+      "model": "qwen3.5:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788644707,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788588804-e8262005.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788588804-e8262005.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 169.67,
+      "avgTotalMs": 18974.94,
+      "avgTps": 9.52,
+      "avgTtftMs": 514.81,
+      "maxTps": 9.91,
+      "minTps": 9.22,
+      "model": "qwen2.5-coder:3b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788589895,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788589320-ccd44d63.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788589320-ccd44d63.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 185.0,
+      "avgTotalMs": 70673.17,
+      "avgTps": 3.18,
+      "avgTtftMs": 4608.06,
+      "maxTps": 5.31,
+      "minTps": 1.78,
+      "model": "qwen3-coder:30b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788589895,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788589831-44e1d823.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788589831-44e1d823.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 184.33,
+      "avgTotalMs": 65997.89,
+      "avgTps": 3.21,
+      "avgTtftMs": 5423.43,
+      "maxTps": 3.48,
+      "minTps": 2.8,
+      "model": "qwen3-coder:30b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788589895,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788590146-000e6321.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788590146-000e6321.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 255.0,
+      "avgTotalMs": 39612.38,
+      "avgTps": 7.32,
+      "avgTtftMs": 3562.84,
+      "maxTps": 7.83,
+      "minTps": 6.6,
+      "model": "gpt-oss-20b-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788590168,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788590671-2c9139d9.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788590671-2c9139d9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 231.0,
+      "avgTotalMs": 79604.12,
+      "avgTps": 3.1,
+      "avgTtftMs": 3471.01,
+      "maxTps": 3.24,
+      "minTps": 2.85,
+      "model": "phi4-latest-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788594922-20cd726b.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788594922-20cd726b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 87874.45,
+      "avgTps": 3.58,
+      "avgTtftMs": 3357.82,
+      "maxTps": 3.68,
+      "minTps": 3.49,
+      "model": "gemma4-12b-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595165-1fabdd1e.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595165-1fabdd1e.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 268.0,
+      "avgTotalMs": 64563.1,
+      "avgTps": 4.66,
+      "avgTtftMs": 6626.15,
+      "maxTps": 5.26,
+      "minTps": 4.2,
+      "model": "gpt-oss-20b-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595252-e718baed.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595252-e718baed.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 242.33,
+      "avgTotalMs": 24955.73,
+      "avgTps": 10.03,
+      "avgTtftMs": 974.02,
+      "maxTps": 11.61,
+      "minTps": 8.71,
+      "model": "granite4-2-3b-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595514-8fbaa398.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595514-8fbaa398.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 62010.03,
+      "avgTps": 5.04,
+      "avgTtftMs": 1886.72,
+      "maxTps": 5.06,
+      "minTps": 5.02,
+      "model": "huihui_ai-qwen3-5-abliterated-9b-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595602-cc6d9b9f.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595602-cc6d9b9f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 269.0,
+      "avgTotalMs": 21067.76,
+      "avgTps": 14.11,
+      "avgTtftMs": 1203.17,
+      "maxTps": 16.91,
+      "minTps": 11.62,
+      "model": "lfm2-5-8b-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595694-795fea1b.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595694-795fea1b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 114.33,
+      "avgTotalMs": 22603.85,
+      "avgTps": 5.43,
+      "avgTtftMs": 1374.7,
+      "maxTps": 5.69,
+      "minTps": 4.98,
+      "model": "llama3-groq-tool-use-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595827-84cd2687.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595827-84cd2687.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 187.0,
+      "avgTotalMs": 33354.52,
+      "avgTps": 5.87,
+      "avgTtftMs": 1285.82,
+      "maxTps": 6.04,
+      "minTps": 5.59,
+      "model": "llama3-1-8b-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595937-49f17e87.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788595937-49f17e87.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 246.0,
+      "avgTotalMs": 33505.41,
+      "avgTps": 7.58,
+      "avgTtftMs": 1336.22,
+      "maxTps": 8.54,
+      "minTps": 5.98,
+      "model": "nemotron-3-nano-4b-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596108-ca246f43.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596108-ca246f43.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 200.67,
+      "avgTotalMs": 44755.34,
+      "avgTps": 4.8,
+      "avgTtftMs": 2523.11,
+      "maxTps": 4.81,
+      "minTps": 4.8,
+      "model": "ornith-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596148-afdf37b5.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596148-afdf37b5.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 222.33,
+      "avgTotalMs": 12201.81,
+      "avgTps": 20.46,
+      "avgTtftMs": 348.24,
+      "maxTps": 23.82,
+      "minTps": 18.03,
+      "model": "qwen2-5-1-5b-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596266-7fd34c50.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596266-7fd34c50.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 195.33,
+      "avgTotalMs": 34859.18,
+      "avgTps": 5.75,
+      "avgTtftMs": 1854.01,
+      "maxTps": 6.32,
+      "minTps": 4.89,
+      "model": "qwen2-5-7b-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596438-d1a3d4fa.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596438-d1a3d4fa.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 38140.05,
+      "avgTps": 8.18,
+      "avgTtftMs": 908.92,
+      "maxTps": 8.29,
+      "minTps": 8.1,
+      "model": "qwen3-5-4b-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596725-76d324e4.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596725-76d324e4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 69162.4,
+      "avgTps": 4.54,
+      "avgTtftMs": 2543.63,
+      "maxTps": 4.58,
+      "minTps": 4.52,
+      "model": "qwen3-5-9b-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596968-11fb336f.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788596968-11fb336f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 283.33,
+      "avgTotalMs": 57109.38,
+      "avgTps": 5.15,
+      "avgTtftMs": 1792.29,
+      "maxTps": 5.25,
+      "minTps": 4.95,
+      "model": "qwen3-8b-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788597093-dad514d5.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788597093-dad514d5.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 110.0,
+      "avgTotalMs": 24727.47,
+      "avgTps": 4.88,
+      "avgTtftMs": 1683.94,
+      "maxTps": 4.9,
+      "minTps": 4.86,
+      "model": "rnj-1-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788597236-6b2bad06.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788597236-6b2bad06.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 271.0,
+      "avgTotalMs": 40129.57,
+      "avgTps": 7.18,
+      "avgTtftMs": 1953.49,
+      "maxTps": 7.33,
+      "minTps": 6.91,
+      "model": "gemma4-latest-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616113-05d11579.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616113-05d11579.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 163.33,
+      "avgTotalMs": 10132.92,
+      "avgTps": 17.12,
+      "avgTtftMs": 408.34,
+      "maxTps": 17.7,
+      "minTps": 16.8,
+      "model": "qwen2-5-coder-3b-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616290-b22c8fa6.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616290-b22c8fa6.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 256.33,
+      "avgTotalMs": 22275.38,
+      "avgTps": 12.2,
+      "avgTtftMs": 1002.16,
+      "maxTps": 12.48,
+      "minTps": 11.78,
+      "model": "phi3-mini-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616444-93a71311.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616444-93a71311.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 223.33,
+      "avgTotalMs": 18604.31,
+      "avgTps": 12.41,
+      "avgTtftMs": 360.47,
+      "maxTps": 12.88,
+      "minTps": 12.1,
+      "model": "ministral-3-3b-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616602-66d45aaf.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616602-66d45aaf.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 219.67,
+      "avgTotalMs": 20769.83,
+      "avgTps": 10.86,
+      "avgTtftMs": 378.81,
+      "maxTps": 11.42,
+      "minTps": 10.42,
+      "model": "phi4-mini-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616792-39d9427d.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788616792-39d9427d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 169.0,
+      "avgTotalMs": 30218.5,
+      "avgTps": 5.65,
+      "avgTtftMs": 575.97,
+      "maxTps": 5.93,
+      "minTps": 5.33,
+      "model": "glm4-9b-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788617045-591d2440.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788617045-591d2440.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 251.0,
+      "avgTotalMs": 41311.15,
+      "avgTps": 6.3,
+      "avgTtftMs": 1054.41,
+      "maxTps": 6.41,
+      "minTps": 6.23,
+      "model": "deepseek-r1-8b-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788617320-deead0c0.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788617320-deead0c0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 218.33,
+      "avgTotalMs": 53969.78,
+      "avgTps": 4.11,
+      "avgTtftMs": 1690.87,
+      "maxTps": 4.33,
+      "minTps": 3.7,
+      "model": "gemma3-12b-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788617493-8bb3b979.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788617493-8bb3b979.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 219.67,
+      "avgTotalMs": 18202.69,
+      "avgTps": 12.65,
+      "avgTtftMs": 1577.16,
+      "maxTps": 13.94,
+      "minTps": 10.12,
+      "model": "deepseek-v2-16b-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788617818-5a08d77c.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788617818-5a08d77c.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 239.33,
+      "avgTotalMs": 69515.87,
+      "avgTps": 3.58,
+      "avgTtftMs": 2967.77,
+      "maxTps": 3.66,
+      "minTps": 3.43,
+      "model": "phi4-latest-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788622560,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788636444-3014cefc.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788636444-3014cefc.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 52902.12,
+      "avgTps": 5.84,
+      "avgTtftMs": 907.35,
+      "maxTps": 6.23,
+      "minTps": 5.31,
+      "model": "deepseek-agent-latest-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788636574,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen2.5-coder:3b | ollama | 9.5 | 514.8 |
| qwen3-coder:30b | ollama | 3.2 | 4608.1 |
| qwen3-coder:30b | ollama | 3.2 | 5423.4 |

_Submitted without the `gh` CLI via the GitHub device flow._
