### PR TITLE
Feat/974 tui confidence prefill

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -64,13 +64,15 @@ The scoring model, speed estimation, and the model database.
 
    **Confidence** -- A measured throughput and a formula guess are both "tok/s", so every fit carries an `estimate_confidence` saying which it is. First match wins:
 
-   | Confidence           | Meaning                                                        |
-   |----------------------|----------------------------------------------------------------|
-   | `measured_local`     | Benchmarked by you on this machine (`llmfit bench`)            |
-   | `measured_community` | Benchmarked by others on hardware matching this machine        |
-   | `calibrated`         | Formula, scaled by a factor derived from runs on this hardware |
-   | `estimated`          | Formula only, with no measurement behind it                    |
-   | `unsupported`        | No estimate -- the model needs a runtime llmfit can't model    |
+   | Confidence           | Table | Meaning                                                        |
+   |----------------------|-------|----------------------------------------------------------------|
+   | `measured_local`     | local | Benchmarked by you on this machine (`llmfit bench`)            |
+   | `measured_community` | comm  | Benchmarked by others on hardware matching this machine        |
+   | `calibrated`         | calib | Formula, scaled by a factor derived from runs on this hardware |
+   | `estimated`          | est   | Formula only, with no measurement behind it                    |
+   | `unsupported`        | n/a   | No estimate -- the model needs a runtime llmfit can't model    |
+
+   The `Table` column is what the CLI fit table's `Conf` column prints; the detail views (`llmfit fit <model>` and the TUI detail pane) print the full name.
 
 6. **Fit analysis** -- Each model is evaluated for memory compatibility:
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -72,7 +72,7 @@ The scoring model, speed estimation, and the model database.
    | `estimated`          | est   | Formula only, with no measurement behind it                    |
    | `unsupported`        | n/a   | No estimate -- the model needs a runtime llmfit can't model    |
 
-   The `Table` column is what the CLI fit table's `Conf` column prints; the detail views (`llmfit fit <model>` and the TUI detail pane) print the full name.
+   The `Table` column is what the CLI fit table's `Conf` column prints; the detail views (`llmfit info <model>` and the TUI detail pane) print the full name.
 
 6. **Fit analysis** -- Each model is evaluated for memory compatibility:
 

--- a/llmfit-core/src/fit.rs
+++ b/llmfit-core/src/fit.rs
@@ -290,6 +290,24 @@ impl EstimateConfidence {
             EstimateConfidence::Unsupported => "unsupported — no basis",
         }
     }
+
+    /// Compact code for width-constrained surfaces such as the CLI table
+    /// column, where [`EstimateConfidence::label`] would wrap the row on a
+    /// narrow terminal (issue #974).
+    ///
+    /// Display-only. [`EstimateConfidence::code`] remains the stable machine
+    /// identifier and [`EstimateConfidence::label`] the full human label; both
+    /// ship in the API/MCP JSON and neither may change. Detail views should
+    /// keep using `label()`.
+    pub fn short_label(&self) -> &'static str {
+        match self {
+            EstimateConfidence::MeasuredLocal => "local",
+            EstimateConfidence::MeasuredCommunity => "comm",
+            EstimateConfidence::Calibrated => "calib",
+            EstimateConfidence::Estimated => "est",
+            EstimateConfidence::Unsupported => "n/a",
+        }
+    }
 }
 
 /// Classify a fit's throughput figure by provenance, first match wins.
@@ -5058,6 +5076,64 @@ mod tests {
                 "serde representation must match code()"
             );
         }
