### PR TITLE
fix(tui): render only visible model rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ llmfit          # interactive TUI: your hardware, every model, ranked
 The TUI shows your detected specs at the top and every model scored for fit, speed, quality, and context. See the [TUI guide](docs/tui.md) for navigation, planning, simulation, downloads, the community leaderboard, and benchmarking.
 
 Keybindings inside the TUI:
-- `Tab` / `Shift+Tab`: Switch tabs (Models, System Info, Benchmark)
+- `b`: Open community benchmarks; `I`: Open live inference benchmarks
+- `h`: Show help and keybindings
 - `↑` / `↓` or `k` / `j`: Navigate list items
 - `/`: Filter models by name, family, or quantization
 - `Esc`: Clear search / Back

--- a/llmfit-tui/src/main.rs
+++ b/llmfit-tui/src/main.rs
@@ -1871,6 +1871,12 @@ fn run_tui_inner(
     // that EnterAlternateScreen leaves visible under sparse frames.
     terminal.clear()?;
 
+    let size = terminal.size()?;
+    tui_events::update_model_viewport(
+        &mut app,
+        ratatui::layout::Rect::new(0, 0, size.width, size.height),
+    );
+
     // Main loop
     loop {
         terminal.draw(|frame| {

--- a/llmfit-tui/src/tui_events.rs
+++ b/llmfit-tui/src/tui_events.rs
@@ -3,8 +3,41 @@ use std::time::Duration;
 
 use crate::tui_app::{App, InputMode};
 
+/// Apply selection and terminal-size changes to the model table's scroll state.
+/// Also used once at startup, before the first frame is drawn.
+pub fn update_model_viewport(app: &mut App, terminal_area: ratatui::layout::Rect) {
+    if app.show_bench
+        || app.show_benchmarks
+        || app.show_downloads
+        || app.show_plan
+        || app.show_multi_compare
+        || app.show_compare
+        || app.show_detail
+    {
+        return;
+    }
+    let table_area = crate::tui_ui::main_layout(terminal_area)[2];
+    let viewport = crate::tui_ui::model_table_viewport(
+        app.filtered_fits.len(),
+        app.selected_row,
+        app.table_state.offset(),
+        usize::from(table_area.height.saturating_sub(3)),
+    );
+    app.table_state
+        .select((!app.filtered_fits.is_empty()).then_some(app.selected_row));
+    *app.table_state.offset_mut() = viewport.start;
+}
+
 /// Poll for and handle events. Returns true if an event was processed.
 pub fn handle_events(app: &mut App) -> std::io::Result<bool> {
+    let processed = handle_pending_events(app)?;
+    // Refresh after keys, resize events, and background-worker state changes.
+    let (width, height) = crossterm::terminal::size()?;
+    update_model_viewport(app, ratatui::layout::Rect::new(0, 0, width, height));
+    Ok(processed)
+}
+
+fn handle_pending_events(app: &mut App) -> std::io::Result<bool> {
     // Always tick the pull progress and worker messages (non-blocking)
     app.tick_pull();
     app.tick_bench();
@@ -819,6 +852,53 @@ mod tests {
 
     fn plain(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn model_viewport_updates_on_events_and_draws_leave_it_unchanged() {
+        use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+
+        let mut app = plan_mode_app();
+        app.input_mode = InputMode::Normal;
+        app.show_plan = false;
+        assert!(!app.all_fits.is_empty());
+        app.filtered_fits = (0..app.all_fits.len().min(100)).collect();
+        app.selected_row = app.filtered_fits.len() - 1;
+        let area = Rect::new(0, 0, 160, 24);
+        update_model_viewport(&mut app, area);
+        let capacity = usize::from(crate::tui_ui::main_layout(area)[2].height - 3);
+        assert_eq!(app.table_state.offset(), app.selected_row + 1 - capacity);
+
+        // Resizing changes persistent scrolling only during event handling.
+        let resized = Rect::new(0, 0, 160, 20);
+        update_model_viewport(&mut app, resized);
+        let capacity = usize::from(crate::tui_ui::main_layout(resized)[2].height - 3);
+        assert_eq!(app.table_state.offset(), app.selected_row + 1 - capacity);
+        let state = app.table_state.clone();
+        let selected = app.selected_row;
+        let tick = app.tick_count;
+        let mut terminal = Terminal::new(TestBackend::new(160, 20)).expect("terminal");
+        terminal
+            .draw(|f| crate::tui_ui::draw(f, &mut app))
+            .expect("first frame");
+        let first_frame = terminal.backend().buffer().clone();
+        terminal
+            .draw(|f| crate::tui_ui::draw(f, &mut app))
+            .expect("second frame");
+        assert_eq!(terminal.backend().buffer(), &first_frame);
+        assert_eq!(app.table_state, state);
+        assert_eq!(app.selected_row, selected);
+        assert_eq!(app.tick_count, tick);
+
+        handle_normal_mode(&mut app, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        update_model_viewport(&mut app, resized);
+        assert_eq!(app.selected_row, selected - 1);
+        assert_eq!(app.table_state.selected(), Some(selected - 1));
+        app.filtered_fits.clear();
+        app.selected_row = 0;
+        update_model_viewport(&mut app, resized);
+        assert_eq!(app.table_state.offset(), 0);
+        assert_eq!(app.table_state.selected(), None);
     }
 
     #[test]

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -24,6 +24,19 @@ use unicode_width::UnicodeWidthStr;
 
 const DM_MODELS_DIR_LABEL: &str = "  Models dir:  ";
 
+/// Shared geometry for drawing and event-driven viewport updates.
+pub(crate) fn main_layout(area: Rect) -> [Rect; 4] {
+    Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4), // system info bar (2 rows)
+            Constraint::Length(3), // search + filters
+            Constraint::Min(10),   // main table
+            Constraint::Length(2), // status bar (model name + keybindings)
+        ])
+        .areas(area)
+}
+
 pub fn draw(frame: &mut Frame, app: &mut App) {
     let tc = app.theme.colors();
 
@@ -33,15 +46,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         frame.render_widget(bg_block, frame.area());
     }
 
-    let outer = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(4), // system info bar (2 rows)
-            Constraint::Length(3), // search + filters
-            Constraint::Min(10),   // main table
-            Constraint::Length(2), // status bar (model name + keybindings)
-        ])
-        .split(frame.area());
+    let outer = main_layout(frame.area());
 
     draw_system_bar(frame, app, outer[0], &tc);
     draw_search_and_filters(frame, app, outer[1], &tc);
@@ -817,7 +822,7 @@ fn model_col_text_width(area: Rect, widths: [Constraint; 14]) -> usize {
 
 /// Visible range for the model table's single-line rows. Keep the widget offset
 /// in full-list coordinates while constructing only rows that fit on screen.
-fn model_table_viewport(
+pub(crate) fn model_table_viewport(
     len: usize,
     selected: usize,
     offset: usize,
@@ -837,7 +842,7 @@ fn model_table_viewport(
     start..start.saturating_add(capacity).min(len)
 }
 
-fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
+fn draw_table(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
     let sort_col = app.sort_column;
     let header_names = [
         "", "Inst", "Model", "Provider", "Params", "Score", "tok/s*", "Quant", "Disk", "Mode",
@@ -1103,23 +1108,15 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
         )
         .highlight_symbol("▶ ");
 
-    if app.filtered_fits.is_empty() {
-        app.table_state.select(None);
-    } else {
-        app.table_state.select(Some(app.selected_row));
-    }
-
-    // Ratatui sees a small table with a local selection. Preserve the global
-    // selection and scroll offset for navigation and the next frame.
+    // Widget selection is local to this frame. Persistent navigation state is
+    // updated by tui_events, never by drawing the table.
     let mut visible_state = TableState::default();
     visible_state.select(
-        app.table_state
-            .selected()
-            .filter(|row| viewport.contains(row))
-            .map(|row| row - viewport.start),
+        viewport
+            .contains(&app.selected_row)
+            .then(|| app.selected_row - viewport.start),
     );
     frame.render_stateful_widget(table, area, &mut visible_state);
-    *app.table_state.offset_mut() = viewport.start;
 
     // Empty-state hint when filters hide all models
     if app.filtered_fits.is_empty() && !app.all_fits.is_empty() {

--- a/llmfit-tui/src/tui_ui.rs
+++ b/llmfit-tui/src/tui_ui.rs
@@ -5,7 +5,7 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{
         Block, Borders, Cell, Clear, Paragraph, Row, Scrollbar, ScrollbarOrientation,
-        ScrollbarState, Table, Wrap,
+        ScrollbarState, Table, TableState, Wrap,
     },
 };
 
@@ -815,6 +815,28 @@ fn model_col_text_width(area: Rect, widths: [Constraint; 14]) -> usize {
         .unwrap_or(0)
 }
 
+/// Visible range for the model table's single-line rows. Keep the widget offset
+/// in full-list coordinates while constructing only rows that fit on screen.
+fn model_table_viewport(
+    len: usize,
+    selected: usize,
+    offset: usize,
+    capacity: usize,
+) -> std::ops::Range<usize> {
+    if len == 0 {
+        return 0..0;
+    }
+    let selected = selected.min(len - 1);
+    let mut start = offset.min(len - 1).min(selected);
+    if capacity == 0 {
+        return start..start;
+    }
+    if selected - start >= capacity {
+        start = selected + 1 - capacity;
+    }
+    start..start.saturating_add(capacity).min(len)
+}
+
 fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
     let sort_col = app.sort_column;
     let header_names = [
@@ -873,11 +895,18 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
 
     let model_col_chars = model_col_text_width(area, widths);
 
-    let rows: Vec<Row> = app
-        .filtered_fits
+    // Two border lines and one header line leave the rest for model rows.
+    let viewport = model_table_viewport(
+        app.filtered_fits.len(),
+        app.selected_row,
+        app.table_state.offset(),
+        usize::from(area.height.saturating_sub(3)),
+    );
+    let rows: Vec<Row> = app.filtered_fits[viewport.clone()]
         .iter()
         .enumerate()
-        .map(|(row_idx, &idx)| {
+        .map(|(local_row, &idx)| {
+            let row_idx = viewport.start + local_row;
             let fit = &app.all_fits[idx];
             let color = fit_color(fit.fit_level, tc);
 
@@ -1080,7 +1109,17 @@ fn draw_table(frame: &mut Frame, app: &mut App, area: Rect, tc: &ThemeColors) {
         app.table_state.select(Some(app.selected_row));
     }
 
-    frame.render_stateful_widget(table, area, &mut app.table_state);
+    // Ratatui sees a small table with a local selection. Preserve the global
+    // selection and scroll offset for navigation and the next frame.
+    let mut visible_state = TableState::default();
+    visible_state.select(
+        app.table_state
+            .selected()
+            .filter(|row| viewport.contains(row))
+            .map(|row| row - viewport.start),
+    );
+    frame.render_stateful_widget(table, area, &mut visible_state);
+    *app.table_state.offset_mut() = viewport.start;
 
     // Empty-state hint when filters hide all models
     if app.filtered_fits.is_empty() && !app.all_fits.is_empty() {
@@ -5712,6 +5751,69 @@ fn draw_bench(frame: &mut Frame, app: &App, area: Rect, tc: &ThemeColors) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn model_viewport_matches_full_table_navigation_and_resize() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut full_state = TableState::default();
+        let mut offset = 0;
+        // Down/up, page jumps, last/first row, resize, and a shrinking filter.
+        for (len, selected, height) in [
+            (100, 0, 10),
+            (100, 1, 10),
+            (100, 7, 10),
+            (100, 8, 10),
+            (100, 50, 10),
+            (100, 49, 10),
+            (100, 99, 10),
+            (100, 99, 20),
+            (100, 99, 5),
+            (100, 0, 5),
+            (3, 2, 10),
+            (1, 0, 10),
+            (0, 0, 10),
+            (100, 50, 10),
+        ] {
+            let mut full = Terminal::new(TestBackend::new(30, height)).expect("full table");
+            let mut window = Terminal::new(TestBackend::new(30, height)).expect("window table");
+            let range = model_table_viewport(len, selected, offset, usize::from(height - 3));
+            let make_table = |range: std::ops::Range<usize>| {
+                Table::new(
+                    range.map(|i| Row::new([format!("Model {i}")])),
+                    [Constraint::Min(10)],
+                )
+                .header(Row::new(["Models"]))
+                .block(Block::default().borders(Borders::ALL))
+                .highlight_symbol("▶ ")
+                .row_highlight_style(Style::default().bg(Color::Blue))
+            };
+            full_state.select((len > 0).then_some(selected));
+            let mut local_state = TableState::default();
+            local_state.select((len > 0).then(|| selected - range.start));
+            full.draw(|f| f.render_stateful_widget(make_table(0..len), f.area(), &mut full_state))
+                .expect("full frame");
+            window
+                .draw(|f| {
+                    f.render_stateful_widget(make_table(range.clone()), f.area(), &mut local_state)
+                })
+                .expect("window frame");
+            assert_eq!(
+                full.backend().buffer(),
+                window.backend().buffer(),
+                "len={len}, selected={selected}, height={height}"
+            );
+            offset = range.start;
+            assert_eq!(offset, full_state.offset());
+        }
+    }
+
+    #[test]
+    fn model_viewport_handles_no_room_for_rows() {
+        assert_eq!(model_table_viewport(0, 0, 0, 0), 0..0);
+        assert_eq!(model_table_viewport(100, 50, 40, 0), 40..40);
+        assert_eq!(model_table_viewport(3, 99, 99, 1), 2..3);
+    }
 
     #[test]
     fn truncate_str_handles_multibyte_utf8() {


### PR DESCRIPTION
The model list rebuilt every filtered row before processing each input event, including thousands of offscreen rows and their provider lookups. Render only the viewport's single-line rows, while preserving global selection, scrolling, comparison markers, and the scrollbar. Event handling updates persistent viewport state after input, resize, and background changes; the model-table renderer takes `&App` and uses only a local widget state. This reduces the work performed for each navigation event as the catalog grows.

Also correct the README's advertised Tab/Shift+Tab switching: the main model list has no such bindings. Document the existing benchmark and help shortcuts instead.

Validation:
- All 105 release binary unit tests passed with the updated patch applied to the earlier buildable base (`7db1b57`). Tests include buffer comparisons against a full Ratatui table for navigation, resize, and shrinking/empty lists, plus event-driven scrolling and repeated draws that preserve the buffer and application navigation state. Validation on current main remains blocked as described below.
- `cargo fmt --all -- --check` and `git diff --check`.
- Local release build succeeded before rebasing onto current main.
- Temporary rendering benchmark: 7,764 filtered models at 160×48, 30 frames after warmup, using the issue's hardware configuration for fit analysis. Average frame time fell from 33.0 ms to 0.39 ms (about 84× faster). Measurements used Ratatui's in-memory backend on a newer CPU; they exclude terminal/SSH overhead and are not an end-to-end reproduction on the reporter's machine. Temporary profiling code was removed.

Current-main build blocker: after rebasing onto `abb1360`, `cargo test --release -p llmfit --bin llmfit` fails with seven non-exhaustive matches for the new `BenchTarget::Ferrum` variant in `tui_app.rs` and `main.rs`. Those match sites are unchanged by this PR. The latest-main test run could not complete.

Fixes #1016
