### PR TITLE
bench: community results for apple-m4

### DIFF
--- a/llmfit-core/data/community/apple-m4/1789171270-998a4fc7.json
+++ b/llmfit-core/data/community/apple-m4/1789171270-998a4fc7.json
@@ -1,0 +1,44 @@
+{
+  "hardware": {
+    "cpu": "Apple M4",
+    "cpuCores": 10,
+    "gpuCount": 1,
+    "hardwareName": "Apple M4",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "macos",
+    "ramGb": 16.0,
+    "unifiedMemory": true,
+    "vramGb": 16.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 262.0,
+      "avgTotalMs": 13525.17,
+      "avgTps": 20.52,
+      "avgTtftMs": 761.85,
+      "maxTps": 21.34,
+      "minTps": 19.84,
+      "model": "gpt-oss:20b",
+      "numRuns": 3,
+      "provider": "ollama"
+    },
+    {
+      "avgOutputTokens": 275.33,
+      "avgTotalMs": 15750.01,
+      "avgTps": 17.67,
+      "avgTtftMs": 187.18,
+      "maxTps": 17.9,
+      "minTps": 17.38,
+      "model": "qwen3:8b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789171988,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/apple-m4/1789171844-4d339236.json
+++ b/llmfit-core/data/community/apple-m4/1789171844-4d339236.json
@@ -1,0 +1,44 @@
+{
+  "hardware": {
+    "cpu": "Apple M4",
+    "cpuCores": 10,
+    "gpuCount": 1,
+    "hardwareName": "Apple M4",
+    "hwClass": "UNIFIED",
+    "memTierGb": 16,
+    "os": "macos",
+    "ramGb": 16.0,
+    "unifiedMemory": true,
+    "vramGb": 16.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 255.0,
+      "avgTotalMs": 11004.08,
+      "avgTps": 24.54,
+      "avgTtftMs": 606.58,
+      "maxTps": 24.64,
+      "minTps": 24.46,
+      "model": "gpt-oss:20b",
+      "numRuns": 3,
+      "provider": "ollama"
+    },
+    {
+      "avgOutputTokens": 294.33,
+      "avgTotalMs": 15088.35,
+      "avgTps": 19.74,
+      "avgTtftMs": 167.64,
+      "maxTps": 19.96,
+      "minTps": 19.42,
+      "model": "qwen3:8b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789171988,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| gpt-oss:20b | ollama | 20.5 | 761.9 |
| qwen3:8b | ollama | 17.7 | 187.2 |
| gpt-oss:20b | ollama | 24.5 | 606.6 |
| qwen3:8b | ollama | 19.7 | 167.6 |

_Submitted without the `gh` CLI via the GitHub device flow._