+    }
+
+    #[test]
+    fn estimate_confidence_short_labels_stay_table_narrow() {
+        // The CLI table column is sized by its widest cell. `label()` peaks at
+        // 23 columns ("measured (this machine)"), which wraps the row on an
+        // 80-column terminal (issue #974). The short form caps the column at
+        // the 4-column "Conf" header instead.
+        for variant in [
+            EstimateConfidence::MeasuredLocal,
+            EstimateConfidence::MeasuredCommunity,
+            EstimateConfidence::Calibrated,
+            EstimateConfidence::Estimated,
+            EstimateConfidence::Unsupported,
+        ] {
+            let short = variant.short_label();
+            assert!(
+                !short.is_empty() && short.len() <= 5,
+                "{short:?} must be 1-5 columns to keep the table narrow"
+            );
+            assert!(
+                short.is_ascii(),
+                "{short:?} must be ASCII \u{2014} this column renders in Windows terminals"
+            );
+        }
+    }
+
+    #[test]
+    fn estimate_confidence_short_labels_are_distinct() {
+        // A table cell is the only confidence signal in the row, so two
+        // confidences must never collapse to the same code.
+        let shorts = [
+            EstimateConfidence::MeasuredLocal.short_label(),
+            EstimateConfidence::MeasuredCommunity.short_label(),
+            EstimateConfidence::Calibrated.short_label(),
+            EstimateConfidence::Estimated.short_label(),
+            EstimateConfidence::Unsupported.short_label(),
+        ];
+        let unique: std::collections::HashSet<&str> = shorts.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            shorts.len(),
+            "short labels collide: {shorts:?}"
+        );
+    }
+
+    #[test]
+    fn estimate_confidence_short_labels_do_not_disturb_the_api_contract() {
+        // `code()` ships as `estimate_confidence` and `label()` as
+        // `estimate_confidence_label` in the API/MCP JSON. `short_label()` is
+        // display-only and additive: it must not become a third spelling that
+        // callers mistake for either.
+        assert_eq!(EstimateConfidence::MeasuredLocal.code(), "measured_local");
+        assert_eq!(
+            EstimateConfidence::MeasuredLocal.label(),
+            "measured (this machine)"
+        );
+        assert_eq!(EstimateConfidence::MeasuredLocal.short_label(), "local");
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/llmfit-tui/src/display.rs
+++ b/llmfit-tui/src/display.rs
@@ -24,7 +24,7 @@ struct ModelRow {
     tps: String,
     #[tabled(rename = "Quant")]
     quant: String,
-    #[tabled(rename = "Confidence")]
+    #[tabled(rename = "Conf")]
     confidence: String,
     #[tabled(rename = "Runtime")]
     runtime: String,
@@ -36,6 +36,16 @@ struct ModelRow {
     context: String,
     #[tabled(rename = "Added to HF")]
     release_date: String,
+}
+
+/// Confidence cell for the fit table.
+///
+/// The table uses the short code so the column stays narrow on an 80-column
+/// terminal; the full label lives in the detail view below (issue #974).
+/// Derived rather than read from `fit.estimate_confidence`, which is stale
+/// unless its writer called `refresh_estimate_confidence` (issue #969).
+fn confidence_cell(fit: &ModelFit) -> &'static str {
+    fit.effective_estimate_confidence().short_label()
 }
 
 pub fn display_all_models(models: &[LlmModel], sort: SortColumn) {
@@ -132,7 +142,7 @@ pub fn display_model_fits(fits: &[ModelFit]) {
                     None => format!("{:.1}", fit.estimated_tps),
                 },
                 quant: display_best_quant(fit).to_string(),
-                confidence: fit.effective_estimate_confidence().label().to_string(),
+                confidence: confidence_cell(fit).to_string(),
                 runtime: fit.runtime_text().to_string(),
                 mode: fit.run_mode_text().to_string(),
                 mem_use: format!("{:.1}%", fit.utilization_pct),
@@ -1261,5 +1271,51 @@ mod tests {
         let fit = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
 
         assert_eq!(display_best_quant(&fit), "Q4_K_M");
+    }
+
+    #[test]
+    fn table_confidence_cell_uses_the_short_code_not_the_full_label() {
+        use llmfit_core::benchmarks::{MeasuredSource, MeasuredTps};
+
+        // Estimated: nothing measured, nothing calibrated.
+        let mut fit = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
+        assert_eq!(confidence_cell(&fit), "est");
+
+        // Calibrated: a local calibration factor, still no measurement.
+        fit.estimate_basis.local_calibration = Some(1.2);
+        assert_eq!(confidence_cell(&fit), "calib");
+
+        // Measured beats calibrated, and is the case that used to render the
+        // 23-column "measured (this machine)" that wrapped the row (#974).
+        fit.measured_tps = Some(MeasuredTps {
+            tok_s: 42.0,
+            sample_count: 3,
+            hardware_label: "this machine".to_string(),
+            source: MeasuredSource::LocalBench,
+        });
+        assert_eq!(confidence_cell(&fit), "local");
+    }
+
+    #[test]
+    fn table_confidence_cell_reads_through_the_stale_stored_field() {
+        use llmfit_core::benchmarks::{MeasuredSource, MeasuredTps};
+
+        // `estimate_confidence` is only correct if every writer remembered to
+        // call refresh_estimate_confidence(); the table must derive it instead,
+        // or it prints "est" beside a measured tok/s figure (issue #969).
+        let mut fit = mock_fit(RunMode::Gpu, UseCase::Chat, "chat");
+        fit.measured_tps = Some(MeasuredTps {
+            tok_s: 42.0,
+            sample_count: 3,
+            hardware_label: "this machine".to_string(),
+            source: MeasuredSource::LocalBench,
+        });
+        // Deliberately left stale — no refresh_estimate_confidence() call.
+        assert_eq!(
+            fit.estimate_confidence,
+            llmfit_core::EstimateConfidence::Estimated
+        );
+
+        assert_eq!(confidence_cell(&fit), "local");
     }
 }

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -1786,6 +1786,30 @@ fn truncate_str(s: &str, max_len: usize) -> String {
     }
 }
 
