### PR TITLE
bench: community results for nvidia-geforce-rtx-4060-ti

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-rtx-4060-ti/1788957186-e4871a22.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-4060-ti/1788957186-e4871a22.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 7600X 6-Core Processor",
+    "cpuCores": 12,
+    "gpuCount": 2,
+    "hardwareName": "NVIDIA GeForce RTX 4060 Ti",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 28.96,
+    "unifiedMemory": false,
+    "vramGb": 18.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 155.67,
+      "avgTotalMs": 36780.65,
+      "avgTps": 20.1,
+      "avgTtftMs": 322.78,
+      "maxTps": 20.2,
+      "minTps": 20.04,
+      "model": "qwen3.8-27b-fixed:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788958787,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-4060-ti/1788957201-87d258fc.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-4060-ti/1788957201-87d258fc.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 7600X 6-Core Processor",
+    "cpuCores": 12,
+    "gpuCount": 2,
+    "hardwareName": "NVIDIA GeForce RTX 4060 Ti",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 28.96,
+    "unifiedMemory": false,
+    "vramGb": 18.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 165.67,
+      "avgTotalMs": 35535.13,
+      "avgTps": 20.09,
+      "avgTtftMs": 299.28,
+      "maxTps": 20.2,
+      "minTps": 20.03,
+      "model": "hf.co/mradermacher/Qwen3.8-27B-i1-GGUF:IQ3_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788958787,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-4060-ti/1788958611-d5879fc0.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-4060-ti/1788958611-d5879fc0.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 5 7600X 6-Core Processor",
+    "cpuCores": 12,
+    "gpuCount": 2,
+    "hardwareName": "NVIDIA GeForce RTX 4060 Ti",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 16,
+    "os": "linux",
+    "ramGb": 28.96,
+    "unifiedMemory": false,
+    "vramGb": 18.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 4339.94,
+      "avgTps": 71.8,
+      "avgTtftMs": 150.27,
+      "maxTps": 72.49,
+      "minTps": 70.6,
+      "model": "gemma4:26b-a4b-it-qat",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1788958787,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.14"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen3.8-27b-fixed:latest | ollama | 20.1 | 322.8 |
| hf.co/mradermacher/Qwen3.8-27B-i1-GGUF:IQ3_M | ollama | 20.1 | 299.3 |
| gemma4:26b-a4b-it-qat | ollama | 71.8 | 150.3 |

_Submitted without the `gh` CLI via the GitHub device flow._
