### PR TITLE
bench: community results for nvidia-geforce-rtx-3050-ti-laptop-gpu

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789092233-8d9645ad.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789092233-8d9645ad.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 194.0,
+      "avgTotalMs": 2548.94,
+      "avgTps": 80.1,
+      "avgTtftMs": 86.98,
+      "maxTps": 82.31,
+      "minTps": 78.35,
+      "model": "gemma3:1b-it-qat",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789092233,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789092890-1ac3c0b4.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789092890-1ac3c0b4.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 192.33,
+      "avgTotalMs": 2440.67,
+      "avgTps": 81.82,
+      "avgTtftMs": 44.15,
+      "maxTps": 84.36,
+      "minTps": 80.05,
+      "model": "qwen2.5-coder:1.5b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789092890,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789093963-4ccee205.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789093963-4ccee205.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 194.67,
+      "avgTotalMs": 2757.12,
+      "avgTps": 82.94,
+      "avgTtftMs": 40.42,
+      "maxTps": 83.74,
+      "minTps": 82.02,
+      "model": "gemma3:1b-it-qat",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789093963,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789126369-8c55c6db.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789126369-8c55c6db.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 160.0,
+      "avgTotalMs": 6096.59,
+      "avgTps": 27.08,
+      "avgTtftMs": 231.72,
+      "maxTps": 27.85,
+      "minTps": 26.04,
+      "model": "llama3.2:1b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789126369,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789126815-5f99cc23.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789126815-5f99cc23.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 211.67,
+      "avgTotalMs": 2619.89,
+      "avgTps": 82.7,
+      "avgTtftMs": 43.72,
+      "maxTps": 83.4,
+      "minTps": 81.71,
+      "model": "qwen2.5-coder:1.5b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789126815,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789127014-a7996ef9.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789127014-a7996ef9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 121.33,
+      "avgTotalMs": 1647.0,
+      "avgTps": 74.68,
+      "avgTtftMs": 73.05,
+      "maxTps": 81.51,
+      "minTps": 70.62,
+      "model": "qwen2.5-coder:1.5b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789127014,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789127487-3fa7521e.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789127487-3fa7521e.json
@@ -1,0 +1,88 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 158.33,
+      "avgTotalMs": 6053.3,
+      "avgTps": 27.01,
+      "avgTtftMs": 210.38,
+      "maxTps": 27.34,
+      "minTps": 26.44,
+      "model": "llama3.2:1b",
+      "numRuns": 3,
+      "provider": "ollama"
+    },
+    {
+      "avgOutputTokens": 196.33,
+      "avgTotalMs": 2449.18,
+      "avgTps": 83.14,
+      "avgTtftMs": 58.78,
+      "maxTps": 85.54,
+      "minTps": 80.49,
+      "model": "qwen2.5-coder:1.5b",
+      "numRuns": 3,
+      "provider": "ollama"
+    },
+    {
+      "avgOutputTokens": 79.33,
+      "avgTotalMs": 17810.23,
+      "avgTps": 333336.5,
+      "avgTtftMs": 1153.59,
+      "maxTps": 1000000.0,
+      "minTps": 4.75,
+      "model": "hf.co/defog/sqlcoder-7b-2:Q5_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    },
+    {
+      "avgOutputTokens": 148.0,
+      "avgTotalMs": 23649.67,
+      "avgTps": 6.87,
+      "avgTtftMs": 1385.2,
+      "maxTps": 7.37,
+      "minTps": 6.58,
+      "model": "sqlcoder:7b",
+      "numRuns": 3,
+      "provider": "ollama"
+    },
+    {
+      "avgOutputTokens": 186.67,
+      "avgTotalMs": 2490.51,
+      "avgTps": 78.85,
+      "avgTtftMs": 87.41,
+      "maxTps": 81.04,
+      "minTps": 77.21,
+      "model": "gemma3:1b-it-qat",
+      "numRuns": 3,
+      "provider": "ollama"
+    },
+    {
+      "avgOutputTokens": 142.0,
+      "avgTotalMs": 23944.56,
+      "avgTps": 12.55,
+      "avgTtftMs": 533.63,
+      "maxTps": 13.42,
+      "minTps": 11.43,
+      "model": "llama3.2:latest",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789127499,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789127499-813c8e2f.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789127499-813c8e2f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 215.0,
+      "avgTotalMs": 23726.1,
+      "avgTps": 81.14,
+      "avgTtftMs": 61.38,
+      "maxTps": 82.59,
+      "minTps": 78.64,
+      "model": "qwen2.5:1.5b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789127499,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789129005-c09ee8ee.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789129005-c09ee8ee.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 211.67,
+      "avgTotalMs": 2793.46,
+      "avgTps": 79.79,
+      "avgTtftMs": 91.03,
+      "maxTps": 82.36,
+      "minTps": 78.41,
+      "model": "gemma3:1b-it-qat",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789129005,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789176437-63ef5a7d.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-3050-ti-laptop-gpu/1789176437-63ef5a7d.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "AMD Ryzen 7 4800H with Radeon Graphics",
+    "cpuCores": 16,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 3050 Ti Laptop GPU",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 31.42,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 184.33,
+      "avgTotalMs": 10641.33,
+      "avgTps": 81.47,
+      "avgTtftMs": 46.05,
+      "maxTps": 84.28,
+      "minTps": 77.53,
+      "model": "qwen2.5-coder:1.5b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789176437,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| gemma3:1b-it-qat | ollama | 80.1 | 87.0 |

_Submitted without the `gh` CLI via the GitHub device flow._