+/// Prompt-processing rows for the detail pane, as `(label, value)` pairs with
+/// the label already padded to the pane's 15-column gutter.
+///
+/// The CLI prints this as one 78-column sentence (`display.rs`), but the detail
+/// pane is only 55% of the terminal — 42 columns at 80, of which the gutter
+/// takes 15. One fact per row keeps every value inside that budget and matches
+/// the rest of the pane (issue #974).
+///
+/// Both figures come from `gpu_compute_tflops_fp16` together, so a missing half
+/// means the pair is unknown. That collapses to a single "not estimated" row
+/// rather than a zero, which would read as "immeasurably slow" (issue #969).
+fn prefill_detail_rows(
+    prefill_tps: Option<f64>,
+    ttft_ms: Option<f64>,
+) -> Vec<(&'static str, String)> {
+    match (prefill_tps, ttft_ms) {
+        (Some(prefill), Some(ttft)) => vec![
+            ("  Prefill:     ", format!("~{prefill:.0} tok/s")),
+            ("  TTFT:        ", format!("~{ttft:.0} ms")),
+        ],
+        _ => vec![("  Prefill:     ", "not estimated".to_string())],
+    }
+}
+
 fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     let fit = match app.selected_fit() {
         Some(f) => f,
@@ -1969,7 +1993,30 @@ fn draw_detail(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
                 Style::default().fg(tc.fg),
             ),
         ]),
+        // The full label, matching the CLI's `Estimate Basis:` block. The fit
+        // table carries the short code instead (issue #974). Derived, not read
+        // from the stale `estimate_confidence` field (issue #969).
+        Line::from(vec![
+            Span::styled("  Confidence:  ", Style::default().fg(tc.muted)),
+            Span::styled(
+                fit.effective_estimate_confidence().label(),
+                Style::default().fg(tc.fg),
+            ),
+        ]),
     ]);
