### PR TITLE
bench: community results for apple-m3-pro

### DIFF
--- a/llmfit-core/data/community/apple-m3-pro/1789033732-36ebadeb.json
+++ b/llmfit-core/data/community/apple-m3-pro/1789033732-36ebadeb.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 11,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "macos",
+    "ramGb": 18.0,
+    "unifiedMemory": true,
+    "vramGb": 18.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 209.0,
+      "avgTotalMs": 3292.57,
+      "avgTps": 65.01,
+      "avgTtftMs": 63.69,
+      "maxTps": 65.49,
+      "minTps": 64.75,
+      "model": "qwen2.5-coder:3b-instruct-q4_0",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789033865,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-pro/1789033740-4d65bbb2.json
+++ b/llmfit-core/data/community/apple-m3-pro/1789033740-4d65bbb2.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 11,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "macos",
+    "ramGb": 18.0,
+    "unifiedMemory": true,
+    "vramGb": 18.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 163.33,
+      "avgTotalMs": 2582.97,
+      "avgTps": 65.31,
+      "avgTtftMs": 63.37,
+      "maxTps": 66.19,
+      "minTps": 64.79,
+      "model": "qwen2.5-coder:3b-instruct-q4_0",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789033865,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-pro/1789033772-3da42c73.json
+++ b/llmfit-core/data/community/apple-m3-pro/1789033772-3da42c73.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 11,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "macos",
+    "ramGb": 18.0,
+    "unifiedMemory": true,
+    "vramGb": 18.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 187.33,
+      "avgTotalMs": 2959.28,
+      "avgTps": 64.74,
+      "avgTtftMs": 63.49,
+      "maxTps": 64.82,
+      "minTps": 64.58,
+      "model": "qwen2.5-coder:3b-instruct-q4_0",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789033865,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-pro/1789055717-c4c15918.json
+++ b/llmfit-core/data/community/apple-m3-pro/1789055717-c4c15918.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 11,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "macos",
+    "ramGb": 18.0,
+    "unifiedMemory": true,
+    "vramGb": 18.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 212.67,
+      "avgTotalMs": 19044.97,
+      "avgTps": 12.49,
+      "avgTtftMs": 596.78,
+      "maxTps": 14.74,
+      "minTps": 10.51,
+      "model": "gemma3:12b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789055922,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/apple-m3-pro/1789055869-52db7ec9.json
+++ b/llmfit-core/data/community/apple-m3-pro/1789055869-52db7ec9.json
@@ -1,0 +1,55 @@
+{
+  "hardware": {
+    "cpu": "Apple M3 Pro",
+    "cpuCores": 11,
+    "gpuCount": 1,
+    "hardwareName": "Apple M3 Pro",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "macos",
+    "ramGb": 18.0,
+    "unifiedMemory": true,
+    "vramGb": 18.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 217.33,
+      "avgTotalMs": 17842.42,
+      "avgTps": 13.28,
+      "avgTtftMs": 399.03,
+      "maxTps": 14.63,
+      "minTps": 10.65,
+      "model": "gemma3:12b",
+      "numRuns": 3,
+      "provider": "ollama"
+    },
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 14184.47,
+      "avgTps": 21.42,
+      "avgTtftMs": 157.05,
+      "maxTps": 21.73,
+      "minTps": 20.86,
+      "model": "deepseek-r1:8b",
+      "numRuns": 3,
+      "provider": "ollama"
+    },
+    {
+      "avgOutputTokens": 164.0,
+      "avgTotalMs": 3529.58,
+      "avgTps": 48.93,
+      "avgTtftMs": 117.33,
+      "maxTps": 50.61,
+      "minTps": 47.38,
+      "model": "qwen2.5-coder:3b-instruct-q4_0",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789055922,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| qwen2.5-coder:3b-instruct-q4_0 | ollama | 65.0 | 63.7 |
| qwen2.5-coder:3b-instruct-q4_0 | ollama | 65.3 | 63.4 |
| qwen2.5-coder:3b-instruct-q4_0 | ollama | 64.7 | 63.5 |

_Submitted without the `gh` CLI via the GitHub device flow._
