### PR TITLE
bench: community results for nvidia-geforce-gtx-1650

### DIFF
--- a/llmfit-core/data/community/nvidia-geforce-gtx-1650/1789222880-777cfc22.json
+++ b/llmfit-core/data/community/nvidia-geforce-gtx-1650/1789222880-777cfc22.json
@@ -1,0 +1,33 @@
+{
+  "hardware": {
+    "cpu": "Intel(R) Core(TM) i5-10300H CPU @ 2.50GHz",
+    "cpuCores": 8,
+    "gpuCount": 1,
+    "hardwareName": "NVIDIA GeForce GTX 1650",
+    "hwClass": "DISCRETE_GPU",
+    "memTierGb": 4,
+    "os": "windows",
+    "ramGb": 15.84,
+    "unifiedMemory": false,
+    "vramGb": 4.0
+  },
+  "results": [
+    {
+      "avgOutputTokens": 300.0,
+      "avgTotalMs": 8393.7,
+      "avgTps": 35.74,
+      "avgTtftMs": null,
+      "maxTps": 35.83,
+      "minTps": 35.67,
+      "model": "Huihui-Qwen3.5-2B-abliterated.Q8_0.gguf",
+      "numRuns": 3,
+      "provider": "llamacpp"
+    }
+  ],
+  "schemaVersion": 1,
+  "submittedAtUnix": 1789222880,
+  "tool": {
+    "name": "llmfit",
+    "version": "1.1.15"
+  }
+}


### PR DESCRIPTION
Automated benchmark contribution from `llmfit bench --share`.

| Model | Provider | Avg TPS | Avg TTFT (ms) |
| --- | --- | --- | --- |
| Huihui-Qwen3.5-2B-abliterated.Q8_0.gguf | llamacpp | 35.7 | — |

_Submitted without the `gh` CLI via the GitHub device flow._
