### PR TITLE
bench: community results for nvidia-geforce-rtx-2080

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789222086-4cb295d9.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789222086-4cb295d9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 15648.87,
+      "avgTps": 64.27,
+      "avgTtftMs": 64.09,
+      "maxTps": 65.44,
+      "minTps": 62.17,
+      "model": "deepseek-r1:7b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789222199,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789222199-1730015c.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789222199-1730015c.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 10244.45,
+      "avgTps": 64.3,
+      "avgTtftMs": 109.03,
+      "maxTps": 65.4,
+      "minTps": 62.88,
+      "model": "deepseek-r1:7b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789222199,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789224996-89ccff69.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789224996-89ccff69.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 241.33,
+      "avgTotalMs": 2517.47,
+      "avgTps": 99.02,
+      "avgTtftMs": 33.23,
+      "maxTps": 99.42,
+      "minTps": 98.69,
+      "model": "qwen3:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789224996,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789225042-b929e9eb.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789225042-b929e9eb.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 3120.23,
+      "avgTps": 99.47,
+      "avgTtftMs": 46.17,
+      "maxTps": 99.73,
+      "minTps": 99.13,
+      "model": "qwen3:4b",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789225042,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789230597-4e60f173.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789230597-4e60f173.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 147.67,
+      "avgTotalMs": 2260.13,
+      "avgTps": 72.13,
+      "avgTtftMs": 74.67,
+      "maxTps": 77.1,
+      "minTps": 66.62,
+      "model": "qwen3:4b-instruct-2507-q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789230597,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789230647-0660235b.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789230647-0660235b.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 156.0,
+      "avgTotalMs": 2370.54,
+      "avgTps": 72.2,
+      "avgTtftMs": 66.9,
+      "maxTps": 75.89,
+      "minTps": 70.02,
+      "model": "qwen3:4b-instruct-2507-q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789230647,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789230673-76b73322.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789230673-76b73322.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 142.67,
+      "avgTotalMs": 2193.26,
+      "avgTps": 70.55,
+      "avgTtftMs": 105.7,
+      "maxTps": 75.85,
+      "minTps": 62.41,
+      "model": "qwen3:4b-instruct-2507-q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789230673,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789231922-cf552a87.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789231922-cf552a87.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 5246.66,
+      "avgTps": 59.36,
+      "avgTtftMs": 130.57,
+      "maxTps": 60.52,
+      "minTps": 58.3,
+      "model": "deepseek-r1:7b-qwen-distill-q4_K_M",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789231922,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789237581-6b6fdfd9.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789237581-6b6fdfd9.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 97.33,
+      "avgTotalMs": 2051.05,
+      "avgTps": 49.73,
+      "avgTtftMs": 54.45,
+      "maxTps": 51.12,
+      "minTps": 48.86,
+      "model": "qwen2.5-coder:7b-instruct-q6_K",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789237581,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789237591-730db5b6.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789237591-730db5b6.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 162.33,
+      "avgTotalMs": 3306.52,
+      "avgTps": 50.34,
+      "avgTtftMs": 41.28,
+      "maxTps": 50.45,
+      "minTps": 50.25,
+      "model": "qwen2.5-coder:7b-instruct-q6_K",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789237591,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}

--- a/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789239218-d75c984f.json
+++ b/llmfit-core/data/community/nvidia-geforce-rtx-2080/1789239218-d75c984f.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz",
+    "cpuCores": 12,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce RTX 2080",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 8,
+    "os": "windows",
+    "ramGb": 31.89,
+    "unifiedMemory": false,
+    "vramGb": 8.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 157.0,
+      "avgTotalMs": 2750.2,
+      "avgTps": 60.34,
+      "avgTtftMs": 56.07,
+      "maxTps": 61.14,
+      "minTps": 59.55,
+      "model": "qwen3:4b-instruct-2507-q8_0",
+      "numRuns": 3,
+      "provider": "ollama"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789239218,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| deepseek-r1:7b | ollama | 64.3 | 64.1 |
| deepseek-r1:7b | ollama | 64.3 | 109.0 |

_Submitted without the `gh` CLI via the GitHub device flow._
