### PR TITLE
bench: community results for intel-raptor-lake-p-iris-xe-graphics-integrated

### DIFF
--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788753837-c7d76608.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788753837-c7d76608.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 1,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 260.0,
+      "avgTotalMs": 97776.03,
+      "avgTps": 2.89,
+      "avgTtftMs": 7033.16,
+      "maxTps": 2.91,
+      "minTps": 2.85,
+      "model": "qwen3.5-4b-super-coder:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788757281,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788754352-b4891a4f.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788754352-b4891a4f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 1,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 100052.78,
+      "avgTps": 3.21,
+      "avgTtftMs": 5862.61,
+      "maxTps": 3.22,
+      "minTps": 3.21,
+      "model": "qwen3.5-4b-agentic-coder-v4:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788757281,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788754915-1021444d.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788754915-1021444d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 1,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 179.67,
+      "avgTotalMs": 88782.08,
+      "avgTps": 2.26,
+      "avgTtftMs": 7799.29,
+      "maxTps": 2.33,
+      "minTps": 2.2,
+      "model": "qwen2.5-coder:7b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788757281,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788755149-bfec0f86.json
+++ b/llmfit-core/data/community/intel-3rd-gen-core-processor-graphics-controller-integrated/1788755149-bfec0f86.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz",
+    "cpuCores": 4,
+    "gpuCount": 1,
+    "hardwareName": "Intel 3rd Gen Core processor Graphics Controller (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 15.52,
+    "unifiedMemory": true,
+    "vramGb": 15.52
+  },
+  "results": [
+    {
+      "avgOutputTokens": 253.33,
+      "avgTotalMs": 35622.16,
+      "avgTps": 7.8,
+      "avgTtftMs": 2396.4,
+      "maxTps": 8.2,
+      "minTps": 7.59,
+      "model": "lfm25-8b-a1b-coder:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788757281,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788708749-3d65cd31.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788708749-3d65cd31.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 66.33,
+      "avgTotalMs": 9976.74,
+      "avgTps": 7.64,
+      "avgTtftMs": 1125.53,
+      "maxTps": 7.82,
+      "minTps": 7.42,
+      "model": "granite-4-1-3b-coder-latest-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788718163,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788708993-6d7c30fe.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788708993-6d7c30fe.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 67048.98,
+      "avgTps": 4.65,
+      "avgTtftMs": 1772.49,
+      "maxTps": 4.96,
+      "minTps": 4.32,
+      "model": "qwen3-5-4b-agentic-coder-latest-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788718163,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788709719-9cbf627d.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788709719-9cbf627d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 75.33,
+      "avgTotalMs": 11557.53,
+      "avgTps": 7.51,
+      "avgTtftMs": 1120.77,
+      "maxTps": 8.02,
+      "minTps": 7.18,
+      "model": "granite-4-1-3b-coder-latest-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788718163,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788710013-c0e61eb1.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788710013-c0e61eb1.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 60777.91,
+      "avgTps": 5.12,
+      "avgTtftMs": 1692.7,
+      "maxTps": 5.17,
+      "minTps": 5.04,
+      "model": "qwen3-5-4b-agentic-coder-latest-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788718163,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788711728-17363dc0.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788711728-17363dc0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 266.0,
+      "avgTotalMs": 129982.9,
+      "avgTps": 2.16,
+      "avgTtftMs": 5331.92,
+      "maxTps": 2.28,
+      "minTps": 2.07,
+      "model": "gemma4-12b-coder-fable5-latest-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788718163,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788717654-59910fb4.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788717654-59910fb4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 255.0,
+      "avgTotalMs": 22327.79,
+      "avgTps": 12.21,
+      "avgTtftMs": 1111.43,
+      "maxTps": 12.3,
+      "minTps": 12.11,
+      "model": "lfm25-8b-a1b-coder-latest-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788718163,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788725507-c4522bf4.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788725507-c4522bf4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 250.67,
+      "avgTotalMs": 18625.5,
+      "avgTps": 15.22,
+      "avgTtftMs": 1201.83,
+      "maxTps": 17.45,
+      "minTps": 13.0,
+      "model": "lfm25-8b-a1b-coder-latest-v2ctx65k-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788725565-eedfe5a9.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788725565-eedfe5a9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 86.67,
+      "avgTotalMs": 12444.35,
+      "avgTps": 7.92,
+      "avgTtftMs": 1226.28,
+      "maxTps": 8.01,
+      "minTps": 7.84,
+      "model": "granite-4-1-3b-coder-latest-v2ctx65k-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788725796-652e19d0.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788725796-652e19d0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 56151.36,
+      "avgTps": 5.54,
+      "avgTtftMs": 1457.93,
+      "maxTps": 5.59,
+      "minTps": 5.47,
+      "model": "qwen3-5-4b-agentic-coder-latest-v2ctx65k-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788725887-c1321ee0.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788725887-c1321ee0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 81.0,
+      "avgTotalMs": 12619.28,
+      "avgTps": 7.3,
+      "avgTtftMs": 1234.23,
+      "maxTps": 7.39,
+      "minTps": 7.22,
+      "model": "granite-4-1-3b-coder-latest-v2ctx65k-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788726217-8df376a6.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788726217-8df376a6.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 60425.16,
+      "avgTps": 5.14,
+      "avgTtftMs": 1485.77,
+      "maxTps": 5.38,
+      "minTps": 4.94,
+      "model": "qwen3-5-4b-agentic-coder-latest-v2ctx65k-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788726501-584f74e5.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788726501-584f74e5.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 240.0,
+      "avgTotalMs": 57552.99,
+      "avgTps": 4.53,
+      "avgTtftMs": 2986.37,
+      "maxTps": 4.85,
+      "minTps": 4.35,
+      "model": "ornith-latest-v2ctx65k-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788726720-e0d3b49f.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788726720-e0d3b49f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 257.33,
+      "avgTotalMs": 34070.01,
+      "avgTps": 9.01,
+      "avgTtftMs": 1720.78,
+      "maxTps": 14.26,
+      "minTps": 6.15,
+      "model": "lfm25-8b-a1b-coder-latest-v2ctx65k-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788731524-15ac0583.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788731524-15ac0583.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 229.0,
+      "avgTotalMs": 30959.86,
+      "avgTps": 8.01,
+      "avgTtftMs": 2720.4,
+      "maxTps": 8.73,
+      "minTps": 7.2,
+      "model": "nemotron-3-nano-4b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788731736-7b6437b6.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788731736-7b6437b6.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 256.0,
+      "avgTotalMs": 38306.11,
+      "avgTps": 7.05,
+      "avgTtftMs": 1789.26,
+      "maxTps": 7.14,
+      "minTps": 6.96,
+      "model": "nemotron-3-nano-4b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788731933-1700095d.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788731933-1700095d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 245.0,
+      "avgTotalMs": 32540.62,
+      "avgTps": 7.92,
+      "avgTtftMs": 1341.15,
+      "maxTps": 8.0,
+      "minTps": 7.87,
+      "model": "nemotron-3-nano-4b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788732111-6eee6b33.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788732111-6eee6b33.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 255.33,
+      "avgTotalMs": 27521.8,
+      "avgTps": 10.06,
+      "avgTtftMs": 888.48,
+      "maxTps": 11.63,
+      "minTps": 9.06,
+      "model": "nemotron-3-nano-4b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788732279-03fb3312.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788732279-03fb3312.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 230.33,
+      "avgTotalMs": 24285.69,
+      "avgTps": 10.89,
+      "avgTtftMs": 619.53,
+      "maxTps": 13.55,
+      "minTps": 8.8,
+      "model": "nemotron-3-nano-4b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788732516-e36ba86b.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788732516-e36ba86b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 297.33,
+      "avgTotalMs": 44652.09,
+      "avgTps": 6.97,
+      "avgTtftMs": 1621.01,
+      "maxTps": 7.12,
+      "minTps": 6.71,
+      "model": "qwen3-5-4b-agentic-coder-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788732842-3bab38d3.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788732842-3bab38d3.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 56330.62,
+      "avgTps": 5.54,
+      "avgTtftMs": 1830.37,
+      "maxTps": 5.62,
+      "minTps": 5.48,
+      "model": "qwen3-5-4b-agentic-coder-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788733129-7f38c571.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788733129-7f38c571.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 48770.31,
+      "avgTps": 6.38,
+      "avgTtftMs": 1381.69,
+      "maxTps": 6.44,
+      "minTps": 6.35,
+      "model": "qwen3-5-4b-agentic-coder-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788733409-801507b9.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788733409-801507b9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 52652.15,
+      "avgTps": 5.9,
+      "avgTtftMs": 1317.97,
+      "maxTps": 6.13,
+      "minTps": 5.71,
+      "model": "qwen3-5-4b-agentic-coder-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788733669-23cdaf37.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788733669-23cdaf37.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 50842.24,
+      "avgTps": 6.1,
+      "avgTtftMs": 1079.37,
+      "maxTps": 6.17,
+      "minTps": 6.05,
+      "model": "qwen3-5-4b-agentic-coder-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788734048-5b341c52.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788734048-5b341c52.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 69535.7,
+      "avgTps": 4.59,
+      "avgTtftMs": 3068.85,
+      "maxTps": 5.18,
+      "minTps": 4.21,
+      "model": "huihui_ai-qwen3-5-abliterated-9b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788734480-569ad538.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788734480-569ad538.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 83904.23,
+      "avgTps": 3.74,
+      "avgTtftMs": 3263.34,
+      "maxTps": 3.84,
+      "minTps": 3.63,
+      "model": "huihui_ai-qwen3-5-abliterated-9b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788734893-7904fdc1.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788734893-7904fdc1.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 77376.05,
+      "avgTps": 4.06,
+      "avgTtftMs": 2613.24,
+      "maxTps": 4.45,
+      "minTps": 3.77,
+      "model": "huihui_ai-qwen3-5-abliterated-9b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788735253-837a05ab.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788735253-837a05ab.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 63536.56,
+      "avgTps": 4.98,
+      "avgTtftMs": 1847.11,
+      "maxTps": 5.57,
+      "minTps": 4.21,
+      "model": "huihui_ai-qwen3-5-abliterated-9b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788735584-9b2ad8f6.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788735584-9b2ad8f6.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 61686.47,
+      "avgTps": 5.03,
+      "avgTtftMs": 1220.04,
+      "maxTps": 5.55,
+      "minTps": 4.69,
+      "model": "huihui_ai-qwen3-5-abliterated-9b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788735808-dd2cbf30.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788735808-dd2cbf30.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 214.67,
+      "avgTotalMs": 40983.12,
+      "avgTps": 5.61,
+      "avgTtftMs": 1857.2,
+      "maxTps": 5.82,
+      "minTps": 5.49,
+      "model": "qwen2-5-7b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736018-1a9aa0a7.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736018-1a9aa0a7.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 205.0,
+      "avgTotalMs": 38032.06,
+      "avgTps": 5.86,
+      "avgTtftMs": 1607.62,
+      "maxTps": 6.4,
+      "minTps": 5.55,
+      "model": "qwen2-5-7b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736210-e2bbcf39.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736210-e2bbcf39.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 205.33,
+      "avgTotalMs": 32286.26,
+      "avgTps": 7.09,
+      "avgTtftMs": 1276.87,
+      "maxTps": 8.19,
+      "minTps": 6.51,
+      "model": "qwen2-5-7b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736385-d0699db0.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736385-d0699db0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 196.0,
+      "avgTotalMs": 26899.94,
+      "avgTps": 8.35,
+      "avgTtftMs": 978.69,
+      "maxTps": 10.21,
+      "minTps": 7.11,
+      "model": "qwen2-5-7b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736553-67d505d5.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736553-67d505d5.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 174.0,
+      "avgTotalMs": 24350.87,
+      "avgTps": 8.11,
+      "avgTtftMs": 749.89,
+      "maxTps": 9.84,
+      "minTps": 7.2,
+      "model": "qwen2-5-7b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736786-f9186001.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788736786-f9186001.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 211.67,
+      "avgTotalMs": 42464.89,
+      "avgTps": 5.83,
+      "avgTtftMs": 5653.61,
+      "maxTps": 6.16,
+      "minTps": 5.63,
+      "model": "ornith-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737021-4d3d4bf0.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737021-4d3d4bf0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 188.0,
+      "avgTotalMs": 42552.97,
+      "avgTps": 4.74,
+      "avgTtftMs": 2443.68,
+      "maxTps": 4.76,
+      "minTps": 4.72,
+      "model": "ornith-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737227-4f297e51.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737227-4f297e51.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 169.0,
+      "avgTotalMs": 35145.76,
+      "avgTps": 5.22,
+      "avgTtftMs": 2275.93,
+      "maxTps": 5.27,
+      "minTps": 5.18,
+      "model": "ornith-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737444-9d00f90a.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737444-9d00f90a.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 189.0,
+      "avgTotalMs": 36901.36,
+      "avgTps": 5.52,
+      "avgTtftMs": 2079.82,
+      "maxTps": 5.63,
+      "minTps": 5.43,
+      "model": "ornith-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737655-41f621b9.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737655-41f621b9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 189.33,
+      "avgTotalMs": 36567.45,
+      "avgTps": 5.52,
+      "avgTtftMs": 2092.24,
+      "maxTps": 5.84,
+      "minTps": 5.13,
+      "model": "ornith-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737766-aa0a293e.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737766-aa0a293e.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 220.33,
+      "avgTotalMs": 6086.57,
+      "avgTps": 39.1,
+      "avgTtftMs": 193.66,
+      "maxTps": 41.45,
+      "minTps": 37.66,
+      "model": "qwen2-5-1-5b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737885-ec2535f4.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737885-ec2535f4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 218.67,
+      "avgTotalMs": 8886.33,
+      "avgTps": 26.27,
+      "avgTtftMs": 269.35,
+      "maxTps": 28.28,
+      "minTps": 25.18,
+      "model": "qwen2-5-1-5b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737995-0b8818aa.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788737995-0b8818aa.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 166.33,
+      "avgTotalMs": 5705.08,
+      "avgTps": 33.28,
+      "avgTtftMs": 198.65,
+      "maxTps": 36.72,
+      "minTps": 28.87,
+      "model": "qwen2-5-1-5b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738106-0209e0a8.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738106-0209e0a8.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 206.33,
+      "avgTotalMs": 6372.21,
+      "avgTps": 34.22,
+      "avgTtftMs": 192.75,
+      "maxTps": 34.33,
+      "minTps": 34.07,
+      "model": "qwen2-5-1-5b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738220-93d4c9a5.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738220-93d4c9a5.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 223.0,
+      "avgTotalMs": 6955.81,
+      "avgTps": 33.68,
+      "avgTtftMs": 164.42,
+      "maxTps": 33.83,
+      "minTps": 33.5,
+      "model": "qwen2-5-1-5b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738379-801310e6.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738379-801310e6.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 247.33,
+      "avgTotalMs": 20220.61,
+      "avgTps": 14.11,
+      "avgTtftMs": 741.32,
+      "maxTps": 17.56,
+      "minTps": 10.24,
+      "model": "granite4-2-3b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738560-406fd568.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738560-406fd568.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 251.33,
+      "avgTotalMs": 26697.86,
+      "avgTps": 9.92,
+      "avgTtftMs": 989.85,
+      "maxTps": 10.23,
+      "minTps": 9.44,
+      "model": "granite4-2-3b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738738-e4dbeb18.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738738-e4dbeb18.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 250.33,
+      "avgTotalMs": 26252.73,
+      "avgTps": 9.89,
+      "avgTtftMs": 867.93,
+      "maxTps": 10.21,
+      "minTps": 9.56,
+      "model": "granite4-2-3b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738907-aeeb9c81.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788738907-aeeb9c81.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 245.0,
+      "avgTotalMs": 24218.1,
+      "avgTps": 11.13,
+      "avgTtftMs": 554.76,
+      "maxTps": 13.46,
+      "minTps": 9.69,
+      "model": "granite4-2-3b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788739089-adb3f0e4.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788739089-adb3f0e4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 254.67,
+      "avgTotalMs": 26903.02,
+      "avgTps": 9.71,
+      "avgTtftMs": 516.53,
+      "maxTps": 9.84,
+      "minTps": 9.47,
+      "model": "granite4-2-3b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788739363-ce3d40b9.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788739363-ce3d40b9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 53832.87,
+      "avgTps": 6.24,
+      "avgTtftMs": 5314.71,
+      "maxTps": 6.31,
+      "minTps": 6.19,
+      "model": "gpt-oss-20b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788739604-9e1a141b.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788739604-9e1a141b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 236.67,
+      "avgTotalMs": 41879.28,
+      "avgTps": 6.44,
+      "avgTtftMs": 4102.47,
+      "maxTps": 6.78,
+      "minTps": 6.2,
+      "model": "gpt-oss-20b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788739833-da0fa199.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788739833-da0fa199.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 246.33,
+      "avgTotalMs": 40120.58,
+      "avgTps": 6.88,
+      "avgTtftMs": 3658.72,
+      "maxTps": 6.98,
+      "minTps": 6.7,
+      "model": "gpt-oss-20b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740087-24ebf0fd.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740087-24ebf0fd.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 283.33,
+      "avgTotalMs": 45943.63,
+      "avgTps": 6.71,
+      "avgTtftMs": 3151.01,
+      "maxTps": 6.87,
+      "minTps": 6.6,
+      "model": "gpt-oss-20b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740310-7fc2de68.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740310-7fc2de68.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 234.67,
+      "avgTotalMs": 34343.75,
+      "avgTps": 7.45,
+      "avgTtftMs": 2479.39,
+      "maxTps": 7.98,
+      "minTps": 7.16,
+      "model": "gpt-oss-20b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740464-2eaf985e.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740464-2eaf985e.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 289.0,
+      "avgTotalMs": 16708.79,
+      "avgTps": 18.7,
+      "avgTtftMs": 678.98,
+      "maxTps": 20.21,
+      "minTps": 16.09,
+      "model": "lfm2-5-8b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740622-ccbda9df.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740622-ccbda9df.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 279.67,
+      "avgTotalMs": 18985.48,
+      "avgTps": 15.82,
+      "avgTtftMs": 909.98,
+      "maxTps": 16.14,
+      "minTps": 15.36,
+      "model": "lfm2-5-8b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740782-4dbf5ac8.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740782-4dbf5ac8.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 292.67,
+      "avgTotalMs": 19969.85,
+      "avgTps": 15.84,
+      "avgTtftMs": 1031.44,
+      "maxTps": 16.76,
+      "minTps": 14.92,
+      "model": "lfm2-5-8b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740940-3187bf5f.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788740940-3187bf5f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 280.33,
+      "avgTotalMs": 19094.92,
+      "avgTps": 16.06,
+      "avgTtftMs": 1189.7,
+      "maxTps": 16.71,
+      "minTps": 15.62,
+      "model": "lfm2-5-8b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788741090-6797c1b7.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788741090-6797c1b7.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 255.0,
+      "avgTotalMs": 16943.51,
+      "avgTps": 16.72,
+      "avgTtftMs": 1321.66,
+      "maxTps": 17.57,
+      "minTps": 16.16,
+      "model": "lfm2-5-8b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788741343-a65a61e9.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788741343-a65a61e9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 39800.91,
+      "avgTps": 7.92,
+      "avgTtftMs": 1333.49,
+      "maxTps": 8.37,
+      "minTps": 7.43,
+      "model": "qwen3-5-4b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788741642-b0db027a.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788741642-b0db027a.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 49818.06,
+      "avgTps": 6.31,
+      "avgTtftMs": 1469.45,
+      "maxTps": 6.8,
+      "minTps": 5.64,
+      "model": "qwen3-5-4b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788741934-769013c2.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788741934-769013c2.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 49071.09,
+      "avgTps": 6.37,
+      "avgTtftMs": 1463.83,
+      "maxTps": 6.5,
+      "minTps": 6.31,
+      "model": "qwen3-5-4b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788742194-593ca24f.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788742194-593ca24f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 43948.48,
+      "avgTps": 7.12,
+      "avgTtftMs": 997.22,
+      "maxTps": 7.98,
+      "minTps": 6.62,
+      "model": "qwen3-5-4b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788742456-d4e229ce.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788742456-d4e229ce.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 42557.47,
+      "avgTps": 7.28,
+      "avgTtftMs": 811.28,
+      "maxTps": 7.42,
+      "minTps": 7.07,
+      "model": "qwen3-5-4b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788742660-1bc6fd2e.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788742660-1bc6fd2e.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 193.67,
+      "avgTotalMs": 33272.59,
+      "avgTps": 6.32,
+      "avgTtftMs": 1669.47,
+      "maxTps": 6.68,
+      "minTps": 5.7,
+      "model": "llama3-1-8b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788742890-574502c7.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788742890-574502c7.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 192.67,
+      "avgTotalMs": 42815.51,
+      "avgTps": 4.83,
+      "avgTtftMs": 2290.24,
+      "maxTps": 4.96,
+      "minTps": 4.75,
+      "model": "llama3-1-8b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743099-89d41712.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743099-89d41712.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 181.67,
+      "avgTotalMs": 36685.88,
+      "avgTps": 5.24,
+      "avgTtftMs": 1877.02,
+      "maxTps": 5.3,
+      "minTps": 5.15,
+      "model": "llama3-1-8b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743317-4f4f4a1d.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743317-4f4f4a1d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 209.0,
+      "avgTotalMs": 40260.66,
+      "avgTps": 5.4,
+      "avgTtftMs": 1387.89,
+      "maxTps": 5.7,
+      "minTps": 5.22,
+      "model": "llama3-1-8b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743527-fe13efbc.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743527-fe13efbc.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 183.33,
+      "avgTotalMs": 36395.88,
+      "avgTps": 5.27,
+      "avgTtftMs": 969.97,
+      "maxTps": 5.43,
+      "minTps": 4.97,
+      "model": "llama3-1-8b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743717-5ca9f2c1.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743717-5ca9f2c1.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 128.0,
+      "avgTotalMs": 28202.48,
+      "avgTps": 5.31,
+      "avgTtftMs": 4051.02,
+      "maxTps": 5.56,
+      "minTps": 4.91,
+      "model": "rnj-1-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743889-623ed871.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788743889-623ed871.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 86.33,
+      "avgTotalMs": 24009.21,
+      "avgTps": 4.05,
+      "avgTtftMs": 2103.55,
+      "maxTps": 4.51,
+      "minTps": 3.45,
+      "model": "rnj-1-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744085-edc29979.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744085-edc29979.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 143.0,
+      "avgTotalMs": 32950.19,
+      "avgTps": 4.58,
+      "avgTtftMs": 1725.44,
+      "maxTps": 5.12,
+      "minTps": 3.59,
+      "model": "rnj-1-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744266-a0200f9f.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744266-a0200f9f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 122.67,
+      "avgTotalMs": 27794.49,
+      "avgTps": 4.86,
+      "avgTtftMs": 1683.12,
+      "maxTps": 5.09,
+      "minTps": 4.6,
+      "model": "rnj-1-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744409-4e67cf30.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744409-4e67cf30.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 78.67,
+      "avgTotalMs": 15171.51,
+      "avgTps": 5.92,
+      "avgTtftMs": 1193.28,
+      "maxTps": 6.1,
+      "minTps": 5.64,
+      "model": "rnj-1-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744563-2c71ed0a.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744563-2c71ed0a.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 269.0,
+      "avgTotalMs": 17821.09,
+      "avgTps": 16.12,
+      "avgTtftMs": 726.31,
+      "maxTps": 16.91,
+      "minTps": 15.51,
+      "model": "lfm25-8b-a1b-coder-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744722-8501c4c4.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744722-8501c4c4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 279.67,
+      "avgTotalMs": 20478.46,
+      "avgTps": 14.49,
+      "avgTtftMs": 929.9,
+      "maxTps": 14.98,
+      "minTps": 14.0,
+      "model": "lfm25-8b-a1b-coder-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744874-bae2615e.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788744874-bae2615e.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 272.67,
+      "avgTotalMs": 18302.93,
+      "avgTps": 16.06,
+      "avgTtftMs": 1013.08,
+      "maxTps": 16.72,
+      "minTps": 15.57,
+      "model": "lfm25-8b-a1b-coder-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745029-dc141c4b.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745029-dc141c4b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 260.0,
+      "avgTotalMs": 18505.26,
+      "avgTps": 15.92,
+      "avgTtftMs": 1396.75,
+      "maxTps": 17.52,
+      "minTps": 14.12,
+      "model": "lfm25-8b-a1b-coder-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745188-c3afdd2c.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745188-c3afdd2c.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 274.0,
+      "avgTotalMs": 19290.93,
+      "avgTps": 16.08,
+      "avgTtftMs": 1549.61,
+      "maxTps": 17.73,
+      "minTps": 13.73,
+      "model": "lfm25-8b-a1b-coder-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745350-c951f079.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745350-c951f079.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 127.33,
+      "avgTotalMs": 21645.23,
+      "avgTps": 6.3,
+      "avgTtftMs": 1502.1,
+      "maxTps": 6.69,
+      "minTps": 6.1,
+      "model": "llama3-groq-tool-use-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745530-7da5b517.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745530-7da5b517.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 144.33,
+      "avgTotalMs": 28371.19,
+      "avgTps": 6.18,
+      "avgTtftMs": 2060.5,
+      "maxTps": 7.83,
+      "minTps": 5.07,
+      "model": "llama3-groq-tool-use-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745682-4a4f7242.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745682-4a4f7242.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 102.67,
+      "avgTotalMs": 19108.96,
+      "avgTps": 6.08,
+      "avgTtftMs": 1770.68,
+      "maxTps": 6.46,
+      "minTps": 5.83,
+      "model": "llama3-groq-tool-use-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745914-47026577.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788745914-47026577.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 104.0,
+      "avgTotalMs": 44369.4,
+      "avgTps": 2.56,
+      "avgTtftMs": 2769.64,
+      "maxTps": 3.43,
+      "minTps": 1.86,
+      "model": "llama3-groq-tool-use-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746043-dfe9f712.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746043-dfe9f712.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 92.67,
+      "avgTotalMs": 11293.3,
+      "avgTps": 8.75,
+      "avgTtftMs": 460.21,
+      "maxTps": 8.94,
+      "minTps": 8.54,
+      "model": "llama3-groq-tool-use-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746164-018f1061.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746164-018f1061.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 90.67,
+      "avgTotalMs": 8325.83,
+      "avgTps": 12.31,
+      "avgTtftMs": 805.26,
+      "maxTps": 12.51,
+      "minTps": 12.04,
+      "model": "granite-4-1-3b-coder-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746306-8693336b.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746306-8693336b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 111.33,
+      "avgTotalMs": 15303.19,
+      "avgTps": 8.63,
+      "avgTtftMs": 1083.62,
+      "maxTps": 9.76,
+      "minTps": 7.18,
+      "model": "granite-4-1-3b-coder-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746418-70c35c81.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746418-70c35c81.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 59.0,
+      "avgTotalMs": 5907.26,
+      "avgTps": 11.93,
+      "avgTtftMs": 775.03,
+      "maxTps": 13.0,
+      "minTps": 11.14,
+      "model": "granite-4-1-3b-coder-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746530-43a92688.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746530-43a92688.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 66.33,
+      "avgTotalMs": 5619.52,
+      "avgTps": 13.58,
+      "avgTtftMs": 620.15,
+      "maxTps": 13.59,
+      "minTps": 13.57,
+      "model": "granite-4-1-3b-coder-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746648-c44aea6c.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746648-c44aea6c.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 103.0,
+      "avgTotalMs": 7902.99,
+      "avgTps": 14.23,
+      "avgTtftMs": 506.76,
+      "maxTps": 14.43,
+      "minTps": 14.03,
+      "model": "granite-4-1-3b-coder-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746956-7e974492.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788746956-7e974492.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 57346.03,
+      "avgTps": 5.48,
+      "avgTtftMs": 2190.24,
+      "maxTps": 5.65,
+      "minTps": 5.32,
+      "model": "qwen3-5-9b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788747311-a4a26561.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788747311-a4a26561.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 66179.88,
+      "avgTps": 4.74,
+      "avgTtftMs": 2475.88,
+      "maxTps": 4.75,
+      "minTps": 4.73,
+      "model": "qwen3-5-9b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788747642-a3405980.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788747642-a3405980.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 60478.13,
+      "avgTps": 5.17,
+      "avgTtftMs": 2059.39,
+      "maxTps": 5.22,
+      "minTps": 5.12,
+      "model": "qwen3-5-9b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788747986-88de836b.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788747986-88de836b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 64651.1,
+      "avgTps": 4.86,
+      "avgTtftMs": 1722.41,
+      "maxTps": 5.55,
+      "minTps": 4.3,
+      "model": "qwen3-5-9b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788748287-a9589c95.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788748287-a9589c95.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 55354.75,
+      "avgTps": 5.61,
+      "avgTtftMs": 1199.0,
+      "maxTps": 5.95,
+      "minTps": 5.14,
+      "model": "qwen3-5-9b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788748572-cb9e469d.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788748572-cb9e469d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 51732.6,
+      "avgTps": 6.04,
+      "avgTtftMs": 1745.77,
+      "maxTps": 6.08,
+      "minTps": 5.98,
+      "model": "qwen3-8b-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788748881-38b4bc48.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788748881-38b4bc48.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 281.33,
+      "avgTotalMs": 65118.8,
+      "avgTps": 4.55,
+      "avgTtftMs": 2284.98,
+      "maxTps": 4.86,
+      "minTps": 3.97,
+      "model": "qwen3-8b-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788749176-afab53a8.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788749176-afab53a8.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 276.67,
+      "avgTotalMs": 55489.5,
+      "avgTps": 5.16,
+      "avgTtftMs": 1717.04,
+      "maxTps": 5.42,
+      "minTps": 4.8,
+      "model": "qwen3-8b-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788749461-a9ec9da2.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788749461-a9ec9da2.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 265.67,
+      "avgTotalMs": 52994.92,
+      "avgTps": 5.23,
+      "avgTtftMs": 1355.28,
+      "maxTps": 5.47,
+      "minTps": 4.77,
+      "model": "qwen3-8b-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788749696-6bad7958.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788749696-6bad7958.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 264.67,
+      "avgTotalMs": 43917.13,
+      "avgTps": 6.23,
+      "avgTtftMs": 877.03,
+      "maxTps": 6.44,
+      "minTps": 6.09,
+      "model": "qwen3-8b-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788750202-eac895a7.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788750202-eac895a7.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 286.0,
+      "avgTotalMs": 128009.53,
+      "avgTps": 2.37,
+      "avgTtftMs": 6692.44,
+      "maxTps": 2.44,
+      "minTps": 2.33,
+      "model": "gemma4-12b-coder-fable5-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788750722-2adebbae.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788750722-2adebbae.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 252.0,
+      "avgTotalMs": 127694.67,
+      "avgTps": 2.08,
+      "avgTtftMs": 5967.89,
+      "maxTps": 2.1,
+      "minTps": 2.06,
+      "model": "gemma4-12b-coder-fable5-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788751241-5929363d.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788751241-5929363d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 269.0,
+      "avgTotalMs": 130610.57,
+      "avgTps": 2.14,
+      "avgTtftMs": 4560.35,
+      "maxTps": 2.21,
+      "minTps": 2.11,
+      "model": "gemma4-12b-coder-fable5-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788751712-3c24a680.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788751712-3c24a680.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 269.33,
+      "avgTotalMs": 114829.3,
+      "avgTps": 2.45,
+      "avgTtftMs": 3375.37,
+      "maxTps": 2.55,
+      "minTps": 2.27,
+      "model": "gemma4-12b-coder-fable5-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788752168-9642291d.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788752168-9642291d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 266.67,
+      "avgTotalMs": 109258.22,
+      "avgTps": 2.56,
+      "avgTtftMs": 2376.32,
+      "maxTps": 2.75,
+      "minTps": 2.21,
+      "model": "gemma4-12b-coder-fable5-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788753131-2ede2319.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788753131-2ede2319.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 278.67,
+      "avgTotalMs": 41418.85,
+      "avgTps": 7.1,
+      "avgTtftMs": 659.06,
+      "maxTps": 8.85,
+      "minTps": 5.91,
+      "model": "qwen3-5-4b-super-coder-latest-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788753578-f250b532.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788753578-f250b532.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 163.67,
+      "avgTotalMs": 34497.93,
+      "avgTps": 4.96,
+      "avgTtftMs": 1259.8,
+      "maxTps": 5.01,
+      "minTps": 4.93,
+      "model": "qwen2-5-coder-7b-enfixed-agent-gpu100:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788754218-77ea61cc.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788754218-77ea61cc.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 289.33,
+      "avgTotalMs": 39935.66,
+      "avgTps": 7.57,
+      "avgTtftMs": 1180.42,
+      "maxTps": 7.97,
+      "minTps": 7.33,
+      "model": "qwen3-5-4b-super-coder-latest-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788754489-d4fbe912.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788754489-d4fbe912.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 241.67,
+      "avgTotalMs": 54573.35,
+      "avgTps": 4.62,
+      "avgTtftMs": 2366.79,
+      "maxTps": 4.84,
+      "minTps": 4.42,
+      "model": "qwen3-5-4b-super-coder-latest-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788754764-b8fa26d4.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788754764-b8fa26d4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 261.33,
+      "avgTotalMs": 55921.15,
+      "avgTps": 4.85,
+      "avgTtftMs": 1837.78,
+      "maxTps": 4.98,
+      "minTps": 4.63,
+      "model": "qwen3-5-4b-super-coder-latest-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755016-f507f5b4.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755016-f507f5b4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 246.33,
+      "avgTotalMs": 46563.49,
+      "avgTps": 5.51,
+      "avgTtftMs": 1257.53,
+      "maxTps": 5.57,
+      "minTps": 5.41,
+      "model": "qwen3-5-4b-super-coder-latest-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755213-b8b74484.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755213-b8b74484.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 155.0,
+      "avgTotalMs": 32127.9,
+      "avgTps": 5.23,
+      "avgTtftMs": 1863.6,
+      "maxTps": 5.42,
+      "minTps": 5.09,
+      "model": "qwen2-5-coder-7b-enfixed-agent-cpu:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755419-7eb53c43.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755419-7eb53c43.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 155.67,
+      "avgTotalMs": 36570.29,
+      "avgTps": 4.87,
+      "avgTtftMs": 2195.0,
+      "maxTps": 5.77,
+      "minTps": 4.32,
+      "model": "qwen2-5-coder-7b-enfixed-agent-gpu25:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755657-255bfb4d.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755657-255bfb4d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 207.0,
+      "avgTotalMs": 47374.73,
+      "avgTps": 4.65,
+      "avgTtftMs": 2091.16,
+      "maxTps": 4.76,
+      "minTps": 4.54,
+      "model": "qwen2-5-coder-7b-enfixed-agent-gpu50:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755847-d74d642f.json
+++ b/llmfit-core/data/community/intel-raptor-lake-p-iris-xe-graphics-integrated/1788755847-d74d642f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "13th Gen Intel(R) Core(TM) i7-1365U",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "Intel Raptor Lake-P [Iris Xe Graphics] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.0,
+    "unifiedMemory": true,
+    "vramGb": 31.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 184.33,
+      "avgTotalMs": 30931.84,
+      "avgTps": 6.3,
+      "avgTtftMs": 1243.44,
+      "maxTps": 6.35,
+      "minTps": 6.24,
+      "model": "qwen2-5-coder-7b-enfixed-agent-gpu75:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788756661,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| granite-4-1-3b-coder-latest-agent-gpu50:latest | ollama | 7.6 | 1125.5 |
| qwen3-5-4b-agentic-coder-latest-agent-gpu50:latest | ollama | 4.7 | 1772.5 |
| granite-4-1-3b-coder-latest-agent-gpu50:latest | ollama | 7.5 | 1120.8 |
| qwen3-5-4b-agentic-coder-latest-agent-gpu50:latest | ollama | 5.1 | 1692.7 |
| gemma4-12b-coder-fable5-latest-agent-gpu25:latest | ollama | 2.2 | 5331.9 |
| lfm25-8b-a1b-coder-latest-agent-gpu25:latest | ollama | 12.2 | 1111.4 |

_Submitted without the `gh` CLI via the GitHub device flow._
