### PR TITLE
docs: clarify Windows code-signing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can also install llmfit as a Python package in the normal way with tools suc
 
 ### Pre-built Binaries
 
-Download signed release binaries for Linux, macOS, and Windows directly from the [GitHub Releases](https://github.com/AlexsJones/llmfit/releases) page.
+Download release binaries for Linux, macOS, and Windows directly from the [GitHub Releases](https://github.com/AlexsJones/llmfit/releases) page. Windows binaries are signed when that release's SignPath step succeeds; verify the executable signature if you require a signed binary.
 
 ---
 
@@ -273,7 +273,7 @@ If you're looking for a different approach, check out [llm-checker](https://gith
 
 ## Code signing
 
-llmfit's Windows release binaries are digitally signed (Authenticode) via [SignPath.io](https://about.signpath.io/), with a free code signing certificate provided by the [SignPath Foundation](https://signpath.org/).
+llmfit's Windows release binaries are intended to be digitally signed (Authenticode) via [SignPath.io](https://about.signpath.io/), with a free code signing certificate provided by the [SignPath Foundation](https://signpath.org/). A given release is signed only when its SignPath step succeeds; verify the executable signature before relying on it.
 
 Signing happens automatically in the [release pipeline](.github/workflows/release.yml): only artifacts built by GitHub Actions from this repository are submitted for signing, and signing requests are approved by the project maintainer ([@AlexsJones](https://github.com/AlexsJones)).
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can also install llmfit as a Python package in the normal way with tools suc
 
 ### Pre-built Binaries
 
-Download release binaries for Linux, macOS, and Windows directly from the [GitHub Releases](https://github.com/AlexsJones/llmfit/releases) page. Windows binaries are signed when that release's SignPath step succeeds; verify the executable signature if you require a signed binary.
+Download release binaries for Linux, macOS, and Windows directly from the [GitHub Releases](https://github.com/AlexsJones/llmfit/releases) page. Windows binaries are signed only when that release's complete `sign-windows` job succeeds, including signing, repackaging, artifact replacement, and checksum upload; a release may still publish an unsigned Windows artifact if signing is skipped or fails. Verify the executable signature if you require a signed binary.
 
 ---
 
@@ -273,7 +273,7 @@ If you're looking for a different approach, check out [llm-checker](https://gith
 
 ## Code signing
 
-llmfit's Windows release binaries are intended to be digitally signed (Authenticode) via [SignPath.io](https://about.signpath.io/), with a free code signing certificate provided by the [SignPath Foundation](https://signpath.org/). A given release is signed only when its SignPath step succeeds; verify the executable signature before relying on it.
+llmfit's Windows release binaries are intended to be digitally signed (Authenticode) via [SignPath.io](https://about.signpath.io/), with a free code signing certificate provided by the [SignPath Foundation](https://signpath.org/). A given release is signed only when its complete `sign-windows` job succeeds, including signing, repackaging, artifact replacement, and checksum upload; signing can be skipped or fail while the release still publishes an unsigned artifact. Verify the executable signature before relying on it.
 
 Signing happens automatically in the [release pipeline](.github/workflows/release.yml): only artifacts built by GitHub Actions from this repository are submitted for signing, and signing requests are approved by the project maintainer ([@AlexsJones](https://github.com/AlexsJones)).
 


### PR DESCRIPTION
Fixes #839.

Clarifies that Windows binaries are signed only when the release's SignPath step succeeds, and tells users to verify the executable signature when they require a signed binary. This keeps the README accurate for releases such as v1.1.8 whose published executable was not signed.

Verification:
- `cargo fmt --all -- --check`
- `cargo test` — 862 passed, 1 ignored
- `npm ci --prefix llmfit-web && npm test --prefix llmfit-web` — 14 passed
- `npm run build --prefix llmfit-web`

`cargo test --workspace` remains blocked by the pre-existing missing `llmfit-desktop/icons/icon.ico`; `cargo clippy -- -D warnings` reports pre-existing findings in unchanged Rust sources.