+
+    // The CLI stops its Estimate Basis block right after Confidence when there
+    // is no estimate left to qualify (display.rs); mirror that here rather than
+    // printing a prefill line under a model that has no throughput estimate.
+    if fit.estimate_basis.method != llmfit_core::fit::UNSUPPORTED_METHOD && fit.estimated_tps > 0.0
+    {
+        for (label, value) in prefill_detail_rows(fit.prefill_tps, fit.ttft_ms) {
+            lines.push(Line::from(vec![
+                Span::styled(label, Style::default().fg(tc.muted)),
+                Span::styled(value, Style::default().fg(tc.fg)),
+            ]));
+        }
+    }
 
     // MoE Architecture section
     if fit.model.is_moe {
@@ -5858,5 +5905,88 @@ mod tests {
             visible_dm_dir_input(input, input.len(), (DM_MODELS_DIR_LABEL.len() + 8) as u16),
             ("二三四".to_string(), 6)
         );
+    }
+
+    /// Width of the detail pane's label gutter, e.g. `"  Baseline Est:"`.
+    const DETAIL_LABEL_WIDTH: usize = 15;
+
+    /// The left detail pane is 55% of the terminal minus 2 border columns. On
+    /// an 80-column terminal that is 42, leaving 27 columns for a value.
+    const NARROW_DETAIL_VALUE_WIDTH: usize = (80 * 55 / 100) - 2 - DETAIL_LABEL_WIDTH;
+
+    #[test]
+    fn prefill_detail_rows_report_both_figures_when_estimated() {
+        let rows = prefill_detail_rows(Some(512.0), Some(16.0));
+        assert_eq!(
+            rows.len(),
+            2,
+            "expected a prefill row and a TTFT row: {rows:?}"
+        );
+        assert!(rows[0].0.contains("Prefill"), "row 0 mislabelled: {rows:?}");
+        assert!(
+            rows[0].1.contains("512"),
+            "prefill throughput missing: {rows:?}"
+        );
+        assert!(rows[1].0.contains("TTFT"), "row 1 mislabelled: {rows:?}");
+        assert!(rows[1].1.contains("16"), "TTFT value missing: {rows:?}");
+    }
+
+    #[test]
+    fn prefill_detail_rows_say_not_estimated_when_either_figure_is_missing() {
+        // Mirrors display.rs: prefill and TTFT are computed together from
+        // gpu_compute_tflops_fp16, so a half-populated pair is still "unknown",
+        // never a zero that would read as "immeasurably slow" (issue #969).
+        for (prefill, ttft) in [(None, None), (Some(512.0), None), (None, Some(16.0))] {
+            let rows = prefill_detail_rows(prefill, ttft);
+            assert_eq!(rows.len(), 1, "unknown prefill needs one row: {rows:?}");
+            assert_eq!(rows[0].1, "not estimated");
+        }
+    }
+
+    #[test]
+    fn prefill_detail_rows_fit_a_narrow_detail_pane() {
+        // The full CLI sentence is 78 columns and would wrap here, which is
+        // half of what issue #974 is about. Check implausibly large values, so
+        // the budget holds for anything real hardware can produce.
+        for (prefill, ttft) in [
+            (Some(99_999.0), Some(99_999.0)),
+            (Some(512.0), Some(16.0)),
+            (None, None),
+        ] {
+            for (label, value) in prefill_detail_rows(prefill, ttft) {
+                assert_eq!(
+                    label.chars().count(),
+                    DETAIL_LABEL_WIDTH,
+                    "{label:?} must fill the label gutter so the pane stays aligned"
+                );
+                assert!(
+                    value.chars().count() <= NARROW_DETAIL_VALUE_WIDTH,
+                    "{value:?} is {} columns, over the {NARROW_DETAIL_VALUE_WIDTH} \
+                     available in an 80-column terminal",
+                    value.chars().count()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn confidence_labels_fit_a_narrow_detail_pane() {
+        // The detail pane carries the full label (the table carries the short
+        // code), so the widest label must still fit the narrow pane.
+        for variant in [
+            llmfit_core::EstimateConfidence::MeasuredLocal,
+            llmfit_core::EstimateConfidence::MeasuredCommunity,
+            llmfit_core::EstimateConfidence::Calibrated,
+            llmfit_core::EstimateConfidence::Estimated,
+            llmfit_core::EstimateConfidence::Unsupported,
+        ] {
+            let label = variant.label();
+            assert!(
+                label.chars().count() <= NARROW_DETAIL_VALUE_WIDTH,
+                "{label:?} is {} columns, over the {NARROW_DETAIL_VALUE_WIDTH} \
+                 available in an 80-column terminal",
+                label.chars().count()
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #974

## What

Two changes, matching the scope agreed in the issue:

1. **TUI detail pane** now shows `Confidence:` (full label) plus conditional `Prefill:` / `TTFT:` rows under `Baseline Est:`, mirroring the CLI's `Estimate Basis:` block from #971.
2. **CLI fit table** Confidence column now prints a short code under a `Conf` header instead of the full label.

## Why

Per the issue and the maintainer's note: the table should stay compact on narrow terminals while the detail pane carries the full label and prefill/TTFT context.

The table column was sized by its widest cell — `measured (this machine)` at 23 columns — which wrapped rows on an 80-column terminal. It is now capped at 5.

The CLI's prefill sentence is 78 columns, and the TUI detail pane is 42 on an 80-column terminal — 27 after the label gutter. Folding both figures onto one line does not fit that budget at high-end values, so prefill and TTFT get a row each, matching the rest of the pane. Both rows are omitted for fits with no throughput estimate, which is where the CLI stops its own block.

## Narrow-width coverage

`prefill_detail_rows` returns plain `(label, value)` pairs rather than ratatui widgets, so it is asserted on directly, in the style of this file's existing `provider_cell` / `truncate_str` tests:

- `prefill_detail_rows_fit_a_narrow_detail_pane` — asserts every value fits the 27-column budget and every label fills the 15-column gutter, at values well past what real hardware produces
- `confidence_labels_fit_a_narrow_detail_pane` — same for the full labels the pane now shows
- `estimate_confidence_short_labels_stay_table_narrow` — caps the table codes at 5 ASCII columns
- `estimate_confidence_short_labels_are_distinct` — no two confidences collapse to one code

I also drove the built TUI in an 80-column terminal to confirm the detail pane renders without wrapping, and eyeballed the CLI table's new `Conf` column.

## API compatibility

`EstimateConfidence::code()` and `label()` are untouched — they ship as `estimate_confidence` and `estimate_confidence_label` in the API/MCP JSON, and their existing pinning tests still pass. `short_label()` is additive and display-only.

Both new call sites derive confidence via `effective_estimate_confidence()` rather than the stored field, per #969.

## Open questions for the maintainer

1. **Placement.** The TUI has no `Estimate Basis` section; this PR puts the two new lines at the end of `Score Breakdown`, right under `Baseline Est:` — the number they qualify. Happy to pull them into a dedicated `── Estimate Basis ──` section if you'd rather mirror the CLI's structure more literally.
2. **Code spelling.** `local` / `comm` / `calib` / `est` / `n/a`. If you'd prefer the serde codes truncated, or symbols (`✓` / `~`), it's a one-line change in `short_label()`.
3. **Header rename.** `Confidence` → `Conf` saves 6 more columns. If anything scrapes the CLI table's header text, let me know and I'll keep the header while shrinking just the cells.