### PR TITLE
bench: community results for intel-coffeelake-s-gt2-uhd-graphics-630-integrated

### DIFF
--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788483459-e5d8cf71.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788483459-e5d8cf71.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 197.67,
+      "avgTotalMs": 33736.95,
+      "avgTps": 6.18,
+      "avgTtftMs": 1117.36,
+      "maxTps": 6.58,
+      "minTps": 5.73,
+      "model": "granite4:micro",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788830912,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788483487-2a29bc22.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788483487-2a29bc22.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 160.33,
+      "avgTotalMs": 8197.22,
+      "avgTps": 19.73,
+      "avgTtftMs": 163.04,
+      "maxTps": 20.85,
+      "minTps": 19.11,
+      "model": "granite3.1-moe:1b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788830912,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}

--- a/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788484052-8c292b4d.json
+++ b/llmfit-core/data/community/intel-coffeelake-s-gt2-uhd-graphics-630-integrated/1788484052-8c292b4d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
+    "cpuCores": 6,
+    "gpuCount": 1,
+    "hardwareName": "Intel CoffeeLake-S GT2 [UHD Graphics 630] (integrated)",
+    "hwClass": "UNIFIED",
+    "memTierGb": 32,
+    "os": "linux",
+    "ramGb": 31.15,
+    "unifiedMemory": true,
+    "vramGb": 31.15
+  },
+  "results": [
+    {
+      "avgOutputTokens": 194.67,
+      "avgTotalMs": 18665.89,
+      "avgTps": 11.55,
+      "avgTtftMs": 1130.61,
+      "maxTps": 12.19,
+      "minTps": 10.42,
+      "model": "granite4:tiny-h",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788830912,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.12"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| granite4:micro | ollama | 6.2 | 1117.4 |
| granite3.1-moe:1b | ollama | 19.7 | 163.0 |
| granite4:tiny-h | ollama | 11.6 | 1130.6 |

_Submitted without the `gh` CLI via the GitHub device flow._